### PR TITLE
rename migration tests

### DIFF
--- a/pkg/localstore/migration_test.go
+++ b/pkg/localstore/migration_test.go
@@ -191,8 +191,8 @@ func TestManyMigrations(t *testing.T) {
 	}
 }
 
-// TestMigrationFailFrom checks that local store boot should fail when the schema we're migrating from cannot be found
-func TestMigrationFailFrom(t *testing.T) {
+// TestMigrationErrorFrom checks that local store boot should fail when the schema we're migrating from cannot be found
+func TestMigrationErrorFrom(t *testing.T) {
 	defer func(v []migration, s string) {
 		schemaMigrations = v
 		DbSchemaCurrent = s
@@ -251,8 +251,8 @@ func TestMigrationFailFrom(t *testing.T) {
 	}
 }
 
-// TestMigrationFailTo checks that local store boot should fail when the schema we're migrating to cannot be found
-func TestMigrationFailTo(t *testing.T) {
+// TestMigrationErrorTo checks that local store boot should fail when the schema we're migrating to cannot be found
+func TestMigrationErrorTo(t *testing.T) {
 	defer func(v []migration, s string) {
 		schemaMigrations = v
 		DbSchemaCurrent = s


### PR DESCRIPTION
a minor nuisance, but when searching the build log for failures when something breaks, we look for the `fail` keyword and these tests always come up first. now they won't.