### PR TITLE
fix db capacity log message

### DIFF
--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -177,7 +177,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if db.capacity == 0 {
 		db.capacity = defaultCapacity
 	}
-	db.logger.Info("setting db capacity to: %v", db.capacity)
+	db.logger.Infof("db capacity: %v", db.capacity)
 	if maxParallelUpdateGC > 0 {
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}


### PR DESCRIPTION
In the PR that introduced db capacity an error was made to call `Info` instead `Infof` resulting badly formatted log message `INFO[2020-06-05T15:55:32+02:00] setting db capacity to: %v5000000`. I have also adjusted the log message to a statement.