### PR TITLE
suppress log messages for debug api metrics, health and readiness

### DIFF
--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -22,7 +22,7 @@ func (s *server) setupRouting() {
 	baseRouter := http.NewServeMux()
 
 	baseRouter.Handle("/metrics", web.ChainHandlers(
-		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		logging.SetAccessLogLevelHandler(0), // suppress access log messages
 		web.FinalHandler(promhttp.InstrumentMetricHandler(
 			s.metricsRegistry,
 			promhttp.HandlerFor(s.metricsRegistry, promhttp.HandlerOpts{}),
@@ -42,11 +42,11 @@ func (s *server) setupRouting() {
 	router.Handle("/debug/vars", expvar.Handler())
 
 	router.Handle("/health", web.ChainHandlers(
-		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		logging.SetAccessLogLevelHandler(0), // suppress access log messages
 		web.FinalHandlerFunc(s.statusHandler),
 	))
 	router.Handle("/readiness", web.ChainHandlers(
-		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		logging.SetAccessLogLevelHandler(0), // suppress access log messages
 		web.FinalHandlerFunc(s.statusHandler),
 	))
 

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -21,9 +21,12 @@ import (
 func (s *server) setupRouting() {
 	baseRouter := http.NewServeMux()
 
-	baseRouter.Handle("/metrics", promhttp.InstrumentMetricHandler(
-		s.metricsRegistry,
-		promhttp.HandlerFor(s.metricsRegistry, promhttp.HandlerOpts{}),
+	baseRouter.Handle("/metrics", web.ChainHandlers(
+		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		web.FinalHandler(promhttp.InstrumentMetricHandler(
+			s.metricsRegistry,
+			promhttp.HandlerFor(s.metricsRegistry, promhttp.HandlerOpts{}),
+		)),
 	))
 
 	router := mux.NewRouter()
@@ -38,8 +41,14 @@ func (s *server) setupRouting() {
 
 	router.Handle("/debug/vars", expvar.Handler())
 
-	router.HandleFunc("/health", s.statusHandler)
-	router.HandleFunc("/readiness", s.statusHandler)
+	router.Handle("/health", web.ChainHandlers(
+		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		web.FinalHandlerFunc(s.statusHandler),
+	))
+	router.Handle("/readiness", web.ChainHandlers(
+		logging.SerAccessLogLevelHandler(0), // suppress access log messages
+		web.FinalHandlerFunc(s.statusHandler),
+	))
 
 	router.Handle("/addresses", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.addressesHandler),

--- a/pkg/logging/http_access.go
+++ b/pkg/logging/http_access.go
@@ -60,10 +60,10 @@ func NewHTTPAccessLogHandler(logger Logger, level logrus.Level, message string) 
 	}
 }
 
-// SerAccessLogLevelHandler overrides the log level set in
+// SetAccessLogLevelHandler overrides the log level set in
 // NewHTTPAccessLogHandler for a specific endpoint. Use log level 0 to suppress
 // log messages.
-func SerAccessLogLevelHandler(level logrus.Level) func(h http.Handler) http.Handler {
+func SetAccessLogLevelHandler(level logrus.Level) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if rl, ok := w.(*responseLogger); ok {

--- a/pkg/logging/http_access.go
+++ b/pkg/logging/http_access.go
@@ -12,13 +12,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// NewHTTPAccessLogHandler creates a handler that will log a message after a
+// request has been served.
 func NewHTTPAccessLogHandler(logger Logger, level logrus.Level, message string) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			startTime := time.Now()
-			rl := &responseLogger{w, 0, 0}
+			rl := &responseLogger{w, 0, 0, level}
 
 			h.ServeHTTP(rl, r)
+
+			if rl.level == 0 {
+				return
+			}
 
 			status := rl.status
 			if status == 0 {
@@ -49,7 +55,21 @@ func NewHTTPAccessLogHandler(logger Logger, level logrus.Level, message string) 
 			if v := r.Header.Get("X-Real-Ip"); v != "" {
 				fields["x-real-ip"] = v
 			}
-			logger.WithFields(fields).Log(level, message)
+			logger.WithFields(fields).Log(rl.level, message)
+		})
+	}
+}
+
+// SerAccessLogLevelHandler overrides the log level set in
+// NewHTTPAccessLogHandler for a specific endpoint. Use log level 0 to suppress
+// log messages.
+func SerAccessLogLevelHandler(level logrus.Level) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if rl, ok := w.(*responseLogger); ok {
+				rl.level = level
+			}
+			h.ServeHTTP(w, r)
 		})
 	}
 }
@@ -58,6 +78,7 @@ type responseLogger struct {
 	w      http.ResponseWriter
 	status int
 	size   int
+	level  logrus.Level
 }
 
 func (l *responseLogger) Header() http.Header {


### PR DESCRIPTION
This PR implements a handler that allows setting log level explicitly for http endpoints and uses that to suppress log messages for debug api /metrics, /readiness and /health endpoints.