### PR TITLE
move pingpong api to debug api

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ curl localhost:6062/addresses
 
 Make sure that Debug API is enabled and address configured as in examples above.
 
-And use that address in the API call on another node, for example, local node 1:
+And use that address in the Debug API call on another node, for example, local node 1:
 
 ```sh
-curl -XPOST localhost:8081/pingpong/d4440baf2d79e481c3c6fd93a2014d2e6fe0386418829439f26d13a8253d04f1
+curl -XPOST localhost:6061/pingpong/d4440baf2d79e481c3c6fd93a2014d2e6fe0386418829439f26d13a8253d04f1
 ```
 
 ## Generating protobuf

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
-	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/tracing"
@@ -27,11 +26,10 @@ type server struct {
 }
 
 type Options struct {
-	Pingpong pingpong.Interface
-	Tags     *tags.Tags
-	Storer   storage.Storer
-	Logger   logging.Logger
-	Tracer   *tracing.Tracer
+	Tags   *tags.Tags
+	Storer storage.Storer
+	Logger logging.Logger
+	Tracer *tracing.Tracer
 }
 
 func New(o Options) Service {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -31,10 +31,9 @@ func newTestServer(t *testing.T, o testServerOptions) *http.Client {
 		o.Logger = logging.New(ioutil.Discard, 0)
 	}
 	s := api.New(api.Options{
-		Pingpong: o.Pingpong,
-		Tags:     o.Tags,
-		Storer:   o.Storer,
-		Logger:   o.Logger,
+		Tags:   o.Tags,
+		Storer: o.Storer,
+		Logger: o.Logger,
 	})
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -5,7 +5,6 @@
 package api
 
 type (
-	PingpongResponse = pingpongResponse
-	RawPostResponse  = rawPostResponse
-	TagResponse      = tagResponse
+	RawPostResponse = rawPostResponse
+	TagResponse     = tagResponse
 )

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -38,12 +38,6 @@ func newMetrics() metrics {
 			Help:      "Histogram of API response durations.",
 			Buckets:   []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}),
-		PingRequestCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "ping_request_count",
-			Help:      "Number HTTP API ping requests.",
-		}),
 	}
 }
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -28,10 +28,6 @@ func (s *server) setupRouting() {
 		fmt.Fprintln(w, "User-agent: *\nDisallow: /")
 	})
 
-	router.Handle("/pingpong/{peer-id}", jsonhttp.MethodHandler{
-		"POST": http.HandlerFunc(s.pingpongHandler),
-	})
-
 	router.Handle("/bzz-raw", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.rawUploadHandler),
 	})

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -10,10 +10,12 @@ import (
 	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/topology"
+	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -32,10 +34,12 @@ type server struct {
 type Options struct {
 	Overlay        swarm.Address
 	P2P            p2p.Service
+	Pingpong       pingpong.Interface
 	Addressbook    addressbook.GetPutter
 	TopologyDriver topology.Notifier
 	Storer         storage.Storer
 	Logger         logging.Logger
+	Tracer         *tracing.Tracer
 	Tags           *tags.Tags
 }
 

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/pingpong"
 	mockstore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -29,6 +30,7 @@ import (
 type testServerOptions struct {
 	Overlay      swarm.Address
 	P2P          p2p.Service
+	Pingpong     pingpong.Interface
 	Storer       storage.Storer
 	TopologyOpts []mock.Option
 	Tags         *tags.Tags
@@ -48,6 +50,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	s := debugapi.New(debugapi.Options{
 		Overlay:        o.Overlay,
 		P2P:            o.P2P,
+		Pingpong:       o.Pingpong,
 		Tags:           o.Tags,
 		Logger:         logging.New(ioutil.Discard, 0),
 		Addressbook:    addrbook,

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -6,6 +6,7 @@ package debugapi
 
 type (
 	StatusResponse           = statusResponse
+	PingpongResponse         = pingpongResponse
 	PeerConnectResponse      = peerConnectResponse
 	PeersResponse            = peersResponse
 	AddressesResponse        = addressesResponse

--- a/pkg/debugapi/pingpong.go
+++ b/pkg/debugapi/pingpong.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package api
+package debugapi
 
 import (
 	"errors"
@@ -44,7 +44,6 @@ func (s *server) pingpongHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, nil)
 		return
 	}
-	s.metrics.PingRequestCount.Inc()
 
 	logger.Infof("pingpong succeeded to peer %s", peerID)
 	jsonhttp.OK(w, pingpongResponse{

--- a/pkg/debugapi/pingpong_test.go
+++ b/pkg/debugapi/pingpong_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package api_test
+package debugapi_test
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/api"
+	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -36,39 +36,39 @@ func TestPingpong(t *testing.T) {
 		return rtt, nil
 	})
 
-	client := newTestServer(t, testServerOptions{
+	ts := newTestServer(t, testServerOptions{
 		Pingpong: pingpongService,
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/pingpong/"+peerID.String(), nil, http.StatusOK, api.PingpongResponse{
+		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+peerID.String(), nil, http.StatusOK, debugapi.PingpongResponse{
 			RTT: rtt.String(),
 		})
 	})
 
 	t.Run("peer not found", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/pingpong/"+unknownPeerID.String(), nil, http.StatusNotFound, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+unknownPeerID.String(), nil, http.StatusNotFound, jsonhttp.StatusResponse{
 			Code:    http.StatusNotFound,
 			Message: "peer not found",
 		})
 	})
 
 	t.Run("invalid peer address", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/pingpong/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
 			Code:    http.StatusBadRequest,
 			Message: "invalid peer address",
 		})
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, "/pingpong/"+errorPeerID.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+errorPeerID.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
 			Code:    http.StatusInternalServerError,
 			Message: http.StatusText(http.StatusInternalServerError), // do not leak internal error
 		})
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, "/pingpong/"+peerID.String(), nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodGet, "/pingpong/"+peerID.String(), nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
 			Code:    http.StatusMethodNotAllowed,
 			Message: http.StatusText(http.StatusMethodNotAllowed),
 		})

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -50,6 +50,10 @@ func (s *server) setupRouting() {
 		web.FinalHandlerFunc(s.statusHandler),
 	))
 
+	router.Handle("/pingpong/{peer-id}", jsonhttp.MethodHandler{
+		"POST": http.HandlerFunc(s.pingpongHandler),
+	})
+
 	router.Handle("/addresses", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.addressesHandler),
 	})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -242,11 +242,10 @@ func NewBee(o Options) (*Bee, error) {
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
-			Pingpong: pingPong,
-			Tags:     tag,
-			Storer:   ns,
-			Logger:   logger,
-			Tracer:   tracer,
+			Tags:   tag,
+			Storer: ns,
+			Logger: logger,
+			Tracer: tracer,
 		})
 		apiListener, err := net.Listen("tcp", o.APIAddr)
 		if err != nil {
@@ -275,7 +274,9 @@ func NewBee(o Options) (*Bee, error) {
 		debugAPIService := debugapi.New(debugapi.Options{
 			Overlay:        address,
 			P2P:            p2ps,
+			Pingpong:       pingPong,
 			Logger:         logger,
+			Tracer:         tracer,
 			Addressbook:    addressbook,
 			TopologyDriver: topologyDriver,
 			Storer:         storer,


### PR DESCRIPTION
This PR moved pingpong api to debug api as this is not the feature of the swarm, only a tool to measure latencies between nodes.

@svetomir this change would require update in beekeeper.