### PR TITLE
fixed redundent debug statements

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -6,6 +6,7 @@ package pusher
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -96,7 +97,9 @@ func (s *Service) chunksWorker() {
 			// for now ignoring the receipt and checking only for error
 			_, err = s.pushSyncer.PushChunkToClosest(ctx, ch)
 			if err != nil {
-				s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
+				if !errors.Is(err, topology.ErrNotFound) {
+					s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
+				}
 				continue
 			}
 

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -6,7 +6,6 @@ package pusher
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -97,9 +96,7 @@ func (s *Service) chunksWorker() {
 			// for now ignoring the receipt and checking only for error
 			_, err = s.pushSyncer.PushChunkToClosest(ctx, ch)
 			if err != nil {
-				if !errors.Is(err, topology.ErrNotFound) {
-					s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
-				}
+				s.logger.Debugf("pusher: error while sending chunk or receiving receipt: %v", err)
 				continue
 			}
 


### PR DESCRIPTION
- removed continuous printing of pusher log when there is only one connected node