### PR TITLE
add content-type header to debug api /topology endpoint

### DIFF
--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -27,5 +27,6 @@ func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
+	w.Header().Set("Content-Type", jsonhttp.DefaultContentTypeHeader)
 	_, _ = io.Copy(w, bytes.NewBuffer(b))
 }


### PR DESCRIPTION
This PR adds a content type header that some clients may relay on. Currently beekeeper requires it.