### PR TITLE
add metrics namespace

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -21,20 +21,28 @@ type metrics struct {
 	PingRequestCount prometheus.Counter
 }
 
-func newMetrics() (m metrics) {
+func newMetrics() metrics {
+	subsystem := "api"
+
 	return metrics{
 		RequestCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "api_request_count",
-			Help: "Number of API requests.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "request_count",
+			Help:      "Number of API requests.",
 		}),
 		ResponseDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "api_response_duration_seconds",
-			Help:    "Histogram of API response durations.",
-			Buckets: []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "response_duration_seconds",
+			Help:      "Histogram of API response durations.",
+			Buckets:   []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}),
 		PingRequestCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "api_ping_request_count",
-			Help: "Number HTTP API ping requests.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "ping_request_count",
+			Help:      "Number HTTP API ping requests.",
 		}),
 	}
 }

--- a/pkg/debugapi/metrics.go
+++ b/pkg/debugapi/metrics.go
@@ -6,6 +6,7 @@ package debugapi
 
 import (
 	"github.com/ethersphere/bee"
+	"github.com/ethersphere/bee/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -14,11 +15,14 @@ func newMetricsRegistry() (r *prometheus.Registry) {
 
 	// register standard metrics
 	r.MustRegister(
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
+			Namespace: metrics.Namespace,
+		}),
 		prometheus.NewGoCollector(),
 		prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "bee_info",
-			Help: "Bee information.",
+			Namespace: metrics.Namespace,
+			Name:      "info",
+			Help:      "Bee information.",
 			ConstLabels: prometheus.Labels{
 				"version": bee.Version,
 			},

--- a/pkg/logging/metrics.go
+++ b/pkg/logging/metrics.go
@@ -21,27 +21,39 @@ type metrics struct {
 	TraceCount prometheus.Counter
 }
 
-func newMetrics() (m metrics) {
+func newMetrics() metrics {
+	subsystem := "log"
+
 	return metrics{
 		ErrorCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "log_error_count",
-			Help: "Number ERROR log messages.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "error_count",
+			Help:      "Number ERROR log messages.",
 		}),
 		WarnCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "log_warn_count",
-			Help: "Number WARN log messages.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "warn_count",
+			Help:      "Number WARN log messages.",
 		}),
 		InfoCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "log_info_count",
-			Help: "Number INFO log messages.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "info_count",
+			Help:      "Number INFO log messages.",
 		}),
 		DebugCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "log_debug_count",
-			Help: "Number DEBUG log messages.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "debug_count",
+			Help:      "Number DEBUG log messages.",
 		}),
 		TraceCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "log_trace_count",
-			Help: "Number TRACE log messages.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "log_trace_count",
+			Help:      "Number TRACE log messages.",
 		}),
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,6 +10,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Namespace is prefixed before every metric. If it is changed, it must be done
+// before any metrics collector is registered.
+var Namespace = "bee"
+
 type Collector interface {
 	Metrics() []prometheus.Collector
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -41,19 +41,26 @@ type service struct {
 }
 
 func newService() *service {
+	subsystem := "api"
 	return &service{
 		RequestCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "api_request_count",
-			Help: "Number of API requests.",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "request_count",
+			Help:      "Number of API requests.",
 		}),
 		ResponseDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "api_response_duration_seconds",
-			Help:    "Histogram of API response durations.",
-			Buckets: []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "response_duration_seconds",
+			Help:      "Histogram of API response durations.",
+			Buckets:   []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}),
 		unexportedCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "api_unexported_count",
-			Help: "This metrics should not be discoverable by metrics.PrometheusCollectorsFromFields.",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "unexported_count",
+			Help:      "This metrics should not be discoverable by metrics.PrometheusCollectorsFromFields.",
 		}),
 	}
 }

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -19,23 +19,33 @@ type metrics struct {
 	HandledStreamCount     prometheus.Counter
 }
 
-func newMetrics() (m metrics) {
+func newMetrics() metrics {
+	subsystem := "libp2p"
+
 	return metrics{
 		CreatedConnectionCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "libp2p_created_connection_count",
-			Help: "Number of initiated outgoing libp2p connections.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "created_connection_count",
+			Help:      "Number of initiated outgoing libp2p connections.",
 		}),
 		HandledConnectionCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "libp2p_handled_connection_count",
-			Help: "Number of handled incoming libp2p connections.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "handled_connection_count",
+			Help:      "Number of handled incoming libp2p connections.",
 		}),
 		CreatedStreamCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "libp2p_created_stream_count",
-			Help: "Number of initiated outgoing libp2p streams.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "created_stream_count",
+			Help:      "Number of initiated outgoing libp2p streams.",
 		}),
 		HandledStreamCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "libp2p_handled_stream_count",
-			Help: "Number of handled incoming libp2p streams.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "handled_stream_count",
+			Help:      "Number of handled incoming libp2p streams.",
 		}),
 	}
 }

--- a/pkg/pingpong/metrics.go
+++ b/pkg/pingpong/metrics.go
@@ -19,23 +19,32 @@ type metrics struct {
 	PongReceivedCount prometheus.Counter
 }
 
-func newMetrics() (m metrics) {
+func newMetrics() metrics {
+	subsystem := "pingpong"
+
 	return metrics{
 		PingSentCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "pingpong_ping_sent_count",
-			Help: "Number ping requests sent.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "ping_sent_count",
+			Help:      "Number ping requests sent.",
 		}),
 		PongSentCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "pingpong_pong_sent_count",
-			Help: "Number of pong responses sent.",
+			Namespace: m.Namespace,
+			Name:      "pong_sent_count",
+			Help:      "Number of pong responses sent.",
 		}),
 		PingReceivedCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "pingpong_ping_received_count",
-			Help: "Number ping requests received.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "ping_received_count",
+			Help:      "Number ping requests received.",
 		}),
 		PongReceivedCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "pingpong_pong_received_count",
-			Help: "Number of pong responses received.",
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "pong_received_count",
+			Help:      "Number of pong responses received.",
 		}),
 	}
 }


### PR DESCRIPTION
This PR improves how metrics names are specified:

- adds a global Namespace which is currently `bee` as the prefix to all service metrics
- adds package local subsystem variable

This PR is not implementing an option to override Namespace variable, as it is not required now.

This PR is mostly related to easier metrics management with prefixes, by the infrastructure.