### PR TITLE
bootnode init improvement + libp2p incoming connection addr fix

### DIFF
--- a/pkg/addressbook/inmem/inmem.go
+++ b/pkg/addressbook/inmem/inmem.go
@@ -46,6 +46,8 @@ func (i *inmem) Put(overlay swarm.Address, addr ma.Multiaddr) (exists bool) {
 }
 
 func (i *inmem) Overlays() []swarm.Address {
+	i.mtx.Lock()
+	defer i.mtx.Unlock()
 	keys := make([]swarm.Address, 0, len(i.entries))
 	for k := range i.entries {
 		keys = append(keys, swarm.MustParseHexAddress(k))
@@ -55,6 +57,8 @@ func (i *inmem) Overlays() []swarm.Address {
 }
 
 func (i *inmem) Multiaddresses() []ma.Multiaddr {
+	i.mtx.Lock()
+	defer i.mtx.Unlock()
 	values := make([]ma.Multiaddr, 0, len(i.entries))
 	for _, v := range i.entries {
 		values = append(values, v.multiaddr)

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -87,6 +87,8 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 		return fmt.Errorf("new stream: %w", err)
 	}
 
+	fmt.Printf("Hive send peers  %s, %s\n", peer, peers)
+
 	defer stream.Close()
 	w, _ := protobuf.NewWriterAndReader(stream)
 	var peersRequest pb.Peers

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -111,14 +111,14 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 }
 
 func (s *Service) peersHandler(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
-	defer stream.Close()
-
 	_, r := protobuf.NewWriterAndReader(stream)
 	var peersReq pb.Peers
 	if err := r.ReadMsgWithTimeout(messageTimeout, &peersReq); err != nil {
+		stream.Close()
 		return fmt.Errorf("read requestPeers message: %w", err)
 	}
 
+	stream.Close()
 	for _, newPeer := range peersReq.Peers {
 		addr, err := ma.NewMultiaddr(newPeer.Underlay)
 		if err != nil {

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -86,10 +86,8 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	if err != nil {
 		return fmt.Errorf("new stream: %w", err)
 	}
-
-	fmt.Printf("Hive send peers  %s, %s\n", peer, peers)
-
 	defer stream.Close()
+
 	w, _ := protobuf.NewWriterAndReader(stream)
 	var peersRequest pb.Peers
 	for _, p := range peers {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -227,32 +227,31 @@ func NewBee(o Options) (*Bee, error) {
 		b.debugAPIServer = debugAPIServer
 	}
 
+	// Connect bootnodes
 	var wg sync.WaitGroup
-
-	// TODO: be more resilient on connection errors and connect in parallel
 	for _, a := range o.Bootnodes {
 		wg.Add(1)
 		go func(aa string) {
 			defer wg.Done()
 			addr, err := ma.NewMultiaddr(aa)
 			if err != nil {
-				logger.Debugf("multiaddress fail %s: %w", aa, err)
-				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				logger.Debugf("multiaddress fail %s: %v", aa, err)
+				logger.Errorf("connect to bootnode %s", aa)
 				return
 			}
 
 			overlay, err := p2ps.Connect(p2pCtx, addr)
 			if err != nil {
-				logger.Debugf("connect fail %s: %w", aa, err)
-				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				logger.Debugf("connect fail %s: %v", aa, err)
+				logger.Errorf("connect to bootnode %s", aa)
 				return
 			}
 
 			addressbook.Put(overlay, addr)
 			if err := topologyDriver.AddPeer(p2pCtx, overlay); err != nil {
 				_ = p2ps.Disconnect(overlay)
-				logger.Debugf("topology add peer fail %s %s: %w", aa, overlay, err)
-				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				logger.Debugf("topology add peer fail %s %s: %v", aa, overlay, err)
+				logger.Errorf("connect to bootnode %s", aa)
 				return
 			}
 		}(a)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -249,15 +249,12 @@ func NewBee(o Options) (*Bee, error) {
 			}
 
 			addressbook.Put(overlay, addr)
-			fmt.Printf("bootnode connected, added to addresbook %s, %s\n", addr, overlay)
 			if err := topologyDriver.AddPeer(p2pCtx, overlay); err != nil {
 				_ = p2ps.Disconnect(overlay)
 				logger.Debugf("topology add peer fail %s %s: %w", aa, overlay, err)
 				logger.Errorf("connect to bootnode %s: %w", aa, err)
 				return
 			}
-
-			fmt.Printf("bootnode connected, added to toplogy driver %s, %s\n", addr, overlay)
 		}(a)
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -123,19 +124,6 @@ func NewBee(o Options) (*Bee, error) {
 	}
 	b.p2pService = p2ps
 
-	// TODO: be more resilient on connection errors and connect in parallel
-	for _, a := range o.Bootnodes {
-		addr, err := ma.NewMultiaddr(a)
-		if err != nil {
-			return nil, fmt.Errorf("bootnode %s: %w", a, err)
-		}
-
-		overlay, err := p2ps.Connect(p2pCtx, addr)
-		if err != nil {
-			return nil, fmt.Errorf("connect to bootnode %s %s: %w", a, overlay, err)
-		}
-	}
-
 	// Construct protocols.
 	pingPong := pingpong.New(pingpong.Options{
 		Streamer: p2ps,
@@ -239,6 +227,41 @@ func NewBee(o Options) (*Bee, error) {
 		b.debugAPIServer = debugAPIServer
 	}
 
+	var wg sync.WaitGroup
+
+	// TODO: be more resilient on connection errors and connect in parallel
+	for _, a := range o.Bootnodes {
+		wg.Add(1)
+		go func(aa string) {
+			defer wg.Done()
+			addr, err := ma.NewMultiaddr(aa)
+			if err != nil {
+				logger.Debugf("multiaddress fail %s: %w", aa, err)
+				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				return
+			}
+
+			overlay, err := p2ps.Connect(p2pCtx, addr)
+			if err != nil {
+				logger.Debugf("connect fail %s: %w", aa, err)
+				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				return
+			}
+
+			addressbook.Put(overlay, addr)
+			fmt.Printf("bootnode connected, added to addresbook %s, %s\n", addr, overlay)
+			if err := topologyDriver.AddPeer(p2pCtx, overlay); err != nil {
+				_ = p2ps.Disconnect(overlay)
+				logger.Debugf("topology add peer fail %s %s: %w", aa, overlay, err)
+				logger.Errorf("connect to bootnode %s: %w", aa, err)
+				return
+			}
+
+			fmt.Printf("bootnode connected, added to toplogy driver %s, %s\n", addr, overlay)
+		}(a)
+	}
+
+	wg.Wait()
 	return b, nil
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -175,6 +175,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 
 	s.host.SetStreamHandlerMatch(id, matcher, func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
+		fmt.Println("peerID " + peerID)
 		i, err := s.handshakeService.Handle(newStream(stream))
 		if err != nil {
 			if err == handshake.ErrNetworkIDIncompatible {
@@ -193,13 +194,26 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		}
 
 		s.peers.add(stream.Conn(), i.Address)
-		s.addrssbook.Put(i.Address, stream.Conn().RemoteMultiaddr())
+		remoteMultiaddr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", stream.Conn().RemoteMultiaddr().String(), peerID.Pretty()))
+		if err != nil {
+			s.logger.Debugf("multiaddr error: handle %s: %v", peerID, err)
+			s.logger.Errorf("unable to connect with peer %v", peerID)
+			_ = s.disconnect(peerID)
+			return
+		}
+
+		s.addrssbook.Put(i.Address, remoteMultiaddr)
+		fmt.Printf("handshake finished, added to addresbook %s, %s\n", i.Address, remoteMultiaddr)
 		if s.peerHandler != nil {
+			fmt.Printf("handshake finished, peer handler is not null %s, %s\n", i.Address, remoteMultiaddr)
 			if err := s.peerHandler(ctx, i.Address); err != nil {
 				s.logger.Debugf("peerhandler error: %s: %v", peerID, err)
 			}
 
 		}
+
+		fmt.Printf("handshake finished, added to topology %s, %s\n", i.Address, remoteMultiaddr)
+		fmt.Printf("handshake finished, added to topology %s, %s\n", i.Address, remoteMultiaddr)
 		s.metrics.HandledStreamCount.Inc()
 		s.logger.Infof("peer %s connected", i.Address)
 	})

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -175,7 +175,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 
 	s.host.SetStreamHandlerMatch(id, matcher, func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
-		fmt.Println("peerID " + peerID)
 		i, err := s.handshakeService.Handle(newStream(stream))
 		if err != nil {
 			if err == handshake.ErrNetworkIDIncompatible {
@@ -203,17 +202,12 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		}
 
 		s.addrssbook.Put(i.Address, remoteMultiaddr)
-		fmt.Printf("handshake finished, added to addresbook %s, %s\n", i.Address, remoteMultiaddr)
 		if s.peerHandler != nil {
-			fmt.Printf("handshake finished, peer handler is not null %s, %s\n", i.Address, remoteMultiaddr)
 			if err := s.peerHandler(ctx, i.Address); err != nil {
 				s.logger.Debugf("peerhandler error: %s: %v", peerID, err)
 			}
-
 		}
 
-		fmt.Printf("handshake finished, added to topology %s, %s\n", i.Address, remoteMultiaddr)
-		fmt.Printf("handshake finished, added to topology %s, %s\n", i.Address, remoteMultiaddr)
 		s.metrics.HandledStreamCount.Inc()
 		s.logger.Infof("peer %s connected", i.Address)
 	})
@@ -223,7 +217,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 	})
 
 	h.Network().Notify(peerRegistry) // update peer registry on network events
-
 	return s, nil
 }
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -6,7 +6,6 @@ package full
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -52,10 +51,8 @@ func New(disc discovery.Driver, addressBook addressbook.GetPutter, p2pService p2
 // The peer would be subsequently broadcasted to all connected peers.
 // All conneceted peers are also broadcasted to the new peer.
 func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
-	fmt.Printf("Add Peer, start %s\n", addr)
 	d.mtx.Lock()
 	if _, ok := d.receivedPeers[addr.ByteString()]; ok {
-		fmt.Printf("Add Peer, already received %s\n", addr)
 		d.mtx.Unlock()
 		return nil
 	}
@@ -64,22 +61,17 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 	d.mtx.Unlock()
 
 	connectedPeers := d.p2pService.Peers()
-	fmt.Printf("Add Peer, connected peers %s, %s\n", addr, connectedPeers)
 	ma, exists := d.addressBook.Get(addr)
 	if !exists {
-		fmt.Printf("Add Peer, addrbook not exists %s\n", addr)
 		return topology.ErrNotFound
 	}
 
 	if !isConnected(addr, connectedPeers) {
-		fmt.Printf("Add Peer, is not already connected %s\n", addr)
 		peerAddr, err := d.p2pService.Connect(ctx, ma)
 		if err != nil {
-			fmt.Printf("Add Peer, connect err %s, %s: %s\n", addr, ma, err.Error())
 			return err
 		}
 
-		fmt.Printf("Add Peer,  connect finished %s\n", addr)
 		// update addr if it is wrong or it has been changed
 		if !addr.Equal(peerAddr) {
 			addr = peerAddr
@@ -91,7 +83,6 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 	for _, addressee := range connectedPeers {
 		// skip newly added peer
 		if addressee.Address.Equal(addr) {
-			fmt.Printf("Add Peer, skip newly added %s\n", addr)
 			continue
 		}
 
@@ -99,7 +90,6 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 		if err := d.discovery.BroadcastPeers(context.Background(), addressee.Address, addr); err != nil {
 			return err
 		}
-		fmt.Printf("Add Peer, broadcasted to addresee  %s, %s\n", addr, addressee.Address)
 	}
 
 	if len(connectedAddrs) == 0 {
@@ -110,7 +100,6 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 		return err
 	}
 
-	fmt.Printf("Add Peer, broadcasted to addr  %s, %s\n", addr, connectedAddrs)
 	return nil
 }
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -59,6 +59,8 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 		d.mtx.Unlock()
 		return nil
 	}
+
+	d.receivedPeers[addr.ByteString()] = struct{}{}
 	d.mtx.Unlock()
 
 	connectedPeers := d.p2pService.Peers()
@@ -98,7 +100,6 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 			return err
 		}
 		fmt.Printf("Add Peer, broadcasted to addresee  %s, %s\n", addr, addressee.Address)
-
 	}
 
 	if len(connectedAddrs) == 0 {
@@ -110,10 +111,6 @@ func (d *Driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 	}
 
 	fmt.Printf("Add Peer, broadcasted to addr  %s, %s\n", addr, connectedAddrs)
-
-	d.mtx.Lock()
-	d.receivedPeers[addr.ByteString()] = struct{}{}
-	d.mtx.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
* Bootnodes init in parallel, and does not fail if bootnode connect fails
* multiaddr creation fix in incoming connection in `libp2p`

@acud, @janos  
When testing I believe I found a problematic behavior which I believe is because the `AddPeer` handler is not async, or at least part of it. Imagine a scenario where you have nodes 0..10, and node 1 nodes about all other nodes. This can happen:
1. Node 2 connects to node 1
2. Node 1 will start to broadcast this node to all other nodes waiting for them to finish connect in order to finish the handle
3. Also, other nodes, will broadcast to other known nodes, in the handler, after connect

Every broadcast hive message is waiting for other side to close the stream, to finish communication, and this could result in lots of waits and timeouts. 
I would like to make `AddPeer` in topology driver async for 2 reasons:
1. It has a connect and broadcast calls which both wait for other nodes to confirm some information before exiting
2. I think that error handling of errors received from `AddPeer` is a bit hard to cover, because It might be different reasons for those errors and the code calling  `AddPeer` should probably not cancel the call if topology fails. 

For example, if one broadcast fails, or connect in the `AddPeer` fails, probably our incoming connection phase (after handshake) in `libp2p` should not actually fail and disconnect, etc... I think this one is very hard to cover. 
The other idea would be to identify parts the code that should async in handlers, but there are not much cuz the `AddPeer` handler is doing hive broadcasts and `libp2p` connect.

Other note, if we wanted some of this errors in `AddPeer` to disconnect the node, I would probably do it using Disconnect call in the handler itself other then wait for it in the calling function. Basically, I think that handlers should not be blocking, as they could block the whole chain and we can never know the implementations of those functions in the chain (like here we have `libp2p.Connect`  & `hive.Broadcast`)

LTKWYT




