### PR TITLE
add traceid log field if tracing context if available

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -24,6 +24,7 @@ type Logger interface {
 	WithField(key string, value interface{}) *logrus.Entry
 	WithFields(fields logrus.Fields) *logrus.Entry
 	WriterLevel(logrus.Level) *io.PipeWriter
+	NewEntry() *logrus.Entry
 }
 
 type logger struct {
@@ -44,4 +45,8 @@ func New(w io.Writer, level logrus.Level) Logger {
 		Logger:  l,
 		metrics: metrics,
 	}
+}
+
+func (l *logger) NewEntry() *logrus.Entry {
+	return logrus.NewEntry(l.Logger)
 }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -248,6 +248,10 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 				return
 			}
 
+			logger := tracing.NewLoggerWithTraceID(ctx, s.logger)
+
+			logger.Tracef("handle protocol %s/%s: stream %s: peer %s", p.Name, p.Version, ss.Name, overlay)
+
 			s.metrics.HandledStreamCount.Inc()
 			if err := ss.Handler(ctx, p2p.Peer{Address: overlay}, stream); err != nil {
 				var e *p2p.DisconnectError
@@ -256,7 +260,8 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 					_ = s.Disconnect(overlay)
 				}
 
-				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: %v", p.Name, p.Version, ss.Name, overlay, err)
+				logger.Debugf("handle protocol %s/%s: stream %s: peer %s: %v", p.Name, p.Version, ss.Name, overlay, err)
+				return
 			}
 		})
 	}

--- a/pkg/p2p/libp2p/tracing_test.go
+++ b/pkg/p2p/libp2p/tracing_test.go
@@ -44,7 +44,7 @@ func TestTracing(t *testing.T) {
 	handled := make(chan struct{})
 	if err := s1.AddProtocol(newTestProtocol(func(ctx context.Context, _ p2p.Peer, _ p2p.Stream) error {
 
-		span, _ := tracer1.StartSpanFromContext(ctx, "test-p2p-handler")
+		span, _, _ := tracer1.StartSpanFromContext(ctx, "test-p2p-handler", nil)
 		defer span.Finish()
 
 		handledTracingSpan = fmt.Sprint(span.Context())
@@ -66,7 +66,7 @@ func TestTracing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	span, ctx := tracer2.StartSpanFromContext(ctx, "test-p2p-client")
+	span, _, ctx := tracer2.StartSpanFromContext(ctx, "test-p2p-client", nil)
 	defer span.Finish()
 
 	if fmt.Sprint(span.Context()) == "" {


### PR DESCRIPTION
This PR extends tracing package to add traceid to log messages if tracing context is available.

The usage example is in the pingpong package as well as in the newly added tests.

This change will allow correlation between logs and traces and their integration.