### PR TITLE
add misspell, gofmt and unconvert linters

### DIFF
--- a/.githooks/pre-push.bash
+++ b/.githooks/pre-push.bash
@@ -10,7 +10,7 @@ fi
 
 if ! command -v golangci-lint &> /dev/null; then
     echo "installing golangci-lint..."
-    go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+    make linter
 fi
 
 make lint vet test-race

--- a/.githooks/pre-push.bash
+++ b/.githooks/pre-push.bash
@@ -8,9 +8,4 @@ if [ -z "$commits" ]; then
     exit 0
 fi
 
-if ! command -v golangci-lint &> /dev/null; then
-    echo "installing golangci-lint..."
-    make linter
-fi
-
-make lint vet test-race
+make build lint vet test-race

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,10 @@ jobs:
         echo "::set-env name=GOPATH::$(go env GOPATH)"
         echo "::add-path::$(go env GOPATH)/bin"
       shell: bash
+    - name: Set git to use LF
+      # make sure that line endings are not converted on windows
+      # as gofmt linter will report that they need to be changed
+      run: git config --global core.autocrlf false
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,7 @@
 run:
   timeout: 10m
+linters:
+  enable:
+    - misspell
+    - gofmt
+    - unconvert

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS += -X github.com/ethersphere/bee.commit="$(COMMIT)"
 endif
 
 .PHONY: all
-all: build lint vet test binary
+all: build lint vet test-race binary
 
 .PHONY: binary
 binary: export CGO_ENABLED=0
@@ -20,12 +20,12 @@ dist:
 	mkdir $@
 
 .PHONY: lint
-lint:
+lint: linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: linter
 linter:
-	cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	which golangci-lint || ( cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) )
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: linter
 
 .PHONY: linter
 linter:
-	which golangci-lint || ( cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) )
+	which $(GOLANGCI_LINT) || ( cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) )
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
+GOLANGCI_LINT_VERSION ?= v1.26.0
 
 LDFLAGS ?= -s -w
 ifdef COMMIT
@@ -21,6 +22,10 @@ dist:
 .PHONY: lint
 lint:
 	$(GOLANGCI_LINT) run
+
+.PHONY: linter
+linter:
+	cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: vet
 vet:

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -30,22 +30,22 @@ var (
 
 type Interface interface {
 	// Execute runs f() if the limit number of consecutive failed calls is not reached within fail interval.
-	// f() call is not locked so it can still be executed concurently.
+	// f() call is not locked so it can still be executed concurrently.
 	// Returns `ErrClosed` if the limit is reached or f() result otherwise.
 	Execute(f func() error) error
 
-	// ClosedUntil retuns the timestamp when the breaker will become open again.
+	// ClosedUntil returns the timestamp when the breaker will become open again.
 	ClosedUntil() time.Time
 }
 
 type breaker struct {
-	limit                int // breaker will not exeucute any more tasks after limit number of consequtive failuers happen
-	consFailedCalls      int // current number of consequtive fails
+	limit                int // breaker will not execute any more tasks after limit number of consecutive failures happen
+	consFailedCalls      int // current number of consecutive fails
 	firstFailedTimestamp time.Time
 	closedTimestamp      time.Time
 	backoff              time.Duration // initial backoff duration
 	maxBackoff           time.Duration
-	failInterval         time.Duration // consequitive failures are counted if they happen withing this interval
+	failInterval         time.Duration // consecutive failures are counted if they happen within this interval
 	mtx                  sync.Mutex
 }
 

--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -47,13 +47,13 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_chunk_synced",
-			Help:      "Total chunks synced succesfully with valid receipts.",
+			Help:      "Total chunks synced successfully with valid receipts.",
 		}),
 		TotalChunksStoredInDB: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_chunk_stored_in_DB",
-			Help:      "Total chunks stored succesfully in local store.",
+			Help:      "Total chunks stored successfully in local store.",
 		}),
 		ChunksSentCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -111,7 +111,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			}
 			ps.metrics.TotalChunksStoredInDB.Inc()
 
-			// Send a receipt immediately once the storage of the chunk is successfull
+			// Send a receipt immediately once the storage of the chunk is successful
 			receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 			err = ps.sendReceipt(w, receipt)
 			if err != nil {
@@ -133,7 +133,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 		}
 		ps.metrics.TotalChunksStoredInDB.Inc()
 
-		// Send a receipt immediately once the storage of the chunk is successfull
+		// Send a receipt immediately once the storage of the chunk is successful
 		receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 		return ps.sendReceipt(w, receipt)
 	}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -14,9 +14,9 @@ import (
 
 const (
 	SectionSize = 32
-	Branches = 128
-	ChunkSize = SectionSize * Branches
-	MaxPO     = 16
+	Branches    = 128
+	ChunkSize   = SectionSize * Branches
+	MaxPO       = 16
 )
 
 // Address represents an address in Swarm metric space of

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/validator"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/validator"
 )
 
 // TestContentAddressValidator checks that the validator evaluates correctly

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -28,7 +28,7 @@ func TestContentAddressValidator(t *testing.T) {
 	fooLength := len(foo)
 	fooBytes := make([]byte, 8+fooLength)
 	binary.LittleEndian.PutUint64(fooBytes, uint64(fooLength))
-	copy(fooBytes[8:], []byte(foo))
+	copy(fooBytes[8:], foo)
 	ch := swarm.NewChunk(address, fooBytes)
 	if !validator.Validate(ch) {
 		t.Fatalf("data '%s' should have validated to hash '%s'", ch.Data(), ch.Address())


### PR DESCRIPTION
This PR adds more linters to golangci-lint suite to improve automatic static checking.

This PR also fixes some minor the problems found by new linters.

It updates the Go GitHub Actions workflow not to use autocrlf to avoid false positive gofmt errors on windows when gofmt is changing line endings.

It adds `linter` Makefile rule to install a specific version of golangci-lint as its master appears not to be stable.

It changes pre-push githook to use `linter` rule.