### PR TITLE
improve TestTags failure log message

### DIFF
--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -214,7 +214,7 @@ func TestTags(t *testing.T) {
 			tagToVerify.Stored != finalTag.Stored ||
 			tagToVerify.Sent != finalTag.Seen ||
 			tagToVerify.Synced != finalTag.Synced {
-			t.Fatalf("Invalid counters")
+			t.Fatalf("got tag %+v, want %+v", tagToVerify, finalTag)
 		}
 	})
 }


### PR DESCRIPTION
This PR improves a log message in test that is potentially flaky. Current message is not useful.