### PR TITLE
swarm: add address hash size

### DIFF
--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -16,6 +16,7 @@ const (
 	SectionSize = 32
 	Branches    = 128
 	ChunkSize   = SectionSize * Branches
+	HashSize    = 32
 	MaxPO       = 16
 )
 


### PR DESCRIPTION
adding a const for hash size in bytes so we can reuse across packages