### PR TITLE
add protobuf Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.24.0
+GOGOPROTOBUF ?= protoc-gen-gogofaster
+GOGOPROTOBUF_VERSION ?= v1.3.1
 
 LDFLAGS ?= -s -w
 ifdef COMMIT
@@ -47,6 +49,16 @@ build:
 .PHONY: githooks
 githooks:
 	ln -f -s ../../.githooks/pre-push.bash .git/hooks/pre-push
+
+.PHONY: protobuftools
+protobuftools:
+	which protoc || ( echo "install protoc for your system from https://github.com/protocolbuffers/protobuf/releases" && exit 1)
+	which $(GOGOPROTOBUF) || ( cd /tmp && GO111MODULE=on $(GO) get -u github.com/gogo/protobuf/$(GOGOPROTOBUF)@$(GOGOPROTOBUF_VERSION) )
+
+.PHONY: protobuf
+protobuf: GOFLAGS=-mod=mod # use modules for protobuf file include option
+protobuf: protobuftools
+	$(GO) generate -run protoc ./...
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ And use that address in the API call on another node, for example, local node 1:
 curl -XPOST localhost:8081/pingpong/d4440baf2d79e481c3c6fd93a2014d2e6fe0386418829439f26d13a8253d04f1
 ```
 
+## Generating protobuf
+
+To process protocol buffer files and generate the Go code from it two tools are needed:
+
+- protoc - https://github.com/protocolbuffers/protobuf/releases
+- protoc-gen-gogofaster - https://github.com/gogo/protobuf
+
+Makefile rule `protobuf` can be used to automate `protoc-gen-gogofaster` installation and code generation:
+
+```sh
+make protobuf
+```
+
 ## Contributing
 
 Please read the [coding guidelines](CODING.md).


### PR DESCRIPTION
This PR adds a convenient Makefile rule to generate Go code from protobuf files and also to half-automate tools installation.