### PR TITLE
improve list and get pinned chunks api endpoints and tests

### DIFF
--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -5,8 +5,10 @@
 package debugapi
 
 type (
-	StatusResponse      = statusResponse
-	PeerConnectResponse = peerConnectResponse
-	PeersResponse       = peersResponse
-	AddressesResponse   = addressesResponse
+	StatusResponse           = statusResponse
+	PeerConnectResponse      = peerConnectResponse
+	PeersResponse            = peersResponse
+	AddressesResponse        = addressesResponse
+	PinnedChunk              = pinnedChunk
+	ListPinnedChunksResponse = listPinnedChunksResponse
 )

--- a/pkg/debugapi/pin_test.go
+++ b/pkg/debugapi/pin_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/storage/mock"
@@ -78,9 +79,9 @@ func TestPinChunkHandler(t *testing.T) {
 		})
 
 		// Check is the chunk is pinned once
-		jsonhttptest.ResponseDirectWithJson(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: `{"Address":"aabbcc","PinCounter":1}`,
-			Code:    http.StatusOK,
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, debugapi.PinnedChunk{
+			Address:    swarm.MustParseHexAddress("aabbcc"),
+			PinCounter: 1,
 		})
 
 	})
@@ -93,9 +94,9 @@ func TestPinChunkHandler(t *testing.T) {
 		})
 
 		// Check is the chunk is pinned twice
-		jsonhttptest.ResponseDirectWithJson(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: `{"Address":"aabbcc","PinCounter":2}`,
-			Code:    http.StatusOK,
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, debugapi.PinnedChunk{
+			Address:    swarm.MustParseHexAddress("aabbcc"),
+			PinCounter: 2,
 		})
 	})
 
@@ -107,9 +108,9 @@ func TestPinChunkHandler(t *testing.T) {
 		})
 
 		// Check is the chunk is pinned once
-		jsonhttptest.ResponseDirectWithJson(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: `{"Address":"aabbcc","PinCounter":1}`,
-			Code:    http.StatusOK,
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusOK, debugapi.PinnedChunk{
+			Address:    swarm.MustParseHexAddress("aabbcc"),
+			PinCounter: 1,
 		})
 	})
 
@@ -121,9 +122,9 @@ func TestPinChunkHandler(t *testing.T) {
 		})
 
 		// Check if the chunk is removed from the pinIndex
-		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Message: "pin chunks: leveldb: not found",
-			Code:    http.StatusInternalServerError,
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin/"+hash.String(), nil, http.StatusNotFound, jsonhttp.StatusResponse{
+			Message: http.StatusText(http.StatusNotFound),
+			Code:    http.StatusNotFound,
 		})
 	})
 
@@ -153,10 +154,17 @@ func TestPinChunkHandler(t *testing.T) {
 			Code:    http.StatusOK,
 		})
 
-		jsonhttptest.ResponseDirectWithJson(t, debugTestServer.Client, http.MethodGet, "/chunks-pin", nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: `{"Address":"aabbcc","PinCounter":1},{"Address":"ddeeff","PinCounter":1}`,
-			Code:    http.StatusOK,
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin", nil, http.StatusOK, debugapi.ListPinnedChunksResponse{
+			Chunks: []debugapi.PinnedChunk{
+				{
+					Address:    swarm.MustParseHexAddress("aabbcc"),
+					PinCounter: 1,
+				},
+				{
+					Address:    swarm.MustParseHexAddress("ddeeff"),
+					PinCounter: 1,
+				},
+			},
 		})
-
 	})
 }

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -57,9 +57,9 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.hasChunkHandler),
 	})
 	router.Handle("/chunks-pin/{address}", jsonhttp.MethodHandler{
+		"GET":    http.HandlerFunc(s.getPinnedChunk),
 		"POST":   http.HandlerFunc(s.pinChunk),
 		"DELETE": http.HandlerFunc(s.unpinChunk),
-		"GET":    http.HandlerFunc(s.listPinnedChunks),
 	})
 	router.Handle("/chunks-pin", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.listPinnedChunks),

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
@@ -11,8 +11,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-
-	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
 func ResponseDirect(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, response interface{}) {
@@ -34,35 +32,6 @@ func ResponseDirect(t *testing.T, client *http.Client, method, url string, body 
 
 	if !bytes.Equal(got, want) {
 		t.Errorf("got response %s, want %s", string(got), string(want))
-	}
-}
-
-// ResponseDirectWithJson checks for responses in json format. It is useful in cases where the response is json.
-func ResponseDirectWithJson(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, response interface{}) {
-	t.Helper()
-
-	resp := request(t, client, method, url, body, responseCode, nil)
-	defer resp.Body.Close()
-
-	got, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got = bytes.TrimSpace(got)
-
-	want, err := json.Marshal(response)
-	if err != nil {
-		t.Error(err)
-	}
-	var wantJson jsonhttp.StatusResponse
-	err = json.Unmarshal(want, &wantJson)
-	if err != nil {
-		t.Error(err)
-	}
-	wantString := "[" + wantJson.Message + "]"
-
-	if wantString != string(got) {
-		t.Errorf("got response %s, want %s", string(got), wantString)
 	}
 }
 

--- a/pkg/localstore/pin.go
+++ b/pkg/localstore/pin.go
@@ -7,11 +7,13 @@ package localstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 const (
@@ -60,6 +62,9 @@ func (db *DB) PinInfo(address swarm.Address) (uint64, error) {
 	}
 	out, err := db.pinIndex.Get(it)
 	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return 0, storage.ErrNotFound
+		}
 		return 0, err
 	}
 	return out.PinCounter, nil

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -116,7 +116,7 @@ func TestPinInfo(t *testing.T) {
 		}
 		_, err = db.PinInfo(swarm.NewAddress(chunk.Address().Bytes()))
 		if err != nil {
-			if !errors.Is(err, leveldb.ErrNotFound) {
+			if !errors.Is(err, storage.ErrNotFound) {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -166,7 +166,7 @@ func (m *MockStorer) PinInfo(address swarm.Address) (uint64, error) {
 			return m.pinnedCounter[i], nil
 		}
 	}
-	return 0, errors.New("could not find address")
+	return 0, storage.ErrNotFound
 }
 
 func (m *MockStorer) Close() error {


### PR DESCRIPTION
This PR addresses some of the issues that were discovered during the Debug API review that I did with @metacertain.

- listPinnedChunks hander is exposing types that are outside of the debugapi package making it possible that a struct changed in different package can result in the api response change
- listPinnedChunks is changed to return the json object, instead the list, making it more extensible in the future without the need for breaking changes
- some of the bad request responses are change to internal server error as they are not related to the user input
- getPinnedChunk is added to properly check if the chunk is pinned, as the current implementation did not use the address parameter at all
- tests are adjusted to explicitly check for types, not json strings
- an explicit and consistent error is returned by storage PinInfo by localstore and mock, so that it can be handled as not found response in the api 