### PR TITLE
Add collections interfaces

### DIFF
--- a/pkg/collection/collection.go
+++ b/pkg/collection/collection.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package collection provides high-level abstractions for collections of files
+package collection
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type MetadataType uint8
+
+const (
+	FilenameMimetype MetadataType = iota
+)
+
+// Collection provides a specific ordering of a collection of binary data vectors
+// stored in bee.
+type Collection interface {
+	Addresses() []swarm.Address
+}
+
+// Entry encapsulates data defining a single file entry.
+// It may contain any number of data blobs providing context to the
+// given data vector concealed by Reference.
+type Entry interface {
+	Reference() swarm.Address
+	Metadata(MetadataType) swarm.Address
+}

--- a/pkg/collection/collection.go
+++ b/pkg/collection/collection.go
@@ -27,4 +27,5 @@ type Collection interface {
 type Entry interface {
 	Reference() swarm.Address
 	Metadata(MetadataType) swarm.Address
+	SetMetadata(MetadataType, swarm.Address)
 }

--- a/pkg/file/entry/entry.go
+++ b/pkg/file/entry/entry.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package entry
+
+import (
+	"github.com/ethersphere/bee/pkg/collection"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type Entry struct {
+	reference swarm.Address
+	meta      swarm.Address
+}
+
+func New(reference swarm.Address) collection.Entry {
+	return &Entry{
+		reference: reference,
+	}
+}
+
+func (e *Entry) Reference() swarm.Address {
+	return e.reference
+}
+
+func (e *Entry) Metadata(collection.MetadataType) swarm.Address {
+	return swarm.ZeroAddress
+}

--- a/pkg/file/entry/entry.go
+++ b/pkg/file/entry/entry.go
@@ -14,10 +14,14 @@ type Entry struct {
 	meta      swarm.Address
 }
 
-func New(reference swarm.Address) collection.Entry {
+func New(reference swarm.Address) *Entry {
 	return &Entry{
 		reference: reference,
 	}
+}
+
+func (e *Entry) SetMetadata(metadataAddress swarm.Address) {
+	e.meta = metadataAddress
 }
 
 func (e *Entry) Reference() swarm.Address {
@@ -25,5 +29,5 @@ func (e *Entry) Reference() swarm.Address {
 }
 
 func (e *Entry) Metadata(collection.MetadataType) swarm.Address {
-	return swarm.ZeroAddress
+	return e.meta
 }

--- a/pkg/file/entry/entry_test.go
+++ b/pkg/file/entry/entry_test.go
@@ -1,0 +1,16 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package entry_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/file/entry"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func TestEntry(t *testing.T) {
+	_ = entry.New(swarm.ZeroAddress)
+}


### PR DESCRIPTION
This PR adds generic interfaces needed for representing nodes and leaves in a file- and directory-oriented view of Swarm.