### PR TITLE
remove tag address field for bzz-chunk api

### DIFF
--- a/pkg/api/bzzchunk.go
+++ b/pkg/api/bzzchunk.go
@@ -114,7 +114,6 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tag.Address = address
 	w.Header().Set(TagHeaderUid, fmt.Sprint(tag.Uid))
 	w.Header().Set("Access-Control-Expose-Headers", TagHeaderUid)
 	jsonhttp.OK(w, nil)

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -49,10 +49,6 @@ func (s *server) setupRouting() {
 		"POST": http.HandlerFunc(s.CreateTag),
 	})
 
-	router.Handle("/bzz-tag/addr/{addr}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.getTagInfoUsingAddress),
-	})
-
 	router.Handle("/bzz-tag/uuid/{uuid}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.getTagInfoUsingUUid),
 	})

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -60,28 +60,6 @@ func (s *server) CreateTag(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func (s *server) getTagInfoUsingAddress(w http.ResponseWriter, r *http.Request) {
-	addr := mux.Vars(r)["addr"]
-	address, err := swarm.ParseHexAddress(addr)
-	if err != nil {
-		s.Logger.Debugf("bzz-tag: parse chunk address %s: %v", addr, err)
-		s.Logger.Error("bzz-tag: parse chunk address")
-		jsonhttp.BadRequest(w, "invalid chunk address")
-		return
-	}
-
-	tag, err := s.Tags.GetByAddress(address)
-	if err != nil {
-		s.Logger.Debugf("bzz-tag: tag not present %s : %v, ", address.String(), err)
-		s.Logger.Error("bzz-tag: tag not present")
-		jsonhttp.InternalServerError(w, "tag not present")
-		return
-	}
-
-	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
-	jsonhttp.OK(w, newTagResponse(tag))
-}
-
 func (s *server) getTagInfoUsingUUid(w http.ResponseWriter, r *http.Request) {
 	uidStr := mux.Vars(r)["uuid"]
 

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -23,7 +23,6 @@ import (
 func TestTags(t *testing.T) {
 	var (
 		resource             = func(addr swarm.Address) string { return "/bzz-chunk/" + addr.String() }
-		tagResourceAddress   = func(addr swarm.Address) string { return "/bzz-tag/addr/" + addr.String() }
 		tagResourceUidCreate = func(name string) string { return "/bzz-tag/name/" + name }
 		tagResourceUUid      = func(uuid uint64) string { return "/bzz-tag/uuid/" + strconv.FormatUint(uuid, 10) }
 		validHash            = swarm.MustParseHexAddress("aabbcc")
@@ -143,34 +142,6 @@ func TestTags(t *testing.T) {
 		}
 	})
 
-	t.Run("get-tag-using-address", func(t *testing.T) {
-		// Get a tag
-		ta := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagResourceUidCreate("file.jpg"), nil, http.StatusOK, &ta)
-
-		if ta.Name != "file.jpg" {
-			t.Fatalf("tagname is not the same that we sent")
-		}
-
-		// Now upload a chunk and see if we receive a tag with the same uid
-		sentHheaders := make(http.Header)
-		sentHheaders.Set(api.TagHeaderUid, strconv.FormatUint(uint64(ta.Uid), 10))
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, sentHheaders)
-
-		uuid := isTagFoundInResponse(t, rcvdHeaders, &ta)
-
-		// Request the tag and see if the UUID is the same
-		rtag := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagResourceAddress(validHash), nil, http.StatusOK, &rtag)
-
-		if uuid != uint64(rtag.Uid) {
-			t.Fatalf("Invalid uuid response")
-		}
-	})
-
 	t.Run("get-tag-using-uuid", func(t *testing.T) {
 		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
 			Message: http.StatusText(http.StatusOK),
@@ -197,11 +168,11 @@ func TestTags(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = mockPusher.SendChunk(validHash)
+		err = mockPusher.SendChunk(uint32(uuid1))
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = mockPusher.RcvdReceipt(validHash)
+		err = mockPusher.RcvdReceipt(uint32(uuid1))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/pusher/mock/mock.go
+++ b/pkg/pusher/mock/mock.go
@@ -5,7 +5,6 @@
 package mock
 
 import (
-	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 )
 
@@ -19,8 +18,8 @@ func NewMockPusher(tag *tags.Tags) *MockPusher {
 	}
 }
 
-func (m *MockPusher) SendChunk(address swarm.Address) error {
-	ta, err := m.tag.GetByAddress(address)
+func (m *MockPusher) SendChunk(uid uint32) error {
+	ta, err := m.tag.Get(uid)
 	if err != nil {
 		return err
 	}
@@ -29,8 +28,8 @@ func (m *MockPusher) SendChunk(address swarm.Address) error {
 	return nil
 }
 
-func (m *MockPusher) RcvdReceipt(address swarm.Address) error {
-	ta, err := m.tag.GetByAddress(address)
+func (m *MockPusher) RcvdReceipt(uid uint32) error {
+	ta, err := m.tag.Get(uid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In bzz-api tag.address field is set to the chunk that arrives. It is usually used to represent the root chunk in tagging. since this does not fit here, i have removed assigning the received address to the ta.address field.

Also removed the api which gets the tag address and gives back the tag details.