### PR TITLE
fix api /bzz post endpoint

### DIFF
--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -61,7 +61,7 @@ func (s *server) bzzUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	addr := swarm.NewAddress(hasher.Sum(nil))
-	_, err = s.Storer.Put(ctx, storage.ModePutUpload, swarm.NewChunk(addr, data[8:]))
+	_, err = s.Storer.Put(ctx, storage.ModePutUpload, swarm.NewChunk(addr, data))
 	if err != nil {
 		s.Logger.Debugf("bzz: write error: %v, addr %s", err, addr)
 		s.Logger.Error("bzz: write error")
@@ -97,5 +97,5 @@ func (s *server) bzzGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
-	_, _ = io.Copy(w, bytes.NewReader(chunk.Data()))
+	_, _ = io.Copy(w, bytes.NewReader(chunk.Data()[8:]))
 }

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -21,7 +21,7 @@ import (
 // downloading and requesting a resource that cannot be found.
 func TestBzz(t *testing.T) {
 	var (
-		resource        = "/bzz/"
+		resource        = "/bzz"
 		content         = []byte("foo")
 		expHash         = "2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48"
 		mockStorer      = mock.NewStorer()
@@ -38,7 +38,7 @@ func TestBzz(t *testing.T) {
 	})
 
 	t.Run("download", func(t *testing.T) {
-		resp := request(t, client, http.MethodGet, resource+expHash, nil, http.StatusOK)
+		resp := request(t, client, http.MethodGet, resource+"/"+expHash, nil, http.StatusOK)
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -50,7 +50,7 @@ func TestBzz(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, resource+"abcd", nil, http.StatusNotFound, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, client, http.MethodGet, resource+"/abcd", nil, http.StatusNotFound, jsonhttp.StatusResponse{
 			Message: "not found",
 			Code:    http.StatusNotFound,
 		})

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -32,7 +32,7 @@ func (s *server) setupRouting() {
 		"POST": http.HandlerFunc(s.pingpongHandler),
 	})
 
-	router.Handle("/bzz/", jsonhttp.MethodHandler{
+	router.Handle("/bzz", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.bzzUploadHandler),
 	})
 


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/ethersphere/bee/issues/151.

The problem is in expected chunk data that needs to be passed to the storer. A chunk should be put with its span data prepended in bzzUploadHandler, and returned without it in bzzGetHandler. Current implementation assumes that span should not be stored in localstore and with that assumption validator panics on data that are less than 8 bytes long, as it does not do bounds check.

This PR also removes the need to have a trailing slash on /bzz endpoint.

To reproduce the error do on master code `curl --data-binary '12345' localhost:8080/bzz/`, it will produce a panic.

To validate the fix in this branch `curl --data-binary '12345' localhost:8080/bzz`, it should return a valid response with a hash value.

fixes https://github.com/ethersphere/bee/issues/151