### PR TITLE
Pusher: Move push sync logic in to pusher

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -7,8 +7,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/ethersphere/bee/pkg/pusher"
-	"github.com/ethersphere/bee/pkg/pushsync"
 	"io"
 	"log"
 	"net"
@@ -16,9 +14,6 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
-
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/api"
@@ -34,6 +29,8 @@ import (
 	"github.com/ethersphere/bee/pkg/netstore"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/pkg/pingpong"
+	"github.com/ethersphere/bee/pkg/pusher"
+	"github.com/ethersphere/bee/pkg/pushsync"
 	"github.com/ethersphere/bee/pkg/retrieval"
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
 	mockinmem "github.com/ethersphere/bee/pkg/statestore/mock"
@@ -43,6 +40,8 @@ import (
 	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/ethersphere/bee/pkg/validator"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 type Bee struct {

--- a/pkg/pusher/metrics.go
+++ b/pkg/pusher/metrics.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pusher
+
+import (
+	m "github.com/ethersphere/bee/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	// all metrics fields must be exported
+	// to be able to return them by Metrics()
+	// using reflection
+
+	TotalChunksToBeSentCounter prometheus.Counter
+	TotalChunksSynced          prometheus.Counter
+	ErrorSettingChunkToSynced  prometheus.Counter
+	MarkAndSweepTimer          prometheus.Histogram
+}
+
+func newMetrics() metrics {
+	subsystem := "pushsync"
+
+	return metrics{
+		TotalChunksToBeSentCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_chunk_to_be_sent",
+			Help:      "Total chunks to be sent.",
+		}),
+		TotalChunksSynced: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_chunk_synced",
+			Help:      "Total chunks synced succesfully with valid receipts.",
+		}),
+		ErrorSettingChunkToSynced: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "cannot_set_chunk_sync_in_DB",
+			Help:      "Total no of times the chunk cannot be synced in DB.",
+		}),
+		MarkAndSweepTimer: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "mark_and_sweep_time_histogram",
+			Help:      "Histogram of time spent in mark and sweep.",
+			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60},
+		}),
+	}
+}
+
+func (s *Service) Metrics() []prometheus.Collector {
+	return m.PrometheusCollectorsFromFields(s.metrics)
+}

--- a/pkg/pusher/metrics.go
+++ b/pkg/pusher/metrics.go
@@ -39,7 +39,7 @@ func newMetrics() metrics {
 		ErrorSettingChunkToSynced: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "cannot_set_chunk_sync_in_DB",
+			Name:      "cannot_set_chunk_sync_in_db",
 			Help:      "Total no of times the chunk cannot be synced in DB.",
 		}),
 		MarkAndSweepTimer: prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/pkg/pusher/metrics.go
+++ b/pkg/pusher/metrics.go
@@ -34,7 +34,7 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_chunk_synced",
-			Help:      "Total chunks synced succesfully with valid receipts.",
+			Help:      "Total chunks synced successfully with valid receipts.",
 		}),
 		ErrorSettingChunkToSynced: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -1,0 +1,147 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pusher
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/pushsync"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
+)
+
+type Service struct {
+	storer            storage.Storer
+	peerSuggester     topology.ClosestPeerer
+	pushSyncer        pushsync.PushSyncer
+	logger            logging.Logger
+	metrics           metrics
+	quit              chan struct{}
+	chunksWorkerQuitC chan struct{}
+}
+
+type Options struct {
+	Storer        storage.Storer
+	PeerSuggester topology.ClosestPeerer
+	PushSyncer    pushsync.PushSyncer
+	Logger        logging.Logger
+}
+
+var retryInterval = 10 * time.Second // time interval between retries
+
+func New(o Options) *Service {
+	service := &Service{
+		storer:            o.Storer,
+		peerSuggester:     o.PeerSuggester,
+		pushSyncer:        o.PushSyncer,
+		logger:            o.Logger,
+		metrics:           newMetrics(),
+		quit:              make(chan struct{}),
+		chunksWorkerQuitC: make(chan struct{}),
+	}
+	go service.chunksWorker()
+	return service
+}
+
+// chunksWorker is a loop that keeps looking for chunks that are locally uploaded ( by monitoring pushIndex )
+// and pushes them to the closest peer and get a receipt.
+func (s *Service) chunksWorker() {
+	var chunks <-chan swarm.Chunk
+	var unsubscribe func()
+	// timer, initially set to 0 to fall through select case on timer.C for initialisation
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	defer close(s.chunksWorkerQuitC)
+	chunksInBatch := -1
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-s.quit
+		cancel()
+	}()
+	for {
+		select {
+		// handle incoming chunks
+		case ch, more := <-chunks:
+			// if no more, set to nil, reset timer to 0 to finalise batch immediately
+			if !more {
+				chunks = nil
+				var dur time.Duration
+				if chunksInBatch == 0 {
+					dur = 500 * time.Millisecond
+				}
+				timer.Reset(dur)
+				break
+			}
+
+			chunksInBatch++
+			s.metrics.TotalChunksToBeSentCounter.Inc()
+			peer, err := s.peerSuggester.ClosestPeer(ch.Address())
+			if err != nil {
+				if errors.Is(err, topology.ErrWantSelf) {
+					// set chunk status to synced
+					s.setChunkAsSynced(ctx, ch.Address())
+					continue
+				}
+			}
+
+			_, err = s.pushSyncer.SendChunkAndReceiveReceipt(ctx, peer, ch)
+			if err != nil {
+				s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
+				continue
+			}
+
+			// set chunk status to synced
+			s.setChunkAsSynced(ctx, ch.Address())
+			continue
+
+			// retry interval timer triggers starting from new
+		case <-timer.C:
+			// initially timer is set to go off as well as every time we hit the end of push index
+			startTime := time.Now()
+
+			// if subscribe was running, stop it
+			if unsubscribe != nil {
+				unsubscribe()
+			}
+
+			// and start iterating on Push index from the beginning
+			chunks, unsubscribe = s.storer.SubscribePush(ctx)
+
+			// reset timer to go off after retryInterval
+			timer.Reset(retryInterval)
+			s.metrics.MarkAndSweepTimer.Observe(time.Since(startTime).Seconds())
+
+		case <-s.quit:
+			if unsubscribe != nil {
+				unsubscribe()
+			}
+			return
+		}
+	}
+}
+
+func (s *Service) setChunkAsSynced(ctx context.Context, addr swarm.Address) {
+	if err := s.storer.Set(ctx, storage.ModeSetSyncPush, addr); err != nil {
+		s.logger.Errorf("pusher: error setting chunk as synced: %v", err)
+		s.metrics.ErrorSettingChunkToSynced.Inc()
+	} else {
+		s.metrics.TotalChunksSynced.Inc()
+	}
+}
+
+func (s *Service) Close() error {
+	close(s.quit)
+
+	// Wait for chunks worker to finish
+	select {
+	case <-s.chunksWorkerQuitC:
+	case <-time.After(3 * time.Second):
+	}
+	return nil
+}

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -90,7 +90,9 @@ func (s *Service) chunksWorker() {
 				}
 			}
 
-			_, err = s.pushSyncer.SendChunkAndReceiveReceipt(ctx, peer, ch)
+			// Later when we process receipt, get the receipt and process it
+			// for now ignoring the receipt and checking only for error
+			_, err = s.pushSyncer.ChunkPusher(ctx, peer, ch)
 			if err != nil {
 				s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
 				continue

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -1,0 +1,173 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pusher_test
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/localstore"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/pusher"
+	"github.com/ethersphere/bee/pkg/pushsync"
+	pushsyncmock "github.com/ethersphere/bee/pkg/pushsync/mock"
+	"github.com/ethersphere/bee/pkg/pushsync/pb"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology/mock"
+)
+
+type Store struct {
+	storage.Storer
+	ModeSet   map[string]storage.ModeSet
+	modeSetMu sync.Mutex
+}
+
+func (s Store) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Address) error {
+	s.modeSetMu.Lock()
+	defer s.modeSetMu.Unlock()
+	for _, addr := range addrs {
+		s.ModeSet[addr.String()] = mode
+	}
+	return s.Set(ctx, mode, addrs...)
+}
+
+func TestSendChunkToPushSync(t *testing.T) {
+	chunk := createChunk(t)
+
+	// create a trigger  and a closestpeer
+	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error) {
+		receipt := &pb.Receipt{
+			Address: chunk.Address().Bytes(),
+		}
+		return receipt, nil
+	})
+
+	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+
+	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Give some time for chunk to be pushed and receipt to be received
+	time.Sleep(10 * time.Millisecond)
+
+	err = checkIfModeSet(t, chunk.Address(), storage.ModeSetSyncPush, storer)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
+	chunk := createChunk(t)
+
+	// create a trigger  and a closestpeer
+	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error) {
+		return nil, errors.New("invalid receipt")
+	})
+
+	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+
+	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Give some time for chunk to be pushed and receipt to be received
+	time.Sleep(10 * time.Millisecond)
+
+	err = checkIfModeSet(t, chunk.Address(), storage.ModeSetSyncPush, storer)
+	if err == nil {
+		t.Fatalf("chunk not syned error expected")
+	}
+}
+
+func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
+	chunk := createChunk(t)
+
+	// create a trigger  and a closestpeer
+	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error) {
+		// Set 10 times more than the time we wait for the test to complete so that
+		// the response never reaches our testcase
+		time.Sleep(100 * time.Millisecond)
+		return nil, nil
+	})
+
+	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+
+	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Give some time for chunk to be pushed and receipt to be received
+	time.Sleep(10 * time.Millisecond)
+
+	err = checkIfModeSet(t, chunk.Address(), storage.ModeSetSyncPush, storer)
+	if err == nil {
+		t.Fatalf("chunk not syned error expected")
+	}
+}
+
+func createChunk(t *testing.T) swarm.Chunk {
+	t.Helper()
+
+	// chunk data to upload
+	chunkAddress := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
+	chunkData := []byte("1234")
+	return swarm.NewChunk(chunkAddress, chunkData)
+}
+
+func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, mockOpts ...mock.Option) (*pusher.Service, *Store) {
+	t.Helper()
+	logger := logging.New(ioutil.Discard, 0)
+	storer, err := localstore.New("", addr.Bytes(), nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pusherStorer := &Store{
+		Storer:  storer,
+		ModeSet: make(map[string]storage.ModeSet),
+	}
+	peerSuggester := mock.NewTopologyDriver(mockOpts...)
+	pusherService := pusher.New(pusher.Options{Storer: pusherStorer, PushSyncer: pushSyncService, PeerSuggester: peerSuggester, Logger: logger})
+	return pusherService, pusherStorer
+}
+
+func checkIfModeSet(t *testing.T, addr swarm.Address, mode storage.ModeSet, storer *Store) error {
+	t.Helper()
+
+	var found bool
+	storer.modeSetMu.Lock()
+	defer storer.modeSetMu.Unlock()
+
+	for k, v := range storer.ModeSet {
+		if addr.String() == k {
+			found = true
+			if v != mode {
+				return errors.New("chunk mode is not properly set as synced")
+			}
+		}
+	}
+	if !found {
+		return errors.New("Chunk not synced")
+	}
+	return nil
+}

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -47,14 +47,14 @@ func TestSendChunkToPushSync(t *testing.T) {
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
-		time.Sleep(30 * time.Millisecond)
 		receipt := &pushsync.Receipt{
 			Address: swarm.NewAddress(chunk.Address().Bytes()),
 		}
 		return receipt, nil
 	})
 
-	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	defer storer.Close()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -74,6 +74,7 @@ func TestSendChunkToPushSync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	p.Close()
 }
 
 func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
@@ -87,7 +88,8 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 		return nil, errors.New("invalid receipt")
 	})
 
-	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	defer storer.Close()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -107,6 +109,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 	if err == nil {
 		t.Fatalf("chunk not syned error expected")
 	}
+	p.Close()
 }
 
 func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
@@ -123,7 +126,8 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 		return nil, nil
 	})
 
-	_, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
+	defer storer.Close()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -143,6 +147,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 	if err == nil {
 		t.Fatalf("chunk not syned error expected")
 	}
+	p.Close()
 }
 
 func createChunk() swarm.Chunk {

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -26,7 +26,7 @@ import (
 type Store struct {
 	storage.Storer
 	ModeSet   map[string]storage.ModeSet
-	modeSetMu sync.Mutex
+	modeSetMu *sync.Mutex
 }
 
 func (s Store) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Address) error {
@@ -145,6 +145,8 @@ func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.Pus
 	pusherStorer := &Store{
 		Storer:  storer,
 		ModeSet: make(map[string]storage.ModeSet),
+		modeSetMu: &sync.Mutex{},
+
 	}
 	peerSuggester := mock.NewTopologyDriver(mockOpts...)
 	pusherService := pusher.New(pusher.Options{Storer: pusherStorer, PushSyncer: pushSyncService, PeerSuggester: peerSuggester, Logger: logger})

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -143,10 +143,9 @@ func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.Pus
 	}
 
 	pusherStorer := &Store{
-		Storer:  storer,
-		ModeSet: make(map[string]storage.ModeSet),
+		Storer:    storer,
+		ModeSet:   make(map[string]storage.ModeSet),
 		modeSetMu: &sync.Mutex{},
-
 	}
 	peerSuggester := mock.NewTopologyDriver(mockOpts...)
 	pusherService := pusher.New(pusher.Options{Storer: pusherStorer, PushSyncer: pushSyncService, PeerSuggester: peerSuggester, Logger: logger})

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -35,7 +35,7 @@ func (s Store) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Add
 	for _, addr := range addrs {
 		s.ModeSet[addr.String()] = mode
 	}
-	return s.Set(ctx, mode, addrs...)
+	return nil
 }
 
 func TestSendChunkToPushSync(t *testing.T) {

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -52,7 +52,7 @@ func TestSendChunkToPushSync(t *testing.T) {
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
-	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		receipt := &pushsync.Receipt{
 			Address: swarm.NewAddress(chunk.Address().Bytes()),
 		}
@@ -93,7 +93,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
-	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		return nil, errors.New("invalid receipt")
 	})
 
@@ -131,7 +131,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
-	pushSyncService := pushsyncmock.New(func(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
+	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		// Set 10 times more than the time we wait for the test to complete so that
 		// the response never reaches our testcase
 		time.Sleep(1 * time.Second)

--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -37,7 +37,7 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_chunk_stored_in_DB",
-			Help:      "Total chunks stored succesfully in local store.",
+			Help:      "Total chunks stored successfully in local store.",
 		}),
 		ChunksSentCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -14,8 +14,6 @@ type metrics struct {
 	// to be able to return them by Metrics()
 	// using reflection
 
-	TotalChunksToBeSentCounter prometheus.Counter
-	TotalChunksSynced          prometheus.Counter
 	TotalChunksStoredInDB      prometheus.Counter
 	ChunksSentCounter          prometheus.Counter
 	ChunksReceivedCounter      prometheus.Counter
@@ -25,35 +23,21 @@ type metrics struct {
 	ReceiptsSentCounter        prometheus.Counter
 	SendReceiptErrorCounter    prometheus.Counter
 	ReceiveReceiptErrorCounter prometheus.Counter
-	ErrorSettingChunkToSynced  prometheus.Counter
 	RetriesExhaustedCounter    prometheus.Counter
 	InvalidReceiptReceived     prometheus.Counter
 	SendChunkTimer             prometheus.Histogram
 	ReceiptRTT                 prometheus.Histogram
-	MarkAndSweepTimer          prometheus.Histogram
 }
 
 func newMetrics() metrics {
 	subsystem := "pushsync"
 
 	return metrics{
-		TotalChunksToBeSentCounter: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "total_chunk_to_be_sent",
-			Help:      "Total chunks to be sent.",
-		}),
-		TotalChunksSynced: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "total_chunk_synced",
-			Help:      "Total chunks synced successfully with valid receipts.",
-		}),
 		TotalChunksStoredInDB: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_chunk_stored_in_DB",
-			Help:      "Total chunks stored successfully in local store.",
+			Help:      "Total chunks stored succesfully in local store.",
 		}),
 		ChunksSentCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
@@ -103,13 +87,6 @@ func newMetrics() metrics {
 			Name:      "receive_receipt_error",
 			Help:      "Total no of time error received while receiving receipt.",
 		}),
-
-		ErrorSettingChunkToSynced: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "cannot_set_chunk_sync_in_DB",
-			Help:      "Total no of times the chunk cannot be synced in DB.",
-		}),
 		RetriesExhaustedCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
@@ -127,13 +104,6 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "send_chunk_time_histogram",
 			Help:      "Histogram for Time taken to send a chunk.",
-			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60},
-		}),
-		MarkAndSweepTimer: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "mark_and_sweep_time_histogram",
-			Help:      "Histogram of time spent in mark and sweep.",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60},
 		}),
 		ReceiptRTT: prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/pkg/pushsync/mock/mock.go
+++ b/pkg/pushsync/mock/mock.go
@@ -1,0 +1,24 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/ethersphere/bee/pkg/pushsync/pb"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type PushSync struct {
+	SendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error)
+}
+
+func New(sendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error)) *PushSync {
+	return &PushSync{SendChunk: sendChunk}
+}
+
+func (s *PushSync) SendChunkAndReceiveReceipt(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error) {
+	return s.SendChunk(ctx, address, chunk)
+}

--- a/pkg/pushsync/mock/mock.go
+++ b/pkg/pushsync/mock/mock.go
@@ -12,13 +12,13 @@ import (
 )
 
 type PushSync struct {
-	SendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error)
+	SendChunk func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error)
 }
 
-func New(sendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error)) *PushSync {
+func New(sendChunk func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error)) *PushSync {
 	return &PushSync{SendChunk: sendChunk}
 }
 
-func (s *PushSync) ChunkPusher(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
-	return s.SendChunk(ctx, address, chunk)
+func (s *PushSync) PushChunkToClosest(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
+	return s.SendChunk(ctx, chunk)
 }

--- a/pkg/pushsync/mock/mock.go
+++ b/pkg/pushsync/mock/mock.go
@@ -7,18 +7,18 @@ package mock
 import (
 	"context"
 
-	"github.com/ethersphere/bee/pkg/pushsync/pb"
+	"github.com/ethersphere/bee/pkg/pushsync"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 type PushSync struct {
-	SendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error)
+	SendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error)
 }
 
-func New(sendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error)) *PushSync {
+func New(sendChunk func(ctx context.Context, peer swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error)) *PushSync {
 	return &PushSync{SendChunk: sendChunk}
 }
 
-func (s *PushSync) SendChunkAndReceiveReceipt(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pb.Receipt, error) {
+func (s *PushSync) ChunkPusher(ctx context.Context, address swarm.Address, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 	return s.SendChunk(ctx, address, chunk)
 }

--- a/pkg/pushsync/mock/mock.go
+++ b/pkg/pushsync/mock/mock.go
@@ -12,13 +12,13 @@ import (
 )
 
 type PushSync struct {
-	SendChunk func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error)
+	sendChunk func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error)
 }
 
 func New(sendChunk func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error)) *PushSync {
-	return &PushSync{SendChunk: sendChunk}
+	return &PushSync{sendChunk: sendChunk}
 }
 
 func (s *PushSync) PushChunkToClosest(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
-	return s.SendChunk(ctx, chunk)
+	return s.sendChunk(ctx, chunk)
 }

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -95,7 +95,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			}
 			ps.metrics.TotalChunksStoredInDB.Inc()
 
-			// Send a receipt immediately once the storage of the chunk is successfull
+			// Send a receipt immediately once the storage of the chunk is successfully
 			receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 			err = ps.sendReceipt(w, receipt)
 			if err != nil {
@@ -117,7 +117,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 		}
 		ps.metrics.TotalChunksStoredInDB.Inc()
 
-		// Send a receipt immediately once the storage of the chunk is successfull
+		// Send a receipt immediately once the storage of the chunk is successfully
 		receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 		return ps.sendReceipt(w, receipt)
 	}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -25,40 +25,35 @@ const (
 	streamName      = "pushsync"
 )
 
+type PushSyncer interface {
+	SendChunkAndReceiveReceipt(ctx context.Context, peer swarm.Address, ch swarm.Chunk) (*pb.Receipt, error)
+}
+
 type PushSync struct {
-	streamer          p2p.Streamer
-	storer            storage.Storer
-	peerSuggester     topology.ClosestPeerer
-	logger            logging.Logger
-	metrics           metrics
-	quit              chan struct{}
-	chunksWorkerQuitC chan struct{}
+	streamer      p2p.Streamer
+	storer        storage.Putter
+	peerSuggester topology.ClosestPeerer
+	logger        logging.Logger
+	metrics       metrics
 }
 
 type Options struct {
 	Streamer      p2p.Streamer
-	Storer        storage.Storer
+	Storer        storage.Putter
 	ClosestPeerer topology.ClosestPeerer
 	Logger        logging.Logger
 }
 
-var (
-	retryInterval        = 10 * time.Second // time interval between retries
-	timeToWaitForReceipt = 3 * time.Second  // time to wait to get a receipt for a chunk
-)
+var timeToWaitForReceipt = 3 * time.Second // time to wait to get a receipt for a chunk
 
 func New(o Options) *PushSync {
 	ps := &PushSync{
-		streamer:          o.Streamer,
-		storer:            o.Storer,
-		peerSuggester:     o.ClosestPeerer,
-		logger:            o.Logger,
-		metrics:           newMetrics(),
-		quit:              make(chan struct{}),
-		chunksWorkerQuitC: make(chan struct{}),
+		streamer:      o.Streamer,
+		storer:        o.Storer,
+		peerSuggester: o.ClosestPeerer,
+		logger:        o.Logger,
+		metrics:       newMetrics(),
 	}
-
-	go ps.chunksWorker()
 	return ps
 }
 
@@ -73,17 +68,6 @@ func (s *PushSync) Protocol() p2p.ProtocolSpec {
 			},
 		},
 	}
-}
-
-func (ps *PushSync) Close() error {
-	close(ps.quit)
-
-	// Wait for chunks worker to finish
-	select {
-	case <-ps.chunksWorkerQuitC:
-	case <-time.After(3 * time.Second):
-	}
-	return nil
 }
 
 // handler handles chunk delivery from other node and forwards to its destination node.
@@ -111,7 +95,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			}
 			ps.metrics.TotalChunksStoredInDB.Inc()
 
-			// Send a receipt immediately once the storage of the chunk is successful
+			// Send a receipt immediately once the storage of the chunk is successfull
 			receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 			err = ps.sendReceipt(w, receipt)
 			if err != nil {
@@ -133,7 +117,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 		}
 		ps.metrics.TotalChunksStoredInDB.Inc()
 
-		// Send a receipt immediately once the storage of the chunk is successful
+		// Send a receipt immediately once the storage of the chunk is successfull
 		receipt := &pb.Receipt{Address: chunk.Address().Bytes()}
 		return ps.sendReceipt(w, receipt)
 	}
@@ -220,115 +204,32 @@ func (ps *PushSync) receiveReceipt(r protobuf.Reader) (receipt pb.Receipt, err e
 	return receipt, nil
 }
 
-// chunksWorker is a loop that keeps looking for chunks that are locally uploaded ( by monitoring pushIndex )
-// and pushes them to the closest peer and get a receipt.
-func (ps *PushSync) chunksWorker() {
-	var chunks <-chan swarm.Chunk
-	var unsubscribe func()
-	// timer, initially set to 0 to fall through select case on timer.C for initialisation
-	timer := time.NewTimer(0)
-	defer timer.Stop()
-	defer close(ps.chunksWorkerQuitC)
-	chunksInBatch := -1
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-ps.quit
-		cancel()
-	}()
-	for {
-		select {
-		// handle incoming chunks
-		case ch, more := <-chunks:
-			// if no more, set to nil, reset timer to 0 to finalise batch immediately
-			if !more {
-				chunks = nil
-				var dur time.Duration
-				if chunksInBatch == 0 {
-					dur = 500 * time.Millisecond
-				}
-				timer.Reset(dur)
-				break
-			}
-
-			chunksInBatch++
-			ps.metrics.TotalChunksToBeSentCounter.Inc()
-			peer, err := ps.peerSuggester.ClosestPeer(ch.Address())
-			if err != nil {
-				if errors.Is(err, topology.ErrWantSelf) {
-					if err := ps.storer.Set(ctx, storage.ModeSetSyncPush, ch.Address()); err != nil {
-						ps.logger.Errorf("pushsync: error setting chunks to synced: %v", err)
-					}
-					continue
-				}
-			}
-
-			// TODO: make this function as a go routine and process several chunks in parallel
-			if err := ps.SendChunkAndReceiveReceipt(ctx, peer, ch); err != nil {
-				ps.logger.Errorf("pushsync: error while sending chunk or receiving receipt: %v", err)
-				continue
-			}
-
-			// retry interval timer triggers starting from new
-		case <-timer.C:
-			// initially timer is set to go off as well as every time we hit the end of push index
-			startTime := time.Now()
-
-			// if subscribe was running, stop it
-			if unsubscribe != nil {
-				unsubscribe()
-			}
-
-			// and start iterating on Push index from the beginning
-			chunks, unsubscribe = ps.storer.SubscribePush(ctx)
-
-			// reset timer to go off after retryInterval
-			timer.Reset(retryInterval)
-			ps.metrics.MarkAndSweepTimer.Observe(time.Since(startTime).Seconds())
-
-		case <-ps.quit:
-			if unsubscribe != nil {
-				unsubscribe()
-			}
-			return
-		}
-	}
-}
-
 // sendChunkAndReceiveReceipt sends chunk to a given peer
-// by opening a stream. It then waits for a receipt from that peer.
-// Once the receipt is received within a given time frame it marks that this chunk
-// as synced in the localstore.
-func (ps *PushSync) SendChunkAndReceiveReceipt(ctx context.Context, peer swarm.Address, ch swarm.Chunk) error {
+// by opening a stream. It then waits for a receipt from that peer and
+// returns error or nil based on the receiving and the validity of the receipt.
+func (ps *PushSync) SendChunkAndReceiveReceipt(ctx context.Context, peer swarm.Address, ch swarm.Chunk) (*pb.Receipt, error) {
 	streamer, err := ps.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
-		return fmt.Errorf("new stream: %w", err)
+		return nil, fmt.Errorf("new stream: %w", err)
 	}
 	defer streamer.Close()
 
 	w, r := protobuf.NewWriterAndReader(streamer)
 	if err := ps.sendChunkDelivery(w, ch); err != nil {
-		return fmt.Errorf("chunk deliver: %w", err)
+		return nil, fmt.Errorf("chunk deliver: %w", err)
 	}
 	receiptRTTTimer := time.Now()
 
 	receipt, err := ps.receiveReceipt(r)
 	if err != nil {
-		return fmt.Errorf("receive receipt: %w", err)
+		return nil, fmt.Errorf("receive receipt: %w", err)
 	}
 	ps.metrics.ReceiptRTT.Observe(time.Since(receiptRTTTimer).Seconds())
 
 	// Check if the receipt is valid
 	if !ch.Address().Equal(swarm.NewAddress(receipt.Address)) {
 		ps.metrics.InvalidReceiptReceived.Inc()
-		return errors.New("invalid receipt")
+		return nil, errors.New("invalid receipt")
 	}
-
-	// set chunk status to synced, insert to db GC index
-	if err := ps.storer.Set(ctx, storage.ModeSetSyncPush, ch.Address()); err != nil {
-		ps.metrics.ErrorSettingChunkToSynced.Inc()
-		return fmt.Errorf("chunk store: %w", err)
-	}
-
-	ps.metrics.TotalChunksSynced.Inc()
-	return nil
+	return &receipt, nil
 }

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -52,12 +52,12 @@ func TestSendChunkAndReceiveReceipt(t *testing.T) {
 	defer storerPivot.Close()
 
 	// Trigger the sending of chunk to the closest node
-	receipt, err := psPivot.SendChunkAndReceiveReceipt(context.Background(), closestPeer, chunk)
+	receipt, err := psPivot.ChunkPusher(context.Background(), closestPeer, chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !chunk.Address().Equal(swarm.NewAddress(receipt.Address)) {
+	if !chunk.Address().Equal(receipt.Address) {
 		t.Fatal("invalid receipt")
 	}
 
@@ -112,12 +112,12 @@ func TestHandler(t *testing.T) {
 	psTriggerPeer, triggerStorerDB := createPushSyncNode(t, triggerPeer, pivotRecorder, mock.WithClosestPeer(pivotPeer))
 	defer triggerStorerDB.Close()
 
-	receipt, err := psTriggerPeer.SendChunkAndReceiveReceipt(context.Background(), pivotPeer, chunk)
+	receipt, err := psTriggerPeer.ChunkPusher(context.Background(), pivotPeer, chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !chunk.Address().Equal(swarm.NewAddress(receipt.Address)) {
+	if !chunk.Address().Equal(receipt.Address) {
 		t.Fatal("invalid receipt")
 	}
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -52,7 +52,7 @@ func TestSendChunkAndReceiveReceipt(t *testing.T) {
 	defer storerPivot.Close()
 
 	// Trigger the sending of chunk to the closest node
-	receipt, err := psPivot.ChunkPusher(context.Background(), closestPeer, chunk)
+	receipt, err := psPivot.PushChunkToClosest(context.Background(), chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestHandler(t *testing.T) {
 	psTriggerPeer, triggerStorerDB := createPushSyncNode(t, triggerPeer, pivotRecorder, mock.WithClosestPeer(pivotPeer))
 	defer triggerStorerDB.Close()
 
-	receipt, err := psTriggerPeer.ChunkPusher(context.Background(), pivotPeer, chunk)
+	receipt, err := psTriggerPeer.PushChunkToClosest(context.Background(), chunk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -143,7 +143,6 @@ type Putter interface {
 	Put(ctx context.Context, mode ModePut, chs ...swarm.Chunk) (exist []bool, err error)
 }
 
-
 // StateStorer defines methods required to get, set, delete values for different keys
 // and close the underlying resources.
 type StateStorer interface {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -139,6 +139,11 @@ type Storer interface {
 	io.Closer
 }
 
+type Putter interface {
+	Put(ctx context.Context, mode ModePut, chs ...swarm.Chunk) (exist []bool, err error)
+}
+
+
 // StateStorer defines methods required to get, set, delete values for different keys
 // and close the underlying resources.
 type StateStorer interface {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -129,7 +129,7 @@ func (d *Descriptor) String() string {
 type Storer interface {
 	Get(ctx context.Context, mode ModeGet, addr swarm.Address) (ch swarm.Chunk, err error)
 	GetMulti(ctx context.Context, mode ModeGet, addrs ...swarm.Address) (ch []swarm.Chunk, err error)
-	Put(ctx context.Context, mode ModePut, chs ...swarm.Chunk) (exist []bool, err error)
+	Putter
 	Has(ctx context.Context, addr swarm.Address) (yes bool, err error)
 	HasMulti(ctx context.Context, addrs ...swarm.Address) (yes []bool, err error)
 	Set(ctx context.Context, mode ModeSet, addrs ...swarm.Address) (err error)


### PR DESCRIPTION
- Moved chunksWorker in to pusher package
- Made pushsync protocol dummy and it handles only one put chunk using a restricted storer interface
- Added pushed to node start and shutdown

Refer https://github.com/ethersphere/bee/issues/159