### PR TITLE
fix debugapi pprof profiles router

### DIFF
--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -29,11 +29,12 @@ func (s *server) setupRouting() {
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 
-	router.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	router.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
 	router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 	router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	router.PathPrefix("/debug/pprof/").Handler(http.HandlerFunc(pprof.Index))
 
 	router.Handle("/debug/vars", expvar.Handler())
 


### PR DESCRIPTION
This PR fixes the issue with DebugAPI router serving pprof profiles. Currently profiles such as goroutines is not accessible as gorilla mux Handle was used incorrectly (expecting the behaviour as http.ServeMux). Here, pprof.Index is configured correctly to serve index and also profiles under it.