### PR TITLE
clear peer addresses on disconnect to fix ws data race

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -313,6 +313,7 @@ func (s *Service) disconnect(peerID libp2ppeer.ID) error {
 	if err := s.host.Network().ClosePeer(peerID); err != nil {
 		return err
 	}
+	s.host.Peerstore().ClearAddrs(peerID)
 	s.peers.remove(peerID)
 	return nil
 }

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -27,13 +27,6 @@ import (
 func newService(t *testing.T, o libp2p.Options) (s *libp2p.Service, overlay swarm.Address, cleanup func()) {
 	t.Helper()
 
-	// disable ws until the race condition in:
-	// github.com/gorilla/websocket@v1.4.1/conn.go:614
-	// github.com/gorilla/websocket@v1.4.1/conn.go:781
-	// using github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1
-	// is solved
-	o.DisableWS = true
-
 	if o.PrivateKey == nil {
 		var err error
 		o.PrivateKey, err = crypto.GenerateSecp256k1Key()


### PR DESCRIPTION
This PR introduces other problems reproducible only in GitHub Actions at this moment.

This PR addresses a data race discovered when running p2p/libp2p tests when listening for websocket connections on multiple network interfaces, by cleaning up peer addresses information.

```
==================
WARNING: DATA RACE
Read at 0x00c0006b1be0 by goroutine 205:
  github.com/gorilla/websocket.(*messageWriter).flushFrame()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:614 +0x7cd
  github.com/gorilla/websocket.(*messageWriter).Close()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:724 +0xba
  github.com/gorilla/websocket.(*Conn).WriteMessage()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:773 +0x315
  github.com/libp2p/go-ws-transport.(*Conn).Write()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/conn_native.go:74 +0x11a
  go.(*struct { net.Conn; github.com/multiformats/go-multiaddr-net.maEndpoints }).Write()
      <autogenerated>:1 +0x87
  crypto/tls.(*Conn).write()
      /usr/local/go/src/crypto/tls/conn.go:915 +0x243
  crypto/tls.(*Conn).writeRecordLocked()
      /usr/local/go/src/crypto/tls/conn.go:964 +0x56d
  crypto/tls.(*Conn).sendAlertLocked()
      /usr/local/go/src/crypto/tls/conn.go:816 +0xac
  crypto/tls.(*Conn).closeNotify()
      /usr/local/go/src/crypto/tls/conn.go:1337 +0x116
  crypto/tls.(*Conn).Close()
      /usr/local/go/src/crypto/tls/conn.go:1310 +0x140
  github.com/libp2p/go-libp2p-tls.(*conn).Close()
      <autogenerated>:1 +0x5d
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:127 +0x266
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).upgrade()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:91 +0x570
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeOutbound()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:57 +0x125
  github.com/libp2p/go-ws-transport.(*WebsocketTransport).Dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/websocket.go:63 +0x177
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:462 +0x2c2
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:450 +0x96
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).executeDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:218 +0x29f

Previous write at 0x00c0006b1be0 by goroutine 223:
  github.com/libp2p/go-ws-transport.(*Conn).SetDeadline()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:781 +0xd0
  go.(*struct { net.Conn; github.com/multiformats/go-multiaddr-net.maEndpoints }).SetDeadline()
      <autogenerated>:1 +0x84
  crypto/tls.(*Conn).SetDeadline()
      /usr/local/go/src/crypto/tls/conn.go:131 +0x72
  github.com/libp2p/go-libp2p-tls.(*conn).SetDeadline()
      <autogenerated>:1 +0x7f
  github.com/libp2p/go-stream-muxer-multistream.(*Transport).NewConn()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-stream-muxer-multistream@v0.2.0/multistream.go:64 +0x329
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer.func1()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:119 +0xd4

Goroutine 205 (running) created at:
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).addCheckFdLimit()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:168 +0x330
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).addCheckPeerLimit()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:182 +0x863
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).AddDialJob()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:193 +0x181
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddrs()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:442 +0xb10
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:317 +0x6d5
  github.com/libp2p/go-libp2p-swarm.(*Swarm).doDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:249 +0x250
  github.com/libp2p/go-libp2p-swarm.(*Swarm).doDial-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:234 +0x70
  github.com/libp2p/go-libp2p-swarm.(*activeDial).start()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/dial_sync.go:80 +0xb4

Goroutine 223 (finished) created at:
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:117 +0x16b
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).upgrade()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:91 +0x570
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeOutbound()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:57 +0x125
  github.com/libp2p/go-ws-transport.(*WebsocketTransport).Dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/websocket.go:63 +0x177
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:462 +0x2c2
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:450 +0x96
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).executeDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:218 +0x29f
==================
--- FAIL: TestConnectDisconnectOnAllAddresses (3.34s)
    testing.go:853: race detected during execution of test
```

Minimal test to reproduce is when `Peerstore().ClearAddrs` call is removed:

```go
package bee_test

import (
	"context"
	"fmt"
	"testing"

	"github.com/libp2p/go-libp2p"
	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
	libp2ptls "github.com/libp2p/go-libp2p-tls"
	ma "github.com/multiformats/go-multiaddr"
)

func TestWS(t *testing.T) {
	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()

	h1, err := libp2p.New(ctx,
		libp2p.ListenAddrStrings(
			"/ip4/127.0.0.1/tcp/3223/ws",
			"/ip4/127.0.0.1/tcp/3224/ws",
		),
		libp2p.Security(libp2ptls.ID, libp2ptls.New),
		libp2p.DefaultTransports)
	if err != nil {
		t.Fatal(err)
	}
	defer h1.Close()

	h2, err := libp2p.New(ctx,
		libp2p.ListenAddrStrings(
			"/ip4/127.0.0.1/tcp/3225/ws",
			"/ip4/127.0.0.1/tcp/3226/ws",
		),
		libp2p.Security(libp2ptls.ID, libp2ptls.New),
		libp2p.DefaultTransports)
	if err != nil {
		t.Fatal(err)
	}
	defer h2.Close()

	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", h1.ID().Pretty()))
	if err != nil {
		t.Fatal(err)
	}

	for _, addr := range h1.Addrs() {
		info1, err := libp2ppeer.AddrInfoFromP2pAddr(addr.Encapsulate(hostAddr))
		if err != nil {
			t.Fatal(err)
		}

		func() {
			ctx, cancel := context.WithCancel(context.Background())
			defer cancel()

			if err := h2.Connect(ctx, *info1); err != nil {
				t.Fatal(err)
			}

			if err := h2.Network().ClosePeer(info1.ID); err != nil {
				t.Fatal(err)
			}

			// remove this call to reproduce the race condition
			h2.Peerstore().ClearAddrs(info1.ID)
		}()
	}
}
```

By removing all known addresses from Peerstore on disconnect, the data race is gone, since goroutnes are terminated.