### PR TITLE
add dedicated peerstore for every libp2p host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/libp2p/go-libp2p v0.5.1
 	github.com/libp2p/go-libp2p-autonat-svc v0.1.0
 	github.com/libp2p/go-libp2p-core v0.3.0
+	github.com/libp2p/go-libp2p-peerstore v0.1.4
 	github.com/libp2p/go-libp2p-quic-transport v0.2.2
 	github.com/libp2p/go-libp2p-secio v0.2.1
 	github.com/libp2p/go-libp2p-tls v0.1.3


### PR DESCRIPTION
This PR changes which libp2p peerstore is used when constructing new libp2p Service. By default the DefaultPeerstore is called creating a new peerstore implicitly, which is never closed creating goroutine leaks in tests. Here, a dedicated peerstore is created and closed on Service.Close.