### PR TITLE
Rename handshake mocks

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -28,7 +28,7 @@ func TestHandshake(t *testing.T) {
 		Light:     false,
 	}
 
-	peerFinderMock := &mock.PeerFinderMock{}
+	peerFinderMock := &mock.PeerFinder{}
 	handshakeService := New(peerFinderMock, info.Address, info.NetworkID, logger)
 
 	t.Run("OK", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestHandshake(t *testing.T) {
 	t.Run("ERROR - Syn write error ", func(t *testing.T) {
 		testErr := errors.New("test error")
 		expectedErr := fmt.Errorf("write syn message: %w", testErr)
-		stream := &mock.StreamMock{}
+		stream := &mock.Stream{}
 		stream.SetWriteErr(testErr, 0)
 		res, err := handshakeService.Handshake(stream)
 		if err == nil || err.Error() != expectedErr.Error() {
@@ -213,7 +213,7 @@ func TestHandle(t *testing.T) {
 	}
 
 	logger := logging.New(ioutil.Discard, 0)
-	peerFinderMock := &mock.PeerFinderMock{}
+	peerFinderMock := &mock.PeerFinder{}
 	handshakeService := New(peerFinderMock, nodeInfo.Address, nodeInfo.NetworkID, logger)
 
 	t.Run("OK", func(t *testing.T) {
@@ -264,7 +264,7 @@ func TestHandle(t *testing.T) {
 	t.Run("ERROR - read error ", func(t *testing.T) {
 		testErr := errors.New("test error")
 		expectedErr := fmt.Errorf("read syn message: %w", testErr)
-		stream := &mock.StreamMock{}
+		stream := &mock.Stream{}
 		stream.SetReadErr(testErr, 0)
 		res, err := handshakeService.Handle(stream)
 		if err == nil || err.Error() != expectedErr.Error() {

--- a/pkg/p2p/libp2p/internal/handshake/mock/peer.go
+++ b/pkg/p2p/libp2p/internal/handshake/mock/peer.go
@@ -6,6 +6,7 @@ package mock
 
 import "github.com/ethersphere/bee/pkg/swarm"
 
+// todo: implement peer registry mocks, export appropriate interface and move those in libp2p so it can be used in handshake
 type PeerFinder struct {
 	found bool
 }

--- a/pkg/p2p/libp2p/internal/handshake/mock/peer.go
+++ b/pkg/p2p/libp2p/internal/handshake/mock/peer.go
@@ -6,14 +6,14 @@ package mock
 
 import "github.com/ethersphere/bee/pkg/swarm"
 
-type PeerFinderMock struct {
+type PeerFinder struct {
 	found bool
 }
 
-func (p *PeerFinderMock) SetFound(found bool) {
+func (p *PeerFinder) SetFound(found bool) {
 	p.found = found
 }
 
-func (p *PeerFinderMock) Exists(overlay swarm.Address) (found bool) {
+func (p *PeerFinder) Exists(overlay swarm.Address) (found bool) {
 	return p.found
 }

--- a/pkg/p2p/libp2p/internal/handshake/mock/stream.go
+++ b/pkg/p2p/libp2p/internal/handshake/mock/stream.go
@@ -6,7 +6,7 @@ package mock
 
 import "bytes"
 
-type StreamMock struct {
+type Stream struct {
 	readBuffer        *bytes.Buffer
 	writeBuffer       *bytes.Buffer
 	writeCounter      int
@@ -17,20 +17,20 @@ type StreamMock struct {
 	writeErrCheckmark int
 }
 
-func NewStream(readBuffer, writeBuffer *bytes.Buffer) *StreamMock {
-	return &StreamMock{readBuffer: readBuffer, writeBuffer: writeBuffer}
+func NewStream(readBuffer, writeBuffer *bytes.Buffer) *Stream {
+	return &Stream{readBuffer: readBuffer, writeBuffer: writeBuffer}
 }
-func (s *StreamMock) SetReadErr(err error, checkmark int) {
+func (s *Stream) SetReadErr(err error, checkmark int) {
 	s.readError = err
 	s.readErrCheckmark = checkmark
 }
 
-func (s *StreamMock) SetWriteErr(err error, checkmark int) {
+func (s *Stream) SetWriteErr(err error, checkmark int) {
 	s.writeError = err
 	s.writeErrCheckmark = checkmark
 }
 
-func (s *StreamMock) Read(p []byte) (n int, err error) {
+func (s *Stream) Read(p []byte) (n int, err error) {
 	if s.readError != nil && s.readErrCheckmark <= s.readCounter {
 		return 0, s.readError
 	}
@@ -39,7 +39,7 @@ func (s *StreamMock) Read(p []byte) (n int, err error) {
 	return s.readBuffer.Read(p)
 }
 
-func (s *StreamMock) Write(p []byte) (n int, err error) {
+func (s *Stream) Write(p []byte) (n int, err error) {
 	if s.writeError != nil && s.writeErrCheckmark <= s.writeCounter {
 		return 0, s.writeError
 	}
@@ -48,6 +48,6 @@ func (s *StreamMock) Write(p []byte) (n int, err error) {
 	return s.writeBuffer.Write(p)
 }
 
-func (s *StreamMock) Close() error {
+func (s *Stream) Close() error {
 	return nil
 }


### PR DESCRIPTION
TODO: 
- implement peer registry mocks insted of `PeerFinder`, move them to `libp2p/mock` and use them in `handshake_test`
- try to re-implement handshake tests to use `streamtest`