### PR TITLE
use only libp2p default security to avoid websockets data race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/libp2p/go-libp2p-autonat-svc v0.1.0
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-quic-transport v0.2.2
-	github.com/libp2p/go-libp2p-secio v0.2.1
-	github.com/libp2p/go-libp2p-tls v0.1.3
+	github.com/libp2p/go-tcp-transport v0.1.1
+	github.com/libp2p/go-ws-transport v0.2.0
 	github.com/multiformats/go-multiaddr v0.2.0
 	github.com/multiformats/go-multistream v0.1.0
 	github.com/prometheus/client_golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,7 @@ github.com/libp2p/go-libp2p-testing v0.0.4/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MB
 github.com/libp2p/go-libp2p-testing v0.1.0/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-testing v0.1.1 h1:U03z3HnGI7Ni8Xx6ONVZvUFOAzWYmolWf5W5jAOPNmU=
 github.com/libp2p/go-libp2p-testing v0.1.1/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
+github.com/libp2p/go-libp2p-tls v0.1.1 h1:tjW7njTM8JX8FbEvqr8/VSKBdZYZ7CtGtv3i6NiFf10=
 github.com/libp2p/go-libp2p-tls v0.1.1/go.mod h1:wZfuewxOndz5RTnCAxFliGjvYSDA40sKitV4c50uI1M=
 github.com/libp2p/go-libp2p-tls v0.1.3 h1:twKMhMu44jQO+HgQK9X8NHO5HkeJu2QbhLzLJpa8oNM=
 github.com/libp2p/go-libp2p-tls v0.1.3/go.mod h1:wZfuewxOndz5RTnCAxFliGjvYSDA40sKitV4c50uI1M=

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -27,8 +27,8 @@ import (
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
 	libp2pquic "github.com/libp2p/go-libp2p-quic-transport"
-	secio "github.com/libp2p/go-libp2p-secio"
-	libp2ptls "github.com/libp2p/go-libp2p-tls"
+	"github.com/libp2p/go-tcp-transport"
+	ws "github.com/libp2p/go-ws-transport"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multistream"
 )
@@ -100,15 +100,11 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		}
 	}
 
+	security := libp2p.DefaultSecurity
+
 	opts := []libp2p.Option{
-		// Multiple listen addresses
 		libp2p.ListenAddrStrings(listenAddrs...),
-		// support TLS connections
-		libp2p.Security(libp2ptls.ID, libp2ptls.New),
-		// support secio connections
-		libp2p.Security(secio.ID, secio.New),
-		// support any other default transports (TCP)
-		libp2p.DefaultTransports,
+		security,
 		// Attempt to open ports using uPNP for NATed hosts.
 		libp2p.NATPortMap(),
 	}
@@ -119,12 +115,19 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		)
 	}
 
-	if !o.DisableQUIC {
-		opts = append(opts,
-			// support QUIC - experimental
-			libp2p.Transport(libp2pquic.NewTransport),
-		)
+	transports := []libp2p.Option{
+		libp2p.Transport(tcp.NewTCPTransport),
 	}
+
+	if !o.DisableWS {
+		transports = append(transports, libp2p.Transport(ws.New))
+	}
+
+	if !o.DisableQUIC {
+		transports = append(transports, libp2p.Transport(libp2pquic.NewTransport))
+	}
+
+	opts = append(opts, transports...)
 
 	h, err := libp2p.New(ctx, opts...)
 	if err != nil {
@@ -137,10 +140,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 	if _, err = autonat.NewAutoNATService(ctx, h,
 		// Support same non default security and transport options as
 		// original host.
-		libp2p.Security(libp2ptls.ID, libp2ptls.New),
-		libp2p.Security(secio.ID, secio.New),
-		libp2p.Transport(libp2pquic.NewTransport),
-		libp2p.DefaultTransports,
+		append(transports, security)...,
 	); err != nil {
 		return nil, fmt.Errorf("autonat: %w", err)
 	}

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -27,13 +27,6 @@ import (
 func newService(t *testing.T, o libp2p.Options) (s *libp2p.Service, overlay swarm.Address, cleanup func()) {
 	t.Helper()
 
-	// disable ws until the race condition in:
-	// github.com/gorilla/websocket@v1.4.1/conn.go:614
-	// github.com/gorilla/websocket@v1.4.1/conn.go:781
-	// using github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1
-	// is solved
-	o.DisableWS = true
-
 	if o.PrivateKey == nil {
 		var err error
 		o.PrivateKey, err = crypto.GenerateSecp256k1Key()


### PR DESCRIPTION
This PR addresses a data race achieved when multiple websocket listeners are created, with websockets and tls security enabled.

Data race is on github.com/gorilla/websocket when multiple connects and disconnects are performed while using tls security. The default security in go-libp2p is secio, so this PR is suing only it to avoid data race.

Additionally, a few changes to options handling is added to libp2p.New constructor.

Data race

```
==================
WARNING: DATA RACE
Read at 0x00c0006b1be0 by goroutine 205:
  github.com/gorilla/websocket.(*messageWriter).flushFrame()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:614 +0x7cd
  github.com/gorilla/websocket.(*messageWriter).Close()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:724 +0xba
  github.com/gorilla/websocket.(*Conn).WriteMessage()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:773 +0x315
  github.com/libp2p/go-ws-transport.(*Conn).Write()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/conn_native.go:74 +0x11a
  go.(*struct { net.Conn; github.com/multiformats/go-multiaddr-net.maEndpoints }).Write()
      <autogenerated>:1 +0x87
  crypto/tls.(*Conn).write()
      /usr/local/go/src/crypto/tls/conn.go:915 +0x243
  crypto/tls.(*Conn).writeRecordLocked()
      /usr/local/go/src/crypto/tls/conn.go:964 +0x56d
  crypto/tls.(*Conn).sendAlertLocked()
      /usr/local/go/src/crypto/tls/conn.go:816 +0xac
  crypto/tls.(*Conn).closeNotify()
      /usr/local/go/src/crypto/tls/conn.go:1337 +0x116
  crypto/tls.(*Conn).Close()
      /usr/local/go/src/crypto/tls/conn.go:1310 +0x140
  github.com/libp2p/go-libp2p-tls.(*conn).Close()
      <autogenerated>:1 +0x5d
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:127 +0x266
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).upgrade()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:91 +0x570
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeOutbound()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:57 +0x125
  github.com/libp2p/go-ws-transport.(*WebsocketTransport).Dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/websocket.go:63 +0x177
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:462 +0x2c2
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:450 +0x96
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).executeDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:218 +0x29f

Previous write at 0x00c0006b1be0 by goroutine 223:
  github.com/libp2p/go-ws-transport.(*Conn).SetDeadline()
      /Users/janos/go/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:781 +0xd0
  go.(*struct { net.Conn; github.com/multiformats/go-multiaddr-net.maEndpoints }).SetDeadline()
      <autogenerated>:1 +0x84
  crypto/tls.(*Conn).SetDeadline()
      /usr/local/go/src/crypto/tls/conn.go:131 +0x72
  github.com/libp2p/go-libp2p-tls.(*conn).SetDeadline()
      <autogenerated>:1 +0x7f
  github.com/libp2p/go-stream-muxer-multistream.(*Transport).NewConn()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-stream-muxer-multistream@v0.2.0/multistream.go:64 +0x329
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer.func1()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:119 +0xd4

Goroutine 205 (running) created at:
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).addCheckFdLimit()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:168 +0x330
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).addCheckPeerLimit()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:182 +0x863
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).AddDialJob()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:193 +0x181
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddrs()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:442 +0xb10
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:317 +0x6d5
  github.com/libp2p/go-libp2p-swarm.(*Swarm).doDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:249 +0x250
  github.com/libp2p/go-libp2p-swarm.(*Swarm).doDial-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:234 +0x70
  github.com/libp2p/go-libp2p-swarm.(*activeDial).start()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/dial_sync.go:80 +0xb4

Goroutine 223 (finished) created at:
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:117 +0x16b
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).upgrade()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:91 +0x570
  github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeOutbound()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1/upgrader.go:57 +0x125
  github.com/libp2p/go-ws-transport.(*WebsocketTransport).Dial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-ws-transport@v0.2.0/websocket.go:63 +0x177
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:462 +0x2c2
  github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddr-fm()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/swarm_dial.go:450 +0x96
  github.com/libp2p/go-libp2p-swarm.(*dialLimiter).executeDial()
      /Users/janos/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.2/limiter.go:218 +0x29f
==================
--- FAIL: TestConnectDisconnectOnAllAddresses (3.34s)
    testing.go:853: race detected during execution of test
```

Test to reproduce it:

```go
package bee_test

import (
	"context"
	"fmt"
	"testing"

	"github.com/libp2p/go-libp2p"
	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
	ma "github.com/multiformats/go-multiaddr"
)

func TestWS(t *testing.T) {
	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()

	h1, err := libp2p.New(ctx,
		libp2p.ListenAddrStrings(
			"/ip4/127.0.0.1/tcp/3223/ws",
			"/ip4/127.0.0.1/tcp/3224/ws",
		),
		// add tls security to reproduce the data race
		// libp2p.Security(libp2ptls.ID, libp2ptls.New),
		libp2p.DefaultSecurity,
		libp2p.DefaultTransports,
	)
	if err != nil {
		t.Fatal(err)
	}
	defer h1.Close()

	h2, err := libp2p.New(ctx,
		libp2p.ListenAddrStrings(
			"/ip4/127.0.0.1/tcp/3225/ws",
			"/ip4/127.0.0.1/tcp/3226/ws",
		),
		// add tls security to reproduce the data race
		// libp2p.Security(libp2ptls.ID, libp2ptls.New),
		libp2p.DefaultSecurity,
		libp2p.DefaultTransports,
	)
	if err != nil {
		t.Fatal(err)
	}
	defer h2.Close()

	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", h1.ID().Pretty()))
	if err != nil {
		t.Fatal(err)
	}

	for _, addr := range h1.Addrs() {
		info1, err := libp2ppeer.AddrInfoFromP2pAddr(addr.Encapsulate(hostAddr))
		if err != nil {
			t.Fatal(err)
		}

		func() {
			ctx, cancel := context.WithCancel(context.Background())
			defer cancel()

			if err := h2.Connect(ctx, *info1); err != nil {
				t.Fatal(err)
			}

			if err := h2.Network().ClosePeer(info1.ID); err != nil {
				t.Fatal(err)
			}
		}()
	}
}
```