### PR TITLE
api, storage: add http interface to accept chunks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/coreos/go-semver v0.3.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/coreos/go-semver v0.3.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
 	"github.com/ethersphere/bee/pkg/pingpong"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/tracing"
 )
 
@@ -26,6 +27,7 @@ type server struct {
 
 type Options struct {
 	Pingpong pingpong.Interface
+	Storer   storage.Storer
 	Logger   logging.Logger
 	Tracer   *tracing.Tracer
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -5,10 +5,10 @@
 package api_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/api"
@@ -27,7 +27,7 @@ func newTestServer(t *testing.T, o testServerOptions) (client *http.Client, clea
 	s := api.New(api.Options{
 		Pingpong: o.Pingpong,
 		Storer:   o.Storer,
-		Logger:   logging.New(ioutil.Discard, 0),
+		Logger:   logging.New(os.Stdout, 5),
 	})
 	ts := httptest.NewServer(s)
 	cleanup = ts.Close

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -14,16 +14,19 @@ import (
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/pingpong"
+	"github.com/ethersphere/bee/pkg/storage"
 	"resenje.org/web"
 )
 
 type testServerOptions struct {
 	Pingpong pingpong.Interface
+	Storer   storage.Storer
 }
 
 func newTestServer(t *testing.T, o testServerOptions) (client *http.Client, cleanup func()) {
 	s := api.New(api.Options{
 		Pingpong: o.Pingpong,
+		Storer:   o.Storer,
 		Logger:   logging.New(ioutil.Discard, 0),
 	})
 	ts := httptest.NewServer(s)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -5,10 +5,10 @@
 package api_test
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/api"
@@ -27,7 +27,7 @@ func newTestServer(t *testing.T, o testServerOptions) (client *http.Client, clea
 	s := api.New(api.Options{
 		Pingpong: o.Pingpong,
 		Storer:   o.Storer,
-		Logger:   logging.New(os.Stdout, 5),
+		Logger:   logging.New(ioutil.Discard, 0),
 	})
 	ts := httptest.NewServer(s)
 	cleanup = ts.Close

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -70,7 +70,7 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 			return
 
 		}
-		s.Logger.Debugf("bzz-chunk: chunk read error: %v", err)
+		s.Logger.Debugf("bzz-chunk: chunk read error: %v ,addr %s", err, address)
 		s.Logger.Error("bzz-chunk: chunk read error")
 		jsonhttp.InternalServerError(w, "chunk read error")
 		return

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -70,5 +70,8 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "binary/octet-stream")
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, bytes.NewReader(data))
+	_, err = io.Copy(w, bytes.NewReader(data))
+	if err != nil {
+		s.Logger.Debugf("bzz-chunk: write to http writer: %v", err)
+	}
 }

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -24,6 +24,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	address, err := swarm.ParseHexAddress(addr)
 	if err != nil {
 		s.Logger.Debugf("bzz-chunk: parse chunk address %s: %v", addr, err)
+		s.Logger.Error("bzz-chunk: error uploading chunk")
 		jsonhttp.BadRequest(w, "invalid chunk address")
 		return
 	}
@@ -60,6 +61,7 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 	data, err := s.Storer.Get(ctx, address)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
+			s.Logger.Trace("bzz-chunk: chunk not found. addr %s", address)
 			jsonhttp.NotFound(w, "chunk not found")
 			return
 
@@ -69,7 +71,6 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "binary/octet-stream")
-	w.WriteHeader(http.StatusOK)
 	_, err = io.Copy(w, bytes.NewReader(data))
 	if err != nil {
 		s.Logger.Debugf("bzz-chunk: write to http writer: %v", err)

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -65,7 +65,6 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			s.Logger.Trace("bzz-chunk: chunk not found. addr %s", address)
-			s.Logger.Error("bzz-chunk: chunk not found")
 			jsonhttp.NotFound(w, "chunk not found")
 			return
 

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+)
+
+func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
+}

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -5,8 +5,39 @@
 package api
 
 import (
+	"io/ioutil"
 	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/gorilla/mux"
 )
 
 func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["addr"]
+	ctx := r.Context()
+
+	address, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("bzz-chunk: parse chunk address %s: %v", addr, err)
+		jsonhttp.BadRequest(w, "invalid chunk address")
+		return
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		s.Logger.Debugf("bzz-chunk: read chunk data error: %v", err)
+		jsonhttp.InternalServerError(w, "cannot read chunk data")
+		return
+
+	}
+
+	err = s.Storer.Put(ctx, address, data)
+	if err != nil {
+		s.Logger.Debugf("bzz-chunk: chunk write error: %v", err)
+		jsonhttp.BadRequest(w, "chunk write error")
+		return
+	}
+
+	jsonhttp.OK(w, nil)
 }

--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -56,7 +56,7 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 	address, err := swarm.ParseHexAddress(addr)
 	if err != nil {
 		s.Logger.Debugf("bzz-chunk: parse chunk address %s: %v", addr, err)
-		s.Logger.Error("bzz-chunk: parse chunk addrss error")
+		s.Logger.Error("bzz-chunk: parse chunk address error")
 		jsonhttp.BadRequest(w, "invalid chunk address")
 		return
 	}

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -55,8 +55,8 @@ func TestChunkUploadDownload(t *testing.T) {
 	client, cleanup := newTestServer(t, testServerOptions{
 		Storer: mockValidatingStorer,
 	})
-
 	defer cleanup()
+
 	t.Run("invalid hash", func(t *testing.T) {
 		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource(invalidHash), bytes.NewReader(validContent), http.StatusBadRequest, jsonhttp.StatusResponse{
 			Message: "chunk write error",

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -5,9 +5,14 @@
 package api_test
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestChunkUpload(t *testing.T) {
@@ -20,21 +25,83 @@ func TestChunkUpload(t *testing.T) {
 
 	// download the chunk in both cases, in the first one - make sure it is retrievable
 	// in the second - that it isnt
+
+	const requestPath = "/bzz-chunk"
+
+	validHash, err := swarm.ParseHexAddress("aabbcc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	invalidHash, err := swarm.ParseHexAddress("bbccdd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validContent := []byte("bbaatt")
+	invalidContent := []byte("bbaattss")
+
+	validContentBuffer := bytes.NewBuffer(validContent)
+	invalidContentBuffer := bytes.NewBuffer(invalidContent)
+
+	validatorF := func(addr swarm.Address, data []byte) bool {
+		if !addr.Equal(validHash) {
+			return false
+
+		}
+		if !bytes.Equal(data, validContent) {
+			return false
+		}
+		return true
+	}
+
+	mockValidatingStorer := mock.NewValidatingStorer(validatorF)
+	client, cleanup := newTestServer(t, testServerOptions{
+		Storer: mockValidatingStorer,
+	})
+	defer cleanup()
+
+	t.Run("ok", func(t *testing.T) {
+		res := request(t, client, http.MethodPost, requestPath+"/"+validHash.String(), validContentBuffer, 200)
+		if res == nil {
+			t.Fatal("err nil resposen")
+		}
+	})
+
+	t.Run("invalid hash", func(t *testing.T) {
+		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), validContentBuffer, 200)
+		if res == nil {
+			t.Fatal("err nil resposen")
+		}
+	})
+
+	t.Run("invalid content", func(t *testing.T) {
+		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), invalidContentBuffer, 200)
+		if res == nil {
+			t.Fatal("err nil resposen")
+		}
+	})
 }
 
-func request(t *testing.T, method, url string, body io.Reader, responseCode int) *http.Response {
+func request(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int) *http.Response {
 	t.Helper()
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp.StatusCode != responseCode {
 		t.Errorf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
 	}
+
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return resp
 }

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -69,14 +69,14 @@ func TestChunkUpload(t *testing.T) {
 	})
 
 	t.Run("invalid hash", func(t *testing.T) {
-		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), validContentBuffer, 200)
+		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), validContentBuffer, 400)
 		if res == nil {
 			t.Fatal("err nil resposen")
 		}
 	})
 
 	t.Run("invalid content", func(t *testing.T) {
-		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), invalidContentBuffer, 200)
+		res := request(t, client, http.MethodPost, requestPath+"/"+invalidHash.String(), invalidContentBuffer, 400)
 		if res == nil {
 			t.Fatal("err nil resposen")
 		}

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestChunkUpload(t *testing.T) {
+	// define a mock chunk data, i.e. addr abcd chunk data efgh
+	// define some storage service with a validator, the validator is a mock validator
+	// that checks that if the data is efgh and hash is abcd then it is valid
+
+	// upload the chunk, "store" it to the mock storage in case it is valid
+	// return an http error Bad request in case it isn't
+
+	// download the chunk in both cases, in the first one - make sure it is retrievable
+	// in the second - that it isnt
+}
+
+func request(t *testing.T, method, url string, body io.Reader, responseCode int) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != responseCode {
+		t.Errorf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
+	}
+	return resp
+}

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -19,9 +19,6 @@ import (
 
 // TestChunkUpload uploads a chunk to an API that verifies the chunk according
 // to a given validator, then tries to download the uploaded data.
-// It does not test for the chunk validation logic but
-// rather that the chunk which is Put to the storage is passed through a validator
-// and that respective possible flows are handled correctly.
 func TestChunkUploadDownload(t *testing.T) {
 	resource := func(addr swarm.Address) string {
 		return "/bzz-chunk/" + addr.String()

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -17,21 +17,14 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-func TestChunkUpload(t *testing.T) {
-	// define a mock chunk data, i.e. addr abcd chunk data efgh
-	// define some storage service with a validator, the validator is a mock validator
-	// that checks that if the data is efgh and hash is abcd then it is valid
-
-	// upload the chunk, "store" it to the mock storage in case it is valid
-	// return an http error Bad request in case it isn't
-
-	// download the chunk in both cases, in the first one - make sure it is retrievable
-	// in the second - that it isnt
-
-	const resourcePath = "/bzz-chunk/"
-
+// TestChunkUpload uploads a chunk to an API that verifies the chunk according
+// to a given validator, then tries to download the uploaded data.
+// It does not test for the chunk validation logic but
+// rather that the chunk which is Put to the storage is passed through a validator
+// and that respective possible flows are handled correctly.
+func TestChunkUploadDownload(t *testing.T) {
 	resource := func(addr swarm.Address) string {
-		return resourcePath + addr.String()
+		return "/bzz-chunk/" + addr.String()
 	}
 
 	validHash, err := swarm.ParseHexAddress("aabbcc")

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -33,6 +33,7 @@ func (s *server) setupRouting() {
 	})
 
 	router.Handle("/bzz-chunk/{addr}", jsonhttp.MethodHandler{
+		"GET":  http.HandlerFunc(s.chunkGetHandler),
 		"POST": http.HandlerFunc(s.chunkUploadHandler),
 	})
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -32,6 +32,10 @@ func (s *server) setupRouting() {
 		"POST": http.HandlerFunc(s.pingpongHandler),
 	})
 
+	router.Handle("/bzz-chunk/", jsonhttp.MethodHandler{
+		"POST": http.HandlerFunc(s.chunkUploadHandler),
+	})
+
 	s.Handler = web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "api access"),
 		handlers.CompressHandler,

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -32,7 +32,7 @@ func (s *server) setupRouting() {
 		"POST": http.HandlerFunc(s.pingpongHandler),
 	})
 
-	router.Handle("/bzz-chunk/", jsonhttp.MethodHandler{
+	router.Handle("/bzz-chunk/{addr}", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.chunkUploadHandler),
 	})
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethersphere/bee/pkg/metrics"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/pkg/pingpong"
+	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/topology/full"
 	"github.com/ethersphere/bee/pkg/tracing"
 	ma "github.com/multiformats/go-multiaddr"
@@ -169,11 +170,15 @@ func NewBee(o Options) (*Bee, error) {
 		logger.Infof("p2p address: %s", addr)
 	}
 
+	// for now, storer is an in-memory store.
+	storer := mock.NewStorer()
+
 	var apiService api.Service
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
 			Pingpong: pingPong,
+			Storer:   storer,
 			Logger:   logger,
 			Tracer:   tracer,
 		})

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -17,20 +17,16 @@ type mockStorer struct {
 }
 
 func NewStorer() storage.Storer {
-	s := &mockStorer{
+	return &mockStorer{
 		store: make(map[string][]byte),
 	}
-
-	return s
 }
 
 func NewValidatingStorer(f storage.ChunkValidatorFunc) storage.Storer {
-	s := &mockStorer{
+	return &mockStorer{
 		store:     make(map[string][]byte),
 		validator: f,
 	}
-
-	return s
 }
 
 func (m *mockStorer) Get(ctx context.Context, addr swarm.Address) (data []byte, err error) {

--- a/pkg/storage/mock/storer_test.go
+++ b/pkg/storage/mock/storer_test.go
@@ -66,7 +66,6 @@ func TestMockValidatingStorer(t *testing.T) {
 	validatorF := func(addr swarm.Address, data []byte) bool {
 		if !addr.Equal(keyValid) {
 			return false
-
 		}
 		if !bytes.Equal(data, validContent) {
 			return false

--- a/pkg/storage/mock/storer_test.go
+++ b/pkg/storage/mock/storer_test.go
@@ -46,3 +46,60 @@ func TestMockStorer(t *testing.T) {
 		}
 	}
 }
+
+func TestMockValidatingStorer(t *testing.T) {
+	validAddr := "aabbcc"
+	invalidAddr := "bbccdd"
+
+	keyValid, err := swarm.ParseHexAddress(validAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyInvalid, err := swarm.ParseHexAddress(invalidAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validContent := []byte("bbaatt")
+	invalidContent := []byte("bbaattss")
+
+	validatorF := func(addr swarm.Address, data []byte) bool {
+		if !addr.Equal(keyValid) {
+			return false
+
+		}
+		if !bytes.Equal(data, validContent) {
+			return false
+		}
+		return true
+	}
+
+	s := mock.NewValidatingStorer(validatorF)
+
+	ctx := context.Background()
+
+	if err := s.Put(ctx, keyValid, validContent); err != nil {
+		t.Fatalf("expected not error but got: %v", err)
+	}
+
+	if err := s.Put(ctx, keyInvalid, validContent); err == nil {
+		t.Fatalf("expected error but got none")
+	}
+
+	if err := s.Put(ctx, keyInvalid, invalidContent); err == nil {
+		t.Fatalf("expected error but got none")
+	}
+
+	if data, err := s.Get(ctx, keyValid); err != nil {
+		t.Fatalf("got error on get but expected none: %v", err)
+	} else {
+		if !bytes.Equal(data, validContent) {
+			t.Fatal("stored content not identical to input data")
+		}
+	}
+
+	if _, err := s.Get(ctx, keyInvalid); err == nil {
+		t.Fatal("got no error on get but expected one")
+	}
+
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -11,7 +11,13 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var ErrNotFound = errors.New("storage: not found")
+var (
+	ErrNotFound     = errors.New("storage: not found")
+	ErrInvalidChunk = errors.New("storage: invalid chunk")
+)
+
+// ChunkValidatorFunc validates Swarm chunk address and chunk data
+type ChunkValidatorFunc func(swarm.Address, []byte) bool
 
 type Storer interface {
 	Get(ctx context.Context, addr swarm.Address) (data []byte, err error)


### PR DESCRIPTION
This PR adds functionality to upload and download a chunk from `bee`.
Right now chunks are stored in-memory using a mock `storage.Storer` implementation.
Chunks are "verified" only through the test harness - i.e. it is ready to accept flows that would be generated from errors while putting the chunk, but does not expose which errors occurred (this will be done once the necessity will be shown).

Once localstore gets imported we can switch to that as storage engine. Same for BMT and chunk verification.
cc @jmozah @nolash 