### PR TITLE
use netstore in retrieval protocol

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -205,7 +205,6 @@ func NewBee(o Options) (*Bee, error) {
 	retrieve := retrieval.New(retrieval.Options{
 		Streamer:    p2ps,
 		ChunkPeerer: topologyDriver,
-		Storer:      storer,
 		Logger:      logger,
 	})
 	tag := tags.NewTags()
@@ -215,6 +214,8 @@ func NewBee(o Options) (*Bee, error) {
 	}
 
 	ns := netstore.New(storer, retrieve, validator.NewContentAddressValidator())
+
+	retrieve.SetStorer(ns)
 
 	pushSyncProtocol := pushsync.New(pushsync.Options{
 		Streamer:      p2ps,

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -113,3 +113,8 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) er
 
 	return nil
 }
+
+// SetStorer sets the storer. This call is not goroutine safe.
+func (s *Service) SetStorer(storer storage.Storer) {
+	s.storer = storer
+}


### PR DESCRIPTION
This PR sets NetStore as the Storer for the Retrieval protocol in order to forward requests.

It solves the problem with the retrieval described in https://github.com/ethersphere/bee/issues/259.

This change is tested with integrations tests on various size clusters up to 50 nodes, by running this check:

`./dist/beekeeper check retrieval --api-insecure-tls --debug-api-insecure-tls -n janos -c 50 -u 50 -p 100`

fixes: https://github.com/ethersphere/bee/issues/259