### PR TITLE
[bee #49]: get closest peer

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -25,14 +25,14 @@ const (
 
 type Service struct {
 	streamer      p2p.Streamer
-	peerSuggester topology.ChunkPeerer
+	peerSuggester topology.ClosestPeerer
 	storer        storage.Storer
 	logger        logging.Logger
 }
 
 type Options struct {
 	Streamer    p2p.Streamer
-	ChunkPeerer topology.ChunkPeerer
+	ChunkPeerer topology.ClosestPeerer
 	Storer      storage.Storer
 	Logger      logging.Logger
 }
@@ -63,7 +63,7 @@ func (s *Service) Protocol() p2p.ProtocolSpec {
 }
 
 func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (data []byte, err error) {
-	peerID, err := s.peerSuggester.ChunkPeer(addr)
+	peerID, err := s.peerSuggester.ClosestPeer(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -75,7 +75,7 @@ func TestDelivery(t *testing.T) {
 	if !bytes.Equal(v, reqData) {
 		t.Fatalf("request and response data not equal. got %s want %s", v, reqData)
 	}
-	peerID, _ := ps.ChunkPeer(swarm.ZeroAddress)
+	peerID, _ := ps.ClosestPeer(swarm.ZeroAddress)
 	records, err := recorder.Records(peerID, "retrieval", "1.0.0", "retrieval")
 	if err != nil {
 		t.Fatal(err)
@@ -124,6 +124,6 @@ type mockPeerSuggester struct {
 	spFunc func(swarm.Address) (swarm.Address, error)
 }
 
-func (v mockPeerSuggester) ChunkPeer(addr swarm.Address) (swarm.Address, error) {
+func (v mockPeerSuggester) ClosestPeer(addr swarm.Address) (swarm.Address, error) {
 	return v.spFunc(addr)
 }

--- a/pkg/topology/full/full_test.go
+++ b/pkg/topology/full/full_test.go
@@ -187,7 +187,7 @@ func TestAddPeer(t *testing.T) {
 }
 
 // TestSyncPeer tests that SyncPeer method returns closest connected peer to a given chunk.
-func TestSyncPeer(t *testing.T) {
+func TestClosestPeer(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 	baseOverlay := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 	connectedPeers := []p2p.Peer{
@@ -247,7 +247,7 @@ func TestSyncPeer(t *testing.T) {
 			expectedPeer: -1,
 		},
 	} {
-		peer, err := fullDriver.SyncPeer(tc.chunkAddress)
+		peer, err := fullDriver.ClosestPeer(tc.chunkAddress)
 		if err != nil {
 			if tc.expectedPeer == -1 && !errors.Is(err, topology.ErrWantSelf) {
 				t.Fatalf("wanted %v but got %v", topology.ErrWantSelf, err)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -16,18 +16,13 @@ var ErrWantSelf = errors.New("node wants self")
 
 type Driver interface {
 	PeerAdder
-	ChunkPeerer
-	SyncPeerer
+	ClosestPeerer
 }
 
 type PeerAdder interface {
 	AddPeer(ctx context.Context, addr swarm.Address) error
 }
 
-type ChunkPeerer interface {
-	ChunkPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
-}
-
-type SyncPeerer interface {
-	SyncPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
+type ClosestPeerer interface {
+	ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
 }


### PR DESCRIPTION
As a requirement of #49, we need to request a chunk from the closest peer that we're connected to.

This functionality was already implemented as part of #97, but since the functionalities are overlapping and are exactly the same - I am getting rid of the separate `ChunkPeerer` and `SyncPeerer` interfaces  in favor of just one `ClosestPeerer` interface.