### PR TITLE
fix metrics names in logging and pingpong

### DIFF
--- a/pkg/logging/metrics.go
+++ b/pkg/logging/metrics.go
@@ -52,7 +52,7 @@ func newMetrics() metrics {
 		TraceCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "log_trace_count",
+			Name:      "trace_count",
 			Help:      "Number TRACE log messages.",
 		}),
 	}

--- a/pkg/pingpong/metrics.go
+++ b/pkg/pingpong/metrics.go
@@ -31,6 +31,7 @@ func newMetrics() metrics {
 		}),
 		PongSentCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
+			Subsystem: subsystem,
 			Name:      "pong_sent_count",
 			Help:      "Number of pong responses sent.",
 		}),


### PR DESCRIPTION
This PR fixes to metrics names that were incorrectly changed in previous PR.