### PR TITLE
add debugapi /addresses endpoint to expose libp2p mutiaddresses

### DIFF
--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/topology/mock"
+	"github.com/multiformats/go-multiaddr"
 	"resenje.org/web"
 )
 
@@ -60,4 +61,14 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 		TopologyDriver: topologyDriver,
 		Cleanup:        cleanup,
 	}
+}
+
+func mustMultiaddr(t *testing.T, s string) multiaddr.Multiaddr {
+	t.Helper()
+
+	a, err := multiaddr.NewMultiaddr(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
 }

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -8,4 +8,5 @@ type (
 	StatusResponse      = statusResponse
 	PeerConnectResponse = peerConnectResponse
 	PeersResponse       = peersResponse
+	AddressesResponse   = addressesResponse
 )

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -1,0 +1,28 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type addressesResponse struct {
+	Addresses []multiaddr.Multiaddr `json:"addresses"`
+}
+
+func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
+	addresses, err := s.P2P.Addresses()
+	if err != nil {
+		s.Logger.Debugf("debug api: p2p addresses: %v", err)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+	jsonhttp.OK(w, addressesResponse{
+		Addresses: addresses,
+	})
+}

--- a/pkg/debugapi/p2p_test.go
+++ b/pkg/debugapi/p2p_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/p2p/mock"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func TestAddresses(t *testing.T) {
+	addresses := []multiaddr.Multiaddr{
+		mustMultiaddr(t, "/ip4/127.0.0.1/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"),
+		mustMultiaddr(t, "/ip4/192.168.0.101/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"),
+		mustMultiaddr(t, "/ip4/127.0.0.1/udp/7071/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"),
+	}
+
+	testServer := newTestServer(t, testServerOptions{
+		P2P: mock.New(mock.WithAddressesFunc(func() ([]multiaddr.Multiaddr, error) {
+			return addresses, nil
+		})),
+	})
+	defer testServer.Cleanup()
+
+	t.Run("ok", func(t *testing.T) {
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/addresses", nil, http.StatusOK, debugapi.AddressesResponse{
+			Addresses: addresses,
+		})
+	})
+
+	t.Run("post method not allowed", func(t *testing.T) {
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/addresses", nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
+			Code:    http.StatusMethodNotAllowed,
+			Message: http.StatusText(http.StatusMethodNotAllowed),
+		})
+	})
+}
+
+func TestAddresses_error(t *testing.T) {
+	testErr := errors.New("test error")
+
+	testServer := newTestServer(t, testServerOptions{
+		P2P: mock.New(mock.WithAddressesFunc(func() ([]multiaddr.Multiaddr, error) {
+			return nil, testErr
+		})),
+	})
+	defer testServer.Cleanup()
+
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/addresses", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+		Code:    http.StatusInternalServerError,
+		Message: testErr.Error(),
+	})
+}

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -40,6 +40,9 @@ func (s *server) setupRouting() {
 	router.HandleFunc("/health", s.statusHandler)
 	router.HandleFunc("/readiness", s.statusHandler)
 
+	router.Handle("/addresses", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.addressesHandler),
+	})
 	router.Handle("/connect/{multi-address:.+}", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.peerConnectHandler),
 	})

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -19,6 +19,7 @@ type Service struct {
 	disconnectFunc          func(overlay swarm.Address) error
 	peersFunc               func() []p2p.Peer
 	setPeerAddedHandlerFunc func(func(context.Context, swarm.Address) error)
+	addressesFunc           func() ([]ma.Multiaddr, error)
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -48,6 +49,12 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 func WithSetPeerAddedHandlerFunc(f func(func(context.Context, swarm.Address) error)) Option {
 	return optionFunc(func(s *Service) {
 		s.setPeerAddedHandlerFunc = f
+	})
+}
+
+func WithAddressesFunc(f func() ([]ma.Multiaddr, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.addressesFunc = f
 	})
 }
 
@@ -86,6 +93,13 @@ func (s *Service) SetPeerAddedHandler(f func(context.Context, swarm.Address) err
 	}
 
 	s.setPeerAddedHandlerFunc(f)
+}
+
+func (s *Service) Addresses() ([]ma.Multiaddr, error) {
+	if s.addressesFunc == nil {
+		return nil, errors.New("function Addresses not configured")
+	}
+	return s.addressesFunc()
 }
 
 func (s *Service) Peers() []p2p.Peer {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -19,6 +19,7 @@ type Service interface {
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
 	SetPeerAddedHandler(func(context.Context, swarm.Address) error)
+	Addresses() ([]ma.Multiaddr, error)
 }
 
 // Streamer is able to create a new Stream.


### PR DESCRIPTION
This PR is adding a new endpoint to debug api to expose LibP2P MultiAddresses. This is mainly needed for infrastructure automation to provide addresses that other nodes can connect to.

If the debug api is enabled a GET request to `http://localhost:6060/addresses` should return a list of addresses that node is listening to, for example:

```json
{
    "addresses": [
        "/ip4/127.0.0.1/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip4/192.168.0.101/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip4/127.0.0.1/udp/7071/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip4/192.168.0.101/udp/7071/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip6/::1/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip6/::1/udp/7071/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip4/109.245.209.24/tcp/19049/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb",
        "/ip4/109.245.209.24/udp/19049/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"
    ]
}
```