### PR TITLE
Kademlia balance

### DIFF
--- a/pkg/kademlia/pslice/metabin.go
+++ b/pkg/kademlia/pslice/metabin.go
@@ -1,0 +1,122 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pslice
+
+import (
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// MetaBinTree + MetaBin forms a binary tree augmented with the following properties:
+
+// Order : first variable digit in metabin ( equals PO + 2 for root, as PO + 1 bits are determined by proximity order of bin)
+// Used for keeping track of the significant bit of the metabin
+
+// Required : number of connected peers we want for a metabin.
+// It should equal nnlowwatermark for root, halved for each depth of metabins
+
+// Unsorted : If "Required" is less than or equal to 1, we only want 1 address to connect to from the metabin,
+// so we will not create further metabins, just store the known addresses in a slice
+
+// b0: Metabin containing addresses with '0' at significant bit
+// b1: Metabin containing addresses with '1' at significant bit
+
+type MetaBinTree struct {
+	order    int
+	required int
+	root     *MetaBin
+	Logger   logging.Logger
+}
+
+type MetaBin struct {
+	order    int // significant bit of current metabin
+	required int // required number of connected peers
+
+	b0 *MetaBin // containing addresses continuing with '0' in digit 'order + 1'
+	b1 *MetaBin // containing addresses continuing with '1' in digit 'order + 1'
+
+	unsorted map[string]struct{}
+	Logger   logging.Logger
+}
+
+func (b *MetaBinTree) insert(new swarm.Address) *MetaBinTree {
+	if b.root == nil {
+		b.root = &MetaBin{order: b.order, required: b.required}
+	}
+	b.root.insert(new)
+	return b
+}
+
+func (b *MetaBinTree) remove(old swarm.Address) *MetaBinTree {
+	if b.root != nil {
+		b.root.remove(old)
+	}
+	return b
+}
+
+func (b *MetaBinTree) metabinSize() int {
+	if b.root != nil {
+		return b.root.metabinSize()
+	}
+	return 0
+}
+
+func (b *MetaBin) insert(new swarm.Address) {
+	// If we need more than 1 connections for this metabin, we will partition this to further metabins
+	if b.required > 1 {
+		// If we haven't partitioned this metabin yet, let's create the partitions now with half-half of the required number of connections
+		if b.b0 == nil {
+			b.b0 = &MetaBin{order: b.order + 1, required: b.required / 2}
+		}
+		if b.b1 == nil {
+			b.b1 = &MetaBin{order: b.order + 1, required: b.required / 2}
+		}
+		// Add the new peer to the right metabin
+		if new.Get(b.order) {
+			b.b1.insert(new)
+		} else {
+			b.b0.insert(new)
+		}
+
+		return
+	}
+	// At this point, it is sure we have narrowed to a metabin with a required number of connections less or equal to 1
+	// So we are not going to make more in-depth metabins, we add the new peer to the unsorted list
+	b.unsorted[new.String()] = struct{}{}
+}
+
+func (b *MetaBin) remove(old swarm.Address) {
+	if b.required > 1 {
+		if old.Get(b.order + 1) {
+			b.b1.remove(old)
+		} else {
+			b.b0.remove(old)
+		}
+		return
+	}
+	if _, ok := b.unsorted[old.String()]; ok {
+		delete(b.unsorted, old.String())
+	}
+}
+
+func (b *MetaBin) metabinSize() int {
+	l0 := 0
+	l1 := 0
+	lu := 0
+	if b.b0 != nil {
+		l0 = b.b0.metabinSize()
+	}
+	if b.b1 != nil {
+		l1 = b.b1.metabinSize()
+	}
+	if b.unsorted != nil {
+		lu = len(b.unsorted)
+	}
+	if (l0 > 0 || l1 > 0) && lu > 0 {
+		b.Logger.Errorf("Metabin anomaly present: both metabin and unsorted list sibling has length")
+		// The reason this shouldn't ever actually happen, is because we either insert to unsorted if R <= 1, or create metabins otherwise
+	}
+	return l0 + l1 + lu
+}

--- a/pkg/kademlia/pslice/metabin.go
+++ b/pkg/kademlia/pslice/metabin.go
@@ -42,16 +42,16 @@ type MetaBin struct {
 	Logger   logging.Logger
 }
 
-func NewTreeMap(maxBins, requires int) *[]MetaBinTree {
-	barr := make([]MetaBinTree, maxBins)
+func NewTreeMap(maxBins, requires int) []*MetaBinTree {
+	barr := make([]*MetaBinTree, maxBins)
 	for i := 0; i < maxBins; i++ {
-		barr[i] = MetaBinTree{order: i + 1, required: requires}
+		barr[i] = &MetaBinTree{order: i + 1, required: requires}
 	}
-	return &barr
+	return barr
 
 }
 
-func (b *MetaBinTree) insert(new swarm.Address) *MetaBinTree {
+func (b *MetaBinTree) Insert(new swarm.Address) *MetaBinTree {
 	if b.root == nil {
 		b.root = &MetaBin{order: b.order, required: b.required}
 	}
@@ -59,21 +59,21 @@ func (b *MetaBinTree) insert(new swarm.Address) *MetaBinTree {
 	return b
 }
 
-func (b *MetaBinTree) remove(old swarm.Address) *MetaBinTree {
+func (b *MetaBinTree) Remove(old swarm.Address) *MetaBinTree {
 	if b.root != nil {
 		b.root.remove(old)
 	}
 	return b
 }
 
-func (b *MetaBinTree) metabinSize() int {
+func (b *MetaBinTree) MetaBinSize() int {
 	if b.root != nil {
 		return b.root.metabinSize()
 	}
 	return 0
 }
 
-func (b *MetaBinTree) completelyNonEmpty() bool {
+func (b *MetaBinTree) CompletelyNonEmpty() bool {
 	if b.root != nil {
 		return b.root.completelyNonEmpty()
 	}
@@ -81,17 +81,13 @@ func (b *MetaBinTree) completelyNonEmpty() bool {
 
 }
 
-func (b *MetaBinTree) print() {
+func (b *MetaBinTree) Print() {
 	fmt.Println("\n Printing Metabin for PO: %v \n", b.order-1)
 	if b.root != nil {
 		b.root.print()
 		return
 	}
 	fmt.Println("Empty MetaBinTree")
-}
-
-func (b *MetaBinTree) pv() *MetaBinTree {
-	return b
 }
 
 func (b *MetaBin) insert(new swarm.Address) {

--- a/pkg/kademlia/pslice/metabin.go
+++ b/pkg/kademlia/pslice/metabin.go
@@ -5,6 +5,7 @@
 package pslice
 
 import (
+	"fmt"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -41,6 +42,15 @@ type MetaBin struct {
 	Logger   logging.Logger
 }
 
+func NewTreeMap(maxBins, requires int) *[]MetaBinTree {
+	barr := make([]MetaBinTree, maxBins)
+	for i := 0; i < maxBins; i++ {
+		barr[i] = MetaBinTree{order: i + 1, required: requires}
+	}
+	return &barr
+
+}
+
 func (b *MetaBinTree) insert(new swarm.Address) *MetaBinTree {
 	if b.root == nil {
 		b.root = &MetaBin{order: b.order, required: b.required}
@@ -61,6 +71,27 @@ func (b *MetaBinTree) metabinSize() int {
 		return b.root.metabinSize()
 	}
 	return 0
+}
+
+func (b *MetaBinTree) completelyNonEmpty() bool {
+	if b.root != nil {
+		return b.root.completelyNonEmpty()
+	}
+	return false
+
+}
+
+func (b *MetaBinTree) print() {
+	fmt.Println("\n Printing Metabin for PO: %v \n", b.order-1)
+	if b.root != nil {
+		b.root.print()
+		return
+	}
+	fmt.Println("Empty MetaBinTree")
+}
+
+func (b *MetaBinTree) pv() *MetaBinTree {
+	return b
 }
 
 func (b *MetaBin) insert(new swarm.Address) {
@@ -119,4 +150,29 @@ func (b *MetaBin) metabinSize() int {
 		// The reason this shouldn't ever actually happen, is because we either insert to unsorted if R <= 1, or create metabins otherwise
 	}
 	return l0 + l1 + lu
+}
+
+func (b *MetaBin) completelyNonEmpty() bool {
+	if b.required > 1 {
+		return b.b0.completelyNonEmpty() && b.b1.completelyNonEmpty()
+	}
+	if len(b.unsorted) > 0 {
+		return true
+	}
+
+	return false
+
+}
+
+func (b *MetaBin) print() {
+
+	if b.required > 1 {
+		fmt.Print("0")
+		b.b0.print()
+		fmt.Print("1")
+		b.b1.print()
+	}
+	if b.required <= 1 {
+		fmt.Println("\n %v", b.unsorted)
+	}
 }

--- a/pkg/swarm/bitops.go
+++ b/pkg/swarm/bitops.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package swarm
+
+// Bit related utility functions
+
+func (a *Address) Get(i int) bool {
+	return Get(a.b, i)
+}
+
+func (a *Address) Set(i int, v bool) {
+	Set(a.b, i, v)
+}
+
+func (a *Address) SwitchOneBit(i int) {
+	Set(a.b, i, !Get(a.b, i))
+}
+
+func Get(by []byte, i int) bool {
+	e := i / 8
+	return by[e]&(0x1<<uint(i%8)) != 0
+}
+
+func Set(by []byte, i int, v bool) {
+	e := i / 8
+	cv := Get(by, i)
+	if cv != v {
+		by[e] ^= 0x1 << uint8(i%8)
+	}
+	//fmt.Println("sot %v", i)
+}
+
+// Prefix(n) returns first n bits of an address padded by zeroes
+func (a *Address) Prefix(n int) Address {
+	prefb := make([]byte, 64)
+	pref := NewAddress(prefb)
+	for i := 1; i <= n; i++ {
+		pref.Set(i, a.Get(i))
+	}
+	for i := n + 1; i <= len(a.b)*8; i++ {
+		pref.Set(i, false)
+	}
+	return pref
+}
+
+//AddSuffix sets the bits in an address beginning from "suffixfrom" until length of suffix byteslice to the bits in suffix
+func (a *Address) AddSuffix(suffix []byte, suffixfrom int) *Address {
+	suffixtill := MinimumInt(suffixfrom+len(suffix)*8-1, len(a.b)*8)
+	for i := suffixfrom; i < suffixtill; i++ {
+		currentsuffixbit := i + 1 - suffixfrom
+		a.Set(i, Get(suffix, currentsuffixbit))
+	}
+	return a
+}
+
+func MinimumInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
This PR intends to implement balanced PO bins

High level overview

N. Saturation check -n-> if no, connect all
I. Balancedness check -y-> if saturated and balanced, skip bin
II. If not balanced:
Fore each empty metabin in connectedMetaBin[PO], connect a node from the corresponding knownMetaBin[PO]

