### PR TITLE
Binary encoding of networkID

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -70,7 +70,7 @@ func New(overlay swarm.Address, peerID libp2ppeer.ID, signer crypto.Signer, netw
 	}
 
 	networkIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(networkIDBytes, networkID)
+	binary.BigEndian.PutUint64(networkIDBytes, networkID)
 	signature, err := signer.Sign(append(underlay, networkIDBytes...))
 	if err != nil {
 		return nil, err

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -62,12 +62,26 @@ func TestHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	node1Overlay := crypto.NewOverlayAddress(privateKey1.PublicKey, 0)
-	node2Overlay := crypto.NewOverlayAddress(privateKey2.PublicKey, 0)
+	node1Overlay := crypto.NewOverlayAddress(privateKey1.PublicKey, 3)
+	node2Overlay := crypto.NewOverlayAddress(privateKey2.PublicKey, 3)
+	node1Info := handshake.Info{
+		Overlay:   node1Overlay,
+		Underlay:  node1Underlay,
+		NetworkID: 3,
+		Light:     false,
+	}
+
+	node2Info := handshake.Info{
+		Overlay:   node2Overlay,
+		Underlay:  node2Underlay,
+		NetworkID: 3,
+		Light:     false,
+	}
+
 	signer1 := crypto.NewDefaultSigner(privateKey1)
 	signer2 := crypto.NewDefaultSigner(privateKey2)
 	networkIDBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(networkIDBytes, 0)
+	binary.BigEndian.PutUint64(networkIDBytes, node1Info.NetworkID)
 	signature1, err := signer1.Sign(append(node1Underlay, networkIDBytes...))
 	if err != nil {
 		t.Fatal(err)
@@ -78,26 +92,11 @@ func TestHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	node1Info := handshake.Info{
-		Overlay:   node1Overlay,
-		Underlay:  node1Underlay,
-		NetworkID: 0,
-		Light:     false,
-	}
-
 	node1BzzAddress := &pb.BzzAddress{
 		Overlay:   node1Info.Overlay.Bytes(),
 		Underlay:  node1Info.Underlay,
 		Signature: signature1,
 	}
-
-	node2Info := handshake.Info{
-		Overlay:   node2Overlay,
-		Underlay:  node2Underlay,
-		NetworkID: 0,
-		Light:     false,
-	}
-
 	node2BzzAddress := &pb.BzzAddress{
 		Overlay:   node2Info.Overlay.Bytes(),
 		Underlay:  node2Info.Underlay,
@@ -288,7 +287,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - OK", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -332,7 +331,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - read error ", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -351,7 +350,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - write error ", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -380,7 +379,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - ack read error ", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -411,7 +410,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - networkID mismatch ", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -440,7 +439,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - duplicate handshake", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -489,7 +488,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - invalid ack", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -518,7 +517,7 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handle - invalid signature ", func(t *testing.T) {
-		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+		handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -104,7 +104,7 @@ func TestHandshake(t *testing.T) {
 		Signature: signature2,
 	}
 
-	handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, 0, logger)
+	handshakeService, err := handshake.New(node1Info.Overlay, node1Addr.ID, signer1, node1Info.NetworkID, logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -47,7 +47,7 @@ type Service struct {
 	metrics          metrics
 	networkID        uint64
 	handshakeService *handshake.Service
-	addrssbook       addressbook.Putter
+	addressbook      addressbook.Putter
 	peers            *peerRegistry
 	peerHandler      func(context.Context, swarm.Address) error
 	conectionBreaker breaker.Interface
@@ -154,7 +154,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		return nil, fmt.Errorf("autonat: %w", err)
 	}
 
-	handshakeService, err := handshake.New(overlay, h.ID().String(), signer, networkID, o.Logger)
+	handshakeService, err := handshake.New(overlay, h.ID(), signer, networkID, o.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("handshake service: %w", err)
 	}
@@ -168,7 +168,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		networkID:        networkID,
 		handshakeService: handshakeService,
 		peers:            peerRegistry,
-		addrssbook:       o.Addressbook,
+		addressbook:      o.Addressbook,
 		logger:           o.Logger,
 		tracer:           o.Tracer,
 		conectionBreaker: breaker.NewBreaker(breaker.Options{}), // todo: fill non-default options
@@ -206,7 +206,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		err = s.addrssbook.Put(i.Overlay, remoteMultiaddr)
+		err = s.addressbook.Put(i.Overlay, remoteMultiaddr)
 		if err != nil {
 			s.logger.Debugf("handshake: addressbook put error %s: %v", peerID, err)
 			s.logger.Errorf("unable to persist peer %v", peerID)


### PR DESCRIPTION
@zelig 's comments from: https://github.com/ethersphere/bee/pull/196.
Moved handshake tests to single function to re-use data init.