### PR TITLE
[bee #47, #56] integrate kademlia instead of full driver

### DIFF
--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -9,5 +9,4 @@ type (
 	PeerConnectResponse = peerConnectResponse
 	PeersResponse       = peersResponse
 	AddressesResponse   = addressesResponse
-	TopologyResponse    = topologyResponse
 )

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -5,15 +5,13 @@
 package debugapi
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
-
-type topologyResponse struct {
-	Topology string `json:"topology"` //TODO: this is not so great since it makes the actual kademlia state to be an escaped string
-}
 
 func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 	ms, ok := s.TopologyDriver.(json.Marshaler)
@@ -23,11 +21,11 @@ func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bytes, err := ms.MarshalJSON()
+	b, err := ms.MarshalJSON()
 	if err != nil {
 		s.Logger.Errorf("topology marshal to json: %v", err)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
-	jsonhttp.OK(w, topologyResponse{Topology: string(bytes)})
+	io.Copy(w, bytes.NewBuffer(b))
 }

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -12,7 +12,7 @@ import (
 )
 
 type topologyResponse struct {
-	Topology string `json:"topology"`
+	Topology string `json:"topology"` //TODO: this is not so great since it makes the actual kademlia state to be an escaped string
 }
 
 func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -27,5 +27,5 @@ func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
-	io.Copy(w, bytes.NewBuffer(b))
+	_, _ = io.Copy(w, bytes.NewBuffer(b))
 }

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -5,26 +5,30 @@
 package debugapi_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	topmock "github.com/ethersphere/bee/pkg/topology/mock"
 )
 
+type topologyResponse struct {
+	Topology string `json:"topology"` //TODO: this is not so great since it makes the actual kademlia state to be an escaped string
+}
+
 func TestTopologyOK(t *testing.T) {
 	marshalFunc := func() ([]byte, error) {
-		return []byte("abcd"), nil
+		return json.Marshal(topologyResponse{Topology: "abcd"})
 	}
 	testServer := newTestServer(t, testServerOptions{
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
 	defer testServer.Cleanup()
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, debugapi.TopologyResponse{
+	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, topologyResponse{
 		Topology: "abcd",
 	})
 }

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type topologyResponse struct {
-	Topology string `json:"topology"` //TODO: this is not so great since it makes the actual kademlia state to be an escaped string
+	Topology string `json:"topology"`
 }
 
 func TestTopologyOK(t *testing.T) {

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -6,7 +6,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -30,8 +29,6 @@ func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address,
 		d.records[addressee.String()] = append(d.records[addressee.String()], peer)
 		d.mtx.Unlock()
 	}
-	fmt.Println("addressess", addressee, "peers", peers)
-
 	d.mtx.Lock()
 	d.ctr++
 	d.mtx.Unlock()
@@ -49,4 +46,11 @@ func (d *Discovery) AddresseeRecords(addressee swarm.Address) (peers []swarm.Add
 	defer d.mtx.Unlock()
 	peers, exists = d.records[addressee.String()]
 	return
+}
+
+func (d *Discovery) Reset() {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	d.ctr = 0
+	d.records = make(map[string][]swarm.Address)
 }

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -29,6 +30,7 @@ func (d *Discovery) BroadcastPeers(ctx context.Context, addressee swarm.Address,
 		d.records[addressee.String()] = append(d.records[addressee.String()], peer)
 		d.mtx.Unlock()
 	}
+	fmt.Println("addressess", addressee, "peers", peers)
 
 	d.mtx.Lock()
 	d.ctr++

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -137,7 +137,7 @@ func (k *Kad) manage() {
 				}
 				k.logger.Debugf("kademlia dialing to peer %s", peer.String())
 
-        err = k.connect(ctx, peer, ma, po)
+				err = k.connect(ctx, peer, ma, po)
 				if err != nil {
 					k.logger.Errorf("error connecting to peer %s: %v", peer, err)
 					// continue to next

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -119,7 +119,7 @@ func (k *Kad) manage() {
 
 				currentDepth := k.NeighborhoodDepth()
 				if k.saturationFunc(po, currentDepth, k.connectedPeers) {
-					return false, false, nil
+					return false, true, nil // bin is saturated, skip to next bin
 				}
 
 				ma, err := k.addressBook.Get(peer)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -94,10 +94,8 @@ func (k *Kad) manage() {
 	defer close(k.done)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		select {
-		case <-k.quit:
-			cancel()
-		}
+		<-k.quit
+		cancel()
 	}()
 
 	for {

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -15,6 +15,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethersphere/bee/pkg/addressbook"
+	"github.com/ethersphere/bee/pkg/discovery/mock"
 	"github.com/ethersphere/bee/pkg/kademlia"
 	"github.com/ethersphere/bee/pkg/kademlia/pslice"
 	"github.com/ethersphere/bee/pkg/logging"
@@ -330,10 +331,11 @@ func TestMarshal(t *testing.T) {
 
 func newTestKademlia(p2p p2p.Service, f func(bin, depth uint8, peers *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface) {
 	var (
-		base   = test.RandomAddress()                                                                                     // base address
-		logger = logging.New(ioutil.Discard, 0)                                                                           // logger
-		ab     = addressbook.New(mockstate.NewStateStore())                                                               // address book
-		kad    = kademlia.New(kademlia.Options{Base: base, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
+		base   = test.RandomAddress()                                                                                                      // base address
+		logger = logging.New(ioutil.Discard, 0)                                                                                            // logger
+		ab     = addressbook.New(mockstate.NewStateStore())                                                                                // address book
+		disc   = mock.NewDiscovery()                                                                                                       // mock discovery
+		kad    = kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
 	)
 	return base, kad, ab
 }

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -7,7 +7,6 @@ package kademlia_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -305,6 +304,8 @@ func TestDiscoveryHooks(t *testing.T) {
 	waitBcast(t, disc, p1, p2)
 	waitBcast(t, disc, p2, p1)
 
+	disc.Reset()
+
 	// add another peer that dialed in, check that all peers gossiped
 	// correctly to each other
 	connectOne(t, kad, ab, p3)
@@ -547,9 +548,7 @@ func waitBcast(t *testing.T, d *mock.Discovery, pivot swarm.Address, addrs ...sw
 	t.Helper()
 
 	for i := 0; i < 50; i++ {
-		fmt.Println(d.Broadcasts())
 		if d.Broadcasts() > 0 {
-
 			recs, ok := d.AddresseeRecords(pivot)
 			if !ok {
 				t.Fatal("got no records for pivot")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/hive"
+	"github.com/ethersphere/bee/pkg/kademlia"
 	"github.com/ethersphere/bee/pkg/keystore"
 	filekeystore "github.com/ethersphere/bee/pkg/keystore/file"
 	memkeystore "github.com/ethersphere/bee/pkg/keystore/mem"
@@ -36,7 +37,6 @@ import (
 	mockinmem "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/topology/full"
 	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/ethersphere/bee/pkg/validator"
 	ma "github.com/multiformats/go-multiaddr"
@@ -171,7 +171,7 @@ func NewBee(o Options) (*Bee, error) {
 		return nil, fmt.Errorf("hive service: %w", err)
 	}
 
-	topologyDriver := full.New(hive, addressbook, p2ps, logger, address)
+	topologyDriver := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Logger: logger})
 	b.topologyCloser = topologyDriver
 	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
 	p2ps.SetNotifiee(topologyDriver)

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -359,10 +359,14 @@ func TestTopologyNotifiee(t *testing.T) {
 			n2disconnectedAddr = a
 		}
 	)
-	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n1c, n1d)})
+	notifiee1 := mockNotifiee(n1c, n1d)
+	s1, overlay1, cleanup1 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup1()
-	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1, Notifiee: mockNotifiee(n2c, n2d)})
+	s1.SetNotifiee(notifiee1)
+	notifiee2 := mockNotifiee(n2c, n2d)
+	s2, overlay2, cleanup2 := newService(t, libp2p.Options{NetworkID: 1})
 	defer cleanup2()
+	s2.SetNotifiee(notifiee2)
 
 	addr := serviceUnderlayAddress(t, s1)
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -63,7 +63,6 @@ type Options struct {
 	DisableQUIC bool
 	NetworkID   int32
 	Addressbook addressbook.Putter
-	Notifiee    topology.Notifiee
 	Logger      logging.Logger
 	Tracer      *tracing.Tracer
 }
@@ -157,7 +156,7 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		return nil, fmt.Errorf("autonat: %w", err)
 	}
 
-	peerRegistry := newPeerRegistry(registryOptions{disconnecter: o.Notifiee})
+	peerRegistry := newPeerRegistry()
 	s := &Service{
 		ctx:              ctx,
 		host:             h,
@@ -170,7 +169,6 @@ func New(ctx context.Context, o Options) (*Service, error) {
 		logger:           o.Logger,
 		tracer:           o.Tracer,
 		conectionBreaker: breaker.NewBreaker(breaker.Options{}), // todo: fill non-default options
-		topologyNotifiee: o.Notifiee,
 	}
 
 	// Construct protocols.

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -380,6 +380,7 @@ func (s *Service) Peers() []p2p.Peer {
 
 func (s *Service) SetNotifiee(n topology.Notifiee) {
 	s.topologyNotifiee = n
+	s.peers.setDisconnecter(n)
 }
 
 func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers p2p.Headers, protocolName, protocolVersion, streamName string) (p2p.Stream, error) {

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -16,10 +16,6 @@ import (
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-type registryOptions struct {
-	disconnecter topology.Disconnecter
-}
-
 type peerRegistry struct {
 	underlays   map[string]libp2ppeer.ID                    // map overlay address to underlay peer id
 	overlays    map[libp2ppeer.ID]swarm.Address             // map underlay peer id to overlay address
@@ -30,14 +26,13 @@ type peerRegistry struct {
 	network.Notifiee                       // peerRegistry can be the receiver for network.Notify
 }
 
-func newPeerRegistry(o registryOptions) *peerRegistry {
+func newPeerRegistry() *peerRegistry {
 	return &peerRegistry{
 		underlays:   make(map[string]libp2ppeer.ID),
 		overlays:    make(map[libp2ppeer.ID]swarm.Address),
 		connections: make(map[libp2ppeer.ID]map[network.Conn]struct{}),
 
-		disconnecter: o.disconnecter,
-		Notifiee:     new(network.NoopNotifiee),
+		Notifiee: new(network.NoopNotifiee),
 	}
 }
 

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -133,3 +133,7 @@ func (r *peerRegistry) remove(peerID libp2ppeer.ID) {
 		r.disconnecter.Disconnected(overlay)
 	}
 }
+
+func (r *peerRegistry) setDisconnecter(d topology.Disconnecter) {
+	r.disconnecter = d
+}


### PR DESCRIPTION
continued work on kademlia following #155.

this PR:
- implement `ClosestPeer` so that retrievals and push sync will work on kademlia
- improve debug api for topology, so that the actual kadmlia json string is a native JSON, not an escaped string
- hook up kademlia to be the default topology, instead of `full`
- clean up some of the connect logic in kademlia and pull it to a separate method, to clean up the `manage` loop logic
- add peer broadcasting functionality upon connecting to a peer
- add `Connected` hook on kademlia
- add peer announcement on dial-in

related to #47 #56 usw..