### PR TITLE
Connection Breaker

### DIFF
--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -13,6 +13,7 @@ import (
 var _ Interface = (*breaker)(nil)
 
 var (
+	// ErrClosed is the special error type that indicates that breaker is closed and that is not executing functions at the moment.
 	ErrClosed = errors.New("breaker closed")
 	timeNow   = time.Now // used instead of time.Since() so it can be mocked
 )
@@ -66,9 +67,9 @@ func NewBreaker(o Options) Interface {
 	return breaker
 }
 
-// executes f() if the limit number of consecutive failed calls is not reached within fail interval.
-// f() call is not locked so it can still be executed concurently
-// returns `errClosed` if the limit is reached and f() result otherwise
+// Executes runs f() if the limit number of consecutive failed calls is not reached within fail interval.
+// f() call is not locked so it can still be executed concurently.
+// Returns `ErrClosed` if the limit is reached or f() result otherwise.
 func (b *breaker) Execute(f func() error) error {
 	if err := b.beforef(); err != nil {
 		return err

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -10,10 +10,16 @@ import (
 	"time"
 )
 
+var _ Interface = (*breaker)(nil)
+
 var (
 	ErrClosed = errors.New("breaker closed")
 	timeNow   = time.Now // used instead of time.Since() so it can be mocked
 )
+
+type Interface interface {
+	Execute(f func() error) error
+}
 
 type breaker struct {
 	limit                int
@@ -33,7 +39,7 @@ type Options struct {
 	MaxBackoff   time.Duration
 }
 
-func NewBreaker(o Options) *breaker {
+func NewBreaker(o Options) Interface {
 	breaker := &breaker{
 		limit:        o.Limit,
 		backoff:      o.StartBackoff,

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -11,11 +11,8 @@ import (
 )
 
 var (
-	ErrClosed      = errors.New("breaker closed")
-	timeNow        = time.Now // used instead of time.Since() so it can be mocked
-	failInterval   = 10 * time.Minute
-	initialBackoff = 2 * time.Minute
-	backoffLimit   = 1 * time.Hour
+	ErrClosed = errors.New("breaker closed")
+	timeNow   = time.Now // used instead of time.Since() so it can be mocked
 )
 
 type breaker struct {
@@ -24,14 +21,43 @@ type breaker struct {
 	firstFailedTimestamp time.Time
 	closedTimestamp      time.Time
 	backoff              time.Duration
+	maxBackoff           time.Duration
+	failInterval         time.Duration
 	mtx                  sync.Mutex
 }
 
-func NewBreaker(limit int) *breaker {
-	return &breaker{
-		limit:   limit,
-		backoff: initialBackoff,
+type Options struct {
+	Limit        int
+	FailInterval time.Duration
+	StartBackoff time.Duration
+	MaxBackoff   time.Duration
+}
+
+func NewBreaker(o Options) *breaker {
+	breaker := &breaker{
+		limit:        o.Limit,
+		backoff:      o.StartBackoff,
+		maxBackoff:   o.MaxBackoff,
+		failInterval: o.FailInterval,
 	}
+
+	if o.Limit == 0 {
+		breaker.limit = 100
+	}
+
+	if o.FailInterval == 0 {
+		breaker.failInterval = 30 * time.Minute
+	}
+
+	if o.MaxBackoff == 0 {
+		breaker.maxBackoff = time.Hour
+	}
+
+	if o.StartBackoff == 0 {
+		breaker.backoff = 2 * time.Minute
+	}
+
+	return breaker
 }
 
 // executes f() if the limit number of consecutive failed calls is not reached within fail interval.
@@ -49,19 +75,19 @@ func (b *breaker) beforef() error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	if b.consFailedCalls >= b.limit {
-		if b.firstFailedTimestamp.IsZero() || timeNow().Sub(b.closedTimestamp) < b.backoff {
+		if b.closedTimestamp.IsZero() || timeNow().Sub(b.closedTimestamp) < b.backoff {
 			return ErrClosed
 		}
 
 		b.resetFailed()
-		if newBackoff := b.backoff * 2; newBackoff <= backoffLimit {
+		if newBackoff := b.backoff * 2; newBackoff <= b.maxBackoff {
 			b.backoff = newBackoff
 		} else {
-			b.backoff = backoffLimit
+			b.backoff = b.maxBackoff
 		}
 	}
 
-	if !b.firstFailedTimestamp.IsZero() && timeNow().Sub(b.firstFailedTimestamp) >= failInterval {
+	if !b.firstFailedTimestamp.IsZero() && timeNow().Sub(b.firstFailedTimestamp) >= b.failInterval {
 		b.resetFailed()
 	}
 
@@ -73,12 +99,12 @@ func (b *breaker) afterf(err error) error {
 	defer b.mtx.Unlock()
 	if err != nil {
 		if b.consFailedCalls == 0 {
-			b.firstFailedTimestamp = time.Now()
+			b.firstFailedTimestamp = timeNow()
 		}
 
 		b.consFailedCalls++
 		if b.consFailedCalls == b.limit {
-			b.closedTimestamp = time.Now()
+			b.closedTimestamp = timeNow()
 		}
 
 		return err

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -69,7 +69,7 @@ func NewBreaker(o Options) Interface {
 	return breaker
 }
 
-// Executes runs f() if the limit number of consecutive failed calls is not reached within fail interval.
+// Execute runs f() if the limit number of consecutive failed calls is not reached within fail interval.
 // f() call is not locked so it can still be executed concurently.
 // Returns `ErrClosed` if the limit is reached or f() result otherwise.
 func (b *breaker) Execute(f func() error) error {

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -22,7 +22,6 @@ type breaker struct {
 	limit                int
 	consFailedCalls      int
 	firstFailedTimestamp time.Time
-	closed               bool
 	closedTimestamp      time.Time
 	backoff              time.Duration
 	mtx                  sync.Mutex
@@ -58,7 +57,7 @@ func (b *breaker) beforef() error {
 		if newBackoff := b.backoff * 2; newBackoff <= backoffLimit {
 			b.backoff = newBackoff
 		} else {
-			newBackoff = backoffLimit
+			b.backoff = backoffLimit
 		}
 	}
 

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -1,0 +1,95 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package breaker
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrClosed      = errors.New("breaker closed")
+	timeNow        = time.Now // used instead of time.Since() so it can be mocked
+	failInterval   = 10 * time.Minute
+	initialBackoff = 2 * time.Minute
+	backoffLimit   = 1 * time.Hour
+)
+
+type breaker struct {
+	limit                int
+	consFailedCalls      int
+	firstFailedTimestamp time.Time
+	closed               bool
+	closedTimestamp      time.Time
+	backoff              time.Duration
+	mtx                  sync.Mutex
+}
+
+func NewBreaker(limit int) *breaker {
+	return &breaker{
+		limit:   limit,
+		backoff: initialBackoff,
+	}
+}
+
+// executes f() if the limit number of consecutive failed calls is not reached within fail interval.
+// f() call is not locked so it can still be executed concurently
+// returns `errClosed` if the limit is reached and f() result otherwise
+func (b *breaker) Execute(f func() error) error {
+	if err := b.beforef(); err != nil {
+		return err
+	}
+
+	return b.afterf(f())
+}
+
+func (b *breaker) beforef() error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	if b.consFailedCalls >= b.limit {
+		if b.firstFailedTimestamp.IsZero() || timeNow().Sub(b.closedTimestamp) < b.backoff {
+			return ErrClosed
+		}
+
+		b.resetFailed()
+		if newBackoff := b.backoff * 2; newBackoff <= backoffLimit {
+			b.backoff = newBackoff
+		} else {
+			newBackoff = backoffLimit
+		}
+	}
+
+	if !b.firstFailedTimestamp.IsZero() && timeNow().Sub(b.firstFailedTimestamp) >= failInterval {
+		b.resetFailed()
+	}
+
+	return nil
+}
+
+func (b *breaker) afterf(err error) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	if err != nil {
+		if b.consFailedCalls == 0 {
+			b.firstFailedTimestamp = time.Now()
+		}
+
+		b.consFailedCalls++
+		if b.consFailedCalls == b.limit {
+			b.closedTimestamp = time.Now()
+		}
+
+		return err
+	}
+
+	b.resetFailed()
+	return nil
+}
+
+func (b *breaker) resetFailed() {
+	b.consFailedCalls = 0
+	b.firstFailedTimestamp = time.Time{}
+}

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -13,7 +13,7 @@ import (
 var (
 	_ Interface = (*breaker)(nil)
 
-	// timeNow is used to deterrministically mock time.Now() in tests
+	// timeNow is used to deterministically mock time.Now() in tests
 	timeNow = time.Now
 
 	// ErrClosed is the special error type that indicates that breaker is closed and that is not executing functions at the moment.

--- a/pkg/p2p/libp2p/internal/breaker/breaker_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker_test.go
@@ -18,73 +18,96 @@ var (
 )
 
 func TestExecute(t *testing.T) {
+	failInterval := 10 * time.Minute
+	startBackoff := 1 * time.Minute
+	initTime := time.Now()
 	testCases := map[string]struct {
 		limit        int
 		ferrors      []error
 		iterations   int
-		timeOffsets  []time.Duration
+		times        []time.Time
 		expectedErrs []error
 	}{
 		"f() returns nil": {
 			limit:        5,
 			iterations:   1,
 			ferrors:      []error{nil},
-			timeOffsets:  nil,
+			times:        nil,
 			expectedErrs: []error{nil},
 		},
 		"f() returns error": {
 			limit:        5,
 			ferrors:      []error{testErr},
 			iterations:   1,
-			timeOffsets:  nil,
+			times:        nil,
 			expectedErrs: []error{testErr},
 		},
-		"Break error - zero limit": {
-			limit:        0,
-			ferrors:      []error{shouldNotBeCalledErr},
+		"Break error": {
+			limit:        1,
+			ferrors:      []error{testErr, shouldNotBeCalledErr},
 			iterations:   3,
-			timeOffsets:  nil,
-			expectedErrs: []error{breaker.ErrClosed, breaker.ErrClosed, breaker.ErrClosed},
+			times:        nil,
+			expectedErrs: []error{testErr, breaker.ErrClosed, breaker.ErrClosed},
 		},
-		"Break error - multiple iterations": {
+		"Break error - mix iterations": {
 			limit:        3,
-			ferrors:      []error{testErr, testErr, testErr, shouldNotBeCalledErr, shouldNotBeCalledErr},
-			iterations:   5,
-			timeOffsets:  nil,
-			expectedErrs: []error{testErr, testErr, testErr, breaker.ErrClosed, breaker.ErrClosed},
+			ferrors:      []error{testErr, nil, testErr, testErr, testErr, shouldNotBeCalledErr},
+			iterations:   6,
+			times:        nil,
+			expectedErrs: []error{testErr, nil, testErr, testErr, testErr, breaker.ErrClosed},
 		},
 		"Expiration - return f() error": {
 			limit:        3,
 			ferrors:      []error{testErr, testErr, testErr, testErr, testErr},
 			iterations:   5,
-			timeOffsets:  []time.Duration{time.Second, time.Second, 2 * breaker.GetFailInterval(), time.Second, time.Second},
+			times:        []time.Time{initTime, initTime, initTime.Add(2 * failInterval), initTime, initTime, initTime, initTime},
 			expectedErrs: []error{testErr, testErr, testErr, testErr, testErr},
 		},
-		"Backoff - close, reopen": {
-			limit:        3,
-			ferrors:      []error{testErr, testErr, testErr, shouldNotBeCalledErr, shouldNotBeCalledErr, testErr, testErr},
+		"Backoff - close, reopen, close, don't open": {
+			limit:        1,
+			ferrors:      []error{testErr, shouldNotBeCalledErr, testErr, shouldNotBeCalledErr, testErr, shouldNotBeCalledErr, shouldNotBeCalledErr},
 			iterations:   7,
-			timeOffsets:  []time.Duration{time.Second, time.Second, time.Second, time.Second, time.Second, 2 * breaker.GetBackoffLimit(), time.Second},
-			expectedErrs: []error{testErr, testErr, testErr, breaker.ErrClosed, breaker.ErrClosed, testErr, testErr},
+			times:        []time.Time{initTime, initTime, initTime, initTime.Add(startBackoff + time.Second), initTime, initTime, initTime, initTime.Add(2*startBackoff + time.Second), initTime, initTime, initTime, initTime.Add(startBackoff + time.Second)},
+			expectedErrs: []error{testErr, breaker.ErrClosed, testErr, breaker.ErrClosed, testErr, breaker.ErrClosed, breaker.ErrClosed},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			b := breaker.NewBreaker(tc.limit)
-			for i := 0; i < tc.iterations; i++ {
-				if tc.timeOffsets != nil {
-					breaker.SetTimeNow(func() time.Time {
-						return time.Now().Add(tc.timeOffsets[i])
-					})
-				} else {
-					breaker.SetTimeNow(time.Now)
-				}
+			b := breaker.NewBreaker(breaker.Options{
+				Limit:        tc.limit,
+				StartBackoff: startBackoff,
+				FailInterval: failInterval,
+			})
 
-				if err := b.Execute(func() error { return tc.ferrors[i] }); err != tc.expectedErrs[i] {
+			if tc.times != nil {
+				timeMock := timeMock{times: tc.times}
+				breaker.SetTimeNow(timeMock.next)
+			} else {
+				breaker.SetTimeNow(time.Now)
+			}
+
+			for i := 0; i < tc.iterations; i++ {
+				if err := b.Execute(func() error {
+					if tc.ferrors[i] == shouldNotBeCalledErr {
+						t.Fatal(tc.ferrors[i])
+					}
+
+					return tc.ferrors[i]
+				}); err != tc.expectedErrs[i] {
 					t.Fatalf("expected err: %s, got: %s, iteration %v", tc.expectedErrs[i], err, i)
 				}
 			}
 		})
 	}
+}
+
+type timeMock struct {
+	times []time.Time
+	curr  int
+}
+
+func (t *timeMock) next() time.Time {
+	defer func() { t.curr++ }()
+	return t.times[t.curr]
 }

--- a/pkg/p2p/libp2p/internal/breaker/breaker_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package breaker_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/breaker"
+)
+
+var (
+	testErr              = errors.New("test error")
+	shouldNotBeCalledErr = errors.New("should not be called")
+)
+
+func TestExecute(t *testing.T) {
+	testCases := map[string]struct {
+		limit        int
+		ferrors      []error
+		iterations   int
+		timeOffsets  []time.Duration
+		expectedErrs []error
+	}{
+		"f() returns nil": {
+			limit:        5,
+			iterations:   1,
+			ferrors:      []error{nil},
+			timeOffsets:  nil,
+			expectedErrs: []error{nil},
+		},
+		"f() returns error": {
+			limit:        5,
+			ferrors:      []error{testErr},
+			iterations:   1,
+			timeOffsets:  nil,
+			expectedErrs: []error{testErr},
+		},
+		"Break error - zero limit": {
+			limit:        0,
+			ferrors:      []error{shouldNotBeCalledErr},
+			iterations:   3,
+			timeOffsets:  nil,
+			expectedErrs: []error{breaker.ErrClosed, breaker.ErrClosed, breaker.ErrClosed},
+		},
+		"Break error - multiple iterations": {
+			limit:        3,
+			ferrors:      []error{testErr, testErr, testErr, shouldNotBeCalledErr, shouldNotBeCalledErr},
+			iterations:   5,
+			timeOffsets:  nil,
+			expectedErrs: []error{testErr, testErr, testErr, breaker.ErrClosed, breaker.ErrClosed},
+		},
+		"Expiration - return f() error": {
+			limit:        3,
+			ferrors:      []error{testErr, testErr, testErr, testErr, testErr},
+			iterations:   5,
+			timeOffsets:  []time.Duration{time.Second, time.Second, 2 * breaker.GetFailInterval(), time.Second, time.Second},
+			expectedErrs: []error{testErr, testErr, testErr, testErr, testErr},
+		},
+		"Backoff - close, reopen": {
+			limit:        3,
+			ferrors:      []error{testErr, testErr, testErr, shouldNotBeCalledErr, shouldNotBeCalledErr, testErr, testErr},
+			iterations:   7,
+			timeOffsets:  []time.Duration{time.Second, time.Second, time.Second, time.Second, time.Second, 2 * breaker.GetBackoffLimit(), time.Second},
+			expectedErrs: []error{testErr, testErr, testErr, breaker.ErrClosed, breaker.ErrClosed, testErr, testErr},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b := breaker.NewBreaker(tc.limit)
+			for i := 0; i < tc.iterations; i++ {
+				if tc.timeOffsets != nil {
+					breaker.SetTimeNow(func() time.Time {
+						return time.Now().Add(tc.timeOffsets[i])
+					})
+				} else {
+					breaker.SetTimeNow(time.Now)
+				}
+
+				if err := b.Execute(func() error { return tc.ferrors[i] }); err != tc.expectedErrs[i] {
+					t.Fatalf("expected err: %s, got: %s, iteration %v", tc.expectedErrs[i], err, i)
+				}
+			}
+		})
+	}
+}

--- a/pkg/p2p/libp2p/internal/breaker/breaker_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker_test.go
@@ -12,15 +12,13 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/breaker"
 )
 
-var (
-	testErr              = errors.New("test error")
-	shouldNotBeCalledErr = errors.New("should not be called")
-)
-
 func TestExecute(t *testing.T) {
+	testErr := errors.New("test error")
+	shouldNotBeCalledErr := errors.New("should not be called")
 	failInterval := 10 * time.Minute
 	startBackoff := 1 * time.Minute
 	initTime := time.Now()
+
 	testCases := map[string]struct {
 		limit        int
 		ferrors      []error

--- a/pkg/p2p/libp2p/internal/breaker/export_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/export_test.go
@@ -1,0 +1,23 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package breaker
+
+import "time"
+
+func SetTimeNow(f func() time.Time) {
+	timeNow = f
+}
+
+func GetInitialBackoff() time.Duration {
+	return initialBackoff
+}
+
+func GetBackoffLimit() time.Duration {
+	return backoffLimit
+}
+
+func GetFailInterval() time.Duration {
+	return failInterval
+}

--- a/pkg/p2p/libp2p/internal/breaker/export_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/export_test.go
@@ -10,10 +10,6 @@ func SetTimeNow(f func() time.Time) {
 	timeNow = f
 }
 
-func GetInitialBackoff() time.Duration {
-	return initialBackoff
-}
-
 func GetBackoffLimit() time.Duration {
 	return backoffLimit
 }

--- a/pkg/p2p/libp2p/internal/breaker/export_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/export_test.go
@@ -9,11 +9,3 @@ import "time"
 func SetTimeNow(f func() time.Time) {
 	timeNow = f
 }
-
-func GetBackoffLimit() time.Duration {
-	return backoffLimit
-}
-
-func GetFailInterval() time.Duration {
-	return failInterval
-}


### PR DESCRIPTION
Please check linked issue for spec. 
This is a "basic" implementation of connection breaker with exponential back-off. Basically, it is tracking down consequent failed calls in a provided time interval. When the limit is reached, the breaker closes for some time in exponential back-off manner. 
The current implementation treats all errors in the same way. We can add specific error matching, if needed, in the future.
The implementation is very opinionated and I am aware that  it can be done in many different ways, so feel free to LMNWYT :)

TODO: 
1. I have added only dummy usage to `libp2p` as I would like to test it and add some `libp2p` tests in another PR 
2. Use `Breaker` in connectivity driver as well, also in another PR

