### PR TITLE
Fix full connectivity add peer and test

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -359,22 +359,36 @@ func TestConnectWithMockDiscovery(t *testing.T) {
 	s2, _, cleanup2 := newService(t, o2)
 	defer cleanup2()
 
+	s3, _, cleanup3 := newService(t, o2)
+	defer cleanup3()
+
 	addrs, err := s1.Addresses()
 	if err != nil {
 		t.Fatal(err)
 	}
 	addr := addrs[0]
 
-	overlay, err := s2.Connect(context.Background(), addr)
+	_, err = s2.Connect(context.Background(), addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v := disc2.Broadcasts(); v != 0 {
+		t.Fatalf("expected 0 peer broadcasts, got %d", v)
+	}
+
+	addrs, err = s3.Addresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr = addrs[0]
+
+	_, err = s2.Connect(context.Background(), addr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if v := disc2.Broadcasts(); v != 1 {
 		t.Fatalf("expected 1 peer broadcasts, got %d", v)
-	}
-
-	if err := s2.Disconnect(overlay); err != nil {
-		t.Fatal(err)
 	}
 }

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -46,7 +46,6 @@ func (d *driver) AddPeer(overlay swarm.Address) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	d.connected[overlay.String()] = overlay
 	ma, exists := d.addressBook.Get(overlay)
 	if !exists {
 		return topology.ErrNotFound
@@ -58,6 +57,9 @@ func (d *driver) AddPeer(overlay swarm.Address) error {
 			return err
 		}
 	}
+
+	// add peer in the end to avoid broadcast to itself
+	d.connected[overlay.String()] = overlay
 	return nil
 }
 


### PR DESCRIPTION
It looks to me that there was a small bug here. In the `AddPeer` function, the new was added to the map right away, which was making broadcast sending it to itself.

Also, I believe there was no need for disconnect in the tests because of the deferred cleanup function.