### PR TITLE
Add logging to cli commands

### DIFF
--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -22,11 +22,11 @@ import (
 )
 
 var (
-	outFilePath string // flag variable, output file
-	outFileForce bool  // flag variable, overwrite output file if exists
-	host string // flag variable, http api host
-	port int    // flag variable, http api port
-	ssl  bool   // flag variable, uses https for api if set
+	outFilePath  string // flag variable, output file
+	outFileForce bool   // flag variable, overwrite output file if exists
+	host         string // flag variable, http api host
+	port         int    // flag variable, http api port
+	ssl          bool   // flag variable, uses https for api if set
 )
 
 // apiStore provies a storage.Getter that retrieves chunks from swarm through the HTTP chunk API.
@@ -90,7 +90,7 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 			outFileFlags |= os.O_EXCL
 		}
 		// open the file
-		outFile, err= os.OpenFile(outFilePath, outFileFlags , 0o666)
+		outFile, err = os.OpenFile(outFilePath, outFileFlags, 0o666)
 		if err != nil {
 			return err
 		}

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -90,7 +90,7 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 			outFileFlags |= os.O_EXCL
 		}
 		// open the file
-		outFile, err = os.OpenFile(outFilePath, outFileFlags, 0o666)
+		outFile, err = os.OpenFile(outFilePath, outFileFlags, 0o666) // skipcq: GSC-G302
 		if err != nil {
 			return err
 		}

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/file/joiner"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	host        string // flag variable, http api host
+	port        int    // flag variable, http api port
+	ssl         bool   // flag variable, uses https for api if set
+)
+
+// apiStore provies a storage.Getter that retrieves chunks from swarm through the HTTP chunk API.
+type apiStore struct {
+	baseUrl string
+}
+
+// newApiStore creates a new apiStore
+func newApiStore(host string, port int, ssl bool) (storage.Getter, error) {
+	scheme := "http"
+	if ssl {
+		scheme += "s"
+	}
+	u := &url.URL{
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Scheme: scheme,
+		Path:   "bzz-chunk",
+	}
+	return &apiStore{
+		baseUrl: u.String(),
+	}, nil
+}
+
+// Get implements storage.Getter
+func (a *apiStore) Get(ctx context.Context, mode storage.ModeGet, address swarm.Address) (ch swarm.Chunk, err error) {
+	addressHex := address.String()
+	url := strings.Join([]string{a.baseUrl, addressHex}, "/")
+	c := http.DefaultClient
+	res, err := c.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("chunk %s not found", addressHex)
+	}
+	chunkData, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	res.Body.Close()
+	ch = swarm.NewChunk(address, chunkData)
+	return ch, nil
+}
+
+// Join is the underlying procedure for the CLI command
+func Join(cmd *cobra.Command, args []string) (err error) {
+
+	outFile := os.Stdout
+
+	addr, err := swarm.ParseHexAddress(args[0])
+	if err != nil {
+		return err
+	}
+
+	store, err := newApiStore (host, port, ssl)
+	if err != nil {
+		return err
+	}
+	j := joiner.NewSimpleJoiner(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r, l, err := j.Join(ctx, addr)
+	if err != nil {
+		return err
+	}
+
+	teeReader := io.TeeReader(r, outFile)
+	data := make([]byte, swarm.ChunkSize)
+	var total int64
+	for i := int64(0); i < l; i += swarm.ChunkSize {
+		c, err := teeReader.Read(data)
+		if err != nil {
+			return err
+		}
+		total += int64(c)
+	}
+	if total != l {
+		return fmt.Errorf("received only %d of %d total bytes", total, l)
+	}
+	return nil
+}
+
+func main() {
+	c := &cobra.Command{
+		Use: "join [hash]",
+		Args: cobra.ExactArgs(1),
+		Short: "Retrieve data from Swarm",
+		Long: `Assembles chunked data from referenced by a root Swarm Hash.
+
+Will output retrieved data to stdout.`,
+		RunE: Join,
+	}
+	c.Flags().StringVar(&host, "host", "127.0.0.1", "api host")
+	c.Flags().IntVar(&port, "port", 8080, "api port")
+	c.Flags().BoolVar(&ssl, "ssl", false, "use ssl")
+
+	err := c.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -156,7 +156,7 @@ Will output retrieved data to stdout.`,
 
 	err := c.Execute()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -59,7 +59,10 @@ func (a *apiStore) Get(ctx context.Context, mode storage.ModeGet, address swarm.
 	if err != nil {
 		return nil, err
 	}
-	res.Body.Close()
+	err = res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
 	ch = swarm.NewChunk(address, chunkData)
 	return ch, nil
 }

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -35,7 +35,7 @@ type apiStore struct {
 }
 
 // newApiStore creates a new apiStore
-func newApiStore(host string, port int, ssl bool) (storage.Getter, error) {
+func newApiStore(host string, port int, ssl bool) storage.Getter {
 	scheme := "http"
 	if ssl {
 		scheme += "s"
@@ -47,7 +47,7 @@ func newApiStore(host string, port int, ssl bool) (storage.Getter, error) {
 	}
 	return &apiStore{
 		baseUrl: u.String(),
-	}, nil
+	}
 }
 
 // Get implements storage.Getter
@@ -106,10 +106,7 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// initialize interface with HTTP API
-	store, err := newApiStore(host, port, ssl)
-	if err != nil {
-		return err
-	}
+	store := newApiStore(host, port, ssl)
 
 	// create the join and get its data reader
 	j := joiner.NewSimpleJoiner(store)

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -10,16 +10,16 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/file/joiner"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/spf13/cobra"
 )
 
 var (
-	host        string // flag variable, http api host
-	port        int    // flag variable, http api port
-	ssl         bool   // flag variable, uses https for api if set
+	host string // flag variable, http api host
+	port int    // flag variable, http api port
+	ssl  bool   // flag variable, uses https for api if set
 )
 
 // apiStore provies a storage.Getter that retrieves chunks from swarm through the HTTP chunk API.
@@ -74,7 +74,7 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	store, err := newApiStore (host, port, ssl)
+	store, err := newApiStore(host, port, ssl)
 	if err != nil {
 		return err
 	}
@@ -105,8 +105,8 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 
 func main() {
 	c := &cobra.Command{
-		Use: "join [hash]",
-		Args: cobra.ExactArgs(1),
+		Use:   "join [hash]",
+		Args:  cobra.ExactArgs(1),
 		Short: "Retrieve data from Swarm",
 		Long: `Assembles chunked data from referenced by a root Swarm Hash.
 

--- a/cmd/bee-split/main.go
+++ b/cmd/bee-split/main.go
@@ -234,7 +234,7 @@ Chunks are saved in individual files, and the file names will be the hex address
 	c.Flags().BoolVar(&noHttp, "no-http", false, "skip http put")
 	err := c.Execute()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/bee-split/main.go
+++ b/cmd/bee-split/main.go
@@ -89,7 +89,7 @@ type apiStore struct {
 }
 
 // newApiStore creates a new apiStor
-func newApiStore(host string, port int, ssl bool) (storage.Putter, error) {
+func newApiStore(host string, port int, ssl bool) storage.Putter {
 	scheme := "http"
 	if ssl {
 		scheme += "s"
@@ -101,7 +101,7 @@ func newApiStore(host string, port int, ssl bool) (storage.Putter, error) {
 	}
 	return &apiStore{
 		baseUrl: u.String(),
-	}, nil
+	}
 }
 
 // Put implements storage.Putter
@@ -190,10 +190,7 @@ func Split(cmd *cobra.Command, args []string) (err error) {
 		stores.Add(store)
 	}
 	if !noHttp {
-		store, err := newApiStore(host, port, ssl)
-		if err != nil {
-			return err
-		}
+		store := newApiStore(host, port, ssl)
 		stores.Add(store)
 	}
 

--- a/cmd/bee-split/main.go
+++ b/cmd/bee-split/main.go
@@ -222,7 +222,8 @@ The application will expect to transmit the chunks to the bee HTTP API, unless t
 
 If --output-dir is set, the chunks will be saved to the file system, using the flag argument as destination directory. 
 Chunks are saved in individual files, and the file names will be the hex addresses of the chunks.`,
-		RunE: Split,
+		RunE:         Split,
+		SilenceUsage: true,
 	}
 
 	c.Flags().StringVarP(&outdir, "output-dir", "d", "", "saves chunks to given directory")
@@ -233,6 +234,7 @@ Chunks are saved in individual files, and the file names will be the hex address
 	c.Flags().BoolVar(&noHttp, "no-http", false, "skip http put")
 	err := c.Execute()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -50,3 +50,12 @@ func New(w io.Writer, level logrus.Level) Logger {
 func (l *logger) NewEntry() *logrus.Entry {
 	return logrus.NewEntry(l.Logger)
 }
+
+// ToLogLevel bounds a numeric loglevel value to the amount of loglevels
+// provided by the underlying logging package
+func ToLogLevel(level int) logrus.Level {
+	if level >= len(logrus.AllLevels) {
+		level = len(logrus.AllLevels) - 1
+	}
+	return logrus.AllLevels[level]
+}


### PR DESCRIPTION
This PR adds logging capability to cli commands for split and join, as well as a minimum set of logging info from the underlying packages.

Perhaps the single most annoying thing in the world is when it is impossible as an advanced user to get contextual information about what a tool does, at a minimum if it has understood the input parameters passed to it. Let's not be annoying.