### PR TITLE
add p2p.Peer json tag to Address field as it is returned by debug api

### DIFF
--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -51,7 +51,7 @@ type StreamSpec struct {
 
 // Peer holds information about a Peer.
 type Peer struct {
-	Address swarm.Address
+	Address swarm.Address `json:"address"`
 }
 
 // HandlerFunc handles a received Stream from a Peer.


### PR DESCRIPTION
This PR makes Debug API /peers endpoint response a bit prettier by using not capitalised json object key.