### PR TITLE
enable modules caching in separate layer during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.14 AS build
 ARG COMMIT=""
 
 WORKDIR /src
+# enable modules caching in separate layer
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . ./
 
 RUN make binary COMMIT=$COMMIT


### PR DESCRIPTION
Download modules in separate layer for later reuse if modules didn't updated