### PR TITLE
handle already connected peer gracefully in kadmelia connect

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -237,6 +237,9 @@ func (k *Kad) recalcDepth() uint8 {
 func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr, po uint8) error {
 	_, err := k.p2p.Connect(ctx, ma)
 	if err != nil {
+		if errors.Is(err, p2p.ErrAlreadyConnected) {
+			return nil
+		}
 		k.logger.Debugf("error connecting to peer %s: %v", peer, err)
 		k.waitNextMu.Lock()
 		k.waitNext[peer.String()] = time.Now().Add(timeToRetry)


### PR DESCRIPTION
This PR prevents disconnects with peers when a second connection try is attempted. This error should not disconnect peer. This fix is addressing the problem described in https://github.com/ethersphere/bee/issues/219 by not disconnecting them.

But there is still problem with false reports on disconnections in the topology endpoint. Some peers (only bootnode noticed so far by me) are listed as disconnected even they are not, according to the /peers endpoint list and also according to the lack of logs that disconnection happened, and also pingpong protocol works with the peer listed as disconnected in bins. This is another problem related to the kademlia, not connectivity.

This fix can be tested by creating a cluster with multiple nodes and validating that there are no disconnected peers in bins, and to ignore the ones that are actually not disconnected as per /peers reponse.