### PR TITLE
use testing.Cleanup in localstore tests

### DIFF
--- a/pkg/localstore/export_test.go
+++ b/pkg/localstore/export_test.go
@@ -29,8 +29,7 @@ import (
 // chunks and another one to import and validate that all chunks are
 // imported.
 func TestExportImport(t *testing.T) {
-	db1, cleanup1 := newTestDB(t, nil)
-	defer cleanup1()
+	db1 := newTestDB(t, nil)
 
 	var chunkCount = 100
 
@@ -56,8 +55,7 @@ func TestExportImport(t *testing.T) {
 		t.Errorf("got export count %v, want %v", c, wantChunksCount)
 	}
 
-	db2, cleanup2 := newTestDB(t, nil)
-	defer cleanup2()
+	db2 := newTestDB(t, nil)
 
 	c, err = db2.Import(&buf, false)
 	if err != nil {

--- a/pkg/localstore/index_test.go
+++ b/pkg/localstore/index_test.go
@@ -34,8 +34,7 @@ import (
 // validates that pull index iterator will iterate it the same
 // order.
 func TestDB_pullIndex(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	chunkCount := 50
 
@@ -79,8 +78,7 @@ func TestDB_pullIndex(t *testing.T) {
 // a chunk with and performing operations using synced, access and
 // request modes.
 func TestDB_gcIndex(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	chunkCount := 50
 

--- a/pkg/localstore/mode_get_multi_test.go
+++ b/pkg/localstore/mode_get_multi_test.go
@@ -37,8 +37,7 @@ func TestModeGetMulti(t *testing.T) {
 		storage.ModeGetPin,
 	} {
 		t.Run(mode.String(), func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			chunks := generateTestRandomChunks(chunkCount)
 

--- a/pkg/localstore/mode_get_test.go
+++ b/pkg/localstore/mode_get_test.go
@@ -27,8 +27,7 @@ import (
 
 // TestModeGetRequest validates ModeGetRequest index values on the provided DB.
 func TestModeGetRequest(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	uploadTimestamp := time.Now().UTC().UnixNano()
 	defer setNow(func() (t int64) {
@@ -164,8 +163,7 @@ func TestModeGetRequest(t *testing.T) {
 
 // TestModeGetSync validates ModeGetSync index values on the provided DB.
 func TestModeGetSync(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	uploadTimestamp := time.Now().UTC().UnixNano()
 	defer setNow(func() (t int64) {

--- a/pkg/localstore/mode_has_test.go
+++ b/pkg/localstore/mode_has_test.go
@@ -29,8 +29,7 @@ import (
 // TestHas validates that Has method is returning true for
 // the stored chunk and false for one that is not stored.
 func TestHas(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	ch := generateTestRandomChunk()
 
@@ -64,8 +63,7 @@ func TestHasMulti(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			chunks := generateTestRandomChunks(tc.count)
 			want := make([]bool, tc.count)

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -33,8 +33,7 @@ import (
 func TestModePutRequest(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			chunks := generateTestRandomChunks(tc.count)
 
@@ -88,8 +87,7 @@ func TestModePutRequest(t *testing.T) {
 func TestModePutSync(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			wantTimestamp := time.Now().UTC().UnixNano()
 			defer setNow(func() (t int64) {
@@ -120,8 +118,7 @@ func TestModePutSync(t *testing.T) {
 func TestModePutUpload(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			wantTimestamp := time.Now().UTC().UnixNano()
 			defer setNow(func() (t int64) {
@@ -170,8 +167,7 @@ func TestModePutUpload_parallel(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			uploadsCount := 100
 			workerCount := 100
@@ -280,7 +276,7 @@ func TestModePut_sameChunk(t *testing.T) {
 				},
 			} {
 				t.Run(tcn.name, func(t *testing.T) {
-					db, cleanupFunc := newTestDB(t, nil)
+					db := newTestDB(t, nil)
 
 					for i := 0; i < 10; i++ {
 						exist, err := db.Put(context.Background(), tcn.mode, chunks...)
@@ -311,8 +307,6 @@ func TestModePut_sameChunk(t *testing.T) {
 						newItemsCountTest(db.pullIndex, count(tcn.pullIndex))(t)
 						newItemsCountTest(db.pushIndex, count(tcn.pushIndex))(t)
 					}
-
-					cleanupFunc()
 				})
 			}
 		})
@@ -340,8 +334,7 @@ func TestModePut_addToGc(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				retVal = m.putToGc
 
-				db, cleanupFunc := newTestDB(t, opts)
-				defer cleanupFunc()
+				db := newTestDB(t, opts)
 
 				wantTimestamp := time.Now().UTC().UnixNano()
 				defer setNow(func() (t int64) {
@@ -393,8 +386,7 @@ func TestModePut_addToGcExisting(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				retVal = m.putToGc
 
-				db, cleanupFunc := newTestDB(t, opts)
-				defer cleanupFunc()
+				db := newTestDB(t, opts)
 
 				wantStoreTimestamp := time.Now().UTC().UnixNano()
 				defer setNow(func() (t int64) {
@@ -448,8 +440,7 @@ func TestPutDuplicateChunks(t *testing.T) {
 		storage.ModePutSync,
 	} {
 		t.Run(mode.String(), func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			ch := generateTestRandomChunk()
 
@@ -541,8 +532,7 @@ func BenchmarkPutUpload(b *testing.B) {
 // of chunks with specified max parallel uploads.
 func benchmarkPutUpload(b *testing.B, o *Options, count, maxParallelUploads int) {
 	b.StopTimer()
-	db, cleanupFunc := newTestDB(b, o)
-	defer cleanupFunc()
+	db := newTestDB(b, o)
 
 	chunks := make([]swarm.Chunk, count)
 	for i := 0; i < count; i++ {

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -33,8 +33,7 @@ import (
 func TestModeSetAccess(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			chunks := generateTestRandomChunks(tc.count)
 
@@ -71,8 +70,7 @@ func TestModeSetAccess(t *testing.T) {
 // as a result we should expect the tag value to remain in the pull index
 // and we expect that the tag should not be incremented by pull sync set
 func TestModeSetSyncPullNormalTag(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, &Options{Tags: tags.NewTags()})
-	defer cleanupFunc()
+	db := newTestDB(t, &Options{Tags: tags.NewTags()})
 
 	tag, err := db.tags.Create("test", 1, false)
 	if err != nil {
@@ -125,8 +123,7 @@ func TestModeSetSyncPullNormalTag(t *testing.T) {
 // TestModeSetSyncPullAnonymousTag checks that pull sync correcly increments
 // counters on an anonymous tag which is expected to be handled only by pull sync
 func TestModeSetSyncPullAnonymousTag(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, &Options{Tags: tags.NewTags()})
-	defer cleanupFunc()
+	db := newTestDB(t, &Options{Tags: tags.NewTags()})
 
 	tag, err := db.tags.Create("test", 1, true)
 	if err != nil {
@@ -177,8 +174,7 @@ func TestModeSetSyncPullAnonymousTag(t *testing.T) {
 // then tries to Set both with push and pull Sync modes, but asserts that only the pull sync
 // increments were done to the tag
 func TestModeSetSyncPullPushAnonymousTag(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, &Options{Tags: tags.NewTags()})
-	defer cleanupFunc()
+	db := newTestDB(t, &Options{Tags: tags.NewTags()})
 
 	tag, err := db.tags.Create("test", 1, true)
 	if err != nil {
@@ -246,8 +242,7 @@ func TestModeSetSyncPullPushAnonymousTag(t *testing.T) {
 // correctly on a normal tag (that is, a tag that is expected to show progress bars
 // according to push sync progress)
 func TestModeSetSyncPushNormalTag(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, &Options{Tags: tags.NewTags()})
-	defer cleanupFunc()
+	db := newTestDB(t, &Options{Tags: tags.NewTags()})
 
 	tag, err := db.tags.Create("test", 1, false)
 	if err != nil {
@@ -318,8 +313,7 @@ func TestModeSetSyncPushNormalTag(t *testing.T) {
 func TestModeSetRemove(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, cleanupFunc := newTestDB(t, nil)
-			defer cleanupFunc()
+			db := newTestDB(t, nil)
 
 			chunks := generateTestRandomChunks(tc.count)
 

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -25,8 +25,7 @@ func TestPinning(t *testing.T) {
 	sort.Strings(addresses)
 
 	t.Run("empty-db", func(t *testing.T) {
-		db, cleanupFunc := newTestDB(t, nil)
-		defer cleanupFunc()
+		db := newTestDB(t, nil)
 		// Nothing should be there in the pinned DB
 		_, err := db.PinnedChunks(context.Background(), swarm.NewAddress([]byte{0}))
 		if err != nil {
@@ -37,8 +36,7 @@ func TestPinning(t *testing.T) {
 	})
 
 	t.Run("get-pinned-chunks", func(t *testing.T) {
-		db, cleanupFunc := newTestDB(t, nil)
-		defer cleanupFunc()
+		db := newTestDB(t, nil)
 
 		err := db.Set(context.Background(), storage.ModeSetPin, chunkAddresses(chunks)...)
 		if err != nil {
@@ -66,8 +64,7 @@ func TestPinning(t *testing.T) {
 func TestPinInfo(t *testing.T) {
 	chunk := generateTestRandomChunk()
 	t.Run("get-pinned-chunks", func(t *testing.T) {
-		db, cleanupFunc := newTestDB(t, nil)
-		defer cleanupFunc()
+		db := newTestDB(t, nil)
 
 		// pin once
 		err := db.Set(context.Background(), storage.ModeSetPin, swarm.NewAddress(chunk.Address().Bytes()))
@@ -97,8 +94,7 @@ func TestPinInfo(t *testing.T) {
 	})
 
 	t.Run("get-unpinned-chunks", func(t *testing.T) {
-		db, cleanupFunc := newTestDB(t, nil)
-		defer cleanupFunc()
+		db := newTestDB(t, nil)
 
 		// pin once
 		err := db.Set(context.Background(), storage.ModeSetPin, swarm.NewAddress(chunk.Address().Bytes()))

--- a/pkg/localstore/retrieval_index_test.go
+++ b/pkg/localstore/retrieval_index_test.go
@@ -61,8 +61,7 @@ func BenchmarkRetrievalIndexes(b *testing.B) {
 // database options.
 func benchmarkRetrievalIndexes(b *testing.B, o *Options, count int) {
 	b.StopTimer()
-	db, cleanupFunc := newTestDB(b, o)
-	defer cleanupFunc()
+	db := newTestDB(b, o)
 	addrs := make([]swarm.Address, count)
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
@@ -130,8 +129,7 @@ func BenchmarkUpload(b *testing.B) {
 // database options.
 func benchmarkUpload(b *testing.B, o *Options, count int) {
 	b.StopTimer()
-	db, cleanupFunc := newTestDB(b, o)
-	defer cleanupFunc()
+	db := newTestDB(b, o)
 	chunks := make([]swarm.Chunk, count)
 	for i := 0; i < count; i++ {
 		chunk := generateTestRandomChunk()

--- a/pkg/localstore/subscription_pull_test.go
+++ b/pkg/localstore/subscription_pull_test.go
@@ -568,10 +568,8 @@ func readPullSubscriptionBin(ctx context.Context, db *DB, bin uint8, ch <-chan s
 					})
 					if err != nil {
 						err = fmt.Errorf("got chunk (bin id %v in bin %v) from retrieval index %s: %v", i, bin, addrs[bin][i], err)
-					} else {
-						if got.BinID != want.BinID {
-							err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got, want)
-						}
+					} else if got.BinID != want.BinID {
+						err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got, want)
 					}
 				}
 			}

--- a/pkg/localstore/subscription_pull_test.go
+++ b/pkg/localstore/subscription_pull_test.go
@@ -34,8 +34,7 @@ import (
 // which means that the `SubscribePull` method should return chunk with BinID=49 via the channel, and the chunk for BinID=49 is uploaded,
 // after the subscription, then it would have been skipped, where the correct behaviour is to not skip it and return it via the channel.
 func TestDB_SubscribePull_first(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -82,8 +81,7 @@ func TestDB_SubscribePull_first(t *testing.T) {
 // all addresses are received in the right order
 // for expected proximity order bins.
 func TestDB_SubscribePull(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -127,8 +125,7 @@ func TestDB_SubscribePull(t *testing.T) {
 // validates if all addresses are received in the right order
 // for expected proximity order bins.
 func TestDB_SubscribePull_multiple(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -178,8 +175,7 @@ func TestDB_SubscribePull_multiple(t *testing.T) {
 // and validates if all expected addresses are received in the
 // right order for expected proximity order bins.
 func TestDB_SubscribePull_since(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -257,8 +253,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 // and validates if all expected addresses are received in the
 // right order for expected proximity order bins.
 func TestDB_SubscribePull_until(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -336,8 +331,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 // and until arguments, and validates if all expected addresses
 // are received in the right order for expected proximity order bins.
 func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 	var addrsMu sync.Mutex
@@ -430,8 +424,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 //   but before the chunks that are left
 // - validates that no chunks are received on subscription channel
 func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	// keeps track of available chunks in the database
 	// per bin with their bin ids
@@ -617,8 +610,7 @@ func checkErrChan(ctx context.Context, t *testing.T, errChan chan error, wantedC
 // is returning the last chunk descriptor for proximity order bins by
 // doing a few rounds of chunk uploads.
 func TestDB_LastPullSubscriptionBinID(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make(map[uint8][]swarm.Address)
 
@@ -673,8 +665,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 // TestAddressInBin validates that function addressInBin
 // returns a valid address for every proximity order bin.
 func TestAddressInBin(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	for po := uint8(0); po < swarm.MaxPO; po++ {
 		addr := db.addressInBin(po)

--- a/pkg/localstore/subscription_push_test.go
+++ b/pkg/localstore/subscription_push_test.go
@@ -32,8 +32,7 @@ import (
 // push syncing subscription is created and validates if
 // all addresses are received in the right order.
 func TestDB_SubscribePush(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	chunks := make([]swarm.Chunk, 0)
 	var chunksMu sync.Mutex
@@ -118,8 +117,7 @@ func TestDB_SubscribePush(t *testing.T) {
 // multiple push syncing subscriptions are created and
 // validates if all addresses are received in the right order.
 func TestDB_SubscribePush_multiple(t *testing.T) {
-	db, cleanupFunc := newTestDB(t, nil)
-	defer cleanupFunc()
+	db := newTestDB(t, nil)
 
 	addrs := make([]swarm.Address, 0)
 	var addrsMu sync.Mutex


### PR DESCRIPTION
Use testing.Cleanup function in localstore tests to simplify cleanups. It includes slight changes in respect to defer statements and new Cleanup function calls to ensure the right order of test hooks related calls to avoid data races.