### PR TITLE
Flacky tests - NewStream

### DIFF
--- a/pkg/p2p/libp2p/headers_test.go
+++ b/pkg/p2p/libp2p/headers_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 )
 
-// todo: fix
 func TestHeaders(t *testing.T) {
 	headers := p2p.Headers{
 		"test-header-key": []byte("header-value"),

--- a/pkg/p2p/libp2p/headers_test.go
+++ b/pkg/p2p/libp2p/headers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 )
 
+// todo: fix
 func TestHeaders(t *testing.T) {
 	headers := p2p.Headers{
 		"test-header-key": []byte("header-value"),

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -95,7 +95,6 @@ func (s *Service) Handshake(stream p2p.Stream) (i *Info, err error) {
 }
 
 func (s *Service) Handle(stream p2p.Stream, peerID libp2ppeer.ID) (i *Info, err error) {
-	defer stream.Close()
 	s.receivedHandshakesMu.Lock()
 	if _, exists := s.receivedHandshakes[peerID]; exists {
 		s.receivedHandshakesMu.Unlock()

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -341,12 +341,16 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm
 		return swarm.Address{}, fmt.Errorf("handshake: %w", err)
 	}
 
-	if err := helpers.FullClose(stream); err != nil {
-		return swarm.Address{}, err
+	if exists := s.peers.addIfNotExists(stream.Conn(), i.Address); exists {
+		if err := helpers.FullClose(stream); err != nil {
+			return swarm.Address{}, err
+		}
+
+		return i.Address, nil
 	}
 
-	if exists := s.peers.addIfNotExists(stream.Conn(), i.Address); exists {
-		return i.Address, nil
+	if err := helpers.FullClose(stream); err != nil {
+		return swarm.Address{}, err
 	}
 
 	s.metrics.CreatedConnectionCount.Inc()

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -193,12 +193,16 @@ func New(ctx context.Context, o Options) (*Service, error) {
 			return
 		}
 
-		if err := stream.Close(); err != nil {
-			_ = stream.Reset()
+		if exists := s.peers.addIfNotExists(stream.Conn(), i.Address); exists {
+			if err := stream.Close(); err != nil {
+				_ = stream.Reset()
+			}
+
+			return
 		}
 
-		if exists := s.peers.addIfNotExists(stream.Conn(), i.Address); exists {
-			return
+		if err := stream.Close(); err != nil {
+			_ = stream.Reset()
 		}
 
 		remoteMultiaddr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", stream.Conn().RemoteMultiaddr().String(), peerID.Pretty()))

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -178,7 +178,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		peerID := stream.Conn().RemotePeer()
 		i, err := s.handshakeService.Handle(NewStream(stream), peerID)
 		if err != nil {
-			_ = stream.Close()
 			if err == handshake.ErrNetworkIDIncompatible {
 				s.logger.Warningf("peer %s has a different network id.", peerID)
 			}
@@ -257,7 +256,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
-				_ = stream.Close()
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				return
 			}
@@ -398,7 +396,6 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
-		_ = stream.Close()
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -267,9 +267,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				return
 			}
-			if err := stream.Close(); err != nil {
-				_ = stream.Reset()
-			}
 
 			// tracing: get span tracing context and add it to the context
 			// silently ignore if the peer is not providing tracing
@@ -409,10 +406,6 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 	if err := sendHeaders(ctx, headers, stream); err != nil {
 		_ = stream.Reset()
 		return nil, fmt.Errorf("send headers: %w", err)
-	}
-
-	if err := stream.Close(); err != nil {
-		_ = stream.Reset()
 	}
 
 	return stream, nil

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -178,6 +178,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		peerID := stream.Conn().RemotePeer()
 		i, err := s.handshakeService.Handle(NewStream(stream), peerID)
 		if err != nil {
+			_ = stream.Reset()
 			if err == handshake.ErrNetworkIDIncompatible {
 				s.logger.Warningf("peer %s has a different network id.", peerID)
 			}
@@ -190,6 +191,10 @@ func New(ctx context.Context, o Options) (*Service, error) {
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
 			_ = s.disconnect(peerID)
 			return
+		}
+
+		if err := stream.Close(); err != nil {
+			_ = stream.Reset()
 		}
 
 		if exists := s.peers.addIfNotExists(stream.Conn(), i.Address); exists {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -259,8 +259,12 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
+				_ = stream.Reset()
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				return
+			}
+			if err := stream.Close(); err != nil {
+				_ = stream.Reset()
 			}
 
 			// tracing: get span tracing context and add it to the context
@@ -395,7 +399,12 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
+		_ = stream.Reset()
 		return nil, fmt.Errorf("send headers: %w", err)
+	}
+
+	if err := stream.Close(); err != nil {
+		_ = stream.Reset()
 	}
 
 	return stream, nil


### PR DESCRIPTION
I believe this one is caused by https://github.com/ethersphere/bee/pull/65. I did not put peer registry synchronization in the right place. It was after the stream was already closed, resulting in possibly late addition to peer registry in retrospect to the other side of the stream.
To reproduce add  `time.Sleep` of 1s before ln 195 in `libp2p.go` on the code from master. What happens iis that stream handler returns not found from peer registry, and this error log is not visible in tests.  This should result in:
```
--- FAIL: TestHeaders (0.35s)
    headers_test.go:57: send headers: read message: stream reset
--- FAIL: TestHeaders_empty (0.31s)
    headers_test.go:106: send headers: read message: Application error 0x0
--- FAIL: TestHeadler (0.15s)
    headers_test.go:170: send headers: read message: Application error 0x0
--- FAIL: TestNewStream (0.44s)
    protocols_test.go:41: send headers: read message: stream reset
--- FAIL: TestNewStream_semanticVersioning (0.37s)
    protocols_test.go:138: create stream "/swarm/testing/2.0.0/messages" to "16Uiu2HAmNvXoptCFxi8TYbNZDSXz6FLois6CZfTAVtNMpRd5cnYw": stream reset
--- FAIL: TestTracing (0.58s)
    tracing_test.go:78: send headers: read message: Application error 0x0
```

I tested this locally, and by adding empty commits to github actions, you can see commit history. Tests seem to pass now every time. 
Do you guys think it would be useful/possible to enable error logs in tests in github actions for the future? Might be useful.