### PR TITLE
remove libp2p Options type from node Bee Options

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/node"
-	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 )
 
 func (c *command) initStartCmd() (err error) {
@@ -93,17 +92,14 @@ func (c *command) initStartCmd() (err error) {
 			}
 
 			b, err := node.NewBee(node.Options{
-				DataDir:      c.config.GetString(optionNameDataDir),
-				Password:     password,
-				APIAddr:      c.config.GetString(optionNameAPIAddr),
-				DebugAPIAddr: debugAPIAddr,
-				LibP2POptions: libp2p.Options{
-					Addr:        c.config.GetString(optionNameP2PAddr),
-					DisableWS:   c.config.GetBool(optionNameP2PDisableWS),
-					DisableQUIC: c.config.GetBool(optionNameP2PDisableQUIC),
-					NetworkID:   c.config.GetInt32(optionNameNetworkID),
-					Logger:      logger,
-				},
+				DataDir:            c.config.GetString(optionNameDataDir),
+				Password:           password,
+				APIAddr:            c.config.GetString(optionNameAPIAddr),
+				DebugAPIAddr:       debugAPIAddr,
+				Addr:               c.config.GetString(optionNameP2PAddr),
+				DisableWS:          c.config.GetBool(optionNameP2PDisableWS),
+				DisableQUIC:        c.config.GetBool(optionNameP2PDisableQUIC),
+				NetworkID:          c.config.GetInt32(optionNameNetworkID),
 				Bootnodes:          c.config.GetStringSlice(optionNameBootnodes),
 				TracingEnabled:     c.config.GetBool(optionNameTracingEnabled),
 				TracingEndpoint:    c.config.GetString(optionNameTracingEndpoint),

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -47,7 +47,10 @@ type Options struct {
 	Password           string
 	APIAddr            string
 	DebugAPIAddr       string
-	LibP2POptions      libp2p.Options
+	Addr               string
+	DisableWS          bool
+	DisableQUIC        bool
+	NetworkID          int32
 	Bootnodes          []string
 	Logger             logging.Logger
 	TracingEnabled     bool
@@ -104,12 +107,17 @@ func NewBee(o Options) (*Bee, error) {
 		logger.Infof("new libp2p key created")
 	}
 
-	libP2POptions := o.LibP2POptions
-	libP2POptions.Overlay = address
-	libP2POptions.PrivateKey = libp2pPrivateKey
-	libP2POptions.Addressbook = addressbook
-	libP2POptions.Tracer = tracer
-	p2ps, err := libp2p.New(p2pCtx, libP2POptions)
+	p2ps, err := libp2p.New(p2pCtx, libp2p.Options{
+		PrivateKey:  libp2pPrivateKey,
+		Overlay:     address,
+		Addr:        o.Addr,
+		DisableWS:   o.DisableWS,
+		DisableQUIC: o.DisableQUIC,
+		NetworkID:   o.NetworkID,
+		Addressbook: addressbook,
+		Logger:      logger,
+		Tracer:      tracer,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("p2p service: %w", err)
 	}


### PR DESCRIPTION
This PR removes libp2p.Options from node.Options in order to decouple them as libp2p.Options has to be changed (added depndencies) in node.NewBee. This makes node initialisation cleaner and completely independent on libp2p implementation.