### PR TITLE
Fix bzz chunk api

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -48,5 +48,7 @@ jobs:
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test pingpong
         run: ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
-      - name: Test pushsync
+      - name: Test pushsync (bzz API)
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
+      - name: Test pushsync (bzz-chunk API)
+        run: ./beekeeper check pushsync --bzz-chunk --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3

--- a/pkg/api/bzzchunk_test.go
+++ b/pkg/api/bzzchunk_test.go
@@ -6,6 +6,7 @@ package api_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -32,7 +33,7 @@ func TestChunkUploadDownload(t *testing.T) {
 		invalidHash          = swarm.MustParseHexAddress("bbccdd")
 		validContent         = []byte("bbaatt")
 		invalidContent       = []byte("bbaattss")
-		mockValidator        = validator.NewMockValidator(validHash, validContent)
+		mockValidator        = validator.NewMockValidator(validHash, append(newSpan(uint64(len(validContent))), validContent...))
 		tag                  = tags.NewTags()
 		mockValidatingStorer = mock.NewValidatingStorer(mockValidator, tag)
 		client               = newTestServer(t, testServerOptions{
@@ -135,4 +136,10 @@ func request(t *testing.T, client *http.Client, method string, resource string, 
 		t.Fatalf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
 	}
 	return resp
+}
+
+func newSpan(size uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, size)
+	return b
 }

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -28,7 +28,7 @@ func TestTags(t *testing.T) {
 		tagResourceUUid      = func(uuid uint64) string { return "/bzz-tag/uuid/" + strconv.FormatUint(uuid, 10) }
 		validHash            = swarm.MustParseHexAddress("aabbcc")
 		validContent         = []byte("bbaatt")
-		mockValidator        = validator.NewMockValidator(validHash, validContent)
+		mockValidator        = validator.NewMockValidator(validHash, append(newSpan(uint64(len(validContent))), validContent...))
 		tag                  = tags.NewTags()
 		mockValidatingStorer = mock.NewValidatingStorer(mockValidator, tag)
 		mockPusher           = mp.NewMockPusher(tag)
@@ -98,7 +98,7 @@ func TestTags(t *testing.T) {
 		// Add asecond valid contentto validator
 		secondValidHash := swarm.MustParseHexAddress("deadbeaf")
 		secondValidContent := []byte("123456")
-		mockValidator.AddPair(secondValidHash, secondValidContent)
+		mockValidator.AddPair(secondValidHash, append(newSpan(uint64(len(secondValidContent))), secondValidContent...))
 
 		sentHheaders = make(http.Header)
 		sentHheaders.Set(api.TagHeaderUid, strconv.FormatUint(uint64(ta.Uid), 10))

--- a/pkg/debugapi/pin_test.go
+++ b/pkg/debugapi/pin_test.go
@@ -6,6 +6,7 @@ package debugapi_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"net/http"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestPinChunkHandler(t *testing.T) {
 	resource := func(addr swarm.Address) string { return "/bzz-chunk/" + addr.String() }
 	hash := swarm.MustParseHexAddress("aabbcc")
 	data := []byte("bbaatt")
-	mockValidator := validator.NewMockValidator(hash, data)
+	mockValidator := validator.NewMockValidator(hash, append(newSpan(uint64(len(data))), data...))
 	tag := tags.NewTags()
 	mockValidatingStorer := mock.NewValidatingStorer(mockValidator, tag)
 	debugTestServer := newTestServer(t, testServerOptions{
@@ -148,7 +149,7 @@ func TestPinChunkHandler(t *testing.T) {
 		// post another chunk
 		hash2 := swarm.MustParseHexAddress("ddeeff")
 		data2 := []byte("eagle")
-		mockValidator.AddPair(hash2, data2)
+		mockValidator.AddPair(hash2, append(newSpan(uint64(len(data2))), data2...))
 		jsonhttptest.ResponseDirect(t, bzzTestServer, http.MethodPost, resource(hash2), bytes.NewReader(data2), http.StatusOK, jsonhttp.StatusResponse{
 			Message: http.StatusText(http.StatusOK),
 			Code:    http.StatusOK,
@@ -171,4 +172,10 @@ func TestPinChunkHandler(t *testing.T) {
 			},
 		})
 	})
+}
+
+func newSpan(size uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, size)
+	return b
 }


### PR DESCRIPTION
This PR is fixing /bzz-chunk endpoint in relation with the validator. Similar as the previous fix for /bzz endpoint, it puts the chunk data with span, as required by validator, and serves it without the span on download. This issue was discovered while developing beekeeper test that uploads the chunk by calculating it hash as required for this endpoint.