### PR TITLE
downgrade golangci-lint to v1.24.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.OS }}-build-
           ${{ runner.OS }}-
     - name: Setup GolangCI-Lint
-      run: go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+      run: GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
       working-directory: ~
     - name: Lint
       run: make lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,9 @@ jobs:
           ${{ runner.OS }}-build-
           ${{ runner.OS }}-
     - name: Setup GolangCI-Lint
-      run: GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+      run: go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+      env:
+        GO111MODULE: on
       working-directory: ~
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.26.0
+GOLANGCI_LINT_VERSION ?= v1.24.0
 
 LDFLAGS ?= -s -w
 ifdef COMMIT


### PR DESCRIPTION
This is a temporary solution to fix build failures in golangci-ling version >= 1.25.0 doe to breaking changes in gomodguard v1.1.0:

```
# github.com/golangci/golangci-lint/pkg/golinters
go/pkg/mod/github.com/golangci/golangci-lint@v1.26.0/pkg/golinters/gomodguard.go:47:36: unknown field 'k' in struct literal of type gomodguard.BlockedModule
go/pkg/mod/github.com/golangci/golangci-lint@v1.26.0/pkg/golinters/gomodguard.go:51:43: cannot use m (type gomodguard.BlockedModule) as type map[string]gomodguard.BlockedModule in append
```