### PR TITLE
libp2p: DisconnectError test

### DIFF
--- a/pkg/p2p/error.go
+++ b/pkg/p2p/error.go
@@ -49,9 +49,9 @@ type DisconnectError struct {
 	err error
 }
 
-// Disconnect wraps error and creates a special error that is treated specially
+// NewDisconnectError wraps error and creates a special error that is treated specially
 // by p2p. It causes peer to disconnect.
-func Disconnect(err error) error {
+func NewDisconnectError(err error) error {
 	return &DisconnectError{
 		err: err,
 	}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -249,8 +249,7 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			peerID := streamlibp2p.Conn().RemotePeer()
 			overlay, found := s.peers.overlay(peerID)
 			if !found {
-				// todo: this should never happen, should we disconnect in this case?
-				// todo: test connection close and refactor
+				// todo: this should never happen
 				_ = s.disconnect(peerID)
 				s.logger.Errorf("overlay address for peer %q not found", peerID)
 				return
@@ -280,7 +279,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			if err := ss.Handler(ctx, p2p.Peer{Address: overlay}, stream); err != nil {
 				var e *p2p.DisconnectError
 				if errors.As(err, &e) {
-					// todo: test connection close and refactor
 					_ = s.Disconnect(overlay)
 				}
 

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -167,7 +167,7 @@ func TestDisconnectError(t *testing.T) {
 
 	expectPeers(t, s1, overlay2)
 
-	// no need to check the errorrs here as new stream should induce disconnect which could result in errors during headers exchange
+	// no need to check the errors here as new stream should result in disconnect from the node handling the stream
 	// node should disconnect after the new stream function is done
 	_, _ = s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
 	expectPeersEventually(t, s1)

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -167,6 +167,8 @@ func TestDisconnectError(t *testing.T) {
 
 	expectPeers(t, s1, overlay2)
 
+	// no need to check the errorrs here as new stream should induce disconnect which could result in errors during headers exchange
+	// the important this is to check that disconnect actually happens after the stream is created
 	_, _ = s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
 	expectPeersEventually(t, s1)
 }

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -141,7 +141,38 @@ func TestNewStream_semanticVersioning(t *testing.T) {
 			expectErrNotSupported(t, err)
 		}
 	}
+}
 
+func TestDisconnectError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
+	defer cleanup1()
+
+	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
+	defer cleanup2()
+
+	if err := s1.AddProtocol(newTestProtocol(func(_ context.Context, _ p2p.Peer, _ p2p.Stream) error {
+		return p2p.NewDisconnectError(errors.New("test error"))
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	addr := serviceUnderlayAddress(t, s1)
+
+	if _, err := s2.Connect(ctx, addr); err != nil {
+		t.Fatal(err)
+	}
+
+	expectPeers(t, s1, overlay2)
+
+	_, err := s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectPeersEventually(t, s1)
 }
 
 const (

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -168,7 +168,7 @@ func TestDisconnectError(t *testing.T) {
 	expectPeers(t, s1, overlay2)
 
 	// no need to check the errorrs here as new stream should induce disconnect which could result in errors during headers exchange
-	// the important this is to check that disconnect actually happens after the stream is created
+	// node should disconnect after the new stream function is done
 	_, _ = s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
 	expectPeersEventually(t, s1)
 }

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -167,11 +167,7 @@ func TestDisconnectError(t *testing.T) {
 
 	expectPeers(t, s1, overlay2)
 
-	_, err := s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	_, _ = s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
 	expectPeersEventually(t, s1)
 }
 

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -167,8 +167,8 @@ func TestDisconnectError(t *testing.T) {
 
 	expectPeers(t, s1, overlay2)
 
-	// no need to check the errors here as new stream should result in disconnect from the node handling the stream
-	// node should disconnect after the new stream function is done
+	// error is not checked as opening a new stream should cause disconnect from s1 which is async and can make errors in newStream function
+	// it is important to validate that disconnect will happen after NewStream()
 	_, _ = s2.NewStream(ctx, overlay1, nil, testProtocolName, testProtocolVersion, testStreamName)
 	expectPeersEventually(t, s1)
 }


### PR DESCRIPTION
Added missing `DisconnectError` handling test case to `libp2p`.