### PR TITLE
disable race detector on windows github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
       # until the issue with badgerdb memory allocation
       # is solved in this case
       if: matrix.os != 'windows-latest'
-      run: make test
+      run: make test-race
     - name: Test
       if: matrix.os == 'windows-latest'
-      run: make test-race
+      run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,5 +42,12 @@ jobs:
       run: make vet
     - name: Build
       run: make build
-    - name: Test
+    - name: Test with Race Detector
+      # do not tests with race detector on windows
+      # until the issue with badgerdb memory allocation
+      # is solved in this case
+      if: matrix.os != 'windows-latest'
       run: make test
+    - name: Test
+      if: matrix.os == 'windows-latest'
+      run: make test-race

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ lint:
 vet:
 	$(GO) vet ./...
 
+.PHONY: test-race
+test-race:
+	$(GO) test -race -v ./...
+
 .PHONY: test
 test:
 	$(GO) test -v ./...


### PR DESCRIPTION
This PR is reintroducing race detector in tests in github actions but only for ubuntu and macos, and windows is running tests without the race detector. This is due to issue explained in the commend in workflow file.