### PR TITLE
kademlia, topology: introduce pslice

### DIFF
--- a/pkg/kademlia/pslice/export_test.go
+++ b/pkg/kademlia/pslice/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pslice
+
+import "github.com/ethersphere/bee/pkg/swarm"
+
+func PSlicePeers(p *PSlice) []swarm.Address {
+	return p.peers
+}
+
+func PSliceBins(p *PSlice) []uint {
+	return p.bins
+}

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pslice
+
+import (
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
+)
+
+// PSlice maintaines a list of addresses, indexing them by their different proximity orders.
+// Currently, when peers are added or removed, their proximity order must be supplied, this is
+// in order to reduce duplicate PO calculation which is normally known and already needed in the
+// calling context.
+type PSlice struct {
+	peers []swarm.Address
+	bins  []uint
+
+	sync.Mutex
+}
+
+// New creates a new PSlice.
+func New(maxBins int) *PSlice {
+	return &PSlice{
+		peers: make([]swarm.Address, 0),
+		bins:  make([]uint, maxBins),
+	}
+}
+
+// iterates over all peers from deepest bin to shallowest.
+func (s *PSlice) EachBin(pf topology.EachPeerFunc) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if len(s.peers) == 0 {
+		return nil
+	}
+
+	var binEnd = uint(len(s.peers))
+INNER:
+	for i := len(s.bins) - 1; i >= 0; i-- {
+		peers := s.peers[s.bins[i]:binEnd]
+		for _, v := range peers {
+			stop, next, err := pf(v, uint8(i))
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+			if next {
+				break INNER
+			}
+		}
+		binEnd = s.bins[i]
+	}
+
+	return nil
+}
+
+// EachBinRev iterates over all peers from shallowest to deepest.
+func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if len(s.peers) == 0 {
+		return nil
+	}
+
+	var binEnd int
+	for i := 0; i <= len(s.bins)-1; i++ {
+		if i == len(s.bins)-1 {
+			binEnd = len(s.peers)
+		} else {
+			binEnd = int(s.bins[i+1])
+		}
+
+		peers := s.peers[s.bins[i]:binEnd]
+	INNER:
+		for _, v := range peers {
+			stop, next, err := pf(v, uint8(i))
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+			if next {
+				break INNER
+			}
+		}
+	}
+	return nil
+}
+
+// ShallowestEmpty returns the shallowest empty bin if one exists.
+// If such bin does not exists, returns true as bool value.
+// Must be called under lock.
+func (s *PSlice) ShallowestEmpty() (bin uint8, none bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	binCp := make([]uint, len(s.bins)+1)
+	copy(binCp, s.bins)
+	binCp[len(binCp)-1] = uint(len(s.peers))
+
+	for i := uint8(0); i < uint8(len(binCp)-1); i++ {
+		if binCp[i+1]-binCp[i] == 0 {
+			return i, false
+		}
+	}
+	return 0, true
+}
+
+// Exists checks if a peer exists.
+func (s *PSlice) Exists(addr swarm.Address) bool {
+	s.Lock()
+	defer s.Unlock()
+
+	b, _ := s.exists(addr)
+	return b
+}
+
+// checks if a peer exists. must be called under lock.
+func (s *PSlice) exists(addr swarm.Address) (bool, int) {
+	if len(s.peers) == 0 {
+		return false, 0
+	}
+	return peerExists(s.peers, addr)
+}
+
+// Add a peer at a certain PO.
+func (s *PSlice) Add(addr swarm.Address, po uint8) {
+	s.Lock()
+	defer s.Unlock()
+
+	if e, _ := s.exists(addr); e {
+		return
+	}
+
+	s.peers = append(s.peers[:s.bins[po]], append([]swarm.Address{addr}, s.peers[s.bins[po]:]...)...)
+	s.incDeeper(po)
+}
+
+// Remove a peer at a certain PO.
+func (s *PSlice) Remove(addr swarm.Address, po uint8) {
+	s.Lock()
+	defer s.Unlock()
+
+	e, i := s.exists(addr)
+	if !e {
+		return
+	}
+
+	s.peers = append(s.peers[:i], s.peers[i+1:]...)
+	s.decDeeper(po)
+}
+
+// incDeeper increments the peers slice bin index for proximity order > po.
+// Must be called under lock.
+func (s *PSlice) incDeeper(po uint8) {
+	if po > uint8(len(s.bins)) {
+		panic("po too high")
+	}
+
+	for i := po + 1; i < uint8(len(s.bins)); i++ {
+		// don't increment if the value in k.bins == len(k.peers)
+		// otherwise the calling context gets an out of bound error
+		// when accessing the slice
+		if s.bins[i] < uint(len(s.peers)) {
+			s.bins[i]++
+		}
+	}
+}
+
+// decDeeper decrements the peers slice bin indexes for proximity order > po.
+// Must be called under lock.
+func (s *PSlice) decDeeper(po uint8) {
+	if po > uint8(len(s.bins)) {
+		panic("po too high")
+	}
+
+	for i := po + 1; i < uint8(len(s.bins)); i++ {
+		s.bins[i]--
+	}
+}
+
+// check if a certain address exists within the given slice of peers.
+func peerExists(peers []swarm.Address, peer swarm.Address) (exists bool, idx int) {
+	for i, addr := range peers {
+		if addr.Equal(peer) {
+			return true, i
+		}
+	}
+	return false, 0
+}

--- a/pkg/kademlia/pslice/pslice.go
+++ b/pkg/kademlia/pslice/pslice.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/topology"
 )
 
-// PSlice maintaines a list of addresses, indexing them by their different proximity orders.
+// PSlice maintains a list of addresses, indexing them by their different proximity orders.
 // Currently, when peers are added or removed, their proximity order must be supplied, this is
 // in order to reduce duplicate PO calculation which is normally known and already needed in the
 // calling context.
@@ -40,7 +40,7 @@ func (s *PSlice) EachBin(pf topology.EachPeerFunc) error {
 	}
 
 	var binEnd = uint(len(s.peers))
-INNER:
+
 	for i := len(s.bins) - 1; i >= 0; i-- {
 		peers := s.peers[s.bins[i]:binEnd]
 		for _, v := range peers {
@@ -52,7 +52,7 @@ INNER:
 				return nil
 			}
 			if next {
-				break INNER
+				break
 			}
 		}
 		binEnd = s.bins[i]
@@ -79,7 +79,6 @@ func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 		}
 
 		peers := s.peers[s.bins[i]:binEnd]
-	INNER:
 		for _, v := range peers {
 			stop, next, err := pf(v, uint8(i))
 			if err != nil {
@@ -89,7 +88,7 @@ func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 				return nil
 			}
 			if next {
-				break INNER
+				break
 			}
 		}
 	}

--- a/pkg/kademlia/pslice/pslice_test.go
+++ b/pkg/kademlia/pslice/pslice_test.go
@@ -18,16 +18,20 @@ func TestShallowestEmpty(t *testing.T) {
 	var (
 		ps    = pslice.New(16)
 		base  = test.RandomAddress()
-		peers = make([]swarm.Address, 16)
+		peers = make([][]swarm.Address, 16)
 	)
 
 	for i := 0; i < 16; i++ {
-		a := test.RandomAddressAt(base, i)
-		peers[i] = a
+		for j := 0; j < 3; j++ {
+			a := test.RandomAddressAt(base, i)
+			peers[i] = append(peers[i], a)
+		}
 	}
 
 	for i, v := range peers {
-		ps.Add(v, uint8(i))
+		for _, vv := range v {
+			ps.Add(vv, uint8(i))
+		}
 		sd, none := ps.ShallowestEmpty()
 		if i == 15 {
 			if !none {
@@ -69,15 +73,16 @@ func TestShallowestEmpty(t *testing.T) {
 			expectShallowest: 0,
 		},
 	} {
-		po := uint8(swarm.Proximity(base.Bytes(), peers[tc.removePo].Bytes()))
-		ps.Remove(peers[tc.removePo], po)
-
+		for _, v := range peers[tc.removePo] {
+			po := uint8(swarm.Proximity(base.Bytes(), v.Bytes()))
+			ps.Remove(v, po)
+		}
 		sd, none := ps.ShallowestEmpty()
 		if sd != tc.expectShallowest || none {
 			t.Fatalf("empty bin mismatch got %d want %d", sd, tc.expectShallowest)
 		}
 	}
-	ps.Add(peers[0], 0)
+	ps.Add(peers[0][0], 0)
 	if sd, none := ps.ShallowestEmpty(); sd != 1 || none {
 		t.Fatalf("expected bin 1 to be empty shallowest but got %d", sd)
 	}

--- a/pkg/kademlia/pslice/pslice_test.go
+++ b/pkg/kademlia/pslice/pslice_test.go
@@ -31,7 +31,7 @@ func TestShallowestEmpty(t *testing.T) {
 		sd, none := ps.ShallowestEmpty()
 		if i == 15 {
 			if !none {
-				t.Fatal("expected last bin to be empty and return no empty bins")
+				t.Fatal("expected last bin to be empty, thus return no empty bins true")
 			}
 		} else {
 			if sd != uint8(i+1) {
@@ -43,35 +43,38 @@ func TestShallowestEmpty(t *testing.T) {
 		}
 	}
 
+	// this part removes peers in certain bins and asserts
+	// that the shallowest empty bin behaves correctly once the bins
 	for _, tc := range []struct {
-		rmPO  int
-		expSE uint8
+		removePo         int
+		expectShallowest uint8
 	}{
-		{rmPO: 3,
-			expSE: 3,
+		{
+			removePo:         3,
+			expectShallowest: 3,
 		}, {
-			rmPO:  1,
-			expSE: 1,
+			removePo:         1,
+			expectShallowest: 1,
 		}, {
-			rmPO:  10,
-			expSE: 1,
+			removePo:         10,
+			expectShallowest: 1,
 		}, {
-			rmPO:  15,
-			expSE: 1,
+			removePo:         15,
+			expectShallowest: 1,
 		}, {
-			rmPO:  14,
-			expSE: 1,
+			removePo:         14,
+			expectShallowest: 1,
 		}, {
-			rmPO:  0,
-			expSE: 0,
+			removePo:         0,
+			expectShallowest: 0,
 		},
 	} {
-		po := uint8(swarm.Proximity(base.Bytes(), peers[tc.rmPO].Bytes()))
-		ps.Remove(peers[tc.rmPO], po)
+		po := uint8(swarm.Proximity(base.Bytes(), peers[tc.removePo].Bytes()))
+		ps.Remove(peers[tc.removePo], po)
 
 		sd, none := ps.ShallowestEmpty()
-		if sd != tc.expSE || none {
-			t.Fatalf("empty bin mismatch got %d want %d", sd, tc.expSE)
+		if sd != tc.expectShallowest || none {
+			t.Fatalf("empty bin mismatch got %d want %d", sd, tc.expectShallowest)
 		}
 	}
 	ps.Add(peers[0], 0)
@@ -97,7 +100,6 @@ func TestAddRemove(t *testing.T) {
 		b := test.RandomAddressAt(base, i)
 		peers[i+1] = b
 	}
-	chkNotExists(t, ps, peers...)
 
 	// add one
 	ps.Add(peers[0], 0)
@@ -274,10 +276,6 @@ func testIteratorRev(t *testing.T, ps *pslice.PSlice, skipNext, stop bool, itera
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if i != iterations {
-		t.Fatalf("iterations mismatch, want %d got %d", iterations, i)
-	}
 }
 
 func testIterator(t *testing.T, ps *pslice.PSlice, skipNext, stop bool, iterations int, peerseq []swarm.Address) {
@@ -311,7 +309,7 @@ func chkBins(t *testing.T, ps *pslice.PSlice, seq []uint) {
 	pb := pslice.PSliceBins(ps)
 	for i, v := range seq {
 		if pb[i] != v {
-			t.Fatalf("bin seq wrong, get %d want %d", pb[i], v)
+			t.Fatalf("bin seq wrong, get %d want %d, index %v", pb[i], v, pb)
 		}
 	}
 }

--- a/pkg/kademlia/pslice/pslice_test.go
+++ b/pkg/kademlia/pslice/pslice_test.go
@@ -1,0 +1,309 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pslice_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/kademlia/pslice"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology/test"
+)
+
+// TestShallowestEmpty tests that ShallowestEmpty functionality works correctly.
+func TestShallowestEmpty(t *testing.T) {
+	var (
+		ps    = pslice.New(16)
+		base  = test.RandomAddress()
+		peers = make([]swarm.Address, 16)
+	)
+
+	for i := 0; i < 16; i++ {
+		a := test.RandomAddressAt(base, i)
+		peers[i] = a
+	}
+
+	for i, v := range peers {
+		ps.Add(v, uint8(i))
+		sd, none := ps.ShallowestEmpty()
+		if i == 15 {
+			if !none {
+				t.Fatal("expected last bin to be empty and return no empty bins")
+			}
+		} else {
+			if sd != uint8(i+1) {
+				t.Fatalf("expected shallow empty bin to be %d but got %d", i+1, sd)
+			}
+			if none {
+				t.Fatal("got no empty bins but wanted some")
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		rmPO  int
+		expSE uint8
+	}{
+		{rmPO: 3,
+			expSE: 3,
+		}, {
+			rmPO:  1,
+			expSE: 1,
+		}, {
+			rmPO:  10,
+			expSE: 1,
+		}, {
+			rmPO:  15,
+			expSE: 1,
+		}, {
+			rmPO:  14,
+			expSE: 1,
+		}, {
+			rmPO:  0,
+			expSE: 0,
+		},
+	} {
+		po := uint8(swarm.Proximity(base.Bytes(), peers[tc.rmPO].Bytes()))
+		ps.Remove(peers[tc.rmPO], po)
+
+		sd, none := ps.ShallowestEmpty()
+		if sd != tc.expSE || none {
+			t.Fatalf("empty bin mismatch got %d want %d", sd, tc.expSE)
+		}
+	}
+	ps.Add(peers[0], 0)
+	if sd, none := ps.ShallowestEmpty(); sd != 1 || none {
+		t.Fatalf("expected bin 1 to be empty shallowest but got %d", sd)
+	}
+}
+
+// TestAddRemove checks that the Add, Remove and Exists methods work as expected.
+func TestAddRemove(t *testing.T) {
+	var (
+		ps    = pslice.New(4)
+		base  = test.RandomAddress()
+		peers = make([]swarm.Address, 8)
+	)
+
+	// 2 peers per bin
+	// indexes {0,1} {2,3} {4,5} {6,7}
+	for i := 0; i < 8; i += 2 {
+		a := test.RandomAddressAt(base, i)
+		peers[i] = a
+
+		b := test.RandomAddressAt(base, i)
+		peers[i+1] = b
+	}
+	chkNotExists(t, ps, peers...)
+
+	// add one
+	ps.Add(peers[0], 0)
+	chkLen(t, ps, 1)
+	chkExists(t, ps, peers[:1]...)
+	chkNotExists(t, ps, peers[1:]...)
+
+	// check duplicates
+	ps.Add(peers[0], 0)
+	chkLen(t, ps, 1)
+	chkBins(t, ps, []uint{0, 1, 1, 1})
+	chkExists(t, ps, peers[:1]...)
+	chkNotExists(t, ps, peers[1:]...)
+
+	// check empty
+	ps.Remove(peers[0], 0)
+	chkLen(t, ps, 0)
+	chkBins(t, ps, []uint{0, 0, 0, 0})
+	chkNotExists(t, ps, peers...)
+
+	// add two in bin 0
+	ps.Add(peers[0], 0)
+	ps.Add(peers[1], 0)
+	chkLen(t, ps, 2)
+	chkBins(t, ps, []uint{0, 2, 2, 2})
+	chkExists(t, ps, peers[:2]...)
+	chkNotExists(t, ps, peers[2:]...)
+
+	ps.Add(peers[2], 1)
+	ps.Add(peers[3], 1)
+	chkLen(t, ps, 4)
+	chkBins(t, ps, []uint{0, 2, 4, 4})
+	chkExists(t, ps, peers[:4]...)
+	chkNotExists(t, ps, peers[4:]...)
+
+	ps.Remove(peers[1], 0)
+	chkLen(t, ps, 3)
+	chkBins(t, ps, []uint{0, 1, 3, 3})
+	chkExists(t, ps, peers[0], peers[2], peers[3])
+	chkNotExists(t, ps, append([]swarm.Address{peers[1]}, peers[4:]...)...)
+
+	// this should not move the last cursor
+	ps.Add(peers[7], 3)
+	chkLen(t, ps, 4)
+	chkBins(t, ps, []uint{0, 1, 3, 3})
+	chkExists(t, ps, peers[0], peers[2], peers[3], peers[7])
+	chkNotExists(t, ps, append([]swarm.Address{peers[1]}, peers[4:7]...)...)
+
+	ps.Add(peers[5], 2)
+	chkLen(t, ps, 5)
+	chkBins(t, ps, []uint{0, 1, 3, 4})
+	chkExists(t, ps, peers[0], peers[2], peers[3], peers[5], peers[7])
+	chkNotExists(t, ps, []swarm.Address{peers[1], peers[4], peers[6]}...)
+
+	ps.Remove(peers[2], 1)
+	chkLen(t, ps, 4)
+	chkBins(t, ps, []uint{0, 1, 2, 3})
+	chkExists(t, ps, peers[0], peers[3], peers[5], peers[7])
+	chkNotExists(t, ps, []swarm.Address{peers[1], peers[2], peers[4], peers[6]}...)
+
+	p := uint8(0)
+	for i := 0; i < 8; i += 2 {
+		ps.Remove(peers[i], p)
+		ps.Remove(peers[i+1], p)
+		p++
+	}
+
+	// check empty again
+	chkLen(t, ps, 0)
+	chkBins(t, ps, []uint{0, 0, 0, 0})
+	chkNotExists(t, ps, peers...)
+}
+
+// TestIteratorError checks that error propagation works correctly in the iterators.
+func TestIteratorError(t *testing.T) {
+	var (
+		ps   = pslice.New(4)
+		base = test.RandomAddress()
+		a    = test.RandomAddressAt(base, 0)
+		e    = errors.New("err1")
+	)
+
+	ps.Add(a, 0)
+
+	f := func(p swarm.Address, _ uint8) (stop, jumpToNext bool, err error) {
+		return false, false, e
+	}
+
+	err := ps.EachBin(f)
+	if !errors.Is(err, e) {
+		t.Fatal("didnt get expected error")
+	}
+}
+
+// TestIterators tests that the EachBin and EachBinRev iterators work as expected.
+func TestIterators(t *testing.T) {
+	ps := pslice.New(4)
+
+	base := test.RandomAddress()
+	peers := make([]swarm.Address, 4)
+	for i := 0; i < 4; i++ {
+		a := test.RandomAddressAt(base, i)
+		peers[i] = a
+	}
+
+	testIterator(t, ps, 0, []swarm.Address{})
+	testIteratorRev(t, ps, 0, []swarm.Address{})
+
+	for i, v := range peers {
+		ps.Add(v, uint8(i))
+	}
+
+	testIterator(t, ps, 4, []swarm.Address{peers[3], peers[2], peers[1], peers[0]})
+	testIteratorRev(t, ps, 4, peers)
+
+	ps.Remove(peers[2], 2)
+	testIterator(t, ps, 3, []swarm.Address{peers[3], peers[1], peers[0]})
+	testIteratorRev(t, ps, 3, []swarm.Address{peers[0], peers[1], peers[3]})
+
+	ps.Remove(peers[0], 0)
+	testIterator(t, ps, 2, []swarm.Address{peers[3], peers[1]})
+	testIteratorRev(t, ps, 2, []swarm.Address{peers[1], peers[3]})
+
+	ps.Remove(peers[3], 3)
+	testIterator(t, ps, 1, []swarm.Address{peers[1]})
+	testIteratorRev(t, ps, 1, []swarm.Address{peers[1]})
+
+	ps.Remove(peers[1], 1)
+	testIterator(t, ps, 0, []swarm.Address{})
+	testIteratorRev(t, ps, 0, []swarm.Address{})
+}
+
+func testIteratorRev(t *testing.T, ps *pslice.PSlice, iterations int, peerseq []swarm.Address) {
+	t.Helper()
+	i := 0
+	f := func(p swarm.Address, po uint8) (stop, jumpToNext bool, err error) {
+		if i == iterations {
+			t.Fatal("too many iterations!")
+		}
+		if !p.Equal(peerseq[i]) {
+			t.Errorf("got wrong peer seq from iterator")
+		}
+		i++
+		return false, false, nil
+	}
+
+	err := ps.EachBinRev(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != iterations {
+		t.Fatalf("iterations mismatch, want %d got %d", iterations, i)
+	}
+}
+
+func testIterator(t *testing.T, ps *pslice.PSlice, iterations int, peerseq []swarm.Address) {
+	t.Helper()
+	i := 0
+	f := func(p swarm.Address, po uint8) (stop, jumpToNext bool, err error) {
+		if i == iterations {
+			t.Fatal("too many iterations!")
+		}
+		if !p.Equal(peerseq[i]) {
+			t.Errorf("got wrong peer seq from iterator")
+		}
+		i++
+		return false, false, nil
+	}
+
+	err := ps.EachBin(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func chkLen(t *testing.T, ps *pslice.PSlice, l int) {
+	pp := pslice.PSlicePeers(ps)
+	if lp := len(pp); lp != l {
+		t.Fatalf("length mismatch, want %d got %d", l, lp)
+	}
+}
+
+func chkBins(t *testing.T, ps *pslice.PSlice, seq []uint) {
+	pb := pslice.PSliceBins(ps)
+	for i, v := range seq {
+		if pb[i] != v {
+			t.Fatalf("bin seq wrong, get %d want %d", pb[i], v)
+		}
+	}
+}
+
+func chkExists(t *testing.T, ps *pslice.PSlice, addrs ...swarm.Address) {
+	t.Helper()
+	for _, a := range addrs {
+		if !ps.Exists(a) {
+			t.Fatalf("peer %s does not exist but should have", a.String())
+		}
+	}
+}
+
+func chkNotExists(t *testing.T, ps *pslice.PSlice, addrs ...swarm.Address) {
+	t.Helper()
+	for _, a := range addrs {
+		if ps.Exists(a) {
+			t.Fatalf("peer %s does exists but should have not", a.String())
+		}
+	}
+}

--- a/pkg/topology/test/helper.go
+++ b/pkg/topology/test/helper.go
@@ -12,8 +12,7 @@ import (
 )
 
 // RandomAddressAt generates a random address
-// at proximity order prox relative to address
-// if prox is negative a random address is generated.
+// at proximity order prox relative to address.
 func RandomAddressAt(self swarm.Address, prox int) swarm.Address {
 	addr := make([]byte, len(self.Bytes()))
 	copy(addr, self.Bytes())
@@ -42,6 +41,7 @@ func RandomAddressAt(self swarm.Address, prox int) swarm.Address {
 	return a
 }
 
+// RandomAddress generates a random address.
 func RandomAddress() swarm.Address {
 	b := make([]byte, 32)
 	return RandomAddressAt(swarm.NewAddress(b), -1)

--- a/pkg/topology/test/helper.go
+++ b/pkg/topology/test/helper.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// RandomAddressAt generates a random address
+// at proximity order prox relative to address
+// if prox is negative a random address is generated.
+func RandomAddressAt(self swarm.Address, prox int) swarm.Address {
+	addr := make([]byte, len(self.Bytes()))
+	copy(addr, self.Bytes())
+	pos := -1
+	if prox >= 0 {
+		pos = prox / 8
+		trans := prox % 8
+		transbytea := byte(0)
+		for j := 0; j <= trans; j++ {
+			transbytea |= 1 << uint8(7-j)
+		}
+		flipbyte := byte(1 << uint8(7-trans))
+		transbyteb := transbytea ^ byte(255)
+		randbyte := byte(rand.Intn(255))
+		addr[pos] = ((addr[pos] & transbytea) ^ flipbyte) | randbyte&transbyteb
+	}
+
+	for i := pos + 1; i < len(addr); i++ {
+		addr[i] = byte(rand.Intn(255))
+	}
+
+	a := swarm.NewAddress(addr)
+	if a.Equal(self) {
+		panic(fmt.Sprint(a.String(), self.String()))
+	}
+	return a
+}
+
+func RandomAddress() swarm.Address {
+	b := make([]byte, 32)
+	return RandomAddressAt(swarm.NewAddress(b), -1)
+}

--- a/pkg/topology/test/helper_test.go
+++ b/pkg/topology/test/helper_test.go
@@ -12,29 +12,34 @@ import (
 	"github.com/ethersphere/bee/pkg/topology/test"
 )
 
+// TestRandomAddressAt checks that RandomAddressAt generates a correct random address
+// at a given proximity order. It compares the number of leading equal bits in the generated
+// address to the base address.
 func TestRandomAddressAt(t *testing.T) {
 	base := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
-
-	bitsInCommon := 16
-	addr := test.RandomAddressAt(base, bitsInCommon)
 	b0 := base.Bytes()
-	b1 := addr.Bytes()
+	hw0 := []byte{b0[0], b0[1], 0, 0} // highest words of base address
+	hw0int := binary.BigEndian.Uint32(hw0)
 
-	hw0 := []byte{b0[0], b0[1]} // highest words of 0
-	hw1 := []byte{b1[0], b1[1]} // highest words of 1
+	for bitsInCommon := 0; bitsInCommon < 30; bitsInCommon++ {
+		addr := test.RandomAddressAt(base, bitsInCommon)
+		b1 := addr.Bytes()
 
-	// bb0 is the result of the XOR between b0 and b1 words
-	bb0 := uint16(0)
-	for i := 0; i < bitsInCommon; i++ {
-		bb0 |= (1 << (31 - i))
-	}
-	xorb := make([]byte, 2)
-	binary.BigEndian.PutUint16(xorb, bb0)
+		hw1 := []byte{b1[0], b1[1], 0, 0} // highest words of 1
+		hw1int := binary.BigEndian.Uint32(hw1)
 
-	for i := 0; i < 2; i++ {
-		xb := hw0[i] ^ hw1[i]
-		if xorb[i] != xb {
-			t.Fatal("xor value mismatch. good luck debugging this")
+		//bb0 is the bit mask to AND with hw0 and hw1
+		bb0 := uint32(0)
+		for i := 0; i < bitsInCommon; i++ {
+			bb0 |= (1 << (31 - i))
+		}
+
+		andhw0 := hw0int & bb0
+		andhw1 := hw1int & bb0
+
+		// the result of the AND with both highest words of b0 and b1 should be equal
+		if andhw0 != andhw1 {
+			t.Fatalf("hw0 %08b hw1 %08b mask %08b &0 %08b &1 %08b", hw0int, hw1int, bb0, andhw0, andhw1)
 		}
 	}
 }

--- a/pkg/topology/test/helper_test.go
+++ b/pkg/topology/test/helper_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package test_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology/test"
+)
+
+func TestRandomAddressAt(t *testing.T) {
+	base := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
+
+	bitsInCommon := 16
+	addr := test.RandomAddressAt(base, bitsInCommon)
+	b0 := base.Bytes()
+	b1 := addr.Bytes()
+
+	hw0 := []byte{b0[0], b0[1]} // highest words of 0
+	hw1 := []byte{b1[0], b1[1]} // highest words of 1
+
+	// bb0 is the result of the XOR between b0 and b1 words
+	bb0 := uint16(0)
+	for i := 0; i < bitsInCommon; i++ {
+		bb0 |= (1 << (31 - i))
+	}
+	xorb := make([]byte, 2)
+	binary.BigEndian.PutUint16(xorb, bb0)
+
+	for i := 0; i < 2; i++ {
+		xb := hw0[i] ^ hw1[i]
+		if xorb[i] != xb {
+			t.Fatal("xor value mismatch. good luck debugging this")
+		}
+	}
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -29,8 +29,5 @@ type ClosestPeerer interface {
 	ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
 }
 
-// ScoreFunc is implemented by components that need to score peers in a different way than XOR distance.
-type ScoreFunc func(peer swarm.Address) (score float32)
-
 // EachPeerFunc is a callback that is called with a peer and its PO
 type EachPeerFunc func(swarm.Address, uint8) (stop, jumpToNext bool, err error)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -28,3 +28,9 @@ type PeerAdder interface {
 type ClosestPeerer interface {
 	ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
 }
+
+// ScoreFunc is implemented by components that need to score peers in a different way than XOR distance.
+type ScoreFunc func(peer swarm.Address) (score float32)
+
+// EachPeerFunc is a callback that is called with a peer and its PO
+type EachPeerFunc func(swarm.Address, uint8) (stop, jumpToNext bool, err error)


### PR DESCRIPTION
this PR introduces a basic data structure (therein called `pslice`) which is essentially a slice which maintains indexes for POs, that is to index the different proximity order of peers that we populate in the main `peers` slice.

needed by #155 
inadvertently related to #47