### PR TITLE
set golangci-lint timeout to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 10m


### PR DESCRIPTION
This PR is raising golangci-lint timeout from 1m to 10m since it is timing out on github actions.