### PR TITLE
kademlia, debugapi, node: fix connection issues

### DIFF
--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -32,7 +32,7 @@ type Options struct {
 	Overlay        swarm.Address
 	P2P            p2p.Service
 	Addressbook    addressbook.GetPutter
-	TopologyDriver topology.PeerAdder
+	TopologyDriver topology.Notifier
 	Storer         storage.Storer
 	Logger         logging.Logger
 }

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -44,7 +44,7 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.TopologyDriver.Connected(r.Context(), address); err != nil {
 		_ = s.P2P.Disconnect(address)
-		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
+		s.Logger.Debugf("debug api: topologyDriver.Connected %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)
 		jsonhttp.InternalServerError(w, err)
 		return

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -42,7 +42,7 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
-	if err := s.TopologyDriver.AddPeer(r.Context(), address); err != nil {
+	if err := s.TopologyDriver.Connected(r.Context(), address); err != nil {
 		_ = s.P2P.Disconnect(address)
 		s.Logger.Debugf("debug api: topologyDriver.AddPeer %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -304,7 +304,7 @@ func (k *Kad) AddPeer(ctx context.Context, addr swarm.Address) error {
 // Connected is called when a peer has dialed in.
 func (k *Kad) Connected(ctx context.Context, addr swarm.Address) error {
 	po := uint8(swarm.Proximity(k.base.Bytes(), addr.Bytes()))
-	k.knownPeers.Add(addr, uint8(po))
+	k.knownPeers.Add(addr, po)
 	k.connectedPeers.Add(addr, po)
 
 	k.waitNextMu.Lock()

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -242,6 +242,7 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr, 
 	_, err := k.p2p.Connect(ctx, ma)
 	if err != nil {
 		if errors.Is(err, p2p.ErrAlreadyConnected) {
+			k.connectedPeers.Add(peer, po)
 			return nil
 		}
 		k.logger.Debugf("error connecting to peer %s: %v", peer, err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -315,7 +315,6 @@ func NewBee(o Options) (*Bee, error) {
 
 			defer wg.Done()
 			if err := topologyDriver.AddPeer(p2pCtx, overlay); err != nil {
-				_ = p2ps.Disconnect(overlay)
 				logger.Debugf("topology add peer fail %s: %v", overlay, err)
 				logger.Errorf("topology add peer %s", overlay)
 				return


### PR DESCRIPTION
This PR fixes some bugs that were observed on the clusters and on local testing, namely inconsistencies of peers shown as disconnected while being in fact connected.

A short explanation of the changeset with its repercussions:
- `debugapi/peer.go` - the `AddPeer` method on kademlia was called _after connecting to the peer_. this is legacy from the full topology implementation and is incorrect in this case. The resulting behavior would be that the peer would be connected to, then would be added to the _known_ peers list, instead of both _known and connect_ lists. So the kademlia would try to iterate in `manage` but the peer would never show up in the known peers list, so would never show up in the iterator.
- it could be, that under certain circumstances that this peer would be gossiped to the node from another node, eventually triggering adding the peer through `AddPeer`, resulting in it being in the `knownPeers` slice. It is difficult to say what would be the behavior in such case, since `AddPeer` does not guarantee trying to connect to such a node, so we cannot guarantee in such case that the peer will ever shown in the `connectedPeers` list
- `kademlia.go` - moved the addition of a peer to the connect peers list after connect has finished. this is to prevent a data race when we try to connect to a peer, but it has already dialed in but was not yet added to the kademlia (the `Connected` callback was not yet called). In this case the peer should also be added to the connected peers list. This call is of no harm, since duplicates are not allowed as part of `pslice` guarantees (they are skipped and not added)
- `kademlia.go` - add peer to known peers slice on dial in - the problem was that a peer has dialed in, but was never known to us, resulting in an inconsistency in the kademlia
- `node.go` - peer should not be disconnected from when `AddPeer` fails in the case of kademlia (since `AddPeer` doesn't guarantee a connection)

fixes https://github.com/ethersphere/bee/issues/234