### PR TITLE
remove push trigger and go1.x from actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   coverage:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,6 @@
 name: Go
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [1.14, 1.x]
+        go: [1.14]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Setup Go


### PR DESCRIPTION
Make github actions execution time faster, only test for go1.14 and on pull_request event