### PR TITLE
Hive - Topology driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,34 @@ Execute the command terminals to start `node 1`:
 bee start --api-addr :8081 --p2p-addr :7071 --data-dir data1
 ```
 
+### Bootnodes 
 Use one of the multiaddresses as bootnode for `node 2` in order to connect them:
 
 ```sh
 bee start --api-addr :8082 --p2p-addr :7072 --data-dir data2 --bootnode /ip4/127.0.0.1/tcp/30401/p2p/QmT4TNB4cKYanUjdYodw1Cns8cuVaRVo24hHNYcT7JjkTB
 ```
 
+### Debugapi
+Start `node 2` with debugapi enabled:
+
+```sh
+bee start --api-addr :8082 --p2p-addr :7072 --debug-api-addr :6062 --enable-debug-api --data-dir dist/storage2
+```
+
+Use one of the multiaddresses of `node 1` in order to connect them:
+
+```sh
+curl -XPOST localhost:6063/connect/ip4/127.0.0.1/tcp/30401/p2p/QmT4TNB4cKYanUjdYodw1Cns8cuVaRVo24hHNYcT7JjkTB
+```
+
+### Pingpong
 Take the address of the connected peer to `node 1` from log line `peer "4932309428148935717" connected` and make an HTTP POST request to `localhost:{PORT1}/pingpong/{ADDRESS}` like:
 
 ```sh
 curl -XPOST localhost:8502/pingpong/4932309428148935717
 ```
+
+
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use one of the multiaddresses as bootnode for `node 2` in order to connect them:
 bee start --api-addr :8082 --p2p-addr :7072 --data-dir data2 --bootnode /ip4/127.0.0.1/tcp/30401/p2p/QmT4TNB4cKYanUjdYodw1Cns8cuVaRVo24hHNYcT7JjkTB
 ```
 
-### Debugapi
+### Debug API
 Start `node 2` with debugapi enabled:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,17 +39,15 @@ bee start --api-addr :8082 --p2p-addr :7072 --debug-api-addr :6062 --enable-debu
 Use one of the multiaddresses of `node 1` in order to connect them:
 
 ```sh
-curl -XPOST localhost:6063/connect/ip4/127.0.0.1/tcp/30401/p2p/QmT4TNB4cKYanUjdYodw1Cns8cuVaRVo24hHNYcT7JjkTB
+curl -XPOST localhost:6062/connect/ip4/127.0.0.1/tcp/30401/p2p/QmT4TNB4cKYanUjdYodw1Cns8cuVaRVo24hHNYcT7JjkTB
 ```
 
-### Pingpong
+### Ping-pong
 Take the address of the connected peer to `node 1` from log line `peer "4932309428148935717" connected` and make an HTTP POST request to `localhost:{PORT1}/pingpong/{ADDRESS}` like:
 
 ```sh
 curl -XPOST localhost:8502/pingpong/4932309428148935717
 ```
-
-
 
 ## Structure
 

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -98,11 +98,11 @@ func (c *command) initStartCmd() (err error) {
 					Addr:        c.config.GetString(optionNameP2PAddr),
 					DisableWS:   c.config.GetBool(optionNameP2PDisableWS),
 					DisableQUIC: c.config.GetBool(optionNameP2PDisableQUIC),
-					Bootnodes:   c.config.GetStringSlice(optionNameBootnodes),
 					NetworkID:   c.config.GetInt32(optionNameNetworkID),
 					Logger:      logger,
 				},
-				Logger: logger,
+				Bootnodes: c.config.GetStringSlice(optionNameBootnodes),
+				Logger:    logger,
 			})
 			if err != nil {
 				return err

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -10,9 +10,15 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-type GetterPutter interface {
+type GetPutter interface {
 	Getter
 	Putter
+	AddPeerer(peerer Peerer) error
+}
+
+// Peerers method AddPeer is called whenever new peer is added
+type Peerer interface {
+	AddPeer(overlay swarm.Address) error
 }
 
 type Getter interface {

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -13,12 +13,6 @@ import (
 type GetPutter interface {
 	Getter
 	Putter
-	AddPeerer(peerer Peerer) error
-}
-
-// Peerers method AddPeer is called whenever new peer is added
-type Peerer interface {
-	AddPeer(overlay swarm.Address) error
 }
 
 type Getter interface {

--- a/pkg/addressbook/inmem/inmem.go
+++ b/pkg/addressbook/inmem/inmem.go
@@ -45,7 +45,7 @@ func (i *inmem) Put(overlay swarm.Address, addr ma.Multiaddr) (exists bool) {
 	i.mtx.Unlock()
 
 	for _, p := range i.peerers {
-		p.AddPeer(overlay)
+		_ = p.AddPeer(overlay)
 	}
 
 	return e

--- a/pkg/addressbook/inmem/inmem.go
+++ b/pkg/addressbook/inmem/inmem.go
@@ -16,7 +16,6 @@ import (
 type inmem struct {
 	mtx     sync.Mutex
 	entries map[string]peerEntry // key: overlay in string value, value: peerEntry
-	peerers []addressbook.Peerer
 }
 
 type peerEntry struct {
@@ -43,17 +42,7 @@ func (i *inmem) Put(overlay swarm.Address, addr ma.Multiaddr) (exists bool) {
 	_, e := i.entries[overlay.String()]
 	i.entries[overlay.String()] = peerEntry{overlay: overlay, multiaddr: addr}
 	i.mtx.Unlock()
-
-	for _, p := range i.peerers {
-		_ = p.AddPeer(overlay)
-	}
-
 	return e
-}
-
-func (i *inmem) AddPeerer(peerer addressbook.Peerer) error {
-	i.peerers = append(i.peerers, peerer)
-	return nil
 }
 
 func (i *inmem) Overlays() []swarm.Address {

--- a/pkg/addressbook/inmem/inmem.go
+++ b/pkg/addressbook/inmem/inmem.go
@@ -39,9 +39,9 @@ func (i *inmem) Get(overlay swarm.Address) (addr ma.Multiaddr, exists bool) {
 
 func (i *inmem) Put(overlay swarm.Address, addr ma.Multiaddr) (exists bool) {
 	i.mtx.Lock()
+	defer i.mtx.Unlock()
 	_, e := i.entries[overlay.String()]
 	i.entries[overlay.String()] = peerEntry{overlay: overlay, multiaddr: addr}
-	i.mtx.Unlock()
 	return e
 }
 

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -29,7 +29,7 @@ type server struct {
 type Options struct {
 	P2P            p2p.Service
 	Addressbook    addressbook.GetPutter
-	TopologyDriver topology.Peerer
+	TopologyDriver topology.PeerAdder
 	Logger         logging.Logger
 }
 

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -7,8 +7,10 @@ package debugapi
 import (
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -25,8 +27,10 @@ type server struct {
 }
 
 type Options struct {
-	P2P    p2p.Service
-	Logger logging.Logger
+	P2P            p2p.Service
+	Addressbook    addressbook.GetPutter
+	TopologyDriver topology.Peerer
+	Logger         logging.Logger
 }
 
 func New(o Options) Service {

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -11,9 +11,11 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/addressbook/inmem"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/topology/mock"
 	"resenje.org/web"
 )
 
@@ -23,8 +25,10 @@ type testServerOptions struct {
 
 func newTestServer(t *testing.T, o testServerOptions) (client *http.Client, cleanup func()) {
 	s := debugapi.New(debugapi.Options{
-		P2P:    o.P2P,
-		Logger: logging.New(ioutil.Discard, 0),
+		P2P:            o.P2P,
+		Logger:         logging.New(ioutil.Discard, 0),
+		Addressbook:    inmem.New(),
+		TopologyDriver: mock.NewTopologyDriver(),
 	})
 	ts := httptest.NewServer(s)
 	cleanup = ts.Close

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -37,7 +37,11 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 
 	s.Addressbook.Put(address, addr)
 	if err := s.TopologyDriver.AddPeer(r.Context(), address); err != nil {
+		_ = s.P2P.Disconnect(address)
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
+		s.Logger.Errorf("unable to connect to peer %s", addr)
+		jsonhttp.InternalServerError(w, err)
+		return
 	}
 
 	jsonhttp.OK(w, peerConnectResponse{

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -6,6 +6,7 @@ package debugapi
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -36,6 +37,7 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Addressbook.Put(address, addr)
+	fmt.Printf("DEBUGLOG: debug api connect put address book peer %s, %s\n", address, addr)
 	if err := s.TopologyDriver.AddPeer(address); err != nil {
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -35,6 +35,14 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.Addressbook.Put(address, addr)
+	if err := s.TopologyDriver.AddPeer(address); err != nil {
+		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
+		s.Logger.Errorf("unable to connect to peer %s", addr)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+
 	jsonhttp.OK(w, peerConnectResponse{
 		Address: address.String(),
 	})

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -38,9 +38,6 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 	s.Addressbook.Put(address, addr)
 	if err := s.TopologyDriver.AddPeer(r.Context(), address); err != nil {
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
-		s.Logger.Errorf("unable to connect to peer %s", addr)
-		jsonhttp.InternalServerError(w, err)
-		return
 	}
 
 	jsonhttp.OK(w, peerConnectResponse{

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -6,7 +6,6 @@ package debugapi
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -37,7 +36,6 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Addressbook.Put(address, addr)
-	fmt.Printf("DEBUGLOG: debug api connect put address book peer %s, %s\n", address, addr)
 	if err := s.TopologyDriver.AddPeer(address); err != nil {
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -36,7 +36,7 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Addressbook.Put(address, addr)
-	if err := s.TopologyDriver.AddPeer(address); err != nil {
+	if err := s.TopologyDriver.AddPeer(r.Context(), address); err != nil {
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)
 		jsonhttp.InternalServerError(w, err)

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -60,20 +60,18 @@ func TestConnect(t *testing.T) {
 		})
 	})
 
-	t.Run("error - add peer", func(t *testing.T) {
+	t.Run("OK - add peer error", func(t *testing.T) {
 		testServer.TopologyDriver.SetAddPeerErr(testErr)
 		defer testServer.TopologyDriver.SetAddPeerErr(nil)
 
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Code:    http.StatusInternalServerError,
-			Message: testErr.Error(),
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusOK, debugapi.PeerConnectResponse{
+			Address: overlay.String(),
 		})
 
 		multia, exists := testServer.Addressbook.Get(overlay)
 		if exists != true && underlay != multia.String() {
 			t.Fatalf("found wrong underlay.  expected: %s, found: %s", underlay, multia.String())
 		}
-
 	})
 }
 

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -60,9 +60,9 @@ func TestConnect(t *testing.T) {
 		})
 	})
 
-	t.Run("error - add peer error", func(t *testing.T) {
-		testServer.TopologyDriver.SetErr(testErr)
-		defer testServer.TopologyDriver.SetErr(nil)
+	t.Run("error - add peer", func(t *testing.T) {
+		testServer.TopologyDriver.SetAddPeerErr(testErr)
+		defer testServer.TopologyDriver.SetAddPeerErr(nil)
 
 		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
 			Code:    http.StatusInternalServerError,

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -25,7 +25,7 @@ func TestConnect(t *testing.T) {
 	overlay := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 	testErr := errors.New("test error")
 
-	client, cleanup := newTestServer(t, testServerOptions{
+	testServer := newTestServer(t, testServerOptions{
 		P2P: mock.New(mock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
 			if addr.String() == errorUnderlay {
 				return swarm.Address{}, testErr
@@ -33,26 +33,47 @@ func TestConnect(t *testing.T) {
 			return overlay, nil
 		})),
 	})
-	defer cleanup()
+	defer testServer.Cleanup()
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/connect"+underlay, nil, http.StatusOK, debugapi.PeerConnectResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusOK, debugapi.PeerConnectResponse{
 			Address: overlay.String(),
 		})
+
+		multia, exists := testServer.Addressbook.Get(overlay)
+		if exists != true && underlay != multia.String() {
+			t.Fatalf("found wrong underlay.  expected: %s, found: %s", underlay, multia.String())
+		}
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/connect"+errorUnderlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+errorUnderlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
 			Code:    http.StatusInternalServerError,
 			Message: testErr.Error(),
 		})
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, "/connect"+underlay, nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/connect"+underlay, nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
 			Code:    http.StatusMethodNotAllowed,
 			Message: http.StatusText(http.StatusMethodNotAllowed),
 		})
+	})
+
+	t.Run("error - add peer error", func(t *testing.T) {
+		testServer.TopologyDriver.SetErr(testErr)
+		defer testServer.TopologyDriver.SetErr(nil)
+
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+			Code:    http.StatusInternalServerError,
+			Message: testErr.Error(),
+		})
+
+		multia, exists := testServer.Addressbook.Get(overlay)
+		if exists != true && underlay != multia.String() {
+			t.Fatalf("found wrong underlay.  expected: %s, found: %s", underlay, multia.String())
+		}
+
 	})
 }
 
@@ -62,7 +83,7 @@ func TestDisconnect(t *testing.T) {
 	errorAddress := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59a")
 	testErr := errors.New("test error")
 
-	client, cleanup := newTestServer(t, testServerOptions{
+	testServer := newTestServer(t, testServerOptions{
 		P2P: mock.New(mock.WithDisconnectFunc(func(addr swarm.Address) error {
 			if addr.Equal(address) {
 				return nil
@@ -75,31 +96,31 @@ func TestDisconnect(t *testing.T) {
 			return p2p.ErrPeerNotFound
 		})),
 	})
-	defer cleanup()
+	defer testServer.Cleanup()
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, "/peers/"+address.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+address.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
 			Code:    http.StatusOK,
 			Message: http.StatusText(http.StatusOK),
 		})
 	})
 
 	t.Run("unknown", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, "/peers/"+unknownAdddress.String(), nil, http.StatusBadRequest, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+unknownAdddress.String(), nil, http.StatusBadRequest, jsonhttp.StatusResponse{
 			Code:    http.StatusBadRequest,
 			Message: "peer not found",
 		})
 	})
 
 	t.Run("invalid peer address", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, "/peers/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
 			Code:    http.StatusBadRequest,
 			Message: "invalid peer address",
 		})
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, "/peers/"+errorAddress.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+errorAddress.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
 			Code:    http.StatusInternalServerError,
 			Message: testErr.Error(),
 		})
@@ -109,21 +130,21 @@ func TestDisconnect(t *testing.T) {
 func TestPeer(t *testing.T) {
 	overlay := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 
-	client, cleanup := newTestServer(t, testServerOptions{
+	testServer := newTestServer(t, testServerOptions{
 		P2P: mock.New(mock.WithPeersFunc(func() []p2p.Peer {
 			return []p2p.Peer{{Address: overlay}}
 		})),
 	})
-	defer cleanup()
+	defer testServer.Cleanup()
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, "/peers", nil, http.StatusOK, debugapi.PeersResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/peers", nil, http.StatusOK, debugapi.PeersResponse{
 			Peers: []p2p.Peer{{Address: overlay}},
 		})
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/peers", nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/peers", nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
 			Code:    http.StatusMethodNotAllowed,
 			Message: http.StatusText(http.StatusMethodNotAllowed),
 		})

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -60,18 +60,20 @@ func TestConnect(t *testing.T) {
 		})
 	})
 
-	t.Run("OK - add peer error", func(t *testing.T) {
+	t.Run("error - add peer", func(t *testing.T) {
 		testServer.TopologyDriver.SetAddPeerErr(testErr)
 		defer testServer.TopologyDriver.SetAddPeerErr(nil)
 
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusOK, debugapi.PeerConnectResponse{
-			Address: overlay.String(),
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+			Code:    http.StatusInternalServerError,
+			Message: testErr.Error(),
 		})
 
 		multia, exists := testServer.Addressbook.Get(overlay)
 		if exists != true && underlay != multia.String() {
 			t.Fatalf("found wrong underlay.  expected: %s, found: %s", underlay, multia.String())
 		}
+
 	})
 }
 

--- a/pkg/debugapi/status_test.go
+++ b/pkg/debugapi/status_test.go
@@ -13,19 +13,19 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	client, cleanup := newTestServer(t, testServerOptions{})
-	defer cleanup()
+	testServer := newTestServer(t, testServerOptions{})
+	defer testServer.Cleanup()
 
-	jsonhttptest.ResponseDirect(t, client, http.MethodGet, "/health", nil, http.StatusOK, debugapi.StatusResponse{
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/health", nil, http.StatusOK, debugapi.StatusResponse{
 		Status: "ok",
 	})
 }
 
 func TestReadiness(t *testing.T) {
-	client, cleanup := newTestServer(t, testServerOptions{})
-	defer cleanup()
+	testServer := newTestServer(t, testServerOptions{})
+	defer testServer.Cleanup()
 
-	jsonhttptest.ResponseDirect(t, client, http.MethodGet, "/readiness", nil, http.StatusOK, debugapi.StatusResponse{
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/readiness", nil, http.StatusOK, debugapi.StatusResponse{
 		Status: "ok",
 	})
 }

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -8,14 +8,8 @@ import (
 	"context"
 
 	"github.com/ethersphere/bee/pkg/swarm"
-	ma "github.com/multiformats/go-multiaddr"
 )
 
-type BroadcastRecord struct {
-	Overlay swarm.Address
-	Addr    ma.Multiaddr
-}
-
 type Driver interface {
-	BroadcastPeers(ctx context.Context, addressee swarm.Address, peers ...BroadcastRecord) error
+	BroadcastPeers(ctx context.Context, addressee swarm.Address, peers ...swarm.Address) error
 }

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -30,7 +30,9 @@ func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address,
 		d.mtx.Unlock()
 	}
 
+	d.mtx.Lock()
 	d.ctr++
+	d.mtx.Unlock()
 	return nil
 }
 

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -43,9 +43,6 @@ func (d *Discovery) Broadcasts() int {
 func (d *Discovery) AddresseeRecords(addressee swarm.Address) (peers []swarm.Address, exists bool) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	rec, exists := d.records[addressee.String()]
-	if !exists {
-		return []swarm.Address{}, false
-	}
-	return rec, true
+	peers, exists = d.records[addressee.String()]
+	return
 }

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -8,29 +8,26 @@ import (
 	"context"
 	"sync"
 
-	"github.com/ethersphere/bee/pkg/discovery"
 	"github.com/ethersphere/bee/pkg/swarm"
-
-	ma "github.com/multiformats/go-multiaddr"
 )
 
 type Discovery struct {
 	mtx     sync.Mutex
 	ctr     int //how many ops
-	records map[string]discovery.BroadcastRecord
+	records map[string]swarm.Address
 }
 
 func NewDiscovery() *Discovery {
 	return &Discovery{
-		records: make(map[string]discovery.BroadcastRecord),
+		records: make(map[string]swarm.Address),
 	}
 }
 
-func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address, peers ...discovery.BroadcastRecord) error {
+func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address, peers ...swarm.Address) error {
 	for _, peer := range peers {
 		d.mtx.Lock()
 		d.ctr++
-		d.records[addressee.String()] = discovery.BroadcastRecord{Overlay: peer.Overlay, Addr: peer.Addr}
+		d.records[addressee.String()] = peer
 		d.mtx.Unlock()
 	}
 
@@ -43,12 +40,12 @@ func (d *Discovery) Broadcasts() int {
 	return d.ctr
 }
 
-func (d *Discovery) AddresseeRecord(addressee swarm.Address) (overlay swarm.Address, addr ma.Multiaddr) {
+func (d *Discovery) AddresseeRecord(addressee swarm.Address) (overlay swarm.Address, exists bool) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	rec, exists := d.records[addressee.String()]
 	if !exists {
-		return swarm.Address{}, nil
+		return swarm.Address{}, false
 	}
-	return rec.Overlay, rec.Addr
+	return rec, true
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -30,7 +30,7 @@ const (
 type Service struct {
 	streamer    p2p.Streamer
 	addressBook addressbook.GetPutter
-	peerHandler func(swarm.Address) error
+	peerHandler func(context.Context, swarm.Address) error
 	logger      logging.Logger
 }
 
@@ -77,7 +77,7 @@ func (s *Service) BroadcastPeers(ctx context.Context, addressee swarm.Address, p
 	return nil
 }
 
-func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr swarm.Address) error) {
 	s.peerHandler = h
 }
 
@@ -128,7 +128,7 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 
 		s.addressBook.Put(swarm.NewAddress(newPeer.Overlay), addr)
 		if s.peerHandler != nil {
-			if err := s.peerHandler(swarm.NewAddress(newPeer.Overlay)); err != nil {
+			if err := s.peerHandler(context.Background(), swarm.NewAddress(newPeer.Overlay)); err != nil {
 				return err
 			}
 		}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -88,7 +88,6 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	}
 
 	defer stream.Close()
-
 	w, _ := protobuf.NewWriterAndReader(stream)
 	var peersRequest pb.Peers
 	for _, p := range peers {
@@ -103,8 +102,6 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 			Underlay: addr.String(),
 		})
 	}
-
-	s.logger.Infof("sending peer request to peer %s,  req %s", peer, peersRequest)
 
 	if err := w.WriteMsg(&peersRequest); err != nil {
 		return fmt.Errorf("write Peers message: %w", err)
@@ -121,8 +118,6 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 	if err := r.ReadMsgWithTimeout(messageTimeout, &peersReq); err != nil {
 		return fmt.Errorf("read requestPeers message: %w", err)
 	}
-
-	s.logger.Infof("received peer request from peer %s,  req %s", peer, peersReq)
 
 	for _, newPeer := range peersReq.Peers {
 		addr, err := ma.NewMultiaddr(newPeer.Underlay)

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -82,6 +82,7 @@ func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address) error) {
 }
 
 func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swarm.Address) error {
+	fmt.Printf("DEBUGLOG: sendpeers: peers %s, %s\n", peers, peer)
 	stream, err := s.streamer.NewStream(ctx, peer, protocolName, protocolVersion, peersStreamName)
 	if err != nil {
 		return fmt.Errorf("new stream: %w", err)
@@ -103,6 +104,8 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 		})
 	}
 
+	fmt.Printf("DEBUGLOG: sending peers: peers %s, %s\n", peersRequest, peer)
+
 	if err := w.WriteMsg(&peersRequest); err != nil {
 		return fmt.Errorf("write Peers message: %w", err)
 	}
@@ -119,6 +122,8 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 		return fmt.Errorf("read requestPeers message: %w", err)
 	}
 
+	fmt.Printf("DEBUGLOG: Received peersHandler req %s, peer %s\n", peersReq, peer.Address)
+
 	for _, newPeer := range peersReq.Peers {
 		addr, err := ma.NewMultiaddr(newPeer.Underlay)
 		if err != nil {
@@ -126,6 +131,7 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 			continue
 		}
 
+		fmt.Printf("DEBUGLOG: Received peersHandler adding peer to addressbook %s, peer %s\n", newPeer, addr)
 		s.addressBook.Put(swarm.NewAddress(newPeer.Overlay), addr)
 		if s.peerHandler != nil {
 			if err := s.peerHandler(swarm.NewAddress(newPeer.Overlay)); err != nil {

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -82,7 +82,6 @@ func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address) error) {
 }
 
 func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swarm.Address) error {
-	fmt.Printf("DEBUGLOG: sendpeers: peers %s, %s\n", peers, peer)
 	stream, err := s.streamer.NewStream(ctx, peer, protocolName, protocolVersion, peersStreamName)
 	if err != nil {
 		return fmt.Errorf("new stream: %w", err)
@@ -104,8 +103,6 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 		})
 	}
 
-	fmt.Printf("DEBUGLOG: sending peers: peers %s, %s\n", peersRequest, peer)
-
 	if err := w.WriteMsg(&peersRequest); err != nil {
 		return fmt.Errorf("write Peers message: %w", err)
 	}
@@ -122,8 +119,6 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 		return fmt.Errorf("read requestPeers message: %w", err)
 	}
 
-	fmt.Printf("DEBUGLOG: Received peersHandler req %s, peer %s\n", peersReq, peer.Address)
-
 	for _, newPeer := range peersReq.Peers {
 		addr, err := ma.NewMultiaddr(newPeer.Underlay)
 		if err != nil {
@@ -131,7 +126,6 @@ func (s *Service) peersHandler(peer p2p.Peer, stream p2p.Stream) error {
 			continue
 		}
 
-		fmt.Printf("DEBUGLOG: Received peersHandler adding peer to addressbook %s, peer %s\n", newPeer, addr)
 		s.addressBook.Put(swarm.NewAddress(newPeer.Overlay), addr)
 		if s.peerHandler != nil {
 			if err := s.peerHandler(swarm.NewAddress(newPeer.Overlay)); err != nil {

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -77,7 +77,7 @@ func (s *Service) BroadcastPeers(ctx context.Context, addressee swarm.Address, p
 	return nil
 }
 
-func (s *Service) AddPeerHandler(h func(addr swarm.Address)) {
+func (s *Service) AddPeerAddedHandler(h func(addr swarm.Address)) {
 	s.peerHandlers = append(s.peerHandlers, h)
 }
 

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -93,7 +93,7 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	for _, p := range peers {
 		addr, found := s.addressBook.Get(p)
 		if !found {
-			s.logger.Errorf("Peer not found %s", peer, err)
+			s.logger.Debugf("Peer not found %s", peer, err)
 			continue
 		}
 

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -60,46 +60,46 @@ func TestBroadcastPeers(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		addresee         swarm.Address
-		peers            []swarm.Address
-		wantMsgs         []pb.Peers
-		wantOverlays     []swarm.Address
-		wantMultiAddrses []ma.Multiaddr
+		addresee           swarm.Address
+		peers              []swarm.Address
+		wantMsgs           []pb.Peers
+		wantOverlays       []swarm.Address
+		wantMultiAddresses []ma.Multiaddr
 	}{
 		"OK - single record": {
-			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:            []swarm.Address{addrs[0]},
-			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:1]}},
-			wantOverlays:     []swarm.Address{addrs[0]},
-			wantMultiAddrses: []ma.Multiaddr{multiaddrs[0]},
+			addresee:           swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:              []swarm.Address{addrs[0]},
+			wantMsgs:           []pb.Peers{{Peers: wantMsgs[0].Peers[:1]}},
+			wantOverlays:       []swarm.Address{addrs[0]},
+			wantMultiAddresses: []ma.Multiaddr{multiaddrs[0]},
 		},
 		"OK - single batch - multiple records": {
-			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:            addrs[:15],
-			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:15]}},
-			wantOverlays:     addrs[:15],
-			wantMultiAddrses: multiaddrs[:15],
+			addresee:           swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:              addrs[:15],
+			wantMsgs:           []pb.Peers{{Peers: wantMsgs[0].Peers[:15]}},
+			wantOverlays:       addrs[:15],
+			wantMultiAddresses: multiaddrs[:15],
 		},
 		"OK - single batch - max number of records": {
-			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:            addrs[:hive.MaxBatchSize],
-			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:hive.MaxBatchSize]}},
-			wantOverlays:     addrs[:hive.MaxBatchSize],
-			wantMultiAddrses: multiaddrs[:hive.MaxBatchSize],
+			addresee:           swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:              addrs[:hive.MaxBatchSize],
+			wantMsgs:           []pb.Peers{{Peers: wantMsgs[0].Peers[:hive.MaxBatchSize]}},
+			wantOverlays:       addrs[:hive.MaxBatchSize],
+			wantMultiAddresses: multiaddrs[:hive.MaxBatchSize],
 		},
 		"OK - multiple batches": {
-			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:            addrs[:hive.MaxBatchSize+10],
-			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers[:10]}},
-			wantOverlays:     addrs[:hive.MaxBatchSize+10],
-			wantMultiAddrses: multiaddrs[:hive.MaxBatchSize+10],
+			addresee:           swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:              addrs[:hive.MaxBatchSize+10],
+			wantMsgs:           []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers[:10]}},
+			wantOverlays:       addrs[:hive.MaxBatchSize+10],
+			wantMultiAddresses: multiaddrs[:hive.MaxBatchSize+10],
 		},
 		"OK - multiple batches - max number of records": {
-			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:            addrs[:2*hive.MaxBatchSize],
-			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers}},
-			wantOverlays:     addrs[:2*hive.MaxBatchSize],
-			wantMultiAddrses: multiaddrs[:2*hive.MaxBatchSize],
+			addresee:           swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:              addrs[:2*hive.MaxBatchSize],
+			wantMsgs:           []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers}},
+			wantOverlays:       addrs[:2*hive.MaxBatchSize],
+			wantMultiAddresses: multiaddrs[:2*hive.MaxBatchSize],
 		},
 	}
 
@@ -157,8 +157,8 @@ func TestBroadcastPeers(t *testing.T) {
 			t.Errorf("Overlays got %v, want %v", exporter.Overlays(), tc.wantOverlays)
 		}
 
-		if !compareMultiaddrses(exporter.Multiaddresses(), tc.wantMultiAddrses) {
-			t.Errorf("Multiaddresses got %v, want %v", exporter.Multiaddresses(), tc.wantMultiAddrses)
+		if !compareMultiaddrses(exporter.Multiaddresses(), tc.wantMultiAddresses) {
+			t.Errorf("Multiaddresses got %v, want %v", exporter.Multiaddresses(), tc.wantMultiAddresses)
 		}
 	}
 

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -19,7 +19,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethersphere/bee/pkg/addressbook/inmem"
-	"github.com/ethersphere/bee/pkg/discovery"
 	"github.com/ethersphere/bee/pkg/hive"
 	"github.com/ethersphere/bee/pkg/hive/pb"
 	"github.com/ethersphere/bee/pkg/logging"
@@ -36,12 +35,12 @@ type AddressExporter interface {
 func TestBroadcastPeers(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	logger := logging.New(ioutil.Discard, 0)
+	addressbook := inmem.New()
 
 	// populate all expected and needed random resources for 2 full batches
 	// tests cases that uses fewer resources can use sub-slices of this data
 	var multiaddrs []ma.Multiaddr
 	var addrs []swarm.Address
-	var records []discovery.BroadcastRecord
 	var wantMsgs []pb.Peers
 
 	for i := 0; i < 2; i++ {
@@ -56,48 +55,48 @@ func TestBroadcastPeers(t *testing.T) {
 
 		multiaddrs = append(multiaddrs, ma)
 		addrs = append(addrs, swarm.NewAddress(createRandomBytes()))
+		addressbook.Put(addrs[i], multiaddrs[i])
 		wantMsgs[i/hive.MaxBatchSize].Peers = append(wantMsgs[i/hive.MaxBatchSize].Peers, &pb.BzzAddress{Overlay: addrs[i].Bytes(), Underlay: multiaddrs[i].String()})
-		records = append(records, discovery.BroadcastRecord{Overlay: addrs[i], Addr: multiaddrs[i]})
 	}
 
 	testCases := map[string]struct {
 		addresee   swarm.Address
-		peers      []discovery.BroadcastRecord
+		peers      []swarm.Address
 		wantMsgs   []pb.Peers
 		wantKeys   []swarm.Address
 		wantValues []ma.Multiaddr
 	}{
 		"OK - single record": {
 			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      []discovery.BroadcastRecord{{Overlay: addrs[0], Addr: multiaddrs[0]}},
+			peers:      []swarm.Address{addrs[0]},
 			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:1]}},
 			wantKeys:   []swarm.Address{addrs[0]},
 			wantValues: []ma.Multiaddr{multiaddrs[0]},
 		},
 		"OK - single batch - multiple records": {
 			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      records[:15],
+			peers:      addrs[:15],
 			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:15]}},
 			wantKeys:   addrs[:15],
 			wantValues: multiaddrs[:15],
 		},
 		"OK - single batch - max number of records": {
 			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      records[:hive.MaxBatchSize],
+			peers:      addrs[:hive.MaxBatchSize],
 			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:hive.MaxBatchSize]}},
 			wantKeys:   addrs[:hive.MaxBatchSize],
 			wantValues: multiaddrs[:hive.MaxBatchSize],
 		},
 		"OK - multiple batches": {
 			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      records[:hive.MaxBatchSize+10],
+			peers:      addrs[:hive.MaxBatchSize+10],
 			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers[:10]}},
 			wantKeys:   addrs[:hive.MaxBatchSize+10],
 			wantValues: multiaddrs[:hive.MaxBatchSize+10],
 		},
 		"OK - multiple batches - max number of records": {
 			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      records[:2*hive.MaxBatchSize],
+			peers:      addrs[:2*hive.MaxBatchSize],
 			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers}},
 			wantKeys:   addrs[:2*hive.MaxBatchSize],
 			wantValues: multiaddrs[:2*hive.MaxBatchSize],
@@ -105,8 +104,8 @@ func TestBroadcastPeers(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		addressbook := inmem.New()
-		exporter, ok := addressbook.(AddressExporter)
+		addressbookclean := inmem.New()
+		exporter, ok := addressbookclean.(AddressExporter)
 		if !ok {
 			t.Fatal("could not type assert AddressExporter")
 		}
@@ -114,7 +113,7 @@ func TestBroadcastPeers(t *testing.T) {
 		// create a hive server that handles the incoming stream
 		server := hive.New(hive.Options{
 			Logger:      logger,
-			AddressBook: addressbook,
+			AddressBook: addressbookclean,
 		})
 
 		// setup the stream recorder to record stream data
@@ -124,8 +123,9 @@ func TestBroadcastPeers(t *testing.T) {
 
 		// create a hive client that will do broadcast
 		client := hive.New(hive.Options{
-			Streamer: recorder,
-			Logger:   logger,
+			Streamer:    recorder,
+			Logger:      logger,
+			AddressBook: addressbook,
 		})
 
 		if err := client.BroadcastPeers(context.Background(), tc.addresee, tc.peers...); err != nil {

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -60,46 +60,46 @@ func TestBroadcastPeers(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		addresee   swarm.Address
-		peers      []swarm.Address
-		wantMsgs   []pb.Peers
-		wantKeys   []swarm.Address
-		wantValues []ma.Multiaddr
+		addresee         swarm.Address
+		peers            []swarm.Address
+		wantMsgs         []pb.Peers
+		wantOverlays     []swarm.Address
+		wantMultiAddrses []ma.Multiaddr
 	}{
 		"OK - single record": {
-			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      []swarm.Address{addrs[0]},
-			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:1]}},
-			wantKeys:   []swarm.Address{addrs[0]},
-			wantValues: []ma.Multiaddr{multiaddrs[0]},
+			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:            []swarm.Address{addrs[0]},
+			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:1]}},
+			wantOverlays:     []swarm.Address{addrs[0]},
+			wantMultiAddrses: []ma.Multiaddr{multiaddrs[0]},
 		},
 		"OK - single batch - multiple records": {
-			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      addrs[:15],
-			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:15]}},
-			wantKeys:   addrs[:15],
-			wantValues: multiaddrs[:15],
+			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:            addrs[:15],
+			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:15]}},
+			wantOverlays:     addrs[:15],
+			wantMultiAddrses: multiaddrs[:15],
 		},
 		"OK - single batch - max number of records": {
-			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      addrs[:hive.MaxBatchSize],
-			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers[:hive.MaxBatchSize]}},
-			wantKeys:   addrs[:hive.MaxBatchSize],
-			wantValues: multiaddrs[:hive.MaxBatchSize],
+			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:            addrs[:hive.MaxBatchSize],
+			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers[:hive.MaxBatchSize]}},
+			wantOverlays:     addrs[:hive.MaxBatchSize],
+			wantMultiAddrses: multiaddrs[:hive.MaxBatchSize],
 		},
 		"OK - multiple batches": {
-			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      addrs[:hive.MaxBatchSize+10],
-			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers[:10]}},
-			wantKeys:   addrs[:hive.MaxBatchSize+10],
-			wantValues: multiaddrs[:hive.MaxBatchSize+10],
+			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:            addrs[:hive.MaxBatchSize+10],
+			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers[:10]}},
+			wantOverlays:     addrs[:hive.MaxBatchSize+10],
+			wantMultiAddrses: multiaddrs[:hive.MaxBatchSize+10],
 		},
 		"OK - multiple batches - max number of records": {
-			addresee:   swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
-			peers:      addrs[:2*hive.MaxBatchSize],
-			wantMsgs:   []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers}},
-			wantKeys:   addrs[:2*hive.MaxBatchSize],
-			wantValues: multiaddrs[:2*hive.MaxBatchSize],
+			addresee:         swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+			peers:            addrs[:2*hive.MaxBatchSize],
+			wantMsgs:         []pb.Peers{{Peers: wantMsgs[0].Peers}, {Peers: wantMsgs[1].Peers}},
+			wantOverlays:     addrs[:2*hive.MaxBatchSize],
+			wantMultiAddrses: multiaddrs[:2*hive.MaxBatchSize],
 		},
 	}
 
@@ -153,12 +153,12 @@ func TestBroadcastPeers(t *testing.T) {
 			}
 		}
 
-		if !compareOverlays(exporter.Overlays(), tc.wantKeys) {
-			t.Errorf("Overlays got %v, want %v", exporter.Overlays(), tc.wantKeys)
+		if !compareOverlays(exporter.Overlays(), tc.wantOverlays) {
+			t.Errorf("Overlays got %v, want %v", exporter.Overlays(), tc.wantOverlays)
 		}
 
-		if !compareMultiaddrses(exporter.Multiaddresses(), tc.wantValues) {
-			t.Errorf("Multiaddresses got %v, want %v", exporter.Multiaddresses(), tc.wantValues)
+		if !compareMultiaddrses(exporter.Multiaddresses(), tc.wantMultiAddrses) {
+			t.Errorf("Multiaddresses got %v, want %v", exporter.Multiaddresses(), tc.wantMultiAddrses)
 		}
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -133,8 +133,8 @@ func NewBee(o Options) (*Bee, error) {
 	}
 
 	topologyDriver := full.New(hive, addressbook, p2ps, logger)
-	hive.AddPeerHandler(topologyDriver.AddPeerHandler)
-	p2ps.SetPeerHandler(topologyDriver.AddPeerHandler)
+	hive.AddPeerAddedHandler(topologyDriver.PeerAddedHandler)
+	p2ps.SetPeerAddedHandler(topologyDriver.PeerAddedHandler)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
 		return nil, fmt.Errorf("get server addresses: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -134,7 +134,7 @@ func NewBee(o Options) (*Bee, error) {
 
 	topologyDriver := full.New(hive, addressbook, p2ps, logger)
 	hive.AddPeerHandler(topologyDriver.AddPeerHandler)
-
+	p2ps.SetPeerHandler(topologyDriver.AddPeerHandler)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
 		return nil, fmt.Errorf("get server addresses: %w", err)
@@ -176,8 +176,10 @@ func NewBee(o Options) (*Bee, error) {
 	if o.DebugAPIAddr != "" {
 		// Debug API server
 		debugAPIService := debugapi.New(debugapi.Options{
-			P2P:    p2ps,
-			Logger: logger,
+			P2P:            p2ps,
+			Logger:         logger,
+			Addressbook:    addressbook,
+			TopologyDriver: topologyDriver,
 		})
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -133,8 +133,8 @@ func NewBee(o Options) (*Bee, error) {
 	}
 
 	topologyDriver := full.New(hive, addressbook, p2ps, logger)
-	hive.AddPeerAddedHandler(topologyDriver.PeerAddedHandler)
-	p2ps.SetPeerAddedHandler(topologyDriver.PeerAddedHandler)
+	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
+	p2ps.SetPeerAddedHandler(topologyDriver.AddPeer)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
 		return nil, fmt.Errorf("get server addresses: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -52,6 +52,7 @@ type Options struct {
 
 func NewBee(o Options) (*Bee, error) {
 	logger := o.Logger
+	addressbook := inmem.New()
 
 	p2pCtx, p2pCancel := context.WithCancel(context.Background())
 
@@ -91,6 +92,7 @@ func NewBee(o Options) (*Bee, error) {
 	libP2POptions := o.LibP2POptions
 	libP2POptions.Overlay = address
 	libP2POptions.PrivateKey = libp2pPrivateKey
+	libP2POptions.Addressbook = addressbook
 	p2ps, err := libp2p.New(p2pCtx, libP2POptions)
 	if err != nil {
 		return nil, fmt.Errorf("p2p service: %w", err)
@@ -109,8 +111,6 @@ func NewBee(o Options) (*Bee, error) {
 			return nil, fmt.Errorf("connect to bootnode %s %s: %w", a, overlay, err)
 		}
 	}
-
-	addressbook := inmem.New()
 
 	// Construct protocols.
 	pingPong := pingpong.New(pingpong.Options{

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -281,36 +281,6 @@ func TestDifferentNetworkIDs(t *testing.T) {
 	expectPeers(t, s2)
 }
 
-func TestBootnodes(t *testing.T) {
-	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
-	defer cleanup1()
-
-	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
-	defer cleanup2()
-
-	addrs1, err := s1.Addresses()
-	if err != nil {
-		t.Fatal(err)
-	}
-	addrs2, err := s2.Addresses()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s3, overlay3, cleanup3 := newService(t, libp2p.Options{
-		NetworkID: 1,
-		Bootnodes: []string{
-			addrs1[0].String(),
-			addrs2[0].String(),
-		},
-	})
-	defer cleanup3()
-
-	expectPeers(t, s3, overlay1, overlay2)
-	expectPeers(t, s1, overlay3)
-	expectPeers(t, s2, overlay3)
-}
-
 func TestConnectWithDisabledQUICAndWSTransports(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -43,7 +43,7 @@ type Service struct {
 	handshakeService *handshake.Service
 	addrssbook       addressbook.Putter
 	peers            *peerRegistry
-	peerHandler      func(swarm.Address) error
+	peerHandler      func(context.Context, swarm.Address) error
 	logger           logging.Logger
 }
 
@@ -189,7 +189,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		s.peers.add(stream.Conn(), i.Address)
 		s.addrssbook.Put(i.Address, stream.Conn().RemoteMultiaddr())
 		if s.peerHandler != nil {
-			if err := s.peerHandler(i.Address); err != nil {
+			if err := s.peerHandler(ctx, i.Address); err != nil {
 				s.logger.Debugf("peerhandler: %s: %v", peerID, err)
 			}
 
@@ -309,7 +309,7 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr swarm.Address) error) {
 	s.peerHandler = h
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	handshake "github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
@@ -40,6 +41,7 @@ type Service struct {
 	metrics          metrics
 	networkID        int32
 	handshakeService *handshake.Service
+	addrssbook       addressbook.Putter
 	peers            *peerRegistry
 	peerHandler      func(swarm.Address) error
 	logger           logging.Logger
@@ -52,6 +54,7 @@ type Options struct {
 	DisableWS   bool
 	DisableQUIC bool
 	NetworkID   int32
+	Addressbook addressbook.Putter
 	Logger      logging.Logger
 }
 
@@ -152,6 +155,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		networkID:        o.NetworkID,
 		handshakeService: handshake.New(peerRegistry, o.Overlay, o.NetworkID, o.Logger),
 		peers:            peerRegistry,
+		addrssbook:       o.Addressbook,
 		logger:           o.Logger,
 	}
 
@@ -183,6 +187,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		}
 
 		s.peers.add(stream.Conn(), i.Address)
+		s.addrssbook.Put(i.Address, stream.Conn().RemoteMultiaddr())
 		if s.peerHandler != nil {
 			if err := s.peerHandler(i.Address); err != nil {
 				s.logger.Debugf("peerhandler: %s: %v", peerID, err)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -50,7 +50,6 @@ type Options struct {
 	Addr        string
 	DisableWS   bool
 	DisableQUIC bool
-	Bootnodes   []string
 	NetworkID   int32
 	Logger      logging.Logger
 }
@@ -186,19 +185,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		s.metrics.HandledStreamCount.Inc()
 		s.logger.Infof("peer %s connected", i.Address)
 	})
-
-	// TODO: be more resilient on connection errors and connect in parallel
-	for _, a := range o.Bootnodes {
-		addr, err := ma.NewMultiaddr(a)
-		if err != nil {
-			return nil, fmt.Errorf("bootnode %s: %w", a, err)
-		}
-
-		overlay, err := s.Connect(ctx, addr)
-		if err != nil {
-			return nil, fmt.Errorf("connect to bootnode %s %s: %w", a, overlay, err)
-		}
-	}
 
 	h.Network().SetConnHandler(func(_ network.Conn) {
 		s.metrics.HandledConnectionCount.Inc()

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -302,7 +302,7 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetPeerHandler(h func(addr swarm.Address)) {
+func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address)) {
 	s.peerHandler = h
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -11,12 +11,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	handshake "github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/libp2p/go-libp2p"
 	autonat "github.com/libp2p/go-libp2p-autonat-svc"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
@@ -43,22 +41,18 @@ type Service struct {
 	networkID        int32
 	handshakeService *handshake.Service
 	peers            *peerRegistry
-	topologyDriver   topology.Driver
-	addressBook      addressbook.Putter
 	logger           logging.Logger
 }
 
 type Options struct {
-	PrivateKey     *ecdsa.PrivateKey
-	Overlay        swarm.Address
-	Addr           string
-	DisableWS      bool
-	DisableQUIC    bool
-	Bootnodes      []string
-	NetworkID      int32
-	AddressBook    addressbook.GetterPutter
-	TopologyDriver topology.Driver
-	Logger         logging.Logger
+	PrivateKey  *ecdsa.PrivateKey
+	Overlay     swarm.Address
+	Addr        string
+	DisableWS   bool
+	DisableQUIC bool
+	Bootnodes   []string
+	NetworkID   int32
+	Logger      logging.Logger
 }
 
 func New(ctx context.Context, o Options) (*Service, error) {
@@ -158,8 +152,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		networkID:        o.NetworkID,
 		handshakeService: handshake.New(peerRegistry, o.Overlay, o.NetworkID, o.Logger),
 		peers:            peerRegistry,
-		addressBook:      o.AddressBook,
-		topologyDriver:   o.TopologyDriver,
 		logger:           o.Logger,
 	}
 
@@ -294,13 +286,6 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm
 	}
 
 	s.peers.add(stream.Conn(), i.Address)
-	s.addressBook.Put(i.Address, addr)
-
-	err = s.topologyDriver.AddPeer(i.Address)
-	if err != nil {
-		return swarm.Address{}, fmt.Errorf("topology addpeer: %w", err)
-	}
-
 	s.metrics.CreatedConnectionCount.Inc()
 	s.logger.Infof("peer %s connected", i.Address)
 	return i.Address, nil

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -190,7 +190,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		s.addrssbook.Put(i.Address, stream.Conn().RemoteMultiaddr())
 		if s.peerHandler != nil {
 			if err := s.peerHandler(ctx, i.Address); err != nil {
-				s.logger.Debugf("peerhandler: %s: %v", peerID, err)
+				s.logger.Debugf("peerhandler error: %s: %v", peerID, err)
 			}
 
 		}
@@ -198,7 +198,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		s.logger.Infof("peer %s connected", i.Address)
 	})
 
-	h.Network().SetConnHandler(func(c network.Conn) {
+	h.Network().SetConnHandler(func(_ network.Conn) {
 		s.metrics.HandledConnectionCount.Inc()
 	})
 
@@ -309,7 +309,7 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(h func(context.Context, swarm.Address) error) {
 	s.peerHandler = h
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -41,7 +41,7 @@ type Service struct {
 	networkID        int32
 	handshakeService *handshake.Service
 	peers            *peerRegistry
-	peerHandler      func(swarm.Address)
+	peerHandler      func(swarm.Address) error
 	logger           logging.Logger
 }
 
@@ -184,7 +184,9 @@ func New(ctx context.Context, o Options) (*Service, error) {
 
 		s.peers.add(stream.Conn(), i.Address)
 		if s.peerHandler != nil {
-			s.peerHandler(i.Address)
+			if err := s.peerHandler(i.Address); err != nil {
+				s.logger.Debugf("peerhandler: %s: %v", peerID, err)
+			}
 
 		}
 		s.metrics.HandledStreamCount.Inc()
@@ -302,7 +304,7 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address)) {
+func (s *Service) SetPeerAddedHandler(h func(addr swarm.Address) error) {
 	s.peerHandler = h
 }
 

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/addressbook/inmem"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -47,6 +48,10 @@ func newService(t *testing.T, o libp2p.Options) (s *libp2p.Service, overlay swar
 
 	if o.Addr == "" {
 		o.Addr = ":0"
+	}
+
+	if o.Addressbook == nil {
+		o.Addressbook = inmem.New()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -12,14 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/addressbook/inmem"
 	"github.com/ethersphere/bee/pkg/crypto"
-	"github.com/ethersphere/bee/pkg/discovery/mock"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/topology/full"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -50,14 +47,6 @@ func newService(t *testing.T, o libp2p.Options) (s *libp2p.Service, overlay swar
 
 	if o.Addr == "" {
 		o.Addr = ":0"
-	}
-	if o.AddressBook == nil {
-		o.AddressBook = inmem.New()
-	}
-
-	if o.TopologyDriver == nil {
-		disc := mock.NewDiscovery()
-		o.TopologyDriver = full.New(disc, o.AddressBook)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -14,11 +14,11 @@ import (
 )
 
 type Service struct {
-	addProtocolFunc    func(p2p.ProtocolSpec) error
-	connectFunc        func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
-	disconnectFunc     func(overlay swarm.Address) error
-	peersFunc          func() []p2p.Peer
-	setPeerHandlerFunc func(func(overlay swarm.Address))
+	addProtocolFunc         func(p2p.ProtocolSpec) error
+	connectFunc             func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
+	disconnectFunc          func(overlay swarm.Address) error
+	peersFunc               func() []p2p.Peer
+	setPeerAddedHandlerFunc func(func(overlay swarm.Address))
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -45,9 +45,9 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetPeerHandlerFunc(f func(func(overlay swarm.Address))) Option {
+func WithSetPeerAddedHandlerFunc(f func(func(overlay swarm.Address))) Option {
 	return optionFunc(func(s *Service) {
-		s.setPeerHandlerFunc = f
+		s.setPeerAddedHandlerFunc = f
 	})
 }
 
@@ -80,12 +80,12 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetPeerHandler(f func(overlay swarm.Address)) {
-	if s.setPeerHandlerFunc == nil {
+func (s *Service) SetPeerAddedHandler(f func(overlay swarm.Address)) {
+	if s.setPeerAddedHandlerFunc == nil {
 		return
 	}
 
-	s.setPeerHandlerFunc(f)
+	s.setPeerAddedHandlerFunc(f)
 }
 
 func (s *Service) Peers() []p2p.Peer {

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -18,7 +18,7 @@ type Service struct {
 	connectFunc             func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	disconnectFunc          func(overlay swarm.Address) error
 	peersFunc               func() []p2p.Peer
-	setPeerAddedHandlerFunc func(func(overlay swarm.Address) error)
+	setPeerAddedHandlerFunc func(func(context.Context, swarm.Address) error)
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -45,7 +45,7 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetPeerAddedHandlerFunc(f func(func(overlay swarm.Address) error)) Option {
+func WithSetPeerAddedHandlerFunc(f func(func(ctx context.Context, overlay swarm.Address) error)) Option {
 	return optionFunc(func(s *Service) {
 		s.setPeerAddedHandlerFunc = f
 	})
@@ -80,7 +80,7 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetPeerAddedHandler(f func(overlay swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(f func(ctx context.Context, overlay swarm.Address) error) {
 	if s.setPeerAddedHandlerFunc == nil {
 		return
 	}

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -14,10 +14,11 @@ import (
 )
 
 type Service struct {
-	addProtocolFunc func(p2p.ProtocolSpec) error
-	connectFunc     func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
-	disconnectFunc  func(overlay swarm.Address) error
-	peersFunc       func() []p2p.Peer
+	addProtocolFunc    func(p2p.ProtocolSpec) error
+	connectFunc        func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
+	disconnectFunc     func(overlay swarm.Address) error
+	peersFunc          func() []p2p.Peer
+	setPeerHandlerFunc func(func(overlay swarm.Address))
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -41,6 +42,12 @@ func WithDisconnectFunc(f func(overlay swarm.Address) error) Option {
 func WithPeersFunc(f func() []p2p.Peer) Option {
 	return optionFunc(func(s *Service) {
 		s.peersFunc = f
+	})
+}
+
+func WithSetPeerHandlerFunc(f func(func(overlay swarm.Address))) Option {
+	return optionFunc(func(s *Service) {
+		s.setPeerHandlerFunc = f
 	})
 }
 
@@ -71,6 +78,14 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 		return errors.New("function Disconnect not configured")
 	}
 	return s.disconnectFunc(overlay)
+}
+
+func (s *Service) SetPeerHandler(f func(overlay swarm.Address)) {
+	if s.setPeerHandlerFunc == nil {
+		return
+	}
+
+	s.setPeerHandlerFunc(f)
 }
 
 func (s *Service) Peers() []p2p.Peer {

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -18,7 +18,7 @@ type Service struct {
 	connectFunc             func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	disconnectFunc          func(overlay swarm.Address) error
 	peersFunc               func() []p2p.Peer
-	setPeerAddedHandlerFunc func(func(overlay swarm.Address))
+	setPeerAddedHandlerFunc func(func(overlay swarm.Address) error)
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -45,7 +45,7 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetPeerAddedHandlerFunc(f func(func(overlay swarm.Address))) Option {
+func WithSetPeerAddedHandlerFunc(f func(func(overlay swarm.Address) error)) Option {
 	return optionFunc(func(s *Service) {
 		s.setPeerAddedHandlerFunc = f
 	})
@@ -80,7 +80,7 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetPeerAddedHandler(f func(overlay swarm.Address)) {
+func (s *Service) SetPeerAddedHandler(f func(overlay swarm.Address) error) {
 	if s.setPeerAddedHandlerFunc == nil {
 		return
 	}

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -45,7 +45,7 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetPeerAddedHandlerFunc(f func(func(ctx context.Context, overlay swarm.Address) error)) Option {
+func WithSetPeerAddedHandlerFunc(f func(func(context.Context, swarm.Address) error)) Option {
 	return optionFunc(func(s *Service) {
 		s.setPeerAddedHandlerFunc = f
 	})
@@ -80,7 +80,7 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetPeerAddedHandler(f func(ctx context.Context, overlay swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(f func(context.Context, swarm.Address) error) {
 	if s.setPeerAddedHandlerFunc == nil {
 		return
 	}

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -25,6 +25,7 @@ type Connecter interface {
 	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
+	SetPeerHandler(func(addr swarm.Address))
 }
 
 type Stream interface {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -14,13 +14,17 @@ import (
 
 type Service interface {
 	AddProtocol(ProtocolSpec) error
-	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
-	Disconnect(overlay swarm.Address) error
-	Peers() []Peer
+	Connecter
 }
 
 type Streamer interface {
 	NewStream(ctx context.Context, address swarm.Address, protocol, version, stream string) (Stream, error)
+}
+
+type Connecter interface {
+	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
+	Disconnect(overlay swarm.Address) error
+	Peers() []Peer
 }
 
 type Stream interface {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -25,7 +25,7 @@ type Connecter interface {
 	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
-	SetPeerHandler(func(addr swarm.Address))
+	SetPeerAddedHandler(func(addr swarm.Address))
 }
 
 type Stream interface {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -14,18 +14,14 @@ import (
 
 type Service interface {
 	AddProtocol(ProtocolSpec) error
-	Connecter
+	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
+	Disconnect(overlay swarm.Address) error
+	Peers() []Peer
+	SetPeerAddedHandler(func(addr swarm.Address) error)
 }
 
 type Streamer interface {
 	NewStream(ctx context.Context, address swarm.Address, protocol, version, stream string) (Stream, error)
-}
-
-type Connecter interface {
-	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
-	Disconnect(overlay swarm.Address) error
-	Peers() []Peer
-	SetPeerAddedHandler(func(addr swarm.Address))
 }
 
 type Stream interface {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -17,7 +17,7 @@ type Service interface {
 	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
-	SetPeerAddedHandler(func(addr swarm.Address) error)
+	SetPeerAddedHandler(func(context.Context, swarm.Address) error)
 }
 
 type Streamer interface {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -86,6 +86,10 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 		}
 	}
 
+	if len(connectedAddrs) == 0 {
+		return nil
+	}
+
 	if err := d.discovery.BroadcastPeers(context.Background(), addr, connectedAddrs...); err != nil {
 		return err
 	}

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -61,7 +61,6 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 	}
 
 	if !isConnected(addr, connectedPeers) {
-		d.logger.Infof("peer not connected, connecting %s", addr)
 		peerAddr, err := d.connecter.Connect(context.Background(), ma)
 		if err != nil {
 			return err
@@ -72,8 +71,6 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 			addr = peerAddr
 			d.addressBook.Put(peerAddr, ma)
 		}
-	} else {
-		d.logger.Infof("peer already connected %s", addr)
 	}
 
 	connectedAddrs := []swarm.Address{}

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -33,7 +33,7 @@ type Driver struct {
 	addressBook   addressbook.GetPutter
 	p2pService    p2p.Service
 	receivedPeers map[string]struct{} // track already received peers. Note: implement cleanup or expiration if needed to stop infinite grow
-	mtx           sync.RWMutex        // guards received peers
+	mtx           sync.Mutex          // guards received peers
 	logger        logging.Logger
 }
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -6,7 +6,6 @@ package full
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -50,9 +49,7 @@ func New(disc discovery.Driver, addressBook addressbook.GetPutter, connecter p2p
 // The peer would be subsequently broadcasted to all connected peers.
 // All conneceted peers are also broadcasted to the new peer.
 func (d *Driver) AddPeer(addr swarm.Address) error {
-	fmt.Printf("DEBUGLOG: Received AddPeer %s\n", addr)
 	if d.receivedPeers[addr.ByteString()] {
-		fmt.Printf("DEBUGLOG: Received AddPeer already recived %s\n", addr)
 		return nil
 	}
 
@@ -64,7 +61,6 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 	}
 
 	if !isConnected(addr, connectedPeers) {
-		fmt.Printf("DEBUGLOG: Received AddPeer is not connected %s\n", addr)
 		peerAddr, err := d.connecter.Connect(context.Background(), ma)
 		if err != nil {
 			return err
@@ -72,7 +68,6 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 
 		// update addr if it is wrong or it has been changed
 		if !addr.Equal(peerAddr) {
-			fmt.Printf("DEBUGLOG: Received AddPeer update %s\n", addr)
 			addr = peerAddr
 			d.addressBook.Put(peerAddr, ma)
 		}
@@ -80,10 +75,8 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 
 	connectedAddrs := []swarm.Address{}
 	for _, addressee := range connectedPeers {
-		fmt.Printf("DEBUGLOG: Received AddPeer sending to addressee %s, peer %s\n", addressee, addr)
 		// skip newly added peer
 		if addressee.Address.Equal(addr) {
-			fmt.Printf("DEBUGLOG: Received AddPeer skipping newly added peer %s\n", addr)
 			continue
 		}
 
@@ -94,7 +87,6 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 	}
 
 	if len(connectedAddrs) == 0 {
-		fmt.Printf("DEBUGLOG: Received AddPeer no connected peers, peer %s\n", addr)
 		return nil
 	}
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -6,6 +6,7 @@ package full
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -49,7 +50,9 @@ func New(disc discovery.Driver, addressBook addressbook.GetPutter, connecter p2p
 // The peer would be subsequently broadcasted to all connected peers.
 // All conneceted peers are also broadcasted to the new peer.
 func (d *Driver) AddPeer(addr swarm.Address) error {
+	fmt.Printf("DEBUGLOG: Received AddPeer %s\n", addr)
 	if d.receivedPeers[addr.ByteString()] {
+		fmt.Printf("DEBUGLOG: Received AddPeer already recived %s\n", addr)
 		return nil
 	}
 
@@ -61,6 +64,7 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 	}
 
 	if !isConnected(addr, connectedPeers) {
+		fmt.Printf("DEBUGLOG: Received AddPeer is not connected %s\n", addr)
 		peerAddr, err := d.connecter.Connect(context.Background(), ma)
 		if err != nil {
 			return err
@@ -68,6 +72,7 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 
 		// update addr if it is wrong or it has been changed
 		if !addr.Equal(peerAddr) {
+			fmt.Printf("DEBUGLOG: Received AddPeer update %s\n", addr)
 			addr = peerAddr
 			d.addressBook.Put(peerAddr, ma)
 		}
@@ -75,8 +80,10 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 
 	connectedAddrs := []swarm.Address{}
 	for _, addressee := range connectedPeers {
+		fmt.Printf("DEBUGLOG: Received AddPeer sending to addressee %s, peer %s\n", addressee, addr)
 		// skip newly added peer
 		if addressee.Address.Equal(addr) {
+			fmt.Printf("DEBUGLOG: Received AddPeer skipping newly added peer %s\n", addr)
 			continue
 		}
 
@@ -87,6 +94,7 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 	}
 
 	if len(connectedAddrs) == 0 {
+		fmt.Printf("DEBUGLOG: Received AddPeer no connected peers, peer %s\n", addr)
 		return nil
 	}
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -112,7 +112,7 @@ func (d *Driver) ChunkPeer(addr swarm.Address) (peerAddr swarm.Address, err erro
 	return swarm.Address{}, topology.ErrNotFound
 }
 
-func (d *Driver) AddPeerHandler(addr swarm.Address) {
+func (d *Driver) PeerAddedHandler(addr swarm.Address) {
 	// this is a dummy implementation
 	// todo: if needed add cancel, shutdown and limit number of goroutines
 	go func() {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -30,12 +30,12 @@ var _ topology.Driver = (*Driver)(nil)
 type Driver struct {
 	discovery     discovery.Driver
 	addressBook   addressbook.GetPutter
-	connecter     p2p.Connecter
+	connecter     p2p.Service
 	receivedPeers map[string]bool
 	logger        logging.Logger
 }
 
-func New(disc discovery.Driver, addressBook addressbook.GetPutter, connecter p2p.Connecter, logger logging.Logger) *Driver {
+func New(disc discovery.Driver, addressBook addressbook.GetPutter, connecter p2p.Service, logger logging.Logger) *Driver {
 	return &Driver{
 		discovery:     disc,
 		addressBook:   addressBook,
@@ -75,7 +75,7 @@ func (d *Driver) AddPeer(addr swarm.Address) error {
 
 	connectedAddrs := []swarm.Address{}
 	for _, addressee := range connectedPeers {
-		// skip curenttly added peer
+		// skip newly added peer
 		if addressee.Address.Equal(addr) {
 			continue
 		}
@@ -110,14 +110,6 @@ func (d *Driver) ChunkPeer(addr swarm.Address) (peerAddr swarm.Address, err erro
 	}
 
 	return swarm.Address{}, topology.ErrNotFound
-}
-
-func (d *Driver) PeerAddedHandler(addr swarm.Address) {
-	// this is a dummy implementation
-	// todo: if needed add cancel, shutdown and limit number of goroutines
-	go func() {
-		_ = d.AddPeer(addr)
-	}()
 }
 
 func isConnected(addr swarm.Address, connectedPeers []p2p.Peer) bool {

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -1,0 +1,180 @@
+package full_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/addressbook/inmem"
+	"github.com/ethersphere/bee/pkg/discovery/mock"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
+	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology/full"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func TestAddPeer(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+	underlay := "/ip4/127.0.0.1/tcp/7070/p2p/16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkS"
+	overlay := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59a")
+	connectedPeers := []p2p.Peer{
+		{
+			Address: swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59b"),
+		},
+		{
+			Address: swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
+		},
+		{
+			Address: swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59d"),
+		},
+	}
+
+	t.Run("OK - no connected peers", func(t *testing.T) {
+		discovery := mock.NewDiscovery()
+		addressbook := inmem.New()
+		p2p := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			if addr.String() != underlay {
+				t.Fatalf("expected multiaddr %s, got %s", addr.String(), underlay)
+			}
+			return overlay, nil
+		}))
+
+		fullDriver := full.New(discovery, addressbook, p2p, logger)
+		multiaddr, err := ma.NewMultiaddr(underlay)
+		if err != nil {
+			t.Fatal("error creating multiaddr")
+		}
+
+		addressbook.Put(overlay, multiaddr)
+		err = fullDriver.AddPeer(overlay)
+		if err != nil {
+			t.Fatalf("full conn driver returned err %s", err.Error())
+		}
+
+		if discovery.Broadcasts() != 0 {
+			t.Fatalf("broadcasts expected %v, got %v ", 0, discovery.Broadcasts())
+		}
+	})
+
+	t.Run("ERROR - peer not added", func(t *testing.T) {
+		discovery := mock.NewDiscovery()
+		addressbook := inmem.New()
+		p2p := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			t.Fatal("should not be called")
+			return swarm.Address{}, nil
+		}))
+
+		fullDriver := full.New(discovery, addressbook, p2p, logger)
+		err := fullDriver.AddPeer(overlay)
+		if err.Error() != "no peer found" {
+			t.Fatalf("full conn driver returned err %s", err.Error())
+		}
+
+		if discovery.Broadcasts() != 0 {
+			t.Fatalf("broadcasts expected %v, got %v ", 0, discovery.Broadcasts())
+		}
+	})
+
+	t.Run("OK - connected peers - peer already connected", func(t *testing.T) {
+		discovery := mock.NewDiscovery()
+		addressbook := inmem.New()
+		alreadyConnected := connectedPeers[0].Address
+
+		p2p := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			t.Fatal("should not be called")
+			return swarm.Address{}, nil
+		}), p2pmock.WithPeersFunc(func() []p2p.Peer {
+			return connectedPeers
+		}))
+
+		fullDriver := full.New(discovery, addressbook, p2p, logger)
+		multiaddr, err := ma.NewMultiaddr(underlay)
+		if err != nil {
+			t.Fatal("error creating multiaddr")
+		}
+
+		addressbook.Put(alreadyConnected, multiaddr)
+		err = fullDriver.AddPeer(alreadyConnected)
+		if err != nil {
+			t.Fatalf("full conn driver returned err %s", err.Error())
+		}
+
+		if discovery.Broadcasts() != 3 {
+			t.Fatalf("broadcasts expected %v, got %v ", 3, discovery.Broadcasts())
+		}
+
+		// check newly added node
+		if err := checkAddreseeRecords(discovery, alreadyConnected, connectedPeers[1:]); err != nil {
+			t.Fatal(err)
+		}
+
+		// check other nodes
+		for _, p := range connectedPeers[1:] {
+			if err := checkAddreseeRecords(discovery, p.Address, connectedPeers[0:1]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("OK - connected peers - peer not already connected", func(t *testing.T) {
+		discovery := mock.NewDiscovery()
+		addressbook := inmem.New()
+
+		p2ps := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			if addr.String() != underlay {
+				t.Fatalf("expected multiaddr %s, got %s", addr.String(), underlay)
+			}
+			return overlay, nil
+		}), p2pmock.WithPeersFunc(func() []p2p.Peer {
+			return connectedPeers
+		}))
+
+		fullDriver := full.New(discovery, addressbook, p2ps, logger)
+		multiaddr, err := ma.NewMultiaddr(underlay)
+		if err != nil {
+			t.Fatal("error creating multiaddr")
+		}
+
+		addressbook.Put(overlay, multiaddr)
+		err = fullDriver.AddPeer(overlay)
+		if err != nil {
+			t.Fatalf("full conn driver returned err %s", err.Error())
+		}
+
+		if discovery.Broadcasts() != 4 {
+			t.Fatalf("broadcasts expected %v, got %v ", 4, discovery.Broadcasts())
+		}
+
+		// check newly added node
+		if err := checkAddreseeRecords(discovery, overlay, connectedPeers); err != nil {
+			t.Fatal(err)
+		}
+
+		// check other nodes
+		for _, p := range connectedPeers {
+			if err := checkAddreseeRecords(discovery, p.Address, []p2p.Peer{{Address: overlay}}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+func checkAddreseeRecords(discovery *mock.Discovery, addr swarm.Address, expected []p2p.Peer) error {
+	got, exists := discovery.AddresseeRecords(addr)
+	if exists != true {
+		return errors.New("addressee record does not exist")
+	}
+
+	for i, e := range expected {
+		if !e.Address.Equal(got[i]) {
+			return fmt.Errorf("addressee record expected %s, got %s ", e.Address.String(), got[i].String())
+		}
+	}
+
+	return nil
+}

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -77,7 +77,7 @@ func TestAddPeer(t *testing.T) {
 		fullDriver := full.New(discovery, addressbook, p2p, logger)
 		err := fullDriver.AddPeer(context.Background(), overlay)
 		if !errors.Is(err, topology.ErrNotFound) {
-			t.Fatalf("full conn driver returned err %s", err.Error())
+			t.Fatalf("full conn driver returned err %v", err)
 		}
 
 		if discovery.Broadcasts() != 0 {

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p"
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/topology/full"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -51,11 +52,11 @@ func TestAddPeer(t *testing.T) {
 		fullDriver := full.New(discovery, addressbook, p2p, logger)
 		multiaddr, err := ma.NewMultiaddr(underlay)
 		if err != nil {
-			t.Fatal("error creating multiaddr")
+			t.Fatal(err)
 		}
 
 		addressbook.Put(overlay, multiaddr)
-		err = fullDriver.AddPeer(overlay)
+		err = fullDriver.AddPeer(context.Background(), overlay)
 		if err != nil {
 			t.Fatalf("full conn driver returned err %s", err.Error())
 		}
@@ -74,8 +75,8 @@ func TestAddPeer(t *testing.T) {
 		}))
 
 		fullDriver := full.New(discovery, addressbook, p2p, logger)
-		err := fullDriver.AddPeer(overlay)
-		if err.Error() != "no peer found" {
+		err := fullDriver.AddPeer(context.Background(), overlay)
+		if !errors.Is(err, topology.ErrNotFound) {
 			t.Fatalf("full conn driver returned err %s", err.Error())
 		}
 
@@ -103,7 +104,7 @@ func TestAddPeer(t *testing.T) {
 		}
 
 		addressbook.Put(alreadyConnected, multiaddr)
-		err = fullDriver.AddPeer(alreadyConnected)
+		err = fullDriver.AddPeer(context.Background(), alreadyConnected)
 		if err != nil {
 			t.Fatalf("full conn driver returned err %s", err.Error())
 		}
@@ -141,11 +142,11 @@ func TestAddPeer(t *testing.T) {
 		fullDriver := full.New(discovery, addressbook, p2ps, logger)
 		multiaddr, err := ma.NewMultiaddr(underlay)
 		if err != nil {
-			t.Fatal("error creating multiaddr")
+			t.Fatal(err)
 		}
 
 		addressbook.Put(overlay, multiaddr)
-		err = fullDriver.AddPeer(overlay)
+		err = fullDriver.AddPeer(context.Background(), overlay)
 		if err != nil {
 			t.Fatalf("full conn driver returned err %s", err.Error())
 		}

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -42,7 +42,7 @@ func TestAddPeer(t *testing.T) {
 	t.Run("OK - no connected peers", func(t *testing.T) {
 		discovery := mock.NewDiscovery()
 		addressbook := inmem.New()
-		p2p := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+		p2p := p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
 			if addr.String() != underlay {
 				t.Fatalf("expected multiaddr %s, got %s", addr.String(), underlay)
 			}

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package full_test
 
 import (

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -10,13 +10,22 @@ import (
 
 type TopologyDriver struct {
 	peers []swarm.Address
+	err   error
 }
 
 func NewTopologyDriver() *TopologyDriver {
 	return &TopologyDriver{}
 }
 
+func (d *TopologyDriver) SetErr(err error) {
+	d.err = err
+}
+
 func (d *TopologyDriver) AddPeer(addr swarm.Address) error {
+	if d.err != nil {
+		return d.err
+	}
+
 	d.peers = append(d.peers, addr)
 	return nil
 }

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -23,7 +23,7 @@ func (d *TopologyDriver) SetAddPeerErr(err error) {
 	d.addPeerErr = err
 }
 
-func (d *TopologyDriver) AddPeer(ctx context.Context, addr swarm.Address) error {
+func (d *TopologyDriver) AddPeer(_ context.Context, addr swarm.Address) error {
 	if d.addPeerErr != nil {
 		return d.addPeerErr
 	}

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -5,25 +5,27 @@
 package mock
 
 import (
+	"context"
+
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 type TopologyDriver struct {
-	peers []swarm.Address
-	err   error
+	peers      []swarm.Address
+	addPeerErr error
 }
 
 func NewTopologyDriver() *TopologyDriver {
 	return &TopologyDriver{}
 }
 
-func (d *TopologyDriver) SetErr(err error) {
-	d.err = err
+func (d *TopologyDriver) SetAddPeerErr(err error) {
+	d.addPeerErr = err
 }
 
-func (d *TopologyDriver) AddPeer(addr swarm.Address) error {
-	if d.err != nil {
-		return d.err
+func (d *TopologyDriver) AddPeer(ctx context.Context, addr swarm.Address) error {
+	if d.addPeerErr != nil {
+		return d.addPeerErr
 	}
 
 	d.peers = append(d.peers, addr)

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type TopologyDriver struct {
+	peers []swarm.Address
+}
+
+func NewTopologyDriver() *TopologyDriver {
+	return &TopologyDriver{}
+}
+
+func (d *TopologyDriver) AddPeer(addr swarm.Address) error {
+	d.peers = append(d.peers, addr)
+	return nil
+}
+
+func (d *TopologyDriver) Peers() []swarm.Address {
+	return d.peers
+}

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -13,6 +14,7 @@ import (
 type TopologyDriver struct {
 	peers      []swarm.Address
 	addPeerErr error
+	mtx        sync.Mutex
 }
 
 func NewTopologyDriver() *TopologyDriver {
@@ -28,7 +30,9 @@ func (d *TopologyDriver) AddPeer(_ context.Context, addr swarm.Address) error {
 		return d.addPeerErr
 	}
 
+	d.mtx.Lock()
 	d.peers = append(d.peers, addr)
+	d.mtx.Unlock()
 	return nil
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -13,7 +13,7 @@ import (
 var ErrNotFound = errors.New("no peer found")
 
 type Driver interface {
-	AddPeer(overlay swarm.Address) error
+	AddPeer(addr swarm.Address) error
 	ChunkPeerer
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -14,11 +14,11 @@ import (
 var ErrNotFound = errors.New("no peer found")
 
 type Driver interface {
-	Peerer
+	PeerAdder
 	ChunkPeerer
 }
 
-type Peerer interface {
+type PeerAdder interface {
 	AddPeer(ctx context.Context, addr swarm.Address) error
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -13,8 +13,12 @@ import (
 var ErrNotFound = errors.New("no peer found")
 
 type Driver interface {
-	AddPeer(addr swarm.Address) error
+	Peerer
 	ChunkPeerer
+}
+
+type Peerer interface {
+	AddPeer(addr swarm.Address) error
 }
 
 type ChunkPeerer interface {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -5,6 +5,7 @@
 package topology
 
 import (
+	"context"
 	"errors"
 
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -18,7 +19,7 @@ type Driver interface {
 }
 
 type Peerer interface {
-	AddPeer(addr swarm.Address) error
+	AddPeer(ctx context.Context, addr swarm.Address) error
 }
 
 type ChunkPeerer interface {


### PR DESCRIPTION
Points I tried to achieve:
1. `Discovery`, `Topology` interfaces not to know about multiaddr, the `addressbook` is used to fetch multiaddress in concrete implementations if needed
2. Extract business logic from `Hive` to rest of the system
3. Don't put specific logic into `libp2p`
4. Cover both known and connected peer added with/without connect 

I decided to do on a bit of a handler heavy approach, as I tried to do it with subscription and channels, and this seems much more simple. Wanted to cover full connectivity simple case, we can expand if needed.

Also, unrelated to the hive,  I did a few renaming along the way, @acud I renamed `GetterPutter` per Janoses comment on your PR that came a bit late, and I was guilty for the name  `GetterPutter`, I think `GetPutter` is more Go idiomatic.

Known issues:
1. Bootnodes - there is a conversation below
2. Connections between nodes at the same time - handshake error