### PR TITLE
set Secp256k1 private key in libp2p test services instead temp RSA

### DIFF
--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -26,12 +26,12 @@ import (
 func newService(t *testing.T, networkID uint64, o libp2p.Options) (s *libp2p.Service, overlay swarm.Address) {
 	t.Helper()
 
-	privateKey, err := crypto.GenerateSecp256k1Key()
+	swarmKey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	overlay = crypto.NewOverlayAddress(privateKey.PublicKey, networkID)
+	overlay = crypto.NewOverlayAddress(swarmKey.PublicKey, networkID)
 
 	addr := ":0"
 
@@ -44,8 +44,17 @@ func newService(t *testing.T, networkID uint64, o libp2p.Options) (s *libp2p.Ser
 		o.Addressbook = addressbook.New(statestore)
 	}
 
+	if o.PrivateKey == nil {
+		libp2pKey, err := crypto.GenerateSecp256k1Key()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		o.PrivateKey = libp2pKey
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
-	s, err = libp2p.New(ctx, crypto.NewDefaultSigner(privateKey), networkID, overlay, addr, o)
+	s, err = libp2p.New(ctx, crypto.NewDefaultSigner(swarmKey), networkID, overlay, addr, o)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We have experienced slowdowns on CI and timeouts on connectivity tests in libp2p packages. Most frequently timeouts in TestConnectDisconnectOnAllAddresses. After some profiling, I have found that the default RSA key generation is the slowest part of that test and by using Secp256k1 the test is ~2x faster in average. This is an attempt to see if the test will not timeout, but in general the speedup is beneficial.