### PR TITLE
[bee #47, #56]: kademlia phase 0+1

### DIFF
--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -9,5 +9,4 @@ type (
 	PeerConnectResponse = peerConnectResponse
 	PeersResponse       = peersResponse
 	AddressesResponse   = addressesResponse
-	TopologyResponse    = topologyResponse
 )

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -9,4 +9,5 @@ type (
 	PeerConnectResponse = peerConnectResponse
 	PeersResponse       = peersResponse
 	AddressesResponse   = addressesResponse
+	TopologyResponse    = topologyResponse
 )

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -64,6 +64,9 @@ func (s *server) setupRouting() {
 	router.Handle("/chunks-pin", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.listPinnedChunks),
 	})
+	router.Handle("/topology", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.topologyJsonHandler),
+	})
 
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -65,7 +65,7 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.listPinnedChunks),
 	})
 	router.Handle("/topology", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.topologyJsonHandler),
+		"GET": http.HandlerFunc(s.topologyHandler),
 	})
 
 	baseRouter.Handle("/", web.ChainHandlers(

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -16,7 +16,7 @@ import (
 func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 	ms, ok := s.TopologyDriver.(json.Marshaler)
 	if !ok {
-		s.Logger.Error("topology driver cast to json marshaler error")
+		s.Logger.Error("topology driver cast to json marshaler")
 		jsonhttp.InternalServerError(w, "topology json marshal interface error")
 		return
 	}

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+)
+
+type topologyResponse struct {
+	Topology string `json:"topology"`
+}
+
+func (s *server) topologyJsonHandler(w http.ResponseWriter, r *http.Request) {
+	ms, ok := s.TopologyDriver.(json.Marshaler)
+	if !ok {
+		jsonhttp.InternalServerError(w, "topology json marshal interface error")
+		return
+	}
+
+	bytes, err := ms.MarshalJSON()
+	if err != nil {
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+	jsonhttp.OK(w, topologyResponse{Topology: string(bytes)})
+}

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -5,15 +5,13 @@
 package debugapi
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
-
-type topologyResponse struct {
-	Topology string `json:"topology"`
-}
 
 func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 	ms, ok := s.TopologyDriver.(json.Marshaler)
@@ -23,11 +21,11 @@ func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bytes, err := ms.MarshalJSON()
+	b, err := ms.MarshalJSON()
 	if err != nil {
 		s.Logger.Errorf("topology marshal to json: %v", err)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
-	jsonhttp.OK(w, topologyResponse{Topology: string(bytes)})
+	_, _ = io.Copy(w, bytes.NewBuffer(b))
 }

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -15,15 +15,17 @@ type topologyResponse struct {
 	Topology string `json:"topology"`
 }
 
-func (s *server) topologyJsonHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 	ms, ok := s.TopologyDriver.(json.Marshaler)
 	if !ok {
+		s.Logger.Error("topology driver cast to json marshaler error")
 		jsonhttp.InternalServerError(w, "topology json marshal interface error")
 		return
 	}
 
 	bytes, err := ms.MarshalJSON()
 	if err != nil {
+		s.Logger.Errorf("topology marshal to json: %v", err)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -5,26 +5,30 @@
 package debugapi_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	topmock "github.com/ethersphere/bee/pkg/topology/mock"
 )
 
+type topologyResponse struct {
+	Topology string `json:"topology"`
+}
+
 func TestTopologyOK(t *testing.T) {
 	marshalFunc := func() ([]byte, error) {
-		return []byte("abcd"), nil
+		return json.Marshal(topologyResponse{Topology: "abcd"})
 	}
 	testServer := newTestServer(t, testServerOptions{
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
 	defer testServer.Cleanup()
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, debugapi.TopologyResponse{
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, topologyResponse{
 		Topology: "abcd",
 	})
 }

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -26,7 +26,6 @@ func TestTopologyOK(t *testing.T) {
 	testServer := newTestServer(t, testServerOptions{
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
-	defer testServer.Cleanup()
 
 	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, topologyResponse{
 		Topology: "abcd",
@@ -40,7 +39,6 @@ func TestTopologyError(t *testing.T) {
 	testServer := newTestServer(t, testServerOptions{
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
-	defer testServer.Cleanup()
 
 	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
 		Message: "error",

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	topmock "github.com/ethersphere/bee/pkg/topology/mock"
+)
+
+func TestTopologyOK(t *testing.T) {
+	marshalFunc := func() ([]byte, error) {
+		return []byte("abcd"), nil
+	}
+	testServer := newTestServer(t, testServerOptions{
+		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
+	})
+	defer testServer.Cleanup()
+
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, debugapi.TopologyResponse{
+		Topology: "abcd",
+	})
+}
+
+func TestTopologyError(t *testing.T) {
+	marshalFunc := func() ([]byte, error) {
+		return nil, errors.New("error")
+	}
+	testServer := newTestServer(t, testServerOptions{
+		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
+	})
+	defer testServer.Cleanup()
+
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+		Message: "error",
+		Code:    http.StatusInternalServerError,
+	})
+}

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -29,7 +29,6 @@ func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address,
 		d.records[addressee.String()] = append(d.records[addressee.String()], peer)
 		d.mtx.Unlock()
 	}
-
 	d.mtx.Lock()
 	d.ctr++
 	d.mtx.Unlock()
@@ -47,4 +46,11 @@ func (d *Discovery) AddresseeRecords(addressee swarm.Address) (peers []swarm.Add
 	defer d.mtx.Unlock()
 	peers, exists = d.records[addressee.String()]
 	return
+}
+
+func (d *Discovery) Reset() {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	d.ctr = 0
+	d.records = make(map[string][]swarm.Address)
 }

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -9,7 +9,7 @@ in a way that a kademlia connectivity is actively maintained by the node.
 A thorough explanation of the logic in the `manage()` forever loop:
 The `manageC` channel gets triggered every time there's a change in the information regarding peers we know about.
 This can be a result of: (1) A peer has disconnected from us (2) A peer has been added to the list of known peers (from
-discovery, debugapi, bootnode flag or just because she was persisted in the address book and the node has been restarted).
+discovery, debugapi, bootnode flag or just because it was persisted in the address book and the node has been restarted).
 
 So the information has been changed, and potentially upon disconnection, the depth can travel to a shallower depth in result.
 If a peer gets added through AddPeer, this does not necessarily infer an immediate depth change, since the peer might end up in the backlog for a long time until we actually need to connect to her.
@@ -23,7 +23,7 @@ which is deeper. So this becomes our strategy and we operate with this in mind, 
 connections to peers for whatever reason can only result in increasing depth.
 
 Empty intermediate bins should be eliminated by the `binSaturated` method indicating a bin size too short, which in turn means that connections should be established within this bin.
-Empty bins have special status in terms of depth calculation and as mentioned before they are prioritized over deeper, non empty bins and they constitute as the node's depth when the latter is recalculated. For the rational behind this please refer to the appropriate chapters in the book of Swarm.
+Empty bins have special status in terms of depth calculation and as mentioned before they are prioritized over deeper, non empty bins and they constitute as the node's depth when the latter is recalculated. For the rationale behind this please refer to the appropriate chapters in the book of Swarm.
 
 A special case of the `manage()` functionality is that when we iterate over peers and we come across a peer that has PO >= depth, we would always like to connect to that peer. This should always be enforced within the bounds of the `binSaturated` function and guarantees an ever increasing kademlia depth
 in an ever-increasing size of Swarm, resulting in smaller areas of responsibility for the nodes, maintaining a general upper bound of the assigned nominal area of responsibility in terms of actual storage requirement. See book of Swarm for more details.

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -1,0 +1,145 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package kademlia provides an implementation of the topology.Driver interface
+in a way that a kademlia connectivity is actively maintained by the node.
+
+A thorough explanation of the logic in the `manage()` forever loop:
+The `manageC` channel gets triggered every time there's a change in the information regarding peers we know about.
+This can be a result of: (1) A peer has disconnected from us (2) A peer has been added to the list of known peers (from
+discovery, debugapi, bootnode flag or just because she was persisted in the address book and the node has been restarted).
+
+So the information has been changed, and potentially upon disconnection, the depth can travel to a shallower depth in result.
+If a peer gets added through AddPeer, this does not necessarily infer an immediate depth change, since the peer might end up in the backlog for a long time until we actually need to connect to her.
+
+The `manage()` forever-loop will connect to peers in order from shallower to deeper depths. This is because of depth calculation method that prioritizes empty bins
+That are shallower than depth. An in-depth look at `recalcDepth()` method will clarify this (more below).
+So if we will connect to peers from deeper to shallower depths, all peers in all bins will qualify as peers we'd like to connect to (see `binSaturated` method), ending up connecting to everyone we know about.
+
+Another important notion one must observe while inspecting how `manage()` works, is that when we connect to peers depth can only move in one direction,
+which is deeper. So this becomes our strategy and we operate with this in mind, this is also why we iterate from shallower to deeper - since additional
+connections to peers for whatever reason can only result in increasing depth.
+
+Empty intermediate bins should be eliminated by the `binSaturated` method indicating a bin size too short, which in turn means that connections should be established within this bin.
+Empty bins have special status in terms of depth calculation and as mentioned before they are prioritized over deeper, non empty bins and they constitute as the node's depth when the latter is recalculated. For the rational behind this please refer to the appropriate chapters in the book of Swarm.
+
+A special case of the `manage()` functionality is that when we iterate over peers and we come across a peer that has PO >= depth, we would always like to connect to that peer. This should always be enforced within the bounds of the `binSaturated` function and guarantees an ever increasing kademlia depth
+in an ever-increasing size of Swarm, resulting in smaller areas of responsibility for the nodes, maintaining a general upper bound of the assigned nominal area of responsibility in terms of actual storage requirement. See book of Swarm for more details.
+
+Worth to note is that `manage()` will always try to initiate connections when a bin is not saturated, however currently it will not try to eliminate connections on bins which might be over-saturated.
+Ideally it should be very cheap to maintain a connection to a peer in a bin, so we should theoretically not aspire to eliminate connections prematurely.
+It is also safe to assume we will always have more than the lower bound of peers in a bin, why?
+(1) Initially, we will always try to satisfy our own connectivity requirement to saturate the bin
+(2) Later on, other peers will get notified about our advertised address and will try to connect to us in order to satisfy their own connectivity thresholds
+
+We should allow other nodes to dial in, in order to help them maintain a healthy topolgy. It could be, however, that we would need to mark-and-sweep certain connections once a theorical upper bound has been reached.
+
+Depth calculation explained:
+When we calculate depth we must keep in mind the following constraints:
+(1) A nearest-neighborhood constitutes of an arbitrary lower bound of the closest peers we know about, this is defined in `nnLowWatermark` and is currently set to `2`
+(2) Empty bins which are shallower than depth constitute as the node's area of responsibility
+
+As of such, we would calculate depth in the following manner:
+(1) Iterate over all peers we know about, from deepest (closest) to shallowest, and count until we reach `nnLowWatermark`
+(2) Once we reach `nnLowWatermark`, mark current bin as depth candidate
+(3) Iterate over all bins from shallowest to deepest, and look for the shallowest empty bin
+(4) If the shallowest empty bin is shallower than the depth candidate - select shallowest bin as depth, otherwise select the candidate
+
+Note: when we are connected to less or equal to `nnLowWatermark` peers, the depth will always be considered `0`, thus a short-circuit is handling this edge case explicitly in the `recalcDepth` method
+
+A few examples to depth calculation:
+
+1. empty kademlia
+bin | nodes
+-------------
+==DEPTH==
+0			0
+1			0
+2			0
+3			0
+4			0
+depth: 0
+
+
+2. less or equal to two peers (nnLowWatermark=2) (a)
+bin | nodes
+-------------
+==DEPTH==
+0			1
+1			1
+2			0
+3			0
+4			0
+depth: 0
+
+3. less or equal to two peers (nnLowWatermark=2) (b)
+bin | nodes
+-------------
+==DEPTH==
+0			1
+1			0
+2			1
+3			0
+4			0
+depth: 0
+
+4. less or equal to two peers (nnLowWatermark=2) (c)
+bin | nodes
+-------------
+==DEPTH==
+0			2
+1			0
+2			0
+3			0
+4			0
+depth: 0
+
+5. empty shallow bin
+bin | nodes
+-------------
+0			1
+==DEPTH==
+1			0
+2			1
+3			1
+4			0
+depth: 1 (depth candidate is 2, but 1 is shallower and empty)
+
+6. no empty shallower bin, depth after nnLowerWatermark found
+bin | nodes
+-------------
+0			1
+1			1
+==DEPTH==
+2			1
+3			1
+4			0
+depth: 2 (depth candidate is 2, shallowest empty bin is 4)
+
+7. last bin size >= nnLowWatermark
+bin | nodes
+-------------
+0			1
+1			1
+2			1
+==DEPTH==
+3			3
+4			0
+depth: 2 (depth candidate is 3, shallowest empty bin is 4)
+
+8. all bins full
+bin | nodes
+-------------
+0			1
+1			1
+2			1
+3			3
+==DEPTH==
+4			2
+depth: 4 (depth candidate is 2, no empty bins)
+
+
+*/
+package kademlia

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -7,38 +7,63 @@ Package kademlia provides an implementation of the topology.Driver interface
 in a way that a kademlia connectivity is actively maintained by the node.
 
 A thorough explanation of the logic in the `manage()` forever loop:
-The `manageC` channel gets triggered every time there's a change in the information regarding peers we know about.
-This can be a result of: (1) A peer has disconnected from us (2) A peer has been added to the list of known peers (from
-discovery, debugapi, bootnode flag or just because it was persisted in the address book and the node has been restarted).
+The `manageC` channel gets triggered every time there's a change in the
+information regarding peers we know about. This can be a result of: (1) A peer
+has disconnected from us (2) A peer has been added to the list of
+known peers (from discovery, debugapi, bootnode flag or just because it
+was persisted in the address book and the node has been restarted).
 
-So the information has been changed, and potentially upon disconnection, the depth can travel to a shallower depth in result.
-If a peer gets added through AddPeer, this does not necessarily infer an immediate depth change, since the peer might end up in the backlog for a long time until we actually need to connect to her.
+So the information has been changed, and potentially upon disconnection,
+the depth can travel to a shallower depth in result.
+If a peer gets added through AddPeer, this does not necessarily infer
+an immediate depth change, since the peer might end up in the backlog for
+a long time until we actually need to connect to her.
 
-The `manage()` forever-loop will connect to peers in order from shallower to deeper depths. This is because of depth calculation method that prioritizes empty bins
-That are shallower than depth. An in-depth look at `recalcDepth()` method will clarify this (more below).
-So if we will connect to peers from deeper to shallower depths, all peers in all bins will qualify as peers we'd like to connect to (see `binSaturated` method), ending up connecting to everyone we know about.
+The `manage()` forever-loop will connect to peers in order from shallower
+to deeper depths. This is because of depth calculation method that prioritizes empty bins
+That are shallower than depth. An in-depth look at `recalcDepth()` method
+will clarify this (more below). So if we will connect to peers from deeper
+to shallower depths, all peers in all bins will qualify as peers we'd like
+to connect to (see `binSaturated` method), ending up connecting to everyone we know about.
 
-Another important notion one must observe while inspecting how `manage()` works, is that when we connect to peers depth can only move in one direction,
-which is deeper. So this becomes our strategy and we operate with this in mind, this is also why we iterate from shallower to deeper - since additional
+Another important notion one must observe while inspecting how `manage()`
+works, is that when we connect to peers depth can only move in one direction,
+which is deeper. So this becomes our strategy and we operate with this in mind,
+this is also why we iterate from shallower to deeper - since additional
 connections to peers for whatever reason can only result in increasing depth.
 
-Empty intermediate bins should be eliminated by the `binSaturated` method indicating a bin size too short, which in turn means that connections should be established within this bin.
-Empty bins have special status in terms of depth calculation and as mentioned before they are prioritized over deeper, non empty bins and they constitute as the node's depth when the latter is recalculated. For the rationale behind this please refer to the appropriate chapters in the book of Swarm.
+Empty intermediate bins should be eliminated by the `binSaturated` method indicating
+a bin size too short, which in turn means that connections should be established
+within this bin. Empty bins have special status in terms of depth calculation
+and as mentioned before they are prioritized over deeper, non empty bins and
+they constitute as the node's depth when the latter is recalculated.
+For the rationale behind this please refer to the appropriate chapters in the book of Swarm.
 
-A special case of the `manage()` functionality is that when we iterate over peers and we come across a peer that has PO >= depth, we would always like to connect to that peer. This should always be enforced within the bounds of the `binSaturated` function and guarantees an ever increasing kademlia depth
-in an ever-increasing size of Swarm, resulting in smaller areas of responsibility for the nodes, maintaining a general upper bound of the assigned nominal area of responsibility in terms of actual storage requirement. See book of Swarm for more details.
+A special case of the `manage()` functionality is that when we iterate over
+peers and we come across a peer that has PO >= depth, we would always like
+to connect to that peer. This should always be enforced within the bounds of
+the `binSaturated` function and guarantees an ever increasing kademlia depth
+in an ever-increasing size of Swarm, resulting in smaller areas of responsibility
+for the nodes, maintaining a general upper bound of the assigned nominal
+area of responsibility in terms of actual storage requirement. See book of Swarm for more details.
 
-Worth to note is that `manage()` will always try to initiate connections when a bin is not saturated, however currently it will not try to eliminate connections on bins which might be over-saturated.
-Ideally it should be very cheap to maintain a connection to a peer in a bin, so we should theoretically not aspire to eliminate connections prematurely.
+Worth to note is that `manage()` will always try to initiate connections when
+a bin is not saturated, however currently it will not try to eliminate connections
+on bins which might be over-saturated. Ideally it should be very cheap to maintain a
+connection to a peer in a bin, so we should theoretically not aspire to eliminate connections prematurely.
 It is also safe to assume we will always have more than the lower bound of peers in a bin, why?
 (1) Initially, we will always try to satisfy our own connectivity requirement to saturate the bin
-(2) Later on, other peers will get notified about our advertised address and will try to connect to us in order to satisfy their own connectivity thresholds
+(2) Later on, other peers will get notified about our advertised address and
+will try to connect to us in order to satisfy their own connectivity thresholds
 
-We should allow other nodes to dial in, in order to help them maintain a healthy topolgy. It could be, however, that we would need to mark-and-sweep certain connections once a theorical upper bound has been reached.
+We should allow other nodes to dial in, in order to help them maintain a healthy topolgy.
+It could be, however, that we would need to mark-and-sweep certain connections once a
+theorical upper bound has been reached.
 
 Depth calculation explained:
 When we calculate depth we must keep in mind the following constraints:
-(1) A nearest-neighborhood constitutes of an arbitrary lower bound of the closest peers we know about, this is defined in `nnLowWatermark` and is currently set to `2`
+(1) A nearest-neighborhood constitutes of an arbitrary lower bound of the
+closest peers we know about, this is defined in `nnLowWatermark` and is currently set to `2`
 (2) Empty bins which are shallower than depth constitute as the node's area of responsibility
 
 As of such, we would calculate depth in the following manner:
@@ -47,7 +72,9 @@ As of such, we would calculate depth in the following manner:
 (3) Iterate over all bins from shallowest to deepest, and look for the shallowest empty bin
 (4) If the shallowest empty bin is shallower than the depth candidate - select shallowest bin as depth, otherwise select the candidate
 
-Note: when we are connected to less or equal to `nnLowWatermark` peers, the depth will always be considered `0`, thus a short-circuit is handling this edge case explicitly in the `recalcDepth` method
+Note: when we are connected to less or equal to `nnLowWatermark` peers, the
+depth will always be considered `0`, thus a short-circuit is handling this edge
+case explicitly in the `recalcDepth` method
 
 A few examples to depth calculation:
 

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -74,7 +74,9 @@ As of such, we would calculate depth in the following manner:
 
 Note: when we are connected to less or equal to `nnLowWatermark` peers, the
 depth will always be considered `0`, thus a short-circuit is handling this edge
-case explicitly in the `recalcDepth` method
+case explicitly in the `recalcDepth` method.
+
+TODO: add pseudo-code how to calculate depth.
 
 A few examples to depth calculation:
 
@@ -154,7 +156,7 @@ bin | nodes
 ==DEPTH==
 3			3
 4			0
-depth: 2 (depth candidate is 3, shallowest empty bin is 4)
+depth: 3 (depth candidate is 3, shallowest empty bin is 4)
 
 8. all bins full
 bin | nodes
@@ -165,8 +167,6 @@ bin | nodes
 3			3
 ==DEPTH==
 4			2
-depth: 4 (depth candidate is 2, no empty bins)
-
-
+depth: 4 (depth candidate is 4, no empty bins)
 */
 package kademlia

--- a/pkg/kademlia/export_test.go
+++ b/pkg/kademlia/export_test.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package pslice
+package kademlia
 
-func PSliceBins(p *PSlice) []uint {
-	return p.bins
-}
+var MaxBins = maxBins
+var TimeToRetry = &timeToRetry

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -393,10 +393,10 @@ func (k *Kad) MarshalJSON() ([]byte, error) {
 
 func (k *Kad) marshal(indent bool) ([]byte, error) {
 	type binInfo struct {
-		BinPopulation     uint
-		BinConnected      uint
-		DisconnectedPeers []string
-		ConnectedPeers    []string
+		BinPopulation     uint     `json:"population"`
+		BinConnected      uint     `json:"connected"`
+		DisconnectedPeers []string `json:"disconnectedPeers"`
+		ConnectedPeers    []string `json:"connectedPeers"`
 	}
 
 	type kadBins struct {
@@ -419,13 +419,13 @@ func (k *Kad) marshal(indent bool) ([]byte, error) {
 	}
 
 	type kadParams struct {
-		Base           string    // base address string
-		Population     int       // known
-		Connected      int       // connected count
-		Timestamp      time.Time // now
-		NNLowWatermark int       // low watermark for depth calculation
-		Depth          uint8     // current depth
-		Bins           kadBins   // individual bin info
+		Base           string    `json:"baseAddr"`       // base address string
+		Population     int       `json:"population"`     // known
+		Connected      int       `json:"connected"`      // connected count
+		Timestamp      time.Time `json:"timestamp"`      // now
+		NNLowWatermark int       `json:"nnLowWatermark"` // low watermark for depth calculation
+		Depth          uint8     `json:"depth"`          // current depth
+		Bins           kadBins   `json:"bins"`           // individual bin info
 	}
 
 	var infos []binInfo

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -1,0 +1,405 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kademlia
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/addressbook"
+	"github.com/ethersphere/bee/pkg/discovery"
+	"github.com/ethersphere/bee/pkg/kademlia/pslice"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+const (
+	maxBins        = 16
+	nnLowWatermark = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
+)
+
+var (
+	errMissingAddressBookEntry = errors.New("addressbook underlay entry not found")
+	timeToRetry                = 30 * time.Second
+)
+
+type binSaturationFunc func(bin, depth uint8, peers *pslice.PSlice) bool
+
+// Options for injecting services to Kademlia.
+type Options struct {
+	Base           swarm.Address
+	Discovery      discovery.Driver
+	AddressBook    addressbook.Interface
+	P2P            p2p.Service
+	SaturationFunc binSaturationFunc
+	Logger         logging.Logger
+}
+
+// Kad is the Swarm forwarding kademlia implementation.
+type Kad struct {
+	base           swarm.Address         // this node's overlay address
+	discovery      discovery.Driver      // the discovery driver
+	addressBook    addressbook.Interface // address book to get underlays
+	p2p            p2p.Service           // p2p service to connect to nodes with
+	saturationFunc binSaturationFunc     // pluggable saturation function
+	connectedPeers *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
+	knownPeers     *pslice.PSlice        // both are po aware slice of addresses
+	depth          uint8                 // current neighborhood depth
+	depthMu        sync.RWMutex          // protect depth changes
+	manageC        chan struct{}         // trigger the manage forever loop to connect to new peers
+	waitNext       map[string]time.Time  // sancation connections to a peer, key is overlay string and value is time to next retry
+	waitNextMu     sync.Mutex            // synchronize map
+	logger         logging.Logger        // logger
+	quit           chan struct{}         // quit channel
+	done           chan struct{}         // signal that `manage` has quit
+}
+
+// New returns a new Kademlia.
+func New(o Options) *Kad {
+	if o.SaturationFunc == nil {
+		o.SaturationFunc = binSaturated
+	}
+
+	k := &Kad{
+		base:           o.Base,
+		discovery:      o.Discovery,
+		addressBook:    o.AddressBook,
+		p2p:            o.P2P,
+		saturationFunc: o.SaturationFunc,
+		connectedPeers: pslice.New(maxBins),
+		knownPeers:     pslice.New(maxBins),
+		manageC:        make(chan struct{}, 1),
+		waitNext:       make(map[string]time.Time),
+		logger:         o.Logger,
+		quit:           make(chan struct{}),
+		done:           make(chan struct{}),
+	}
+
+	go k.manage()
+	return k
+}
+
+// manage is a forever loop that manages the connection to new peers
+// once they get added or once others leave.
+func (k *Kad) manage() {
+	var peerToRemove swarm.Address
+	defer close(k.done)
+
+	for {
+		select {
+		case <-k.quit:
+			return
+		case <-k.manageC:
+			err := k.knownPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+				if k.connectedPeers.Exists(peer) {
+					return false, false, nil
+				}
+
+				k.waitNextMu.Lock()
+				if next, ok := k.waitNext[peer.String()]; ok && time.Now().Before(next) {
+					k.waitNextMu.Unlock()
+					return false, false, nil
+				}
+				k.waitNextMu.Unlock()
+
+				currentDepth := k.NeighborhoodDepth()
+				if k.saturationFunc(po, currentDepth, k.connectedPeers) {
+					return false, false, nil
+				}
+
+				ma, err := k.addressBook.Get(peer)
+				if err != nil {
+					// either a peer is not known in the address book, in which case it
+					// should be removed, or that some severe I/O problem is at hand
+
+					if errors.Is(err, storage.ErrNotFound) {
+						k.logger.Errorf("failed to get address book entry for peer: %s", peer.String())
+						peerToRemove = peer
+						return false, false, errMissingAddressBookEntry
+					}
+
+					return false, false, err
+				}
+
+				k.logger.Debugf("kademlia dialing to peer %s", peer.String())
+				_, err = k.p2p.Connect(context.Background(), ma)
+				if err != nil {
+					k.logger.Debugf("error connecting to peer %s: %v", peer, err)
+					k.waitNextMu.Lock()
+					k.waitNext[peer.String()] = time.Now().Add(timeToRetry)
+					k.waitNextMu.Unlock()
+
+					// TODO: somehow keep track of attempts and at some point forget about the peer
+					return false, false, nil // dont stop, continue to next peer
+				}
+
+				k.connectedPeers.Add(peer, po)
+
+				k.waitNextMu.Lock()
+				delete(k.waitNext, peer.String())
+				k.waitNextMu.Unlock()
+
+				k.depthMu.Lock()
+				k.depth = k.recalcDepth()
+				k.depthMu.Unlock()
+
+				k.logger.Debugf("connected to peer: %s old depth: %d new depth: %d", peer, currentDepth, k.NeighborhoodDepth())
+
+				// the bin could be saturated or not, so a decision cannot
+				// be made before checking the next peer, so we iterate to next
+				return false, false, nil
+			})
+
+			if err != nil {
+				if errors.Is(err, errMissingAddressBookEntry) {
+					po := uint8(swarm.Proximity(k.base.Bytes(), peerToRemove.Bytes()))
+					k.knownPeers.Remove(peerToRemove, po)
+				} else {
+					k.logger.Errorf("kademlia manage loop iterator: %v", err)
+				}
+			}
+		}
+	}
+}
+
+// binSaturated indicates whether a certain bin is saturated or not.
+// when a bin is not saturated it means we would like to proactively
+// initiate connections to other peers in the bin.
+func binSaturated(bin, depth uint8, peers *pslice.PSlice) bool {
+	// short circuit for bins which are >= depth
+	if bin >= depth {
+		return false
+	}
+
+	// lets assume for now that the minimum number of peers in a bin
+	// would be 2, under which we would always want to connect to new peers
+	// obviously this should be replaced with a better optimization
+	// the iterator is used here since when we check if a bin is saturated,
+	// the plain number of size of bin might not suffice (for example for squared
+	// gaps measurement)
+
+	size := 0
+	_ = peers.EachBin(func(_ swarm.Address, po uint8) (bool, bool, error) {
+		switch {
+		case po < bin:
+			return true, false, nil
+		case po > bin:
+			return false, true, nil
+		}
+
+		size++
+		return false, false, nil
+	})
+
+	return size >= 2
+}
+
+// recalcDepth returns the kademlia depth. Must be called under lock.
+func (k *Kad) recalcDepth() uint8 {
+	// handle edge case separately
+	if k.connectedPeers.Length() <= nnLowWatermark {
+		return 0
+	}
+	var (
+		peers                        = uint(0)
+		candidate                    = uint8(0)
+		shallowestEmpty, noEmptyBins = k.connectedPeers.ShallowestEmpty()
+	)
+
+	_ = k.connectedPeers.EachBin(func(_ swarm.Address, po uint8) (bool, bool, error) {
+		peers++
+		if peers >= nnLowWatermark {
+			candidate = po
+			return true, false, nil
+		}
+		return false, false, nil
+	})
+
+	if noEmptyBins || shallowestEmpty > candidate {
+		return candidate
+	}
+
+	return shallowestEmpty
+}
+
+// AddPeer adds a peer to the knownPeers list.
+// This does not guarantee that a connection will immediately
+// be made to the peer.
+func (k *Kad) AddPeer(ctx context.Context, addr swarm.Address) error {
+	if k.connectedPeers.Exists(addr) || k.knownPeers.Exists(addr) {
+		return nil
+	}
+
+	po := swarm.Proximity(k.base.Bytes(), addr.Bytes())
+	k.knownPeers.Add(addr, uint8(po))
+
+	select {
+	case k.manageC <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+// Disconnected is called when peer disconnects.
+func (k *Kad) Disconnected(addr swarm.Address) {
+	po := uint8(swarm.Proximity(k.base.Bytes(), addr.Bytes()))
+	k.connectedPeers.Remove(addr, po)
+
+	k.waitNextMu.Lock()
+	k.waitNext[addr.String()] = time.Now().Add(timeToRetry)
+	k.waitNextMu.Unlock()
+
+	k.depthMu.Lock()
+	k.depth = k.recalcDepth()
+	k.depthMu.Unlock()
+	select {
+	case k.manageC <- struct{}{}:
+	default:
+	}
+}
+
+// ClosestPeer returns the closest peer to a given address.
+func (k *Kad) ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// NeighborhoodDepth returns the current Kademlia depth.
+func (k *Kad) NeighborhoodDepth() uint8 {
+	k.depthMu.RLock()
+	defer k.depthMu.RUnlock()
+
+	return k.neighborhoodDepth()
+}
+
+func (k *Kad) neighborhoodDepth() uint8 {
+	return k.depth
+}
+
+// MarshalJSON returns a JSON representation of Kademlia.
+func (k *Kad) MarshalJSON() ([]byte, error) {
+	return k.marshal(false)
+}
+
+func (k *Kad) marshal(indent bool) ([]byte, error) {
+	type binInfo struct {
+		BinPopulation  uint
+		BinConnected   uint
+		KnownPeers     []string
+		ConnectedPeers []string
+	}
+
+	type kadBins struct {
+		Bin0  binInfo `json:"bin_0"`
+		Bin1  binInfo `json:"bin_1"`
+		Bin2  binInfo `json:"bin_2"`
+		Bin3  binInfo `json:"bin_3"`
+		Bin4  binInfo `json:"bin_4"`
+		Bin5  binInfo `json:"bin_5"`
+		Bin6  binInfo `json:"bin_6"`
+		Bin7  binInfo `json:"bin_7"`
+		Bin8  binInfo `json:"bin_8"`
+		Bin9  binInfo `json:"bin_9"`
+		Bin10 binInfo `json:"bin_10"`
+		Bin11 binInfo `json:"bin_11"`
+		Bin12 binInfo `json:"bin_12"`
+		Bin13 binInfo `json:"bin_13"`
+		Bin14 binInfo `json:"bin_14"`
+		Bin15 binInfo `json:"bin_15"`
+	}
+
+	type kadParams struct {
+		Base           string    // base address string
+		Population     int       // known
+		Connected      int       // connected count
+		Timestamp      time.Time // now
+		NNLowWatermark int       // low watermark for depth calculation
+		Depth          uint8     // current depth
+		Bins           kadBins   // individual bin info
+	}
+
+	var infos []binInfo
+	for i := (maxBins - 1); i >= 0; i-- {
+		infos = append(infos, binInfo{})
+	}
+
+	_ = k.connectedPeers.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
+		infos[po].BinConnected++
+		infos[po].ConnectedPeers = append(infos[po].ConnectedPeers, addr.String())
+		return false, false, nil
+	})
+
+	// output (k.knownPeers ¬ k.connectedPeers) here to not repeat the peers we already have in the connected peers list
+	_ = k.knownPeers.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
+		infos[po].BinPopulation++
+
+		for _, v := range infos[po].ConnectedPeers {
+			// peer already connected, don't show in the known peers list
+			if v == addr.String() {
+				return false, false, nil
+			}
+		}
+
+		infos[po].KnownPeers = append(infos[po].KnownPeers, addr.String())
+		return false, false, nil
+	})
+
+	j := &kadParams{
+		Base:           k.base.String(),
+		Population:     k.knownPeers.Length(),
+		Connected:      k.connectedPeers.Length(),
+		Timestamp:      time.Now(),
+		NNLowWatermark: nnLowWatermark,
+		Depth:          k.NeighborhoodDepth(),
+		Bins: kadBins{
+			Bin0:  infos[0],
+			Bin1:  infos[1],
+			Bin2:  infos[2],
+			Bin3:  infos[3],
+			Bin4:  infos[4],
+			Bin5:  infos[5],
+			Bin6:  infos[6],
+			Bin7:  infos[7],
+			Bin8:  infos[8],
+			Bin9:  infos[9],
+			Bin10: infos[10],
+			Bin11: infos[11],
+			Bin12: infos[12],
+			Bin13: infos[13],
+			Bin14: infos[14],
+			Bin15: infos[15],
+		},
+	}
+	if indent {
+		return json.MarshalIndent(j, "", "  ")
+	}
+	return json.Marshal(j)
+}
+
+// String returns a string represenstation of Kademlia.
+func (k *Kad) String() string {
+	b, err := k.marshal(true)
+	if err != nil {
+		k.logger.Errorf("error marshaling kademlia into json: %v", err)
+		return ""
+	}
+	return string(b)
+}
+
+// Close shuts down kademlia.
+func (k *Kad) Close() error {
+	close(k.quit)
+	select {
+	case <-k.done:
+	case <-time.After(3 * time.Second):
+		k.logger.Warning("kademlia manage loop did not shut down properly")
+	}
+	return nil
+}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -54,7 +54,7 @@ type Kad struct {
 	depth          uint8                 // current neighborhood depth
 	depthMu        sync.RWMutex          // protect depth changes
 	manageC        chan struct{}         // trigger the manage forever loop to connect to new peers
-	waitNext       map[string]time.Time  // sancation connections to a peer, key is overlay string and value is time to next retry
+	waitNext       map[string]time.Time  // sanction connections to a peer, key is overlay string and value is time to next retry
 	waitNextMu     sync.Mutex            // synchronize map
 	logger         logging.Logger        // logger
 	quit           chan struct{}         // quit channel

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -156,7 +156,6 @@ func (k *Kad) manage() {
 
 				select {
 				case <-k.quit:
-					// shutting down
 					return true, false, nil
 				default:
 				}
@@ -205,7 +204,7 @@ func binSaturated(bin, depth uint8, peers *pslice.PSlice) bool {
 	return size >= 2
 }
 
-// recalcDepth returns the kademlia depth. Must be called under lock.
+// recalcDepth calculates and returns the kademlia depth.
 func (k *Kad) recalcDepth() uint8 {
 	// handle edge case separately
 	if k.connectedPeers.Length() <= nnLowWatermark {
@@ -258,7 +257,6 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 
 	_ = k.connectedPeers.EachBinRev(func(connectedPeer swarm.Address, _ uint8) (bool, bool, error) {
 		if connectedPeer.Equal(peer) {
-			// skip to next
 			return false, false, nil
 		}
 		addrs = append(addrs, connectedPeer)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -118,7 +118,7 @@ func (k *Kad) manage() {
 				k.waitNextMu.Unlock()
 
 				currentDepth := k.NeighborhoodDepth()
-				if k.saturationFunc(po, currentDepth, k.connectedPeers) {
+				if saturated := k.saturationFunc(po, currentDepth, k.connectedPeers); saturated {
 					return false, true, nil // bin is saturated, skip to next bin
 				}
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -91,6 +91,11 @@ func New(o Options) *Kad {
 func (k *Kad) manage() {
 	var peerToRemove swarm.Address
 	defer close(k.done)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-k.quit
+		cancel()
+	}()
 
 	for {
 		select {
@@ -130,17 +135,7 @@ func (k *Kad) manage() {
 				}
 
 				k.logger.Debugf("kademlia dialing to peer %s", peer.String())
-				okc := make(chan struct{})
-				ctx, cancel := context.WithCancel(context.Background())
-				go func() {
-					select {
-					case <-okc:
-					case <-k.quit:
-						cancel()
-					}
-				}()
 				_, err = k.p2p.Connect(ctx, ma)
-				close(okc)
 				if err != nil {
 					k.logger.Debugf("error connecting to peer %s: %v", peer, err)
 					k.waitNextMu.Lock()

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	errMissingAddressBookEntry = errors.New("addressbook underlay entry not found")
-	timeToRetry                = 30 * time.Second
+	timeToRetry                = 60 * time.Second
 )
 
 type binSaturationFunc func(bin, depth uint8, peers *pslice.PSlice) bool

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -240,9 +240,9 @@ func TestBinSaturation(t *testing.T) {
 	waitConns(t, &conns, 1)
 }
 
-// TestNotifieeHooks tests that the Connected/Disconnected hooks
+// TestNotifierHooks tests that the Connected/Disconnected hooks
 // result in the correct behavior once called.
-func TestNotifieeHooks(t *testing.T) {
+func TestNotifierHooks(t *testing.T) {
 	var (
 		base, kad, ab, _ = newTestKademlia(nil, nil)
 		peer             = test.RandomAddressAt(base, 3)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -1,0 +1,395 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kademlia_test
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/ethersphere/bee/pkg/addressbook"
+	"github.com/ethersphere/bee/pkg/kademlia"
+	"github.com/ethersphere/bee/pkg/kademlia/pslice"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
+	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
+	mockstate "github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology/test"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// TestNeighborhoodDepth tests that the kademlia depth changes correctly
+// according to the change to known peers slice. This inadvertently tests
+// the functionality in `manage()` method, however this is not the main aim of the
+// test, since depth calculation happens there and in the disconnect method.
+// A more in depth testing of the functionality in `manage()` is explicitly
+// tested in TestManage below.
+func TestNeighborhoodDepth(t *testing.T) {
+	var (
+		conns int32 // how many connect calls were made to the p2p mock
+
+		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			_ = atomic.AddInt32(&conns, 1)
+			return swarm.ZeroAddress, nil
+		}))
+
+		base, kad, ab = newTestKademlia(p2p, nil)
+		peers         []swarm.Address
+		binEight      []swarm.Address
+	)
+
+	defer kad.Close()
+
+	for i := 0; i < 8; i++ {
+		addr := test.RandomAddressAt(base, i)
+		peers = append(peers, addr)
+	}
+
+	for i := 0; i < 2; i++ {
+		addr := test.RandomAddressAt(base, 8)
+		binEight = append(binEight, addr)
+	}
+
+	// check empty kademlia depth is 0
+	kDepth(t, kad, 0)
+
+	// add two bin 8 peers, verify depth still 0
+	add(t, kad, ab, binEight, 0, 2)
+	kDepth(t, kad, 0)
+
+	// add two first peers (po0,po1)
+	add(t, kad, ab, peers, 0, 2)
+
+	// wait for 4 connections
+	waitConns(t, &conns, 4)
+
+	// depth 2 (shallowest empty bin)
+	kDepth(t, kad, 2)
+
+	// reset the counter
+	atomic.StoreInt32(&conns, 0)
+
+	for i := 2; i < len(peers)-1; i++ {
+		addOne(t, kad, ab, peers[i])
+
+		// wait for one connection
+		waitConn(t, &conns)
+
+		// depth is i+1
+		kDepth(t, kad, i+1)
+
+		// reset
+		atomic.StoreInt32(&conns, 0)
+	}
+
+	// the last peer in bin 7 which is empty we insert manually,
+	addOne(t, kad, ab, peers[len(peers)-1])
+	waitConn(t, &conns)
+
+	// depth is 8 because we have nnLowWatermark neighbors in bin 8
+	kDepth(t, kad, 8)
+
+	atomic.StoreInt32(&conns, 0)
+
+	// now add another ONE peer at depth+1, and expect the depth to still
+	// stay 8, because the counter for nnLowWatermark would be reached only at the next
+	// depth iteration when calculating depth
+	addr := test.RandomAddressAt(base, 9)
+	addOne(t, kad, ab, addr)
+	waitConn(t, &conns)
+	kDepth(t, kad, 8)
+
+	atomic.StoreInt32(&conns, 0)
+
+	// fill the rest up to the bin before last and check that everything works at the edges
+	for i := 10; i < kademlia.MaxBins-1; i++ {
+		addr := test.RandomAddressAt(base, i)
+		addOne(t, kad, ab, addr)
+		waitConn(t, &conns)
+		kDepth(t, kad, i-1)
+		atomic.StoreInt32(&conns, 0)
+	}
+
+	// add a whole bunch of peers in bin 13, expect depth to stay at 13
+	for i := 0; i < 15; i++ {
+		addr = test.RandomAddressAt(base, 13)
+		addOne(t, kad, ab, addr)
+	}
+
+	waitConns(t, &conns, 15)
+	atomic.StoreInt32(&conns, 0)
+	kDepth(t, kad, 13)
+
+	// add one at 14 - depth should be now 14
+	addr = test.RandomAddressAt(base, 14)
+	addOne(t, kad, ab, addr)
+	kDepth(t, kad, 14)
+
+	addr2 := test.RandomAddressAt(base, 15)
+	addOne(t, kad, ab, addr2)
+	kDepth(t, kad, 14)
+
+	addr3 := test.RandomAddressAt(base, 15)
+	addOne(t, kad, ab, addr3)
+	kDepth(t, kad, 15)
+
+	// now remove that peer and check that the depth is back at 14
+	removeOne(kad, addr3)
+	kDepth(t, kad, 14)
+
+	// remove the peer at bin 1, depth should be 1
+	removeOne(kad, peers[1])
+	kDepth(t, kad, 1)
+}
+
+// TestManage explicitly tests that new connections are made according to
+// the addition or subtraction of peers to the knownPeers and connectedPeers
+// data structures. It tests that kademlia will try to initiate (emphesis on _initiate_,
+// since right now this test does not test for a mark-and-sweep behaviour of kademlia
+// that will prune or disconnect old or less performent nodes when a certain condition
+// in a bin has been met - these are future optimizations that still need be sketched out)
+// connections when a certain bin is _not_ saturated, and that kademlia does _not_ try
+// to initiate connections on a saturated bin.
+// Saturation from the local node's perspective means whether a bin has enough connections
+// on a given bin.
+// What Saturation does _not_ mean: that all nodes are performent, that all nodes we know of
+// in a given bin are connected (since some of them might be offline)
+func TestManage(t *testing.T) {
+	var (
+		conns int32 // how many connect calls were made to the p2p mock
+
+		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			_ = atomic.AddInt32(&conns, 1)
+			return swarm.ZeroAddress, nil
+		}))
+
+		saturationVal  = false
+		saturationFunc = func(bin, depth uint8, peers *pslice.PSlice) bool {
+			return saturationVal
+		}
+		base, kad, ab = newTestKademlia(p2p, saturationFunc)
+	)
+	// first, saturationFunc returns always false, this means that the bin is not saturated,
+	// hence we expect that every peer we add to kademlia will be connected to
+	for i := 0; i < 50; i++ {
+		addr := test.RandomAddressAt(base, 0)
+		addOne(t, kad, ab, addr)
+	}
+
+	waitConns(t, &conns, 50)
+	atomic.StoreInt32(&conns, 0)
+	saturationVal = true
+
+	// now since the bin is "saturated", no new connections should be made
+	for i := 0; i < 50; i++ {
+		addr := test.RandomAddressAt(base, 0)
+		addOne(t, kad, ab, addr)
+	}
+
+	waitConns(t, &conns, 0)
+
+	// check other bins just for fun
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 10; j++ {
+			addr := test.RandomAddressAt(base, i)
+			addOne(t, kad, ab, addr)
+		}
+	}
+	waitConns(t, &conns, 0)
+}
+
+// TestBinSaturation tests the builtin binSaturated function.
+// the test must have two phases of adding peers so that the section
+// beyond the first flow control statement gets hit (if po >= depth),
+// meaning, on the first iteration we add peer and this condition will always
+// be true since depth is increasingly moving deeper, but then we add more peers
+// in shallower depth for the rest of the function to be executed
+func TestBinSaturation(t *testing.T) {
+	var (
+		conns int32 // how many connect calls were made to the p2p mock
+
+		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			_ = atomic.AddInt32(&conns, 1)
+			return swarm.ZeroAddress, nil
+		}))
+		base, kad, ab = newTestKademlia(p2p, nil)
+
+		peers []swarm.Address
+	)
+
+	// add two peers in a few bins to generate some depth >= 0, this will
+	// make the next iteration result in binSaturated==true, causing no new
+	// connections to be made
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 2; j++ {
+			addr := test.RandomAddressAt(base, i)
+			addOne(t, kad, ab, addr)
+			peers = append(peers, addr)
+		}
+	}
+	waitConns(t, &conns, 10)
+	atomic.StoreInt32(&conns, 0)
+
+	// add one more peer in each bin shallower than depth and
+	// expect no connections due to saturation. if we add a peer within
+	// depth, the short circuit will be hit and we will connect to the peer
+	for i := 0; i < 4; i++ {
+		addr := test.RandomAddressAt(base, i)
+		addOne(t, kad, ab, addr)
+	}
+	waitConns(t, &conns, 0)
+
+	// add one peer in a bin higher (unsaturated) and expect one connection
+	addr := test.RandomAddressAt(base, 6)
+	addOne(t, kad, ab, addr)
+
+	waitConns(t, &conns, 1)
+	atomic.StoreInt32(&conns, 0)
+
+	// again, one bin higher
+	addr = test.RandomAddressAt(base, 7)
+	addOne(t, kad, ab, addr)
+
+	waitConns(t, &conns, 1)
+	atomic.StoreInt32(&conns, 0)
+
+	// this is in order to hit the `if size < 2` in the saturation func
+	removeOne(kad, peers[2])
+	waitConns(t, &conns, 1)
+}
+
+func TestBackoff(t *testing.T) {
+	// cheat and decrease the timer
+	defer func(t time.Duration) {
+		*kademlia.TimeToRetry = t
+	}(*kademlia.TimeToRetry)
+
+	*kademlia.TimeToRetry = 500 * time.Millisecond
+
+	var (
+		conns int32 // how many connect calls were made to the p2p mock
+
+		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			_ = atomic.AddInt32(&conns, 1)
+			return swarm.ZeroAddress, nil
+		}))
+		base, kad, ab = newTestKademlia(p2p, nil)
+	)
+
+	// add one peer, wait for connection
+	addr := test.RandomAddressAt(base, 1)
+	addOne(t, kad, ab, addr)
+
+	waitConns(t, &conns, 1)
+	atomic.StoreInt32(&conns, 0)
+
+	// remove that peer
+	removeOne(kad, addr)
+
+	// wait for 100ms, add another peer, expect just one more connection
+	time.Sleep(100 * time.Millisecond)
+	addr = test.RandomAddressAt(base, 1)
+	addOne(t, kad, ab, addr)
+
+	waitConns(t, &conns, 1)
+	atomic.StoreInt32(&conns, 0)
+
+	// wait for another 400ms, add another, expect 2 connections
+	time.Sleep(400 * time.Millisecond)
+	addr = test.RandomAddressAt(base, 1)
+	addOne(t, kad, ab, addr)
+
+	waitConns(t, &conns, 2)
+}
+
+func TestMarshal(t *testing.T) {
+	var (
+		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+			return swarm.ZeroAddress, nil
+		}))
+		_, kad, ab = newTestKademlia(p2p, nil)
+	)
+	a := test.RandomAddress()
+	addOne(t, kad, ab, a)
+	_, err := kad.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestKademlia(p2p p2p.Service, f func(bin, depth uint8, peers *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface) {
+	var (
+		base   = test.RandomAddress()                                                                                     // base address
+		logger = logging.New(ioutil.Discard, 0)                                                                           // logger
+		ab     = addressbook.New(mockstate.NewStateStore())                                                               // address book
+		kad    = kademlia.New(kademlia.Options{Base: base, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
+	)
+	return base, kad, ab
+}
+
+func removeOne(k *kademlia.Kad, peer swarm.Address) {
+	k.Disconnected(peer)
+}
+
+const underlayBase = "/ip4/127.0.0.1/tcp/7070/dns/"
+
+func addOne(t *testing.T, k *kademlia.Kad, ab addressbook.Putter, peer swarm.Address) {
+	t.Helper()
+	multiaddr, err := ma.NewMultiaddr(underlayBase + peer.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ab.Put(peer, multiaddr); err != nil {
+		t.Fatal(err)
+	}
+	_ = k.AddPeer(context.Background(), peer)
+}
+
+func add(t *testing.T, k *kademlia.Kad, ab addressbook.Putter, peers []swarm.Address, offset, number int) {
+	t.Helper()
+	for i := offset; i < offset+number; i++ {
+		addOne(t, k, ab, peers[i])
+	}
+}
+
+func kDepth(t *testing.T, k *kademlia.Kad, d int) {
+	t.Helper()
+	var depth int
+	for i := 0; i < 50; i++ {
+		depth = int(k.NeighborhoodDepth())
+		if depth == d {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for depth. want %d got %d", d, depth)
+}
+
+func waitConn(t *testing.T, conns *int32) {
+	t.Helper()
+	waitConns(t, conns, 1)
+}
+
+func waitConns(t *testing.T, conns *int32, exp int32) {
+	t.Helper()
+	var got int32
+	for i := 0; i < 50; i++ {
+		got = atomic.LoadInt32(conns)
+		if got == exp {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for connections to be established. got %d want %d", got, exp)
+}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -6,6 +6,7 @@ package kademlia_test
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"math/rand"
 	"sync/atomic"
@@ -15,6 +16,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethersphere/bee/pkg/addressbook"
+	"github.com/ethersphere/bee/pkg/discovery/mock"
 	"github.com/ethersphere/bee/pkg/kademlia"
 	"github.com/ethersphere/bee/pkg/kademlia/pslice"
 	"github.com/ethersphere/bee/pkg/logging"
@@ -22,6 +24,7 @@ import (
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	mockstate "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/topology/test"
 )
 
@@ -39,14 +42,9 @@ func TestNeighborhoodDepth(t *testing.T) {
 	var (
 		conns int32 // how many connect calls were made to the p2p mock
 
-		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
-			_ = atomic.AddInt32(&conns, 1)
-			return swarm.ZeroAddress, nil
-		}))
-
-		base, kad, ab = newTestKademlia(p2p, nil)
-		peers         []swarm.Address
-		binEight      []swarm.Address
+		base, kad, ab, _ = newTestKademlia(&conns, nil)
+		peers            []swarm.Address
+		binEight         []swarm.Address
 	)
 
 	defer kad.Close()
@@ -77,9 +75,6 @@ func TestNeighborhoodDepth(t *testing.T) {
 	// depth 2 (shallowest empty bin)
 	kDepth(t, kad, 2)
 
-	// reset the counter
-	atomic.StoreInt32(&conns, 0)
-
 	for i := 2; i < len(peers)-1; i++ {
 		addOne(t, kad, ab, peers[i])
 
@@ -88,9 +83,6 @@ func TestNeighborhoodDepth(t *testing.T) {
 
 		// depth is i+1
 		kDepth(t, kad, i+1)
-
-		// reset
-		atomic.StoreInt32(&conns, 0)
 	}
 
 	// the last peer in bin 7 which is empty we insert manually,
@@ -100,8 +92,6 @@ func TestNeighborhoodDepth(t *testing.T) {
 	// depth is 8 because we have nnLowWatermark neighbors in bin 8
 	kDepth(t, kad, 8)
 
-	atomic.StoreInt32(&conns, 0)
-
 	// now add another ONE peer at depth+1, and expect the depth to still
 	// stay 8, because the counter for nnLowWatermark would be reached only at the next
 	// depth iteration when calculating depth
@@ -110,15 +100,12 @@ func TestNeighborhoodDepth(t *testing.T) {
 	waitConn(t, &conns)
 	kDepth(t, kad, 8)
 
-	atomic.StoreInt32(&conns, 0)
-
 	// fill the rest up to the bin before last and check that everything works at the edges
 	for i := 10; i < kademlia.MaxBins-1; i++ {
 		addr := test.RandomAddressAt(base, i)
 		addOne(t, kad, ab, addr)
 		waitConn(t, &conns)
 		kDepth(t, kad, i-1)
-		atomic.StoreInt32(&conns, 0)
 	}
 
 	// add a whole bunch of peers in bin 13, expect depth to stay at 13
@@ -128,7 +115,6 @@ func TestNeighborhoodDepth(t *testing.T) {
 	}
 
 	waitConns(t, &conns, 15)
-	atomic.StoreInt32(&conns, 0)
 	kDepth(t, kad, 13)
 
 	// add one at 14 - depth should be now 14
@@ -169,16 +155,11 @@ func TestManage(t *testing.T) {
 	var (
 		conns int32 // how many connect calls were made to the p2p mock
 
-		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
-			_ = atomic.AddInt32(&conns, 1)
-			return swarm.ZeroAddress, nil
-		}))
-
 		saturationVal  = false
 		saturationFunc = func(bin, depth uint8, peers *pslice.PSlice) bool {
 			return saturationVal
 		}
-		base, kad, ab = newTestKademlia(p2p, saturationFunc)
+		base, kad, ab, _ = newTestKademlia(&conns, saturationFunc)
 	)
 	// first, saturationFunc returns always false, this means that the bin is not saturated,
 	// hence we expect that every peer we add to kademlia will be connected to
@@ -188,7 +169,6 @@ func TestManage(t *testing.T) {
 	}
 
 	waitConns(t, &conns, 50)
-	atomic.StoreInt32(&conns, 0)
 	saturationVal = true
 
 	// now since the bin is "saturated", no new connections should be made
@@ -217,15 +197,9 @@ func TestManage(t *testing.T) {
 // in shallower depth for the rest of the function to be executed
 func TestBinSaturation(t *testing.T) {
 	var (
-		conns int32 // how many connect calls were made to the p2p mock
-
-		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
-			_ = atomic.AddInt32(&conns, 1)
-			return swarm.ZeroAddress, nil
-		}))
-		base, kad, ab = newTestKademlia(p2p, nil)
-
-		peers []swarm.Address
+		conns            int32 // how many connect calls were made to the p2p mock
+		base, kad, ab, _ = newTestKademlia(&conns, nil)
+		peers            []swarm.Address
 	)
 
 	// add two peers in a few bins to generate some depth >= 0, this will
@@ -239,7 +213,6 @@ func TestBinSaturation(t *testing.T) {
 		}
 	}
 	waitConns(t, &conns, 10)
-	atomic.StoreInt32(&conns, 0)
 
 	// add one more peer in each bin shallower than depth and
 	// expect no connections due to saturation. if we add a peer within
@@ -255,18 +228,74 @@ func TestBinSaturation(t *testing.T) {
 	addOne(t, kad, ab, addr)
 
 	waitConns(t, &conns, 1)
-	atomic.StoreInt32(&conns, 0)
 
 	// again, one bin higher
 	addr = test.RandomAddressAt(base, 7)
 	addOne(t, kad, ab, addr)
 
 	waitConns(t, &conns, 1)
-	atomic.StoreInt32(&conns, 0)
 
 	// this is in order to hit the `if size < 2` in the saturation func
 	removeOne(kad, peers[2])
 	waitConns(t, &conns, 1)
+}
+
+// TestNotifieeHooks tests that the Connected/Disconnected hooks
+// result in the correct behavior once called.
+func TestNotifieeHooks(t *testing.T) {
+	var (
+		base, kad, ab, _ = newTestKademlia(nil, nil)
+		peer             = test.RandomAddressAt(base, 3)
+		addr             = test.RandomAddressAt(peer, 4) // address which is closer to peer
+	)
+
+	connectOne(t, kad, ab, peer)
+
+	p, err := kad.ClosestPeer(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !p.Equal(peer) {
+		t.Fatal("got wrong peer address")
+	}
+
+	// disconnect the peer, expect error
+	kad.Disconnected(peer)
+	_, err = kad.ClosestPeer(addr)
+	if !errors.Is(err, topology.ErrNotFound) {
+		t.Fatalf("expected topology.ErrNotFound but got %v", err)
+	}
+}
+
+// TestDiscoveryHooks check that a peer is gossiped to other peers
+// once we establish a connection to this peer. This could be as a result of
+// us proactively dialing in to a peer, or when a peer dials in.
+func TestDiscoveryHooks(t *testing.T) {
+	var (
+		conns            int32
+		_, kad, ab, disc = newTestKademlia(&conns, nil)
+		p1, p2, p3       = test.RandomAddress(), test.RandomAddress(), test.RandomAddress()
+	)
+
+	// first add a peer from AddPeer, wait for the connection
+	addOne(t, kad, ab, p1)
+	waitConn(t, &conns)
+	// add another peer from AddPeer, wait for the connection
+	// then check that peers are gossiped to each other via discovery
+	addOne(t, kad, ab, p2)
+	waitConn(t, &conns)
+	waitBcast(t, disc, p1, p2)
+	waitBcast(t, disc, p2, p1)
+
+	disc.Reset()
+
+	// add another peer that dialed in, check that all peers gossiped
+	// correctly to each other
+	connectOne(t, kad, ab, p3)
+	waitBcast(t, disc, p1, p3)
+	waitBcast(t, disc, p2, p3)
+	waitBcast(t, disc, p3, p1, p2)
 }
 
 func TestBackoff(t *testing.T) {
@@ -280,11 +309,7 @@ func TestBackoff(t *testing.T) {
 	var (
 		conns int32 // how many connect calls were made to the p2p mock
 
-		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
-			_ = atomic.AddInt32(&conns, 1)
-			return swarm.ZeroAddress, nil
-		}))
-		base, kad, ab = newTestKademlia(p2p, nil)
+		base, kad, ab, _ = newTestKademlia(&conns, nil)
 	)
 
 	// add one peer, wait for connection
@@ -292,7 +317,6 @@ func TestBackoff(t *testing.T) {
 	addOne(t, kad, ab, addr)
 
 	waitConns(t, &conns, 1)
-	atomic.StoreInt32(&conns, 0)
 
 	// remove that peer
 	removeOne(kad, addr)
@@ -303,7 +327,6 @@ func TestBackoff(t *testing.T) {
 	addOne(t, kad, ab, addr)
 
 	waitConns(t, &conns, 1)
-	atomic.StoreInt32(&conns, 0)
 
 	// wait for another 400ms, add another, expect 2 connections
 	time.Sleep(400 * time.Millisecond)
@@ -313,12 +336,86 @@ func TestBackoff(t *testing.T) {
 	waitConns(t, &conns, 2)
 }
 
+// TestClosestPeer tests that ClosestPeer method returns closest connected peer to a given address.
+func TestClosestPeer(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+	base := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
+	connectedPeers := []p2p.Peer{
+		{
+			Address: swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000"), // binary 1000 -> po 0 to base
+		},
+		{
+			Address: swarm.MustParseHexAddress("4000000000000000000000000000000000000000000000000000000000000000"), // binary 0100 -> po 1 to base
+		},
+		{
+			Address: swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000"), // binary 0110 -> po 1 to base
+		},
+	}
+
+	disc := mock.NewDiscovery()
+	ab := addressbook.New(mockstate.NewStateStore())
+	var conns int32
+
+	kad := kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2pMock(&conns), Logger: logger})
+	defer kad.Close()
+
+	for _, v := range connectedPeers {
+		addOne(t, kad, ab, v.Address)
+	}
+	waitConns(t, &conns, 3)
+
+	for _, tc := range []struct {
+		chunkAddress swarm.Address // chunk address to test
+		expectedPeer int           // points to the index of the connectedPeers slice. -1 means self (baseOverlay)
+	}{
+		{
+			chunkAddress: swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000"), // 0111, wants peer 2
+			expectedPeer: 2,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("c000000000000000000000000000000000000000000000000000000000000000"), // 1100, want peer 0
+			expectedPeer: 0,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("e000000000000000000000000000000000000000000000000000000000000000"), // 1110, want peer 0
+			expectedPeer: 0,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("a000000000000000000000000000000000000000000000000000000000000000"), // 1010, want peer 0
+			expectedPeer: 0,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("4000000000000000000000000000000000000000000000000000000000000000"), // 0100, want peer 1
+			expectedPeer: 1,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000"), // 0101, want peer 1
+			expectedPeer: 1,
+		},
+		{
+			chunkAddress: swarm.MustParseHexAddress("0000001000000000000000000000000000000000000000000000000000000000"), // want self
+			expectedPeer: -1,
+		},
+	} {
+		peer, err := kad.ClosestPeer(tc.chunkAddress)
+		if err != nil {
+			if tc.expectedPeer == -1 && !errors.Is(err, topology.ErrWantSelf) {
+				t.Fatalf("wanted %v but got %v", topology.ErrWantSelf, err)
+			}
+			continue
+		}
+
+		expected := connectedPeers[tc.expectedPeer].Address
+
+		if !peer.Equal(expected) {
+			t.Fatalf("peers not equal. got %s expected %s", peer, expected)
+		}
+	}
+}
+
 func TestMarshal(t *testing.T) {
 	var (
-		p2p = p2pmock.New(p2pmock.WithConnectFunc(func(_ context.Context, addr ma.Multiaddr) (swarm.Address, error) {
-			return swarm.ZeroAddress, nil
-		}))
-		_, kad, ab = newTestKademlia(p2p, nil)
+		_, kad, ab, _ = newTestKademlia(nil, nil)
 	)
 	a := test.RandomAddress()
 	addOne(t, kad, ab, a)
@@ -328,14 +425,27 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func newTestKademlia(p2p p2p.Service, f func(bin, depth uint8, peers *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface) {
+func newTestKademlia(connCounter *int32, f func(bin, depth uint8, peers *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery) {
 	var (
-		base   = test.RandomAddress()                                                                                     // base address
-		logger = logging.New(ioutil.Discard, 0)                                                                           // logger
-		ab     = addressbook.New(mockstate.NewStateStore())                                                               // address book
-		kad    = kademlia.New(kademlia.Options{Base: base, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
+		base   = test.RandomAddress() // base address
+		p2p    = p2pMock(connCounter)
+		logger = logging.New(ioutil.Discard, 0)                                                                                            // logger
+		ab     = addressbook.New(mockstate.NewStateStore())                                                                                // address book
+		disc   = mock.NewDiscovery()                                                                                                       // mock discovery
+		kad    = kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
 	)
-	return base, kad, ab
+	return base, kad, ab, disc
+}
+
+func p2pMock(counter *int32) p2p.Service {
+	p2ps := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (swarm.Address, error) {
+		if counter != nil {
+			_ = atomic.AddInt32(counter, 1)
+		}
+		return swarm.ZeroAddress, nil
+	}))
+
+	return p2ps
 }
 
 func removeOne(k *kademlia.Kad, peer swarm.Address) {
@@ -343,6 +453,18 @@ func removeOne(k *kademlia.Kad, peer swarm.Address) {
 }
 
 const underlayBase = "/ip4/127.0.0.1/tcp/7070/dns/"
+
+func connectOne(t *testing.T, k *kademlia.Kad, ab addressbook.Putter, peer swarm.Address) {
+	t.Helper()
+	multiaddr, err := ma.NewMultiaddr(underlayBase + peer.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ab.Put(peer, multiaddr); err != nil {
+		t.Fatal(err)
+	}
+	_ = k.Connected(context.Background(), peer)
+}
 
 func addOne(t *testing.T, k *kademlia.Kad, ab addressbook.Putter, peer swarm.Address) {
 	t.Helper()
@@ -381,15 +503,60 @@ func waitConn(t *testing.T, conns *int32) {
 	waitConns(t, conns, 1)
 }
 
+// waits for some connections for some time. resets the pointer value
+// if the correct number of connections have been reached.
 func waitConns(t *testing.T, conns *int32, exp int32) {
 	t.Helper()
 	var got int32
+	if exp == 0 {
+		// sleep for some time before checking for a 0.
+		// this gives some time for unwanted connections to be
+		// established.
+
+		time.Sleep(50 * time.Millisecond)
+	}
 	for i := 0; i < 50; i++ {
-		got = atomic.LoadInt32(conns)
-		if got == exp {
+		if atomic.LoadInt32(conns) == exp {
+			atomic.StoreInt32(conns, 0)
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for connections to be established. got %d want %d", got, exp)
+}
+
+// wait for discovery BroadcastPeers to happen
+func waitBcast(t *testing.T, d *mock.Discovery, pivot swarm.Address, addrs ...swarm.Address) {
+	t.Helper()
+
+	for i := 0; i < 50; i++ {
+		if d.Broadcasts() > 0 {
+			recs, ok := d.AddresseeRecords(pivot)
+			if !ok {
+				t.Fatal("got no records for pivot")
+			}
+			oks := 0
+			for _, a := range addrs {
+				if !isIn(a, recs) {
+					t.Fatalf("address %s not found in discovery records: %s", a, addrs)
+				}
+				oks++
+			}
+
+			if oks == len(addrs) {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for broadcast to happen")
+}
+
+func isIn(addr swarm.Address, addrs []swarm.Address) bool {
+	for _, v := range addrs {
+		if v.Equal(addr) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -61,7 +61,7 @@ func (s *PSlice) EachBin(pf topology.EachPeerFunc) error {
 	return nil
 }
 
-// EachBinRev iterates over all peers from shallowest to deepest.
+// EachBinRev iterates over all peers from shallowest bin to deepest.
 func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 	s.Lock()
 	defer s.Unlock()

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -150,10 +150,10 @@ func (s *PSlice) Add(addr swarm.Address, po uint8) {
 	if e, _ := s.exists(addr); e {
 		return
 	}
-
 	head := s.peers[:s.bins[po]]
 	tail := append([]swarm.Address{addr}, s.peers[s.bins[po]:]...)
 	s.peers = append(head, tail...)
+
 	s.incDeeper(po)
 }
 
@@ -182,9 +182,7 @@ func (s *PSlice) incDeeper(po uint8) {
 		// don't increment if the value in k.bins == len(k.peers)
 		// otherwise the calling context gets an out of bound error
 		// when accessing the slice
-		if s.bins[i] < uint(len(s.peers)) {
-			s.bins[i]++
-		}
+		s.bins[i]++
 	}
 }
 

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -171,7 +171,7 @@ func (s *PSlice) Remove(addr swarm.Address, po uint8) {
 	s.decDeeper(po)
 }
 
-// incDeeper increments the peers slice bin index for proximity order > po.
+// incDeeper increments the peers slice bin index for proximity order > po for non-empty bins only.
 // Must be called under lock.
 func (s *PSlice) incDeeper(po uint8) {
 	if po > uint8(len(s.bins)) {

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -16,8 +16,8 @@ import (
 // in order to reduce duplicate PO calculation which is normally known and already needed in the
 // calling context.
 type PSlice struct {
-	peers []swarm.Address
-	bins  []uint
+	peers []swarm.Address // the slice of peers
+	bins  []uint          // the indexes of every proximity order in the peers slice, index is po, value is index of peers slice
 
 	sync.Mutex
 }
@@ -93,6 +93,13 @@ func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 		}
 	}
 	return nil
+}
+
+func (s *PSlice) Length() int {
+	s.Lock()
+	defer s.Unlock()
+
+	return len(s.peers)
 }
 
 // ShallowestEmpty returns the shallowest empty bin if one exists.

--- a/pkg/kademlia/pslice/pslice_test.go
+++ b/pkg/kademlia/pslice/pslice_test.go
@@ -304,8 +304,7 @@ func testIterator(t *testing.T, ps *pslice.PSlice, skipNext, stop bool, iteratio
 }
 
 func chkLen(t *testing.T, ps *pslice.PSlice, l int) {
-	pp := pslice.PSlicePeers(ps)
-	if lp := len(pp); lp != l {
+	if lp := ps.Length(); lp != l {
 		t.Fatalf("length mismatch, want %d got %d", l, lp)
 	}
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -171,7 +171,7 @@ func NewBee(o Options) (*Bee, error) {
 	topologyDriver := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Logger: logger})
 	b.topologyCloser = topologyDriver
 	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
-	p2ps.SetNotifiee(topologyDriver)
+	p2ps.SetNotifier(topologyDriver)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
 		return nil, fmt.Errorf("get server addresses: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -171,7 +171,7 @@ func NewBee(o Options) (*Bee, error) {
 	topologyDriver := full.New(hive, addressbook, p2ps, logger, address)
 	b.topologyCloser = topologyDriver
 	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
-	p2ps.SetPeerAddedHandler(topologyDriver.AddPeer)
+	p2ps.SetNotifiee(topologyDriver)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
 		return nil, fmt.Errorf("get server addresses: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/hive"
+	"github.com/ethersphere/bee/pkg/kademlia"
 	"github.com/ethersphere/bee/pkg/keystore"
 	filekeystore "github.com/ethersphere/bee/pkg/keystore/file"
 	memkeystore "github.com/ethersphere/bee/pkg/keystore/mem"
@@ -36,7 +37,6 @@ import (
 	mockinmem "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/topology/full"
 	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/ethersphere/bee/pkg/validator"
 	ma "github.com/multiformats/go-multiaddr"
@@ -168,7 +168,7 @@ func NewBee(o Options) (*Bee, error) {
 		return nil, fmt.Errorf("hive service: %w", err)
 	}
 
-	topologyDriver := full.New(hive, addressbook, p2ps, logger, address)
+	topologyDriver := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Logger: logger})
 	b.topologyCloser = topologyDriver
 	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
 	p2ps.SetNotifiee(topologyDriver)

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -338,14 +338,14 @@ func TestTopologyNotifiee(t *testing.T) {
 			n2disconnectedAddr = a
 		}
 	)
-	notifiee1 := mockNotifiee(n1c, n1d)
+	notifier1 := mockNotifier(n1c, n1d)
 	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup1()
-	s1.SetNotifiee(notifiee1)
-	notifiee2 := mockNotifiee(n2c, n2d)
+	s1.SetNotifier(notifier1)
+	notifier2 := mockNotifier(n2c, n2d)
 	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup2()
-	s2.SetNotifiee(notifiee2)
+	s2.SetNotifier(notifier2)
 
 	addr := serviceUnderlayAddress(t, s1)
 
@@ -430,7 +430,7 @@ func (n *notifiee) Disconnected(a swarm.Address) {
 	n.disconnected(a)
 }
 
-func mockNotifiee(c cFunc, d dFunc) topology.Notifiee {
+func mockNotifier(c cFunc, d dFunc) topology.Notifier {
 	return &notifiee{connected: c, disconnected: d}
 }
 

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -338,10 +338,14 @@ func TestTopologyNotifiee(t *testing.T) {
 			n2disconnectedAddr = a
 		}
 	)
-	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n1c, n1d)})
+	notifiee1 := mockNotifiee(n1c, n1d)
+	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup1()
-	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n2c, n2d)})
+	s1.SetNotifiee(notifiee1)
+	notifiee2 := mockNotifiee(n2c, n2d)
+	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup2()
+	s2.SetNotifiee(notifiee2)
 
 	addr := serviceUnderlayAddress(t, s1)
 

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -7,11 +7,15 @@ package libp2p_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -296,3 +300,130 @@ func TestConnectRepeatHandshake(t *testing.T) {
 	expectPeersEventually(t, s2)
 	expectPeersEventually(t, s1)
 }
+
+func TestTopologyNotifiee(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mtx                sync.Mutex
+		n1connectedAddr    swarm.Address
+		n1disconnectedAddr swarm.Address
+		n2connectedAddr    swarm.Address
+		n2disconnectedAddr swarm.Address
+
+		n1c = func(_ context.Context, a swarm.Address) error {
+			mtx.Lock()
+			defer mtx.Unlock()
+			expectZeroAddress(t, n1connectedAddr) // fail if set more than once
+			n1connectedAddr = a
+			return nil
+		}
+		n1d = func(a swarm.Address) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			n1disconnectedAddr = a
+		}
+
+		n2c = func(_ context.Context, a swarm.Address) error {
+			mtx.Lock()
+			defer mtx.Unlock()
+			expectZeroAddress(t, n2connectedAddr) // fail if set more than once
+			n2connectedAddr = a
+			return nil
+		}
+		n2d = func(a swarm.Address) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			n2disconnectedAddr = a
+		}
+	)
+	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n1c, n1d)})
+	defer cleanup1()
+	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n2c, n2d)})
+	defer cleanup2()
+
+	addr := serviceUnderlayAddress(t, s1)
+
+	// s2 connects to s1, thus the notifiee on s1 should be called on Connect
+	overlay, err := s2.Connect(ctx, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectPeers(t, s2, overlay1)
+	expectPeersEventually(t, s1, overlay2)
+
+	// expect that n1 notifee called with s2 overlay
+	waitAddrSet(t, &n1connectedAddr, &mtx, overlay2)
+
+	mtx.Lock()
+	expectZeroAddress(t, n1disconnectedAddr, n2connectedAddr, n2disconnectedAddr)
+	mtx.Unlock()
+
+	// s2 disconnects from s1 so s1 disconnect notifiee should be called
+	if err := s2.Disconnect(overlay); err != nil {
+		t.Fatal(err)
+	}
+
+	expectPeers(t, s2)
+	expectPeersEventually(t, s1)
+	waitAddrSet(t, &n1disconnectedAddr, &mtx, overlay2)
+
+	mtx.Lock()
+	expectZeroAddress(t, n2connectedAddr)
+	mtx.Unlock()
+
+	addr2 := serviceUnderlayAddress(t, s2)
+	// s1 connects to s2, thus the notifiee on s2 should be called on Connect
+	o2, err := s1.Connect(ctx, addr2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectPeers(t, s1, overlay2)
+	expectPeersEventually(t, s2, overlay1)
+	waitAddrSet(t, &n2connectedAddr, &mtx, overlay1)
+
+	// s1 disconnects from s2 so s2 disconnect notifiee should be called
+	if err := s1.Disconnect(o2); err != nil {
+		t.Fatal(err)
+	}
+	expectPeers(t, s1)
+	expectPeersEventually(t, s2)
+	waitAddrSet(t, &n2disconnectedAddr, &mtx, overlay1)
+}
+
+func waitAddrSet(t *testing.T, addr *swarm.Address, mtx *sync.Mutex, exp swarm.Address) {
+	t.Helper()
+	for i := 0; i < 20; i++ {
+		mtx.Lock()
+		if addr.Equal(exp) {
+			mtx.Unlock()
+			return
+		}
+		mtx.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for address to be set")
+}
+
+type notifiee struct {
+	connected    func(context.Context, swarm.Address) error
+	disconnected func(swarm.Address)
+}
+
+func (n *notifiee) Connected(c context.Context, a swarm.Address) error {
+	return n.connected(c, a)
+}
+
+func (n *notifiee) Disconnected(a swarm.Address) {
+	n.disconnected(a)
+}
+
+func mockNotifiee(c cFunc, d dFunc) topology.Notifiee {
+	return &notifiee{connected: c, disconnected: d}
+}
+
+type cFunc func(context.Context, swarm.Address) error
+type dFunc func(swarm.Address)

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -370,6 +370,11 @@ func TestTopologyNotifiee(t *testing.T) {
 	expectPeersEventually(t, s1)
 	waitAddrSet(t, &n1disconnectedAddr, &mtx, overlay2)
 
+	// note that both n1disconnect and n2disconnect callbacks are called after just
+	// one disconnect. this is due to the fact the when the libp2p abstraction is explicitly
+	// called to disconnect from a peer, it will also notify the topology notifiee, since
+	// peer disconnections can also result from components from outside the bound of the
+	// topology driver
 	mtx.Lock()
 	expectZeroAddress(t, n2connectedAddr)
 	mtx.Unlock()

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -339,12 +339,11 @@ func TestTopologyNotifiee(t *testing.T) {
 		}
 	)
 	notifier1 := mockNotifier(n1c, n1d)
-	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
-	defer cleanup1()
+	s1, overlay1 := newService(t, 1, libp2p.Options{})
 	s1.SetNotifier(notifier1)
+
 	notifier2 := mockNotifier(n2c, n2d)
-	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
-	defer cleanup2()
+	s2, overlay2 := newService(t, 1, libp2p.Options{})
 	s2.SetNotifier(notifier2)
 
 	addr := serviceUnderlayAddress(t, s1)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -61,7 +61,6 @@ type Options struct {
 	DisableWS   bool
 	DisableQUIC bool
 	Addressbook addressbook.Putter
-	Notifiee    topology.Notifiee
 	Logger      logging.Logger
 	Tracer      *tracing.Tracer
 }
@@ -161,7 +160,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		return nil, fmt.Errorf("handshake service: %w", err)
 	}
 
-	peerRegistry := newPeerRegistry(registryOptions{disconnecter: o.Notifiee})
+	peerRegistry := newPeerRegistry()
 	s := &Service{
 		ctx:              ctx,
 		host:             h,
@@ -174,7 +173,6 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		logger:           o.Logger,
 		tracer:           o.Tracer,
 		conectionBreaker: breaker.NewBreaker(breaker.Options{}), // todo: fill non-default options
-		topologyNotifiee: o.Notifiee,
 	}
 
 	// Construct protocols.
@@ -374,6 +372,7 @@ func (s *Service) Peers() []p2p.Peer {
 
 func (s *Service) SetNotifiee(n topology.Notifiee) {
 	s.topologyNotifiee = n
+	s.peers.setDisconnecter(n)
 }
 
 func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers p2p.Headers, protocolName, protocolVersion, streamName string) (p2p.Stream, error) {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -215,8 +215,8 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if s.topologyNotifiee != nil {
-			if err := s.topologyNotifiee.Connected(ctx, i.Overlay); err != nil {
+		if s.topologyNotifier != nil {
+			if err := s.topologyNotifier.Connected(ctx, i.Overlay); err != nil {
 				s.logger.Debugf("peerhandler error: %s: %v", peerID, err)
 			}
 		}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -50,7 +50,7 @@ type Service struct {
 	handshakeService *handshake.Service
 	addressbook      addressbook.Putter
 	peers            *peerRegistry
-	topologyNotifiee topology.Notifiee
+	topologyNotifier topology.Notifier
 	conectionBreaker breaker.Interface
 	logger           logging.Logger
 	tracer           *tracing.Tracer
@@ -370,8 +370,8 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetNotifiee(n topology.Notifiee) {
-	s.topologyNotifiee = n
+func (s *Service) SetNotifier(n topology.Notifier) {
+	s.topologyNotifier = n
 	s.peers.setDisconnecter(n)
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/breaker"
 	handshake "github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/libp2p/go-libp2p"
 	autonat "github.com/libp2p/go-libp2p-autonat-svc"
@@ -49,7 +50,7 @@ type Service struct {
 	handshakeService *handshake.Service
 	addressbook      addressbook.Putter
 	peers            *peerRegistry
-	peerHandler      func(context.Context, swarm.Address) error
+	topologyNotifiee topology.Notifiee
 	conectionBreaker breaker.Interface
 	logger           logging.Logger
 	tracer           *tracing.Tracer
@@ -60,6 +61,7 @@ type Options struct {
 	DisableWS   bool
 	DisableQUIC bool
 	Addressbook addressbook.Putter
+	Notifiee    topology.Notifiee
 	Logger      logging.Logger
 	Tracer      *tracing.Tracer
 }
@@ -159,7 +161,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		return nil, fmt.Errorf("handshake service: %w", err)
 	}
 
-	peerRegistry := newPeerRegistry()
+	peerRegistry := newPeerRegistry(registryOptions{disconnecter: o.Notifiee})
 	s := &Service{
 		ctx:              ctx,
 		host:             h,
@@ -172,6 +174,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		logger:           o.Logger,
 		tracer:           o.Tracer,
 		conectionBreaker: breaker.NewBreaker(breaker.Options{}), // todo: fill non-default options
+		topologyNotifiee: o.Notifiee,
 	}
 
 	// Construct protocols.
@@ -214,8 +217,8 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if s.peerHandler != nil {
-			if err := s.peerHandler(ctx, i.Overlay); err != nil {
+		if s.topologyNotifiee != nil {
+			if err := s.topologyNotifiee.Connected(ctx, i.Overlay); err != nil {
 				s.logger.Debugf("peerhandler error: %s: %v", peerID, err)
 			}
 		}
@@ -361,7 +364,6 @@ func (s *Service) disconnect(peerID libp2ppeer.ID) error {
 	if err := s.host.Network().ClosePeer(peerID); err != nil {
 		return err
 	}
-
 	s.peers.remove(peerID)
 	return nil
 }
@@ -370,8 +372,8 @@ func (s *Service) Peers() []p2p.Peer {
 	return s.peers.peers()
 }
 
-func (s *Service) SetPeerAddedHandler(h func(context.Context, swarm.Address) error) {
-	s.peerHandler = h
+func (s *Service) SetNotifiee(n topology.Notifiee) {
+	s.topologyNotifiee = n
 }
 
 func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers p2p.Headers, protocolName, protocolVersion, streamName string) (p2p.Stream, error) {

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -82,7 +82,7 @@ func expectPeers(t *testing.T, s *libp2p.Service, addrs ...swarm.Address) {
 }
 
 // expectPeersEventually validates that peers with addresses are connected with
-// retires. It is supposed to be used to validate asynchronous connecting on the
+// retries. It is supposed to be used to validate asynchronous connecting on the
 // peer that is connected to.
 func expectPeersEventually(t *testing.T, s *libp2p.Service, addrs ...swarm.Address) {
 	t.Helper()

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -115,6 +115,15 @@ func expectPeersEventually(t *testing.T, s *libp2p.Service, addrs ...swarm.Addre
 	}
 }
 
+func expectZeroAddress(t *testing.T, addrs ...swarm.Address) {
+	t.Helper()
+	for i, a := range addrs {
+		if !a.Equal(swarm.ZeroAddress) {
+			t.Fatalf("address did not equal zero address. index %d", i)
+		}
+	}
+}
+
 func serviceUnderlayAddress(t *testing.T, s *libp2p.Service) multiaddr.Multiaddr {
 	t.Helper()
 

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -16,10 +16,6 @@ import (
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-type registryOptions struct {
-	disconnecter topology.Disconnecter
-}
-
 type peerRegistry struct {
 	underlays   map[string]libp2ppeer.ID                    // map overlay address to underlay peer id
 	overlays    map[libp2ppeer.ID]swarm.Address             // map underlay peer id to overlay address
@@ -30,14 +26,13 @@ type peerRegistry struct {
 	network.Notifiee                       // peerRegistry can be the receiver for network.Notify
 }
 
-func newPeerRegistry(o registryOptions) *peerRegistry {
+func newPeerRegistry() *peerRegistry {
 	return &peerRegistry{
 		underlays:   make(map[string]libp2ppeer.ID),
 		overlays:    make(map[libp2ppeer.ID]swarm.Address),
 		connections: make(map[libp2ppeer.ID]map[network.Conn]struct{}),
 
-		disconnecter: o.disconnecter,
-		Notifiee:     new(network.NoopNotifiee),
+		Notifiee: new(network.NoopNotifiee),
 	}
 }
 
@@ -132,4 +127,8 @@ func (r *peerRegistry) remove(peerID libp2ppeer.ID) {
 	if r.disconnecter != nil {
 		r.disconnecter.Disconnected(overlay)
 	}
+}
+
+func (r *peerRegistry) setDisconnecter(d topology.Disconnecter) {
+	r.disconnecter = d
 }

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -11,9 +11,14 @@ import (
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/libp2p/go-libp2p-core/network"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 )
+
+type registryOptions struct {
+	disconnecter topology.Disconnecter
+}
 
 type peerRegistry struct {
 	underlays   map[string]libp2ppeer.ID                    // map overlay address to underlay peer id
@@ -21,15 +26,18 @@ type peerRegistry struct {
 	connections map[libp2ppeer.ID]map[network.Conn]struct{} // list of connections for safe removal on Disconnect notification
 	mu          sync.RWMutex
 
-	network.Notifiee // peerRegistry can be the receiver for network.Notify
+	disconnecter     topology.Disconnecter // peerRegistry notifies topology on peer disconnection
+	network.Notifiee                       // peerRegistry can be the receiver for network.Notify
 }
 
-func newPeerRegistry() *peerRegistry {
+func newPeerRegistry(o registryOptions) *peerRegistry {
 	return &peerRegistry{
 		underlays:   make(map[string]libp2ppeer.ID),
 		overlays:    make(map[libp2ppeer.ID]swarm.Address),
 		connections: make(map[libp2ppeer.ID]map[network.Conn]struct{}),
-		Notifiee:    new(network.NoopNotifiee),
+
+		disconnecter: o.disconnecter,
+		Notifiee:     new(network.NoopNotifiee),
 	}
 }
 
@@ -59,6 +67,9 @@ func (r *peerRegistry) Disconnected(_ network.Network, c network.Conn) {
 	delete(r.connections[peerID], c)
 	if len(r.connections[peerID]) == 0 {
 		delete(r.connections, peerID)
+	}
+	if r.disconnecter != nil {
+		r.disconnecter.Disconnected(overlay)
 	}
 }
 
@@ -117,4 +128,8 @@ func (r *peerRegistry) remove(peerID libp2ppeer.ID) {
 	delete(r.underlays, overlay.ByteString())
 	delete(r.connections, peerID)
 	r.mu.Unlock()
+
+	if r.disconnecter != nil {
+		r.disconnecter.Disconnected(overlay)
+	}
 }

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -19,7 +19,7 @@ type Service struct {
 	connectFunc     func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	disconnectFunc  func(overlay swarm.Address) error
 	peersFunc       func() []p2p.Peer
-	setNotifieeFunc func(topology.Notifiee)
+	setNotifierFunc func(topology.Notifier)
 	addressesFunc   func() ([]ma.Multiaddr, error)
 }
 
@@ -47,9 +47,9 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetNotifieeFunc(f func(topology.Notifiee)) Option {
+func WithSetNotifierFunc(f func(topology.Notifier)) Option {
 	return optionFunc(func(s *Service) {
-		s.setNotifieeFunc = f
+		s.setNotifierFunc = f
 	})
 }
 
@@ -88,12 +88,12 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetNotifiee(f topology.Notifiee) {
-	if s.setNotifieeFunc == nil {
+func (s *Service) SetNotifier(f topology.Notifier) {
+	if s.setNotifierFunc == nil {
 		return
 	}
 
-	s.setNotifieeFunc(f)
+	s.setNotifierFunc(f)
 }
 
 func (s *Service) Addresses() ([]ma.Multiaddr, error) {

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -10,16 +10,17 @@ import (
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
 type Service struct {
-	addProtocolFunc         func(p2p.ProtocolSpec) error
-	connectFunc             func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
-	disconnectFunc          func(overlay swarm.Address) error
-	peersFunc               func() []p2p.Peer
-	setPeerAddedHandlerFunc func(func(context.Context, swarm.Address) error)
-	addressesFunc           func() ([]ma.Multiaddr, error)
+	addProtocolFunc func(p2p.ProtocolSpec) error
+	connectFunc     func(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
+	disconnectFunc  func(overlay swarm.Address) error
+	peersFunc       func() []p2p.Peer
+	setNotifieeFunc func(topology.Notifiee)
+	addressesFunc   func() ([]ma.Multiaddr, error)
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -46,9 +47,9 @@ func WithPeersFunc(f func() []p2p.Peer) Option {
 	})
 }
 
-func WithSetPeerAddedHandlerFunc(f func(func(context.Context, swarm.Address) error)) Option {
+func WithSetNotifieeFunc(f func(topology.Notifiee)) Option {
 	return optionFunc(func(s *Service) {
-		s.setPeerAddedHandlerFunc = f
+		s.setNotifieeFunc = f
 	})
 }
 
@@ -87,12 +88,12 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	return s.disconnectFunc(overlay)
 }
 
-func (s *Service) SetPeerAddedHandler(f func(context.Context, swarm.Address) error) {
-	if s.setPeerAddedHandlerFunc == nil {
+func (s *Service) SetNotifiee(f topology.Notifiee) {
+	if s.setNotifieeFunc == nil {
 		return
 	}
 
-	s.setPeerAddedHandlerFunc(f)
+	s.setNotifieeFunc(f)
 }
 
 func (s *Service) Addresses() ([]ma.Multiaddr, error) {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -18,7 +19,7 @@ type Service interface {
 	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
-	SetPeerAddedHandler(func(context.Context, swarm.Address) error)
+	SetNotifiee(topology.Notifiee)
 	Addresses() ([]ma.Multiaddr, error)
 }
 

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -19,7 +19,7 @@ type Service interface {
 	Connect(ctx context.Context, addr ma.Multiaddr) (overlay swarm.Address, err error)
 	Disconnect(overlay swarm.Address) error
 	Peers() []Peer
-	SetNotifiee(topology.Notifiee)
+	SetNotifier(topology.Notifier)
 	Addresses() ([]ma.Multiaddr, error)
 }
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -6,7 +6,9 @@ package full
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -153,6 +155,28 @@ func (d *driver) ClosestPeer(addr swarm.Address) (swarm.Address, error) {
 	}
 
 	return closest, nil
+}
+
+func (d *driver) Connected(ctx context.Context, addr swarm.Address) error {
+	return d.AddPeer(ctx, addr)
+}
+
+func (d *driver) Disconnected(swarm.Address) {
+	panic("todo")
+}
+
+func (d *driver) MarshalJSON() ([]byte, error) {
+	var peers []string
+	for p := range d.receivedPeers {
+		peers = append(peers, p)
+	}
+	return json.Marshal(struct {
+		Peers []string `json:"peers"`
+	}{Peers: peers})
+}
+
+func (d *driver) String() string {
+	return fmt.Sprintf("%s", d.receivedPeers)
 }
 
 func (d *driver) Close() error {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -162,7 +162,7 @@ func (d *driver) Connected(ctx context.Context, addr swarm.Address) error {
 }
 
 func (d *driver) Disconnected(swarm.Address) {
-	panic("todo")
+	// TODO: implement if necessary
 }
 
 func (d *driver) MarshalJSON() ([]byte, error) {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -12,17 +12,37 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var ErrNotFound = errors.New("no peer found")
-var ErrWantSelf = errors.New("node wants self")
+var (
+	ErrNotFound = errors.New("no peer found")
+	ErrWantSelf = errors.New("node wants self")
+)
 
 type Driver interface {
 	PeerAdder
 	ClosestPeerer
+	Notifiee
 	io.Closer
 }
 
+type Notifiee interface {
+	Connecter
+	Disconnecter
+}
+
 type PeerAdder interface {
+	// AddPeer is called when a peer is added to the topology backlog
+	// for further processing by connectivity strategy.
 	AddPeer(ctx context.Context, addr swarm.Address) error
+}
+
+type Connecter interface {
+	// Connected is called when a peer dials in.
+	Connected(context.Context, swarm.Address) error
+}
+
+type Disconnecter interface {
+	// Disconnected is called when a peer disconnects.
+	Disconnected(swarm.Address)
 }
 
 type ClosestPeerer interface {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -20,11 +20,11 @@ var (
 type Driver interface {
 	PeerAdder
 	ClosestPeerer
-	Notifiee
+	Notifier
 	io.Closer
 }
 
-type Notifiee interface {
+type Notifier interface {
 	Connecter
 	Disconnecter
 }


### PR DESCRIPTION
This PR aims to introduce a simple kademlia implementation into the codebase.

It wires in the `PSlice` type that was merged previously (#169), as a type that manages and indexes a slice of peers by their proximity order.

This PR handles:
1. Implementation of depth calculation for kademlia
2. Implementation of basic connection management that bootstraps a kademlia topology
3. Debug API endpoint for retrieving a JSON output of the current topology
4. Integration into libp2p abstraction layer for peer connect/disconnect notification
5. Dummy `binSaturated` implementation. Right now checks for a constant bin size, but is built to accommodate for more complex operations, such as check square address gaps and so on.
6. implement `ClosestPeer` so that retrievals and push sync will work on kademlia
7. hook up kademlia to be the default topology, instead of `full`
8. Peer announcement on dial-in or dial-out

related to #47 and #56