### PR TITLE
10/12: replace ethersphere/swarm/chunk and related types with bee ones

### DIFF
--- a/pkg/shed/example_store_test.go
+++ b/pkg/shed/example_store_test.go
@@ -19,7 +19,6 @@ package shed_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/shed"
+	"github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -312,7 +312,7 @@ func Example_store() {
 	}
 	defer s.Close()
 
-	ch := GenerateTestRandomChunk(1024)
+	ch := testing.GenerateTestRandomChunk()
 	err = s.Put(context.Background(), ch)
 	if err != nil {
 		log.Fatal(err)
@@ -326,12 +326,4 @@ func Example_store() {
 	fmt.Println(bytes.Equal(got.Data(), ch.Data()))
 
 	//Output: true
-}
-
-func GenerateTestRandomChunk(size int) swarm.Chunk {
-	data := make([]byte, size)
-	_, _ = rand.Read(data)
-	key := make([]byte, 32)
-	_, _ = rand.Read(key)
-	return swarm.NewChunk(swarm.NewAddress(key), data)
 }

--- a/pkg/storage/localstore/export_test.go
+++ b/pkg/storage/localstore/export_test.go
@@ -75,7 +75,7 @@ func TestExportImport(t *testing.T) {
 		}
 		got := ch.Data()
 		if !bytes.Equal(got, want) {
-			t.Fatalf("chunk %s: got data %s, want %x", addr, got, want)
+			t.Fatalf("chunk %s: got data %x, want %x", addr, got, want)
 		}
 	}
 }

--- a/pkg/storage/localstore/export_test.go
+++ b/pkg/storage/localstore/export_test.go
@@ -21,7 +21,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // TestExportImport constructs two databases, one to put and export
@@ -37,11 +38,11 @@ func TestExportImport(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db1.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db1.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
-		chunks[string(ch.Address())] = ch.Data()
+		chunks[ch.Address().String()] = ch.Data()
 	}
 
 	var buf bytes.Buffer
@@ -67,14 +68,14 @@ func TestExportImport(t *testing.T) {
 	}
 
 	for a, want := range chunks {
-		addr := chunk.Address([]byte(a))
-		ch, err := db2.Get(context.Background(), chunk.ModeGetRequest, addr)
+		addr := swarm.MustParseHexAddress(a)
+		ch, err := db2.Get(context.Background(), storage.ModeGetRequest, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		got := ch.Data()
 		if !bytes.Equal(got, want) {
-			t.Fatalf("chunk %s: got data %x, want %x", addr.Hex(), got, want)
+			t.Fatalf("chunk %s: got data %s, want %x", addr, got, want)
 		}
 	}
 }

--- a/pkg/storage/localstore/index_test.go
+++ b/pkg/storage/localstore/index_test.go
@@ -22,7 +22,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // TestDB_pullIndex validates the ordering of keys in pull index.
@@ -44,7 +45,7 @@ func TestDB_pullIndex(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -56,8 +57,8 @@ func TestDB_pullIndex(t *testing.T) {
 	}
 
 	testItemsOrder(t, db.pullIndex, chunks, func(i, j int) (less bool) {
-		poi := chunk.Proximity(db.baseKey, chunks[i].Address())
-		poj := chunk.Proximity(db.baseKey, chunks[j].Address())
+		poi := swarm.Proximity(db.baseKey, chunks[i].Address().Bytes())
+		poj := swarm.Proximity(db.baseKey, chunks[j].Address().Bytes())
 		if poi < poj {
 			return true
 		}
@@ -70,7 +71,7 @@ func TestDB_pullIndex(t *testing.T) {
 		if chunks[i].binID > chunks[j].binID {
 			return false
 		}
-		return bytes.Compare(chunks[i].Address(), chunks[j].Address()) == -1
+		return bytes.Compare(chunks[i].Address().Bytes(), chunks[j].Address().Bytes()) == -1
 	})
 }
 
@@ -89,7 +90,7 @@ func TestDB_gcIndex(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +118,7 @@ func TestDB_gcIndex(t *testing.T) {
 	t.Run("request unsynced", func(t *testing.T) {
 		ch := chunks[1]
 
-		_, err := db.Get(context.Background(), chunk.ModeGetRequest, ch.Address())
+		_, err := db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -134,7 +135,7 @@ func TestDB_gcIndex(t *testing.T) {
 	t.Run("sync one chunk", func(t *testing.T) {
 		ch := chunks[0]
 
-		err := db.Set(context.Background(), chunk.ModeSetSyncPull, ch.Address())
+		err := db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,7 +148,7 @@ func TestDB_gcIndex(t *testing.T) {
 
 	t.Run("sync all chunks", func(t *testing.T) {
 		for i := range chunks {
-			err := db.Set(context.Background(), chunk.ModeSetSyncPull, chunks[i].Address())
+			err := db.Set(context.Background(), storage.ModeSetSyncPull, chunks[i].Address())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -161,7 +162,7 @@ func TestDB_gcIndex(t *testing.T) {
 	t.Run("request one chunk", func(t *testing.T) {
 		i := 6
 
-		_, err := db.Get(context.Background(), chunk.ModeGetRequest, chunks[i].Address())
+		_, err := db.Get(context.Background(), storage.ModeGetRequest, chunks[i].Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +186,7 @@ func TestDB_gcIndex(t *testing.T) {
 		})
 
 		for _, ch := range chunks {
-			_, err := db.Get(context.Background(), chunk.ModeGetRequest, ch.Address())
+			_, err := db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -201,7 +202,7 @@ func TestDB_gcIndex(t *testing.T) {
 	t.Run("remove one chunk", func(t *testing.T) {
 		i := 3
 
-		err := db.Set(context.Background(), chunk.ModeSetRemove, chunks[i].Address())
+		err := db.Set(context.Background(), storage.ModeSetRemove, chunks[i].Address())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/localstore/mode_get_multi_test.go
+++ b/pkg/storage/localstore/mode_get_multi_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
 )
 
 // TestModeGetMulti stores chunks and validates that GetMulti
@@ -29,11 +29,11 @@ import (
 func TestModeGetMulti(t *testing.T) {
 	const chunkCount = 10
 
-	for _, mode := range []chunk.ModeGet{
-		chunk.ModeGetRequest,
-		chunk.ModeGetSync,
-		chunk.ModeGetLookup,
-		chunk.ModeGetPin,
+	for _, mode := range []storage.ModeGet{
+		storage.ModeGetRequest,
+		storage.ModeGetSync,
+		storage.ModeGetLookup,
+		storage.ModeGetPin,
 	} {
 		t.Run(mode.String(), func(t *testing.T) {
 			db, cleanupFunc := newTestDB(t, nil)
@@ -41,15 +41,15 @@ func TestModeGetMulti(t *testing.T) {
 
 			chunks := generateTestRandomChunks(chunkCount)
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, chunks...)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, chunks...)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if mode == chunk.ModeGetPin {
+			if mode == storage.ModeGetPin {
 				// pin chunks so that it is not returned as not found by pinIndex
 				for i, ch := range chunks {
-					err := db.Set(context.Background(), chunk.ModeSetPin, ch.Address())
+					err := db.Set(context.Background(), storage.ModeSetPin, ch.Address())
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -72,7 +72,7 @@ func TestModeGetMulti(t *testing.T) {
 
 			missingChunk := generateTestRandomChunk()
 
-			want := chunk.ErrChunkNotFound
+			want := storage.ErrNotFound
 			_, err = db.GetMulti(context.Background(), mode, append(addrs, missingChunk.Address())...)
 			if err != want {
 				t.Errorf("got error %v, want %v", err, want)

--- a/pkg/storage/localstore/mode_get_test.go
+++ b/pkg/storage/localstore/mode_get_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
 )
 
 // TestModeGetRequest validates ModeGetRequest index values on the provided DB.
@@ -37,7 +37,7 @@ func TestModeGetRequest(t *testing.T) {
 
 	ch := generateTestRandomChunk()
 
-	_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+	_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,14 +53,14 @@ func TestModeGetRequest(t *testing.T) {
 	})()
 
 	t.Run("get unsynced", func(t *testing.T) {
-		got, err := db.Get(context.Background(), chunk.ModeGetRequest, ch.Address())
+		got, err := db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 		// wait for update gc goroutine to be done
 		<-testHookUpdateGCChan
 
-		if !bytes.Equal(got.Address(), ch.Address()) {
+		if !got.Address().Equal(ch.Address()) {
 			t.Errorf("got chunk address %x, want %x", got.Address(), ch.Address())
 		}
 
@@ -76,20 +76,20 @@ func TestModeGetRequest(t *testing.T) {
 	})
 
 	// set chunk to synced state
-	err = db.Set(context.Background(), chunk.ModeSetSyncPull, ch.Address())
+	err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("first get", func(t *testing.T) {
-		got, err := db.Get(context.Background(), chunk.ModeGetRequest, ch.Address())
+		got, err := db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 		// wait for update gc goroutine to be done
 		<-testHookUpdateGCChan
 
-		if !bytes.Equal(got.Address(), ch.Address()) {
+		if !got.Address().Equal(ch.Address()) {
 			t.Errorf("got chunk address %x, want %x", got.Address(), ch.Address())
 		}
 
@@ -112,14 +112,14 @@ func TestModeGetRequest(t *testing.T) {
 			return accessTimestamp
 		})()
 
-		got, err := db.Get(context.Background(), chunk.ModeGetRequest, ch.Address())
+		got, err := db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 		// wait for update gc goroutine to be done
 		<-testHookUpdateGCChan
 
-		if !bytes.Equal(got.Address(), ch.Address()) {
+		if !got.Address().Equal(ch.Address()) {
 			t.Errorf("got chunk address %x, want %x", got.Address(), ch.Address())
 		}
 
@@ -137,14 +137,14 @@ func TestModeGetRequest(t *testing.T) {
 	})
 
 	t.Run("multi", func(t *testing.T) {
-		got, err := db.GetMulti(context.Background(), chunk.ModeGetRequest, ch.Address())
+		got, err := db.GetMulti(context.Background(), storage.ModeGetRequest, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 		// wait for update gc goroutine to be done
 		<-testHookUpdateGCChan
 
-		if !bytes.Equal(got[0].Address(), ch.Address()) {
+		if !got[0].Address().Equal(ch.Address()) {
 			t.Errorf("got chunk address %x, want %x", got[0].Address(), ch.Address())
 		}
 
@@ -174,17 +174,17 @@ func TestModeGetSync(t *testing.T) {
 
 	ch := generateTestRandomChunk()
 
-	_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+	_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := db.Get(context.Background(), chunk.ModeGetSync, ch.Address())
+	got, err := db.Get(context.Background(), storage.ModeGetSync, ch.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(got.Address(), ch.Address()) {
+	if !got.Address().Equal(ch.Address()) {
 		t.Errorf("got chunk address %x, want %x", got.Address(), ch.Address())
 	}
 
@@ -199,12 +199,12 @@ func TestModeGetSync(t *testing.T) {
 	t.Run("gc size", newIndexGCSizeTest(db))
 
 	t.Run("multi", func(t *testing.T) {
-		got, err := db.GetMulti(context.Background(), chunk.ModeGetSync, ch.Address())
+		got, err := db.GetMulti(context.Background(), storage.ModeGetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !bytes.Equal(got[0].Address(), ch.Address()) {
+		if !got[0].Address().Equal(ch.Address()) {
 			t.Errorf("got chunk address %x, want %x", got[0].Address(), ch.Address())
 		}
 

--- a/pkg/storage/localstore/mode_has.go
+++ b/pkg/storage/localstore/mode_has.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // Has returns true if the chunk is stored in database.
-func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
+func (db *DB) Has(ctx context.Context, addr swarm.Address) (bool, error) {
 
 	db.metrics.ModeHas.Inc()
 	defer totalTimeMetric(db.metrics.TotalTimeHas, time.Now())
@@ -38,7 +38,7 @@ func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
 
 // HasMulti returns a slice of booleans which represent if the provided chunks
 // are stored in database.
-func (db *DB) HasMulti(ctx context.Context, addrs ...chunk.Address) ([]bool, error) {
+func (db *DB) HasMulti(ctx context.Context, addrs ...swarm.Address) ([]bool, error) {
 
 	db.metrics.ModeHasMulti.Inc()
 	defer totalTimeMetric(db.metrics.TotalTimeHasMulti, time.Now())

--- a/pkg/storage/localstore/mode_has_test.go
+++ b/pkg/storage/localstore/mode_has_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
 )
 
 // TestHas validates that Has method is returning true for
@@ -34,7 +34,7 @@ func TestHas(t *testing.T) {
 
 	ch := generateTestRandomChunk()
 
-	_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+	_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestHasMulti(t *testing.T) {
 					// randomly exclude half of the chunks
 					continue
 				}
-				_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+				_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/localstore/retrieval_index_test.go
+++ b/pkg/storage/localstore/retrieval_index_test.go
@@ -21,7 +21,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // BenchmarkRetrievalIndexes uploads a number of chunks in order to measure
@@ -62,10 +63,10 @@ func benchmarkRetrievalIndexes(b *testing.B, o *Options, count int) {
 	b.StopTimer()
 	db, cleanupFunc := newTestDB(b, o)
 	defer cleanupFunc()
-	addrs := make([]chunk.Address, count)
+	addrs := make([]swarm.Address, count)
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -83,12 +84,12 @@ func benchmarkRetrievalIndexes(b *testing.B, o *Options, count int) {
 	b.StartTimer()
 
 	for i := 0; i < count; i++ {
-		err := db.Set(context.Background(), chunk.ModeSetSyncPull, addrs[i])
+		err := db.Set(context.Background(), storage.ModeSetSyncPull, addrs[i])
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		_, err = db.Get(context.Background(), chunk.ModeGetRequest, addrs[i])
+		_, err = db.Get(context.Background(), storage.ModeGetRequest, addrs[i])
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -131,7 +132,7 @@ func benchmarkUpload(b *testing.B, o *Options, count int) {
 	b.StopTimer()
 	db, cleanupFunc := newTestDB(b, o)
 	defer cleanupFunc()
-	chunks := make([]chunk.Chunk, count)
+	chunks := make([]swarm.Chunk, count)
 	for i := 0; i < count; i++ {
 		chunk := generateTestRandomChunk()
 		chunks[i] = chunk
@@ -139,7 +140,7 @@ func benchmarkUpload(b *testing.B, o *Options, count int) {
 	b.StartTimer()
 
 	for i := 0; i < count; i++ {
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, chunks[i])
+		_, err := db.Put(context.Background(), storage.ModePutUpload, chunks[i])
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/storage/localstore/subscription_pull_test.go
+++ b/pkg/storage/localstore/subscription_pull_test.go
@@ -17,14 +17,14 @@
 package localstore
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/swarm/shed"
 )
 
@@ -37,7 +37,7 @@ func TestDB_SubscribePull_first(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -85,7 +85,7 @@ func TestDB_SubscribePull(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -101,7 +101,7 @@ func TestDB_SubscribePull(t *testing.T) {
 	// to validate the number of addresses received by the subscription
 	errChan := make(chan error)
 
-	for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+	for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 		ch, stop := db.SubscribePull(ctx, bin, 0, 0)
 		defer stop()
 
@@ -130,7 +130,7 @@ func TestDB_SubscribePull_multiple(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -151,7 +151,7 @@ func TestDB_SubscribePull_multiple(t *testing.T) {
 	// start a number of subscriptions
 	// that all of them will write every address error to errChan
 	for j := 0; j < subsCount; j++ {
-		for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+		for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 			ch, stop := db.SubscribePull(ctx, bin, 0, 0)
 			defer stop()
 
@@ -181,7 +181,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -196,7 +196,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -209,7 +209,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 
 			if wanted {
 				if _, ok := addrs[bin]; !ok {
-					addrs[bin] = make([]chunk.Address, 0)
+					addrs[bin] = make([]swarm.Address, 0)
 				}
 				addrs[bin] = append(addrs[bin], ch.Address())
 				wantedChunksCount++
@@ -236,7 +236,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 	// to validate the number of addresses received by the subscription
 	errChan := make(chan error)
 
-	for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+	for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 		since, ok := first[bin]
 		if !ok {
 			continue
@@ -260,7 +260,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -275,7 +275,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -283,7 +283,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 			bin := db.po(ch.Address())
 
 			if _, ok := addrs[bin]; !ok {
-				addrs[bin] = make([]chunk.Address, 0)
+				addrs[bin] = make([]swarm.Address, 0)
 			}
 			if wanted {
 				addrs[bin] = append(addrs[bin], ch.Address())
@@ -313,7 +313,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 	// to validate the number of addresses received by the subscription
 	errChan := make(chan error)
 
-	for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+	for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 		until, ok := last[bin]
 		if !ok {
 			continue
@@ -339,7 +339,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
 	var wantedChunksCount int
 
@@ -354,7 +354,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -362,7 +362,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 			bin := db.po(ch.Address())
 
 			if _, ok := addrs[bin]; !ok {
-				addrs[bin] = make([]chunk.Address, 0)
+				addrs[bin] = make([]swarm.Address, 0)
 			}
 			if wanted {
 				addrs[bin] = append(addrs[bin], ch.Address())
@@ -398,7 +398,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 	// to validate the number of addresses received by the subscription
 	errChan := make(chan error)
 
-	for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+	for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 		since, ok := upload1[bin]
 		if ok {
 			// start from the next uploaded chunk
@@ -435,7 +435,7 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 
 	// keeps track of available chunks in the database
 	// per bin with their bin ids
-	chunks := make(map[uint8][]chunk.Descriptor)
+	chunks := make(map[uint8][]storage.Descriptor)
 
 	// keeps track of latest bin id for every bin
 	binIDCounter := make(map[uint8]uint64)
@@ -446,7 +446,7 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -457,9 +457,9 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 		binID := binIDCounter[bin]
 
 		if _, ok := chunks[bin]; !ok {
-			chunks[bin] = make([]chunk.Descriptor, 0)
+			chunks[bin] = make([]storage.Descriptor, 0)
 		}
-		chunks[bin] = append(chunks[bin], chunk.Descriptor{
+		chunks[bin] = append(chunks[bin], storage.Descriptor{
 			Address: ch.Address(),
 			BinID:   binID,
 		})
@@ -470,7 +470,7 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 		count := len(chunks[bin])
 		for i := 0; i < count/2; i++ {
 			d := chunks[bin][0]
-			if err := db.Set(context.Background(), chunk.ModeSetRemove, d.Address); err != nil {
+			if err := db.Set(context.Background(), storage.ModeSetRemove, d.Address); err != nil {
 				t.Fatal(err)
 			}
 			chunks[bin] = chunks[bin][1:]
@@ -484,7 +484,7 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 	// signals that there were valid bins for this check to ensure test validity
 	var checkedBins int
 	// subscribe to every bin and validate returned values
-	for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+	for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 		// do not subscribe to bins that do not have chunks
 		if len(chunks[bin]) == 0 {
 			continue
@@ -527,21 +527,21 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 
 // uploadRandomChunksBin uploads random chunks to database and adds them to
 // the map of addresses ber bin.
-func uploadRandomChunksBin(t *testing.T, db *DB, addrs map[uint8][]chunk.Address, addrsMu *sync.Mutex, wantedChunksCount *int, count int) {
+func uploadRandomChunksBin(t *testing.T, db *DB, addrs map[uint8][]swarm.Address, addrsMu *sync.Mutex, wantedChunksCount *int, count int) {
 	addrsMu.Lock()
 	defer addrsMu.Unlock()
 
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		bin := db.po(ch.Address())
 		if _, ok := addrs[bin]; !ok {
-			addrs[bin] = make([]chunk.Address, 0)
+			addrs[bin] = make([]swarm.Address, 0)
 		}
 		addrs[bin] = append(addrs[bin], ch.Address())
 
@@ -549,10 +549,10 @@ func uploadRandomChunksBin(t *testing.T, db *DB, addrs map[uint8][]chunk.Address
 	}
 }
 
-// readPullSubscriptionBin is a helper function that reads all chunk.Descriptors from a channel and
-// sends error to errChan, even if it is nil, to count the number of chunk.Descriptors
+// readPullSubscriptionBin is a helper function that reads all storage.Descriptors from a channel and
+// sends error to errChan, even if it is nil, to count the number of storage.Descriptors
 // returned by the channel.
-func readPullSubscriptionBin(ctx context.Context, db *DB, bin uint8, ch <-chan chunk.Descriptor, addrs map[uint8][]chunk.Address, addrsMu *sync.Mutex, errChan chan error) {
+func readPullSubscriptionBin(ctx context.Context, db *DB, bin uint8, ch <-chan storage.Descriptor, addrs map[uint8][]swarm.Address, addrsMu *sync.Mutex, errChan chan error) {
 	var i int // address index
 	for {
 		select {
@@ -566,15 +566,15 @@ func readPullSubscriptionBin(ctx context.Context, db *DB, bin uint8, ch <-chan c
 				err = fmt.Errorf("got more chunk addresses %v, then expected %v, for bin %v", i+1, len(addrs[bin]), bin)
 			} else {
 				addr := addrs[bin][i]
-				if !bytes.Equal(got.Address, addr) {
-					err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got.Address.Hex(), addr.Hex())
+				if !got.Address.Equal(addr) {
+					err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got.Address, addr)
 				} else {
 					var want shed.Item
 					want, err = db.retrievalDataIndex.Get(shed.Item{
-						Address: addr,
+						Address: addr.Bytes(),
 					})
 					if err != nil {
-						err = fmt.Errorf("got chunk (bin id %v in bin %v) from retrieval index %s: %v", i, bin, addrs[bin][i].Hex(), err)
+						err = fmt.Errorf("got chunk (bin id %v in bin %v) from retrieval index %s: %v", i, bin, addrs[bin][i], err)
 					} else {
 						if got.BinID != want.BinID {
 							err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got, want)
@@ -620,7 +620,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make(map[uint8][]chunk.Address)
+	addrs := make(map[uint8][]swarm.Address)
 
 	binIDCounter := make(map[uint8]uint64)
 	var binIDCounterMu sync.RWMutex
@@ -635,7 +635,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -643,7 +643,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 			bin := db.po(ch.Address())
 
 			if _, ok := addrs[bin]; !ok {
-				addrs[bin] = make([]chunk.Address, 0)
+				addrs[bin] = make([]swarm.Address, 0)
 			}
 			addrs[bin] = append(addrs[bin], ch.Address())
 
@@ -655,7 +655,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 		}
 
 		// check
-		for bin := uint8(0); bin <= uint8(chunk.MaxPO); bin++ {
+		for bin := uint8(0); bin <= uint8(swarm.MaxPO); bin++ {
 			want, ok := last[bin]
 			got, err := db.LastPullSubscriptionBinID(bin)
 			if ok {
@@ -676,7 +676,7 @@ func TestAddressInBin(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	for po := uint8(0); po < chunk.MaxPO; po++ {
+	for po := uint8(0); po < swarm.MaxPO; po++ {
 		addr := db.addressInBin(po)
 
 		got := db.po(addr)

--- a/pkg/storage/localstore/subscription_push.go
+++ b/pkg/storage/localstore/subscription_push.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/swarm/shed"
 )
 
@@ -30,10 +30,10 @@ import (
 // Returned stop function will terminate current and further iterations, and also it will close
 // the returned channel without any errors. Make sure that you check the second returned parameter
 // from the channel to stop iteration when its value is false.
-func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop func()) {
+func (db *DB) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, stop func()) {
 	db.metrics.SubscribePush.Inc()
 
-	chunks := make(chan chunk.Chunk)
+	chunks := make(chan swarm.Chunk)
 	trigger := make(chan struct{}, 1)
 
 	db.pushTriggersMu.Lock()
@@ -75,7 +75,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 					}
 
 					select {
-					case chunks <- chunk.NewChunk(dataItem.Address, dataItem.Data).WithTagID(item.Tag):
+					case chunks <- swarm.NewChunk(swarm.NewAddress(dataItem.Address), dataItem.Data).WithTagID(item.Tag):
 						count++
 						// set next iteration start item
 						// when its chunk is successfully sent to channel

--- a/pkg/storage/localstore/subscription_push_test.go
+++ b/pkg/storage/localstore/subscription_push_test.go
@@ -24,7 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // TestDB_SubscribePush uploads some chunks before and after
@@ -34,7 +35,7 @@ func TestDB_SubscribePush(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	chunks := make([]chunk.Chunk, 0)
+	chunks := make([]swarm.Chunk, 0)
 	var chunksMu sync.Mutex
 
 	uploadRandomChunks := func(count int) {
@@ -44,7 +45,7 @@ func TestDB_SubscribePush(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -84,8 +85,8 @@ func TestDB_SubscribePush(t *testing.T) {
 				if !bytes.Equal(got.Data(), want.Data()) {
 					err = fmt.Errorf("got chunk %v data %x, want %x", i, got.Data(), want.Data())
 				}
-				if !bytes.Equal(got.Address(), want.Address()) {
-					err = fmt.Errorf("got chunk %v address %s, want %s", i, got.Address().Hex(), want.Address().Hex())
+				if !got.Address().Equal(want.Address()) {
+					err = fmt.Errorf("got chunk %v address %s, want %s", i, got.Address(), want.Address())
 				}
 				i++
 				// send one and only one error per received address
@@ -120,7 +121,7 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
-	addrs := make([]chunk.Address, 0)
+	addrs := make([]swarm.Address, 0)
 	var addrsMu sync.Mutex
 
 	uploadRandomChunks := func(count int) {
@@ -130,7 +131,7 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), chunk.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -172,7 +173,7 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 					want := addrs[i]
 					addrsMu.Unlock()
 					var err error
-					if !bytes.Equal(got.Address(), want) {
+					if !got.Address().Equal(want) {
 						err = fmt.Errorf("got chunk %v address on subscription %v %s, want %s", i, j, got, want)
 					}
 					i++

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -7,6 +7,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -19,9 +20,129 @@ var (
 // ChunkValidatorFunc validates Swarm chunk address and chunk data
 type ChunkValidatorFunc func(swarm.Address, []byte) (valid bool)
 
+// ModeGet enumerates different Getter modes.
+type ModeGet int
+
+func (m ModeGet) String() string {
+	switch m {
+	case ModeGetRequest:
+		return "Request"
+	case ModeGetSync:
+		return "Sync"
+	case ModeGetLookup:
+		return "Lookup"
+	case ModeGetPin:
+		return "PinLookup"
+	default:
+		return "Unknown"
+	}
+}
+
+// Getter modes.
+const (
+	// ModeGetRequest: when accessed for retrieval
+	ModeGetRequest ModeGet = iota
+	// ModeGetSync: when accessed for syncing or proof of custody request
+	ModeGetSync
+	// ModeGetLookup: when accessed to lookup a a chunk in feeds or other places
+	ModeGetLookup
+	// ModeGetPin: used when a pinned chunk is accessed
+	ModeGetPin
+)
+
+// ModePut enumerates different Putter modes.
+type ModePut int
+
+func (m ModePut) String() string {
+	switch m {
+	case ModePutRequest:
+		return "Request"
+	case ModePutSync:
+		return "Sync"
+	case ModePutUpload:
+		return "Upload"
+	default:
+		return "Unknown"
+	}
+}
+
+// Putter modes.
+const (
+	// ModePutRequest: when a chunk is received as a result of retrieve request and delivery
+	ModePutRequest ModePut = iota
+	// ModePutSync: when a chunk is received via syncing
+	ModePutSync
+	// ModePutUpload: when a chunk is created by local upload
+	ModePutUpload
+)
+
+// ModeSet enumerates different Setter modes.
+type ModeSet int
+
+func (m ModeSet) String() string {
+	switch m {
+	case ModeSetAccess:
+		return "Access"
+	case ModeSetSyncPush:
+		return "SyncPush"
+	case ModeSetSyncPull:
+		return "SyncPull"
+	case ModeSetRemove:
+		return "Remove"
+	case ModeSetPin:
+		return "ModeSetPin"
+	case ModeSetUnpin:
+		return "ModeSetUnpin"
+	default:
+		return "Unknown"
+	}
+}
+
+// Setter modes.
+const (
+	// ModeSetAccess: when an update request is received for a chunk or chunk is retrieved for delivery
+	ModeSetAccess ModeSet = iota
+	// ModeSetSyncPush: when a push sync receipt is received for a chunk
+	ModeSetSyncPush
+	// ModeSetSyncPull: when a chunk is added to a pull sync batch
+	ModeSetSyncPull
+	// ModeSetRemove: when a chunk is removed
+	ModeSetRemove
+	// ModeSetPin: when a chunk is pinned during upload or separately
+	ModeSetPin
+	// ModeSetUnpin: when a chunk is unpinned using a command locally
+	ModeSetUnpin
+)
+
+// Descriptor holds information required for Pull syncing. This struct
+// is provided by subscribing to pull index.
+type Descriptor struct {
+	Address swarm.Address
+	BinID   uint64
+}
+
+func (d *Descriptor) String() string {
+	if d == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s bin id %v", d.Address, d.BinID)
+}
+
 type Storer interface {
 	Get(ctx context.Context, addr swarm.Address) (data []byte, err error)
 	Put(ctx context.Context, addr swarm.Address, data []byte) (err error)
+}
+
+type Store interface {
+	Get(ctx context.Context, mode ModeGet, addr swarm.Address) (ch swarm.Chunk, err error)
+	GetMulti(ctx context.Context, mode ModeGet, addrs ...swarm.Address) (ch []swarm.Chunk, err error)
+	Put(ctx context.Context, mode ModePut, chs ...swarm.Chunk) (exist []bool, err error)
+	Has(ctx context.Context, addr swarm.Address) (yes bool, err error)
+	HasMulti(ctx context.Context, addrs ...swarm.Address) (yes []bool, err error)
+	Set(ctx context.Context, mode ModeSet, addrs ...swarm.Address) (err error)
+	LastPullSubscriptionBinID(bin uint8) (id uint64, err error)
+	SubscribePull(ctx context.Context, bin uint8, since, until uint64) (c <-chan Descriptor, stop func())
+	Close() (err error)
 }
 
 // StateStorer defines methods required to get, set, delete values for different keys

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -142,7 +143,7 @@ type Store interface {
 	Set(ctx context.Context, mode ModeSet, addrs ...swarm.Address) (err error)
 	LastPullSubscriptionBinID(bin uint8) (id uint64, err error)
 	SubscribePull(ctx context.Context, bin uint8, since, until uint64) (c <-chan Descriptor, stop func())
-	Close() (err error)
+	io.Closer
 }
 
 // StateStorer defines methods required to get, set, delete values for different keys

--- a/pkg/storage/testing/chunk.go
+++ b/pkg/storage/testing/chunk.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func init() {
+	// needed for GenerateTestRandomChunk
+	rand.Seed(time.Now().UnixNano())
+}
+
+// GenerateTestRandomChunk generates a Chunk that is not
+// valid, but it contains a random key and a random value.
+// This function is faster then storage.GenerateRandomChunk
+// which generates a valid chunk.
+// Some tests in do not need valid chunks, just
+// random data, and their execution time can be decreased
+// using this function.
+func GenerateTestRandomChunk() swarm.Chunk {
+	data := make([]byte, swarm.ChunkSize)
+	rand.Read(data)
+	key := make([]byte, 32)
+	rand.Read(key)
+	return swarm.NewChunk(swarm.NewAddress(key), data)
+}
+
+// GenerateTestRandomChunks generates a slice of random
+// Chunks by using GenerateTestRandomChunk function.
+func GenerateTestRandomChunks(count int) []swarm.Chunk {
+	chunks := make([]swarm.Chunk, count)
+	for i := 0; i < count; i++ {
+		chunks[i] = GenerateTestRandomChunk()
+	}
+	return chunks
+}

--- a/pkg/swarm/proximity.go
+++ b/pkg/swarm/proximity.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package swarm
+
+// Proximity returns the proximity order of the MSB distance between x and y
+//
+// The distance metric MSB(x, y) of two equal length byte sequences x an y is the
+// value of the binary integer cast of the x^y, ie., x and y bitwise xor-ed.
+// the binary cast is big endian: most significant bit first (=MSB).
+//
+// Proximity(x, y) is a discrete logarithmic scaling of the MSB distance.
+// It is defined as the reverse rank of the integer part of the base 2
+// logarithm of the distance.
+// It is calculated by counting the number of common leading zeros in the (MSB)
+// binary representation of the x^y.
+//
+// (0 farthest, 255 closest, 256 self)
+func Proximity(one, other []byte) (ret int) {
+	b := (MaxPO-1)/8 + 1
+	if b > len(one) {
+		b = len(one)
+	}
+	m := 8
+	for i := 0; i < b; i++ {
+		oxo := one[i] ^ other[i]
+		for j := 0; j < m; j++ {
+			if (oxo>>uint8(7-j))&0x01 != 0 {
+				return i*8 + j
+			}
+		}
+	}
+	return MaxPO
+}

--- a/pkg/swarm/proximity_test.go
+++ b/pkg/swarm/proximity_test.go
@@ -1,0 +1,186 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package swarm
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestProximity validates Proximity function with explicit
+// values in a table-driven test. It is highly dependant on
+// MaxPO constant and it validates cases up to MaxPO=32.
+func TestProximity(t *testing.T) {
+	// integer from base2 encoded string
+	bx := func(s string) uint8 {
+		i, err := strconv.ParseUint(s, 2, 8)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return uint8(i)
+	}
+	// adjust expected bins in respect to MaxPO
+	limitPO := func(po uint8) uint8 {
+		if po > MaxPO {
+			return MaxPO
+		}
+		return po
+	}
+	base := []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000000")}
+	for _, tc := range []struct {
+		addr []byte
+		po   uint8
+	}{
+		{
+			addr: base,
+			po:   MaxPO,
+		},
+		{
+			addr: []byte{bx("10000000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(0),
+		},
+		{
+			addr: []byte{bx("01000000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(1),
+		},
+		{
+			addr: []byte{bx("00100000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(2),
+		},
+		{
+			addr: []byte{bx("00010000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(3),
+		},
+		{
+			addr: []byte{bx("00001000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(4),
+		},
+		{
+			addr: []byte{bx("00000100"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(5),
+		},
+		{
+			addr: []byte{bx("00000010"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(6),
+		},
+		{
+			addr: []byte{bx("00000001"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(7),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("10000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(8),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("01000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(9),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00100000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(10),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00010000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(11),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00001000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(12),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000100"), bx("00000000"), bx("00000000")},
+			po:   limitPO(13),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000010"), bx("00000000"), bx("00000000")},
+			po:   limitPO(14),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000001"), bx("00000000"), bx("00000000")},
+			po:   limitPO(15),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("10000000"), bx("00000000")},
+			po:   limitPO(16),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("01000000"), bx("00000000")},
+			po:   limitPO(17),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00100000"), bx("00000000")},
+			po:   limitPO(18),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00010000"), bx("00000000")},
+			po:   limitPO(19),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00001000"), bx("00000000")},
+			po:   limitPO(20),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000100"), bx("00000000")},
+			po:   limitPO(21),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000010"), bx("00000000")},
+			po:   limitPO(22),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000001"), bx("00000000")},
+			po:   limitPO(23),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("10000000")},
+			po:   limitPO(24),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("01000000")},
+			po:   limitPO(25),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00100000")},
+			po:   limitPO(26),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00010000")},
+			po:   limitPO(27),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00001000")},
+			po:   limitPO(28),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000100")},
+			po:   limitPO(29),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000010")},
+			po:   limitPO(30),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000001")},
+			po:   limitPO(31),
+		},
+	} {
+		got := uint8(Proximity(base, tc.addr))
+		if got != tc.po {
+			t.Errorf("got %v bin, want %v", got, tc.po)
+		}
+	}
+}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -142,33 +142,3 @@ func (c *chunk) TagID() uint32 {
 func (self *chunk) String() string {
 	return fmt.Sprintf("Address: %v Chunksize: %v", self.addr.String(), len(self.sdata))
 }
-
-// Proximity returns the proximity order of the MSB distance between x and y
-//
-// The distance metric MSB(x, y) of two equal length byte sequences x an y is the
-// value of the binary integer cast of the x^y, ie., x and y bitwise xor-ed.
-// the binary cast is big endian: most significant bit first (=MSB).
-//
-// Proximity(x, y) is a discrete logarithmic scaling of the MSB distance.
-// It is defined as the reverse rank of the integer part of the base 2
-// logarithm of the distance.
-// It is calculated by counting the number of common leading zeros in the (MSB)
-// binary representation of the x^y.
-//
-// (0 farthest, 255 closest, 256 self)
-func Proximity(one, other []byte) (ret int) {
-	b := (MaxPO-1)/8 + 1
-	if b > len(one) {
-		b = len(one)
-	}
-	m := 8
-	for i := 0; i < b; i++ {
-		oxo := one[i] ^ other[i]
-		for j := 0; j < m; j++ {
-			if (oxo>>uint8(7-j))&0x01 != 0 {
-				return i*8 + j
-			}
-		}
-	}
-	return MaxPO
-}

--- a/pkg/tags/tag.go
+++ b/pkg/tags/tag.go
@@ -1,0 +1,276 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tags
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/swarm/spancontext"
+	"github.com/opentracing/opentracing-go"
+)
+
+var (
+	errExists      = errors.New("already exists")
+	errNA          = errors.New("not available yet")
+	errNoETA       = errors.New("unable to calculate ETA")
+	errTagNotFound = errors.New("tag not found")
+)
+
+// State is the enum type for chunk states
+type State = uint32
+
+const (
+	StateSplit  State = iota // chunk has been processed by filehasher/swarm safe call
+	StateStored              // chunk stored locally
+	StateSeen                // chunk previously seen
+	StateSent                // chunk sent to neighbourhood
+	StateSynced              // proof is received; chunk removed from sync db; chunk is available everywhere
+)
+
+// Tag represents info on the status of new chunks
+type Tag struct {
+	Total  int64 // total chunks belonging to a tag
+	Split  int64 // number of chunks already processed by splitter for hashing
+	Seen   int64 // number of chunks already seen
+	Stored int64 // number of chunks already stored locally
+	Sent   int64 // number of chunks sent for push syncing
+	Synced int64 // number of chunks synced with proof
+
+	Uid       uint32        // a unique identifier for this tag
+	Anonymous bool          // indicates if the tag is anonymous (i.e. if only pull sync should be used)
+	Name      string        // a name tag for this tag
+	Address   swarm.Address // the associated swarm hash for this tag
+	StartedAt time.Time     // tag started to calculate ETA
+
+	// end-to-end tag tracing
+	ctx      context.Context  // tracing context
+	span     opentracing.Span // tracing root span
+	spanOnce sync.Once        // make sure we close root span only once
+}
+
+// NewTag creates a new tag, and returns it
+func NewTag(uid uint32, s string, total int64, anon bool) *Tag {
+	t := &Tag{
+		Uid:       uid,
+		Anonymous: anon,
+		Name:      s,
+		StartedAt: time.Now(),
+		Total:     total,
+	}
+
+	// context here is used only to store the root span `new.upload.tag` within Tag,
+	// we don't need any type of ctx Deadline or cancellation for this particular ctx
+	t.ctx, t.span = spancontext.StartSpan(context.Background(), "new.upload.tag")
+	return t
+}
+
+// Context accessor
+func (t *Tag) Context() context.Context {
+	return t.ctx
+}
+
+// FinishRootSpan closes the pushsync span of the tags
+func (t *Tag) FinishRootSpan() {
+	t.spanOnce.Do(func() {
+		t.span.Finish()
+	})
+}
+
+// IncN increments the count for a state
+func (t *Tag) IncN(state State, n int) {
+	var v *int64
+	switch state {
+	case StateSplit:
+		v = &t.Split
+	case StateStored:
+		v = &t.Stored
+	case StateSeen:
+		v = &t.Seen
+	case StateSent:
+		v = &t.Sent
+	case StateSynced:
+		v = &t.Synced
+	}
+	atomic.AddInt64(v, int64(n))
+}
+
+// Inc increments the count for a state
+func (t *Tag) Inc(state State) {
+	t.IncN(state, 1)
+}
+
+// Get returns the count for a state on a tag
+func (t *Tag) Get(state State) int64 {
+	var v *int64
+	switch state {
+	case StateSplit:
+		v = &t.Split
+	case StateStored:
+		v = &t.Stored
+	case StateSeen:
+		v = &t.Seen
+	case StateSent:
+		v = &t.Sent
+	case StateSynced:
+		v = &t.Synced
+	}
+	return atomic.LoadInt64(v)
+}
+
+// GetTotal returns the total count
+func (t *Tag) TotalCounter() int64 {
+	return atomic.LoadInt64(&t.Total)
+}
+
+// WaitTillDone returns without error once the tag is complete
+// wrt the state given as argument
+// it returns an error if the context is done
+func (t *Tag) WaitTillDone(ctx context.Context, s State) error {
+	if t.Done(s) {
+		return nil
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	for {
+		select {
+		case <-ticker.C:
+			if t.Done(s) {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Done returns true if tag is complete wrt the state given as argument
+func (t *Tag) Done(s State) bool {
+	n, total, err := t.Status(s)
+	return err == nil && n == total
+}
+
+// DoneSplit sets total count to SPLIT count and sets the associated swarm hash for this tag
+// is meant to be called when splitter finishes for input streams of unknown size
+func (t *Tag) DoneSplit(address swarm.Address) int64 {
+	total := atomic.LoadInt64(&t.Split)
+	atomic.StoreInt64(&t.Total, total)
+	t.Address = address
+	return total
+}
+
+// Status returns the value of state and the total count
+func (t *Tag) Status(state State) (int64, int64, error) {
+	count, seen, total := t.Get(state), atomic.LoadInt64(&t.Seen), atomic.LoadInt64(&t.Total)
+	if total == 0 {
+		return count, total, errNA
+	}
+	switch state {
+	case StateSplit, StateStored, StateSeen:
+		return count, total, nil
+	case StateSent, StateSynced:
+		stored := atomic.LoadInt64(&t.Stored)
+		if stored < total {
+			return count, total - seen, errNA
+		}
+		return count, total - seen, nil
+	}
+	return count, total, errNA
+}
+
+// ETA returns the time of completion estimated based on time passed and rate of completion
+func (t *Tag) ETA(state State) (time.Time, error) {
+	cnt, total, err := t.Status(state)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if cnt == 0 || total == 0 {
+		return time.Time{}, errNoETA
+	}
+	diff := time.Since(t.StartedAt)
+	dur := time.Duration(total) * diff / time.Duration(cnt)
+	return t.StartedAt.Add(dur), nil
+}
+
+// MarshalBinary marshals the tag into a byte slice
+func (tag *Tag) MarshalBinary() (data []byte, err error) {
+	buffer := make([]byte, 4)
+	binary.BigEndian.PutUint32(buffer, tag.Uid)
+	encodeInt64Append(&buffer, tag.Total)
+	encodeInt64Append(&buffer, tag.Split)
+	encodeInt64Append(&buffer, tag.Seen)
+	encodeInt64Append(&buffer, tag.Stored)
+	encodeInt64Append(&buffer, tag.Sent)
+	encodeInt64Append(&buffer, tag.Synced)
+
+	intBuffer := make([]byte, 8)
+
+	n := binary.PutVarint(intBuffer, tag.StartedAt.Unix())
+	buffer = append(buffer, intBuffer[:n]...)
+
+	n = binary.PutVarint(intBuffer, int64(len(tag.Address.Bytes())))
+	buffer = append(buffer, intBuffer[:n]...)
+	buffer = append(buffer, tag.Address.Bytes()...)
+	buffer = append(buffer, []byte(tag.Name)...)
+
+	return buffer, nil
+}
+
+// UnmarshalBinary unmarshals a byte slice into a tag
+func (tag *Tag) UnmarshalBinary(buffer []byte) error {
+	if len(buffer) < 13 {
+		return errors.New("buffer too short")
+	}
+	tag.Uid = binary.BigEndian.Uint32(buffer)
+	buffer = buffer[4:]
+
+	tag.Total = decodeInt64Splice(&buffer)
+	tag.Split = decodeInt64Splice(&buffer)
+	tag.Seen = decodeInt64Splice(&buffer)
+	tag.Stored = decodeInt64Splice(&buffer)
+	tag.Sent = decodeInt64Splice(&buffer)
+	tag.Synced = decodeInt64Splice(&buffer)
+
+	t, n := binary.Varint(buffer)
+	tag.StartedAt = time.Unix(t, 0)
+	buffer = buffer[n:]
+
+	t, n = binary.Varint(buffer)
+	buffer = buffer[n:]
+	if t > 0 {
+		tag.Address = swarm.NewAddress(buffer[:t])
+	}
+	tag.Name = string(buffer[t:])
+
+	return nil
+}
+
+func encodeInt64Append(buffer *[]byte, val int64) {
+	intBuffer := make([]byte, 8)
+	n := binary.PutVarint(intBuffer, val)
+	*buffer = append(*buffer, intBuffer[:n]...)
+}
+
+func decodeInt64Splice(buffer *[]byte) int64 {
+	val, n := binary.Varint((*buffer))
+	*buffer = (*buffer)[n:]
+	return val
+}

--- a/pkg/tags/tag_test.go
+++ b/pkg/tags/tag_test.go
@@ -1,0 +1,276 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tags
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var (
+	allStates = []State{StateSplit, StateStored, StateSeen, StateSent, StateSynced}
+)
+
+// TestTagSingleIncrements tests if Inc increments the tag state value
+func TestTagSingleIncrements(t *testing.T) {
+	tg := &Tag{Total: 10}
+
+	tc := []struct {
+		state    uint32
+		inc      int
+		expcount int64
+		exptotal int64
+	}{
+		{state: StateSplit, inc: 10, expcount: 10, exptotal: 10},
+		{state: StateStored, inc: 9, expcount: 9, exptotal: 9},
+		{state: StateSeen, inc: 1, expcount: 1, exptotal: 10},
+		{state: StateSent, inc: 9, expcount: 9, exptotal: 9},
+		{state: StateSynced, inc: 9, expcount: 9, exptotal: 9},
+	}
+
+	for _, tc := range tc {
+		for i := 0; i < tc.inc; i++ {
+			tg.Inc(tc.state)
+		}
+	}
+
+	for _, tc := range tc {
+		if tg.Get(tc.state) != tc.expcount {
+			t.Fatalf("not incremented")
+		}
+	}
+}
+
+// TestTagStatus is a unit test to cover Tag.Status method functionality
+func TestTagStatus(t *testing.T) {
+	tg := &Tag{Total: 10}
+	tg.Inc(StateSeen)
+	tg.Inc(StateSent)
+	tg.Inc(StateSynced)
+
+	for i := 0; i < 10; i++ {
+		tg.Inc(StateSplit)
+		tg.Inc(StateStored)
+	}
+	for _, v := range []struct {
+		state    State
+		expVal   int64
+		expTotal int64
+	}{
+		{state: StateStored, expVal: 10, expTotal: 10},
+		{state: StateSplit, expVal: 10, expTotal: 10},
+		{state: StateSeen, expVal: 1, expTotal: 10},
+		{state: StateSent, expVal: 1, expTotal: 9},
+		{state: StateSynced, expVal: 1, expTotal: 9},
+	} {
+		val, total, err := tg.Status(v.state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != v.expVal {
+			t.Fatalf("should be %d, got %d", v.expVal, val)
+		}
+		if total != v.expTotal {
+			t.Fatalf("expected Total to be %d, got %d", v.expTotal, total)
+		}
+	}
+}
+
+// tests ETA is precise
+func TestTagETA(t *testing.T) {
+	now := time.Now()
+	maxDiff := 100000 // 100 microsecond
+	tg := &Tag{Total: 10, StartedAt: now}
+	time.Sleep(100 * time.Millisecond)
+	tg.Inc(StateSplit)
+	eta, err := tg.ETA(StateSplit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := time.Until(eta) - 9*time.Since(now)
+	if int(diff) > maxDiff {
+		t.Fatalf("ETA is not precise, got diff %v > .1ms", diff)
+	}
+}
+
+// TestTagConcurrentIncrements tests Inc calls concurrently
+func TestTagConcurrentIncrements(t *testing.T) {
+	tg := &Tag{}
+	n := 1000
+	wg := sync.WaitGroup{}
+	wg.Add(5 * n)
+	for _, f := range allStates {
+		go func(f State) {
+			for j := 0; j < n; j++ {
+				go func() {
+					tg.Inc(f)
+					wg.Done()
+				}()
+			}
+		}(f)
+	}
+	wg.Wait()
+	for _, f := range allStates {
+		v := tg.Get(f)
+		if v != int64(n) {
+			t.Fatalf("expected state %v to be %v, got %v", f, n, v)
+		}
+	}
+}
+
+// TestTagsMultipleConcurrentIncrements tests Inc calls concurrently
+func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
+	ts := NewTags()
+	n := 100
+	wg := sync.WaitGroup{}
+	wg.Add(10 * 5 * n)
+	for i := 0; i < 10; i++ {
+		s := string([]byte{uint8(i)})
+		tag, err := ts.Create(s, int64(n), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range allStates {
+			go func(tag *Tag, f State) {
+				for j := 0; j < n; j++ {
+					go func() {
+						tag.Inc(f)
+						wg.Done()
+					}()
+				}
+			}(tag, f)
+		}
+	}
+	wg.Wait()
+	i := 0
+	ts.Range(func(k, v interface{}) bool {
+		i++
+		uid := k.(uint32)
+		for _, f := range allStates {
+			tag, err := ts.Get(uid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stateVal := tag.Get(f)
+			if stateVal != int64(n) {
+				t.Fatalf("expected tag %v state %v to be %v, got %v", uid, f, n, v)
+			}
+		}
+		return true
+
+	})
+	if i != 10 {
+		t.Fatal("not enough tagz")
+	}
+}
+
+// TestMarshallingWithAddr tests that marshalling and unmarshalling is done correctly when the
+// tag Address (byte slice) contains some arbitrary value
+func TestMarshallingWithAddr(t *testing.T) {
+	tg := NewTag(111, "test/tag", 10, false)
+	tg.Address = swarm.NewAddress([]byte{0, 1, 2, 3, 4, 5, 6})
+
+	for _, f := range allStates {
+		tg.Inc(f)
+	}
+
+	b, err := tg.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unmarshalledTag := &Tag{}
+	err = unmarshalledTag.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshalledTag.Uid != tg.Uid {
+		t.Fatalf("tag uids not equal. want %d got %d", tg.Uid, unmarshalledTag.Uid)
+	}
+
+	if unmarshalledTag.Name != tg.Name {
+		t.Fatalf("tag names not equal. want %s got %s", tg.Name, unmarshalledTag.Name)
+	}
+	if unmarshalledTag.Anonymous != tg.Anonymous {
+		t.Fatalf("tag anon field not equal. want %t got %t", tg.Anonymous, unmarshalledTag.Anonymous)
+	}
+
+	for _, state := range allStates {
+		uv, tv := unmarshalledTag.Get(state), tg.Get(state)
+		if uv != tv {
+			t.Fatalf("state %d inconsistent. expected %d to equal %d", state, uv, tv)
+		}
+	}
+
+	if unmarshalledTag.TotalCounter() != tg.TotalCounter() {
+		t.Fatalf("tag names not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
+	}
+
+	if len(unmarshalledTag.Address.Bytes()) != len(tg.Address.Bytes()) {
+		t.Fatalf("tag addresses length mismatch, want %d, got %d", len(tg.Address.Bytes()), len(unmarshalledTag.Address.Bytes()))
+	}
+
+	if !unmarshalledTag.Address.Equal(tg.Address) {
+		t.Fatalf("expected tag address to be %v got %v", unmarshalledTag.Address, tg.Address)
+	}
+}
+
+// TestMarshallingNoAddress tests that marshalling and unmarshalling is done correctly
+func TestMarshallingNoAddr(t *testing.T) {
+	tg := NewTag(111, "test/tag", 10, false)
+	for _, f := range allStates {
+		tg.Inc(f)
+	}
+
+	b, err := tg.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unmarshalledTag := &Tag{}
+	err = unmarshalledTag.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshalledTag.Uid != tg.Uid {
+		t.Fatalf("tag uids not equal. want %d got %d", tg.Uid, unmarshalledTag.Uid)
+	}
+
+	if unmarshalledTag.Name != tg.Name {
+		t.Fatalf("tag names not equal. want %s got %s", tg.Name, unmarshalledTag.Name)
+	}
+
+	for _, state := range allStates {
+		uv, tv := unmarshalledTag.Get(state), tg.Get(state)
+		if uv != tv {
+			t.Fatalf("state %d inconsistent. expected %d to equal %d", state, uv, tv)
+		}
+	}
+
+	if unmarshalledTag.TotalCounter() != tg.TotalCounter() {
+		t.Fatalf("tag names not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
+	}
+
+	if len(unmarshalledTag.Address.Bytes()) != len(tg.Address.Bytes()) {
+		t.Fatalf("expected tag addresses to be equal length")
+	}
+}

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -1,0 +1,156 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tags
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/swarm/sctx"
+)
+
+var (
+	TagUidFunc     = rand.Uint32
+	TagNotFoundErr = errors.New("tag not found")
+)
+
+// Tags hold tag information indexed by a unique random uint32
+type Tags struct {
+	tags *sync.Map
+}
+
+// NewTags creates a tags object
+func NewTags() *Tags {
+	return &Tags{
+		tags: &sync.Map{},
+	}
+}
+
+// Create creates a new tag, stores it by the name and returns it
+// it returns an error if the tag with this name already exists
+func (ts *Tags) Create(s string, total int64, anon bool) (*Tag, error) {
+	t := NewTag(TagUidFunc(), s, total, anon)
+
+	if _, loaded := ts.tags.LoadOrStore(t.Uid, t); loaded {
+		return nil, errExists
+	}
+
+	return t, nil
+}
+
+// All returns all existing tags in Tags' sync.Map
+// Note that tags are returned in no particular order
+func (ts *Tags) All() (t []*Tag) {
+	ts.tags.Range(func(k, v interface{}) bool {
+		t = append(t, v.(*Tag))
+
+		return true
+	})
+
+	return t
+}
+
+// Get returns the underlying tag for the uid or an error if not found
+func (ts *Tags) Get(uid uint32) (*Tag, error) {
+	t, ok := ts.tags.Load(uid)
+	if !ok {
+		return nil, TagNotFoundErr
+	}
+	return t.(*Tag), nil
+}
+
+// GetByAddress returns the latest underlying tag for the address or an error if not found
+func (ts *Tags) GetByAddress(address swarm.Address) (*Tag, error) {
+	var t *Tag
+	var lastTime time.Time
+	ts.tags.Range(func(key interface{}, value interface{}) bool {
+		rcvdTag := value.(*Tag)
+		if rcvdTag.Address.Equal(address) && rcvdTag.StartedAt.After(lastTime) {
+			t = rcvdTag
+			lastTime = rcvdTag.StartedAt
+		}
+		return true
+	})
+
+	if t == nil {
+		return nil, errTagNotFound
+	}
+	return t, nil
+}
+
+// GetFromContext gets a tag from the tag uid stored in the context
+func (ts *Tags) GetFromContext(ctx context.Context) (*Tag, error) {
+	uid := sctx.GetTag(ctx)
+	t, ok := ts.tags.Load(uid)
+	if !ok {
+		return nil, errTagNotFound
+	}
+	return t.(*Tag), nil
+}
+
+// Range exposes sync.Map's iterator
+func (ts *Tags) Range(fn func(k, v interface{}) bool) {
+	ts.tags.Range(fn)
+}
+
+func (ts *Tags) Delete(k interface{}) {
+	ts.tags.Delete(k)
+}
+
+func (ts *Tags) MarshalJSON() (out []byte, err error) {
+	m := make(map[string]*Tag)
+	ts.Range(func(k, v interface{}) bool {
+		key := fmt.Sprintf("%d", k)
+		val := v.(*Tag)
+
+		// don't persist tags which were already done
+		if !val.Done(StateSynced) {
+			m[key] = val
+		}
+		return true
+	})
+	return json.Marshal(m)
+}
+
+func (ts *Tags) UnmarshalJSON(value []byte) error {
+	m := make(map[string]*Tag)
+	err := json.Unmarshal(value, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		key, err := strconv.ParseUint(k, 10, 32)
+		if err != nil {
+			return err
+		}
+
+		// prevent a condition where a chunk was sent before shutdown
+		// and the node was turned off before the receipt was received
+		v.Sent = v.Synced
+
+		ts.tags.Store(key, v)
+	}
+
+	return err
+}

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tags
+
+import (
+	"testing"
+)
+
+func TestAll(t *testing.T) {
+	ts := NewTags()
+	if _, err := ts.Create("1", 1, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ts.Create("2", 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	all := ts.All()
+
+	if len(all) != 2 {
+		t.Fatalf("expected length to be 2 got %d", len(all))
+	}
+
+	if n := all[0].TotalCounter(); n != 1 {
+		t.Fatalf("expected tag 0 Total to be 1 got %d", n)
+	}
+
+	if n := all[1].TotalCounter(); n != 1 {
+		t.Fatalf("expected tag 1 Total to be 1 got %d", n)
+	}
+
+	if _, err := ts.Create("3", 1, false); err != nil {
+		t.Fatal(err)
+	}
+	all = ts.All()
+
+	if len(all) != 3 {
+		t.Fatalf("expected length to be 3 got %d", len(all))
+	}
+}

--- a/pkg/tags/testing/tag.go
+++ b/pkg/tags/testing/tag.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/tags"
+)
+
+// CheckTag checks the first tag in the api struct to be in a certain state
+func CheckTag(t *testing.T, tag *tags.Tag, split, stored, seen, sent, synced, total int64) {
+	t.Helper()
+	if tag == nil {
+		t.Fatal("no tag found")
+	}
+	tSplit := tag.Get(tags.StateSplit)
+	if tSplit != split {
+		t.Fatalf("should have had split chunks, got %d want %d", tSplit, split)
+	}
+
+	tSeen := tag.Get(tags.StateSeen)
+	if tSeen != seen {
+		t.Fatalf("should have had seen chunks, got %d want %d", tSeen, seen)
+	}
+
+	tStored := tag.Get(tags.StateStored)
+	if tStored != stored {
+		t.Fatalf("mismatch stored chunks, got %d want %d", tStored, stored)
+	}
+
+	tSent := tag.Get(tags.StateSent)
+	if tStored != stored {
+		t.Fatalf("mismatch sent chunks, got %d want %d", tSent, sent)
+	}
+
+	tSynced := tag.Get(tags.StateSynced)
+	if tSynced != synced {
+		t.Fatalf("mismatch synced chunks, got %d want %d", tSynced, synced)
+	}
+
+	tTotal := tag.TotalCounter()
+	if tTotal != total {
+		t.Fatalf("mismatch total chunks, got %d want %d", tTotal, total)
+	}
+}


### PR DESCRIPTION
This PR is related to the 10th point in https://github.com/ethersphere/bee/issues/66.

It brings types from swarm needed for localstore to function without ethersphere/swarm/chunk.

This PR does not remove all dependencies from ethersphere/swarm, but it removes ethersphere/swarm/chunk, while preserving the functionality of localstore in bee.

Dependecies that has to be removed in the following PR:
- github.com/ethersphere/swarm/storage/mock (probably to remove mock from bee locastore)
- github.com/ethersphere/swarm/spancontext (replace with bee tracing)
- github.com/ethersphere/swarm/sctx
- github.com/ethersphere/swarm/shed (planed as PR 11 in #66)