### PR TITLE
annotate errors in shed

### DIFF
--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -19,6 +19,7 @@ package localstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -114,7 +115,7 @@ func testDBCollectGarbageWorker(t *testing.T) {
 	// the first synced chunk should be removed
 	t.Run("get the first synced chunk", func(t *testing.T) {
 		_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[0])
-		if err != storage.ErrNotFound {
+		if !errors.Is(err, storage.ErrNotFound) {
 			t.Errorf("got error %v, want %v", err, storage.ErrNotFound)
 		}
 	})
@@ -122,7 +123,7 @@ func testDBCollectGarbageWorker(t *testing.T) {
 	t.Run("only first inserted chunks should be removed", func(t *testing.T) {
 		for i := 0; i < (chunkCount - int(gcTarget)); i++ {
 			_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[i])
-			if err != storage.ErrNotFound {
+			if !errors.Is(err, storage.ErrNotFound) {
 				t.Errorf("got error %v, want %v", err, storage.ErrNotFound)
 			}
 		}
@@ -238,7 +239,7 @@ func TestPinGC(t *testing.T) {
 	t.Run("first chunks after pinned chunks should be removed", func(t *testing.T) {
 		for i := pinChunksCount; i < (int(dbCapacity) - int(gcTarget)); i++ {
 			_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[i])
-			if err != leveldb.ErrNotFound {
+			if !errors.Is(err, leveldb.ErrNotFound) {
 				t.Fatal(err)
 			}
 		}
@@ -410,7 +411,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	// the second synced chunk should be removed
 	t.Run("get gc-ed chunk", func(t *testing.T) {
 		_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[1])
-		if err != storage.ErrNotFound {
+		if !errors.Is(err, storage.ErrNotFound) {
 			t.Errorf("got error %v, want %v", err, storage.ErrNotFound)
 		}
 	})

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -181,7 +181,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}
 
-	db.shed, err = shed.NewDB(path, logger)
+	db.shed, err = shed.NewDB(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -19,6 +19,7 @@ package localstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -248,7 +249,7 @@ func newRetrieveIndexesTest(db *DB, chunk swarm.Chunk, storeTimestamp, accessTim
 		// access index should not be set
 		wantErr := leveldb.ErrNotFound
 		_, err = db.retrievalAccessIndex.Get(addressToItem(chunk.Address()))
-		if err != wantErr {
+		if !errors.Is(err, wantErr) {
 			t.Errorf("got error %v, want %v", err, wantErr)
 		}
 	}
@@ -286,7 +287,7 @@ func newPullIndexTest(db *DB, ch swarm.Chunk, binID uint64, wantError error) fun
 			Address: ch.Address().Bytes(),
 			BinID:   binID,
 		})
-		if err != wantError {
+		if !errors.Is(err, wantError) {
 			t.Errorf("got error %v, want %v", err, wantError)
 		}
 		if err == nil {
@@ -305,7 +306,7 @@ func newPushIndexTest(db *DB, ch swarm.Chunk, storeTimestamp int64, wantError er
 			Address:        ch.Address().Bytes(),
 			StoreTimestamp: storeTimestamp,
 		})
-		if err != wantError {
+		if !errors.Is(err, wantError) {
 			t.Errorf("got error %v, want %v", err, wantError)
 		}
 		if err == nil {
@@ -325,7 +326,7 @@ func newGCIndexTest(db *DB, chunk swarm.Chunk, storeTimestamp, accessTimestamp i
 			BinID:           binID,
 			AccessTimestamp: accessTimestamp,
 		})
-		if err != wantError {
+		if !errors.Is(err, wantError) {
 			t.Errorf("got error %v, want %v", err, wantError)
 		}
 		if err == nil {

--- a/pkg/localstore/mode_get.go
+++ b/pkg/localstore/mode_get.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/shed"
@@ -43,7 +44,7 @@ func (db *DB) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address)
 
 	out, err := db.get(mode, addr)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return nil, storage.ErrNotFound
 		}
 		return nil, err
@@ -129,10 +130,10 @@ func (db *DB) updateGC(item shed.Item) (err error) {
 	// update accessTimeStamp in retrieve, gc
 
 	i, err := db.retrievalAccessIndex.Get(item)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		item.AccessTimestamp = i.AccessTimestamp
-	case leveldb.ErrNotFound:
+	case errors.Is(err, leveldb.ErrNotFound):
 		// no chunk accesses
 	default:
 		return err

--- a/pkg/localstore/mode_get_multi.go
+++ b/pkg/localstore/mode_get_multi.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/shed"
@@ -42,7 +43,7 @@ func (db *DB) GetMulti(ctx context.Context, mode storage.ModeGet, addrs ...swarm
 
 	out, err := db.getMulti(mode, addrs...)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return nil, storage.ErrNotFound
 		}
 		return nil, err

--- a/pkg/localstore/mode_get_multi_test.go
+++ b/pkg/localstore/mode_get_multi_test.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -74,7 +75,7 @@ func TestModeGetMulti(t *testing.T) {
 
 			want := storage.ErrNotFound
 			_, err = db.GetMulti(context.Background(), mode, append(addrs, missingChunk.Address())...)
-			if err != want {
+			if !errors.Is(err, want) {
 				t.Errorf("got error %v, want %v", err, want)
 			}
 		})

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/shed"
@@ -159,12 +160,12 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 // Provided batch and binID map are updated.
 func (db *DB) putRequest(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.Item) (exists bool, gcSizeChange int64, err error) {
 	i, err := db.retrievalDataIndex.Get(item)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		exists = true
 		item.StoreTimestamp = i.StoreTimestamp
 		item.BinID = i.BinID
-	case leveldb.ErrNotFound:
+	case errors.Is(err, leveldb.ErrNotFound):
 		// no chunk accesses
 		exists = false
 	default:
@@ -318,15 +319,15 @@ func (db *DB) setGC(batch *leveldb.Batch, item shed.Item) (gcSizeChange int64, e
 		item.BinID = i.BinID
 	}
 	i, err := db.retrievalAccessIndex.Get(item)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		item.AccessTimestamp = i.AccessTimestamp
 		err = db.gcIndex.DeleteInBatch(batch, item)
 		if err != nil {
 			return 0, err
 		}
 		gcSizeChange--
-	case leveldb.ErrNotFound:
+	case errors.Is(err, leveldb.ErrNotFound):
 		// the chunk is not accessed before
 	default:
 		return 0, err

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -336,13 +337,13 @@ func TestModeSetRemove(t *testing.T) {
 				for _, ch := range chunks {
 					wantErr := leveldb.ErrNotFound
 					_, err := db.retrievalDataIndex.Get(addressToItem(ch.Address()))
-					if err != wantErr {
+					if !errors.Is(err, wantErr) {
 						t.Errorf("got error %v, want %v", err, wantErr)
 					}
 
 					// access index should not be set
 					_, err = db.retrievalAccessIndex.Get(addressToItem(ch.Address()))
-					if err != wantErr {
+					if !errors.Is(err, wantErr) {
 						t.Errorf("got error %v, want %v", err, wantErr)
 					}
 				}

--- a/pkg/localstore/pin.go
+++ b/pkg/localstore/pin.go
@@ -30,7 +30,7 @@ func (db *DB) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChu
 
 	it, err := db.pinIndex.First(prefix)
 	if err != nil {
-		return nil, fmt.Errorf("pin chunks: %w", err)
+		return nil, fmt.Errorf("get first pin: %w", err)
 	}
 	err = db.pinIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 		pinnedChunks = append(pinnedChunks,

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -6,6 +6,7 @@ package localstore
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestPinning(t *testing.T) {
 		// Nothing should be there in the pinned DB
 		_, err := db.PinnedChunks(context.Background(), swarm.NewAddress([]byte{0}))
 		if err != nil {
-			if err.Error() != "pin chunks: leveldb: not found" {
+			if !errors.Is(err, leveldb.ErrNotFound) {
 				t.Fatal(err)
 			}
 		}
@@ -119,7 +120,7 @@ func TestPinInfo(t *testing.T) {
 		}
 		_, err = db.PinInfo(swarm.NewAddress(chunk.Address().Bytes()))
 		if err != nil {
-			if err != leveldb.ErrNotFound {
+			if !errors.Is(err, leveldb.ErrNotFound) {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/localstore/subscription_pull.go
+++ b/pkg/localstore/subscription_pull.go
@@ -187,7 +187,7 @@ func (db *DB) LastPullSubscriptionBinID(bin uint8) (id uint64, err error) {
 
 	item, err := db.pullIndex.Last([]byte{bin})
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return 0, nil
 		}
 		return 0, err

--- a/pkg/shed/db_test.go
+++ b/pkg/shed/db_test.go
@@ -20,8 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/ethersphere/bee/pkg/logging"
 )
 
 // TestNewDB constructs a new DB
@@ -56,9 +54,8 @@ func TestDB_persistence(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	logger := logging.New(ioutil.Discard, 0)
 
-	db, err := NewDB(dir, logger)
+	db, err := NewDB(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +73,7 @@ func TestDB_persistence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db2, err := NewDB(dir, logger)
+	db2, err := NewDB(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,8 +95,7 @@ func TestDB_persistence(t *testing.T) {
 // be called to remove the data.
 func newTestDB(t *testing.T) (db *DB, cleanupFunc func()) {
 	t.Helper()
-	logger := logging.New(ioutil.Discard, 0)
-	db, err := NewDB("", logger)
+	db, err := NewDB("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/shed/field_string.go
+++ b/pkg/shed/field_string.go
@@ -17,16 +17,17 @@
 package shed
 
 import (
-	"github.com/ethersphere/bee/pkg/logging"
+	"errors"
+	"fmt"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // StringField is the most simple field implementation
 // that stores an arbitrary string under a specific LevelDB key.
 type StringField struct {
-	db     *DB
-	key    []byte
-	logger logging.Logger
+	db  *DB
+	key []byte
 }
 
 // NewStringField retruns a new Instance of StringField.
@@ -34,12 +35,11 @@ type StringField struct {
 func (db *DB) NewStringField(name string) (f StringField, err error) {
 	key, err := db.schemaFieldKey(name, "string")
 	if err != nil {
-		return f, err
+		return f, fmt.Errorf("get schema key: %w", err)
 	}
 	return StringField{
-		db:     db,
-		key:    key,
-		logger: db.logger,
+		db:  db,
+		key: key,
 	}, nil
 }
 
@@ -49,8 +49,7 @@ func (db *DB) NewStringField(name string) (f StringField, err error) {
 func (f StringField) Get() (val string, err error) {
 	b, err := f.db.Get(f.key)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Errorf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return "", nil
 		}
 		return "", err

--- a/pkg/shed/field_struct.go
+++ b/pkg/shed/field_struct.go
@@ -18,17 +18,16 @@ package shed
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // StructField is a helper to store complex structure by
 // encoding it in RLP format.
 type StructField struct {
-	db     *DB
-	key    []byte
-	logger logging.Logger
+	db  *DB
+	key []byte
 }
 
 // NewStructField returns a new StructField.
@@ -36,12 +35,11 @@ type StructField struct {
 func (db *DB) NewStructField(name string) (f StructField, err error) {
 	key, err := db.schemaFieldKey(name, "struct-rlp")
 	if err != nil {
-		return f, err
+		return f, fmt.Errorf("get schema key: %w", err)
 	}
 	return StructField{
-		db:     db,
-		key:    key,
-		logger: db.logger,
+		db:  db,
+		key: key,
 	}, nil
 }
 
@@ -50,7 +48,6 @@ func (db *DB) NewStructField(name string) (f StructField, err error) {
 func (f StructField) Get(val interface{}) (err error) {
 	b, err := f.db.Get(f.key)
 	if err != nil {
-		f.logger.Debugf("could not GET key %s", string(f.key))
 		return err
 	}
 	return json.Unmarshal(b, val)
@@ -60,7 +57,6 @@ func (f StructField) Get(val interface{}) (err error) {
 func (f StructField) Put(val interface{}) (err error) {
 	b, err := json.Marshal(val)
 	if err != nil {
-		f.logger.Debugf("could not PUT key %s", string(f.key))
 		return err
 	}
 	return f.db.Put(f.key, b)
@@ -70,7 +66,6 @@ func (f StructField) Put(val interface{}) (err error) {
 func (f StructField) PutInBatch(batch *leveldb.Batch, val interface{}) (err error) {
 	b, err := json.Marshal(val)
 	if err != nil {
-		f.logger.Debugf("could not PUT key %s in batch", string(f.key))
 		return err
 	}
 	batch.Put(f.key, b)

--- a/pkg/shed/field_uint64.go
+++ b/pkg/shed/field_uint64.go
@@ -18,17 +18,17 @@ package shed
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 
-	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // Uint64Field provides a way to have a simple counter in the database.
 // It transparently encodes uint64 type value to bytes.
 type Uint64Field struct {
-	db     *DB
-	key    []byte
-	logger logging.Logger
+	db  *DB
+	key []byte
 }
 
 // NewUint64Field returns a new Uint64Field.
@@ -36,12 +36,11 @@ type Uint64Field struct {
 func (db *DB) NewUint64Field(name string) (f Uint64Field, err error) {
 	key, err := db.schemaFieldKey(name, "uint64")
 	if err != nil {
-		return f, err
+		return f, fmt.Errorf("get schema key: %w", err)
 	}
 	return Uint64Field{
-		db:     db,
-		key:    key,
-		logger: db.logger,
+		db:  db,
+		key: key,
 	}, nil
 }
 
@@ -51,8 +50,7 @@ func (db *DB) NewUint64Field(name string) (f Uint64Field, err error) {
 func (f Uint64Field) Get() (val uint64, err error) {
 	b, err := f.db.Get(f.key)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Errorf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return 0, nil
 		}
 		return 0, err
@@ -76,12 +74,10 @@ func (f Uint64Field) PutInBatch(batch *leveldb.Batch, val uint64) {
 func (f Uint64Field) Inc() (val uint64, err error) {
 	val, err = f.Get()
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Debugf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Errorf("key %s not found. Error: %s", string(f.key), err.Error())
-			return 0, err
+			return 0, fmt.Errorf("get value: %w", err)
 		}
 	}
 	val++
@@ -94,12 +90,10 @@ func (f Uint64Field) Inc() (val uint64, err error) {
 func (f Uint64Field) IncInBatch(batch *leveldb.Batch) (val uint64, err error) {
 	val, err = f.Get()
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Debugf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Errorf("key %s not found. Error: %s", string(f.key), err.Error())
-			return 0, err
+			return 0, fmt.Errorf("get value: %w", err)
 		}
 	}
 	val++
@@ -113,12 +107,10 @@ func (f Uint64Field) IncInBatch(batch *leveldb.Batch) (val uint64, err error) {
 func (f Uint64Field) Dec() (val uint64, err error) {
 	val, err = f.Get()
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Debugf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Errorf("key %s not found. Error: %s", string(f.key), err.Error())
-			return 0, err
+			return 0, fmt.Errorf("get value: %w", err)
 		}
 	}
 	if val != 0 {
@@ -134,12 +126,10 @@ func (f Uint64Field) Dec() (val uint64, err error) {
 func (f Uint64Field) DecInBatch(batch *leveldb.Batch) (val uint64, err error) {
 	val, err = f.Get()
 	if err != nil {
-		if err == leveldb.ErrNotFound {
-			f.logger.Debugf("key %s not found", string(f.key))
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Errorf("key %s not found. Error: %s", string(f.key), err.Error())
-			return 0, err
+			return 0, fmt.Errorf("get value: %w", err)
 		}
 	}
 	if val != 0 {

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -50,7 +50,7 @@ type Item struct {
 // Merge is a helper method to construct a new
 // Item by filling up fields with default values
 // of a particular Item with values from another one.
-func (i Item) Merge(i2 Item) (new Item) {
+func (i Item) Merge(i2 Item) Item {
 	if i.Address == nil {
 		i.Address = i2.Address
 	}

--- a/pkg/shed/index_test.go
+++ b/pkg/shed/index_test.go
@@ -1020,10 +1020,8 @@ func TestIndex_firstAndLast(t *testing.T) {
 		got, err = index.First(tc.prefix)
 		if !errors.Is(err, tc.err) {
 			t.Errorf("got error %v for First with prefix %v, want %v", err, tc.prefix, tc.err)
-		} else {
-			if !bytes.Equal(got.Address, tc.first) {
-				t.Errorf("got %v for First with prefix %v, want %v", got.Address, tc.prefix, tc.first)
-			}
+		} else if !bytes.Equal(got.Address, tc.first) {
+			t.Errorf("got %v for First with prefix %v, want %v", got.Address, tc.prefix, tc.first)
 		}
 	}
 }

--- a/pkg/shed/index_test.go
+++ b/pkg/shed/index_test.go
@@ -19,6 +19,7 @@ package shed
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -254,7 +255,7 @@ func TestIndex(t *testing.T) {
 		_, err = index.Get(Item{
 			Address: want.Address,
 		})
-		if err != wantErr {
+		if !errors.Is(err, wantErr) {
 			t.Fatalf("got error %v, want %v", err, wantErr)
 		}
 	})
@@ -294,7 +295,7 @@ func TestIndex(t *testing.T) {
 		_, err = index.Get(Item{
 			Address: want.Address,
 		})
-		if err != wantErr {
+		if !errors.Is(err, wantErr) {
 			t.Fatalf("got error %v, want %v", err, wantErr)
 		}
 	})
@@ -355,7 +356,7 @@ func TestIndex(t *testing.T) {
 			})
 			want := leveldb.ErrNotFound
 			err := index.Fill(items)
-			if err != want {
+			if !errors.Is(err, want) {
 				t.Errorf("got error %v, want %v", err, want)
 			}
 		})
@@ -1008,7 +1009,7 @@ func TestIndex_firstAndLast(t *testing.T) {
 		},
 	} {
 		got, err := index.Last(tc.prefix)
-		if tc.err != err {
+		if !errors.Is(err, tc.err) {
 			t.Errorf("got error %v for Last with prefix %v, want %v", err, tc.prefix, tc.err)
 		} else {
 			if !bytes.Equal(got.Address, tc.last) {
@@ -1017,7 +1018,7 @@ func TestIndex_firstAndLast(t *testing.T) {
 		}
 
 		got, err = index.First(tc.prefix)
-		if tc.err != err {
+		if !errors.Is(err, tc.err) {
 			t.Errorf("got error %v for First with prefix %v, want %v", err, tc.prefix, tc.err)
 		} else {
 			if !bytes.Equal(got.Address, tc.first) {

--- a/pkg/shed/index_test.go
+++ b/pkg/shed/index_test.go
@@ -1011,10 +1011,8 @@ func TestIndex_firstAndLast(t *testing.T) {
 		got, err := index.Last(tc.prefix)
 		if !errors.Is(err, tc.err) {
 			t.Errorf("got error %v for Last with prefix %v, want %v", err, tc.prefix, tc.err)
-		} else {
-			if !bytes.Equal(got.Address, tc.last) {
-				t.Errorf("got %v for Last with prefix %v, want %v", got.Address, tc.prefix, tc.last)
-			}
+		} else if !bytes.Equal(got.Address, tc.last) {
+			t.Errorf("got %v for Last with prefix %v, want %v", got.Address, tc.prefix, tc.last)
 		}
 
 		got, err = index.First(tc.prefix)

--- a/pkg/shed/schema.go
+++ b/pkg/shed/schema.go
@@ -63,7 +63,7 @@ func (db *DB) schemaFieldKey(name, fieldType string) (key []byte, err error) {
 	}
 	s, err := db.getSchema()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get schema: %w", err)
 	}
 	var found bool
 	for n, f := range s.Fields {
@@ -80,7 +80,7 @@ func (db *DB) schemaFieldKey(name, fieldType string) (key []byte, err error) {
 		}
 		err := db.putSchema(s)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("put schema: %w", err)
 		}
 	}
 	return append([]byte{keyPrefixFields}, []byte(name)...), nil
@@ -102,7 +102,7 @@ func (db *DB) RenameIndex(name, newName string) (renamed bool, err error) {
 	}
 	s, err := db.getSchema()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("get schema: %w", err)
 	}
 	for i, f := range s.Indexes {
 		if f.Name == name {
@@ -126,7 +126,7 @@ func (db *DB) schemaIndexPrefix(name string) (id byte, err error) {
 	}
 	s, err := db.getSchema()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("get schema: %w", err)
 	}
 	nextID := keyPrefixIndexStart
 	for i, f := range s.Indexes {

--- a/pkg/shed/vector_uint64.go
+++ b/pkg/shed/vector_uint64.go
@@ -18,17 +18,17 @@ package shed
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 
-	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // Uint64Vector provides a way to have multiple counters in the database.
 // It transparently encodes uint64 type value to bytes.
 type Uint64Vector struct {
-	db     *DB
-	key    []byte
-	logger logging.Logger
+	db  *DB
+	key []byte
 }
 
 // NewUint64Vector returns a new Uint64Vector.
@@ -36,12 +36,11 @@ type Uint64Vector struct {
 func (db *DB) NewUint64Vector(name string) (f Uint64Vector, err error) {
 	key, err := db.schemaFieldKey(name, "vector-uint64")
 	if err != nil {
-		return f, err
+		return f, fmt.Errorf("get schema key: %w", err)
 	}
 	return Uint64Vector{
-		db:     db,
-		key:    key,
-		logger: db.logger,
+		db:  db,
+		key: key,
 	}, nil
 }
 
@@ -51,7 +50,7 @@ func (db *DB) NewUint64Vector(name string) (f Uint64Vector, err error) {
 func (f Uint64Vector) Get(i uint64) (val uint64, err error) {
 	b, err := f.db.Get(f.indexKey(i))
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			return 0, nil
 		}
 		return 0, err
@@ -75,10 +74,9 @@ func (f Uint64Vector) PutInBatch(batch *leveldb.Batch, i, val uint64) {
 func (f Uint64Vector) Inc(i uint64) (val uint64, err error) {
 	val, err = f.Get(i)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Debugf("error getiing value while doing Inc. Error: %s", err.Error())
 			return 0, err
 		}
 	}
@@ -92,10 +90,9 @@ func (f Uint64Vector) Inc(i uint64) (val uint64, err error) {
 func (f Uint64Vector) IncInBatch(batch *leveldb.Batch, i uint64) (val uint64, err error) {
 	val, err = f.Get(i)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Debugf("error getiing value while doing IncInBatch. Error: %s", err.Error())
 			return 0, err
 		}
 	}
@@ -110,10 +107,9 @@ func (f Uint64Vector) IncInBatch(batch *leveldb.Batch, i uint64) (val uint64, er
 func (f Uint64Vector) Dec(i uint64) (val uint64, err error) {
 	val, err = f.Get(i)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Debugf("error getiing value while doing Dec. Error: %s", err.Error())
 			return 0, err
 		}
 	}
@@ -130,10 +126,9 @@ func (f Uint64Vector) Dec(i uint64) (val uint64, err error) {
 func (f Uint64Vector) DecInBatch(batch *leveldb.Batch, i uint64) (val uint64, err error) {
 	val, err = f.Get(i)
 	if err != nil {
-		if err == leveldb.ErrNotFound {
+		if errors.Is(err, leveldb.ErrNotFound) {
 			val = 0
 		} else {
-			f.logger.Debugf("error getiing value while doing DecInBatch. Error: %s", err.Error())
 			return 0, err
 		}
 	}


### PR DESCRIPTION
This PR removes extensive logging next to returning the error in shed and properly annotates these errors so that their path is known. The consequence is that error checking has to be done with errors.Is function, which is also changed in this PR. This PR is based on the bad user experience when uploading and downloading chunks results with error messages that are not clear and not needed. There is no need to log errors in shed as they are all returned, so logger is removed, just as it does not exist in the swarm project code.