### PR TITLE
add bee-debug endpoint to /etc/hosts for beekeeper test

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Add entries to /etc/hosts
         run: |
           echo -e "127.0.0.10\tregistry.localhost" | sudo tee -a /etc/hosts
-          for ((i=0; i<REPLICA; i++)); do echo -e "127.0.1.$((i+1))\tbee-${i}.localhost"; done | sudo tee -a /etc/hosts
+          for ((i=0; i<REPLICA; i++)); do echo -e "127.0.1.$((i+1))\tbee-${i}.localhost bee-${i}-debug.localhost"; done | sudo tee -a /etc/hosts
       - name: Set helm repo and namespace
         run: |
           helm repo add ethersphere "https://ethersphere.github.io/helm"


### PR DESCRIPTION
bee-debug endpoint needed to check when service is up missing from /etc/hosts