### PR TITLE
Init topology driver

### DIFF
--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -22,6 +22,7 @@ var _ Interface = (*store)(nil)
 type Interface interface {
 	GetPutter
 	Overlays() ([]swarm.Address, error)
+	Multiaddresses() ([]ma.Multiaddr, error)
 }
 
 type GetPutter interface {

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -17,7 +17,12 @@ import (
 
 const keyPrefix = "addressbook_entry_"
 
-var _ GetPutter = (*store)(nil)
+var _ Interface = (*store)(nil)
+
+type Interface interface {
+	GetPutter
+	Overlays() ([]swarm.Address, error)
+}
 
 type GetPutter interface {
 	Getter
@@ -36,7 +41,7 @@ type store struct {
 	store storage.StateStorer
 }
 
-func New(storer storage.StateStorer) GetPutter {
+func New(storer storage.StateStorer) Interface {
 	return &store{
 		store: storer,
 	}

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -18,7 +18,7 @@ import (
 
 	ma "github.com/multiformats/go-multiaddr"
 
-	book "github.com/ethersphere/bee/pkg/addressbook"
+	ab "github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/hive"
 	"github.com/ethersphere/bee/pkg/hive/pb"
 	"github.com/ethersphere/bee/pkg/logging"
@@ -28,16 +28,11 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-type AddressExporter interface {
-	Overlays() ([]swarm.Address, error)
-	Multiaddresses() ([]ma.Multiaddr, error)
-}
-
 func TestBroadcastPeers(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	logger := logging.New(ioutil.Discard, 0)
 	statestore := mock.NewStateStore()
-	addressbook := book.New(statestore)
+	addressbook := ab.New(statestore)
 
 	// populate all expected and needed random resources for 2 full batches
 	// tests cases that uses fewer resources can use sub-slices of this data
@@ -110,9 +105,9 @@ func TestBroadcastPeers(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			addressbookclean := book.New(mock.NewStateStore())
+			addressbookclean := ab.New(mock.NewStateStore())
 
-			exporter, ok := addressbookclean.(AddressExporter)
+			exporter, ok := addressbookclean.(ab.Interface)
 			if !ok {
 				t.Fatal("could not type assert AddressExporter")
 			}
@@ -166,7 +161,7 @@ func TestBroadcastPeers(t *testing.T) {
 	}
 }
 
-func expectOverlaysEventually(t *testing.T, exporter AddressExporter, wantOverlays []swarm.Address) {
+func expectOverlaysEventually(t *testing.T, exporter ab.Interface, wantOverlays []swarm.Address) {
 	for i := 0; i < 100; i++ {
 		var stringOverlays []string
 		var stringWantOverlays []string
@@ -199,7 +194,7 @@ func expectOverlaysEventually(t *testing.T, exporter AddressExporter, wantOverla
 	t.Errorf("Overlays got %v, want %v", o, wantOverlays)
 }
 
-func expectMultiaddresessEventually(t *testing.T, exporter AddressExporter, wantMultiaddresses []ma.Multiaddr) {
+func expectMultiaddresessEventually(t *testing.T, exporter ab.Interface, wantMultiaddresses []ma.Multiaddr) {
 	for i := 0; i < 10; i++ {
 		var stringMultiaddresses []string
 		m, err := exporter.Multiaddresses()

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -107,11 +107,6 @@ func TestBroadcastPeers(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			addressbookclean := ab.New(mock.NewStateStore())
 
-			exporter, ok := addressbookclean.(ab.Interface)
-			if !ok {
-				t.Fatal("could not type assert AddressExporter")
-			}
-
 			// create a hive server that handles the incoming stream
 			server := hive.New(hive.Options{
 				Logger:      logger,
@@ -155,8 +150,8 @@ func TestBroadcastPeers(t *testing.T) {
 				}
 			}
 
-			expectOverlaysEventually(t, exporter, tc.wantOverlays)
-			expectMultiaddresessEventually(t, exporter, tc.wantMultiAddresses)
+			expectOverlaysEventually(t, addressbookclean, tc.wantOverlays)
+			expectMultiaddresessEventually(t, addressbookclean, tc.wantMultiAddresses)
 		})
 	}
 }


### PR DESCRIPTION
The different way would be to try to connect to some `limit` amount of nodes, and add them to a topology driver already connected. This makes sense if we don't want to let topology driver choose which and amount of nodes connected when node is starting.