### PR TITLE
Add logging to cli

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -50,3 +50,12 @@ func New(w io.Writer, level logrus.Level) Logger {
 func (l *logger) NewEntry() *logrus.Entry {
 	return logrus.NewEntry(l.Logger)
 }
+
+// ToLogLevel bounds a numeric loglevel value to the amount of loglevels
+// provided by the underlying logging package
+func ToLogLevel(level int) logrus.Level {
+	if level >= len(logrus.AllLevels) {
+		level = len(logrus.AllLevels) - 1
+	}
+	return logrus.AllLevels[level]
+}


### PR DESCRIPTION
This PR adds logging capability to cli commands for split and join, as well as a minimum set of logging info from the underlying packages.

Perhaps the single most annoying thing in the world is when it is impossible as an advanced user to get contextual information about what a tool does, at a minimum if it has understood the input parameters passed to it. Let's not be annoying.