### PR TITLE
api bzz-chunk and bzz-raw rename

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -48,9 +48,9 @@ jobs:
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test pingpong
         run: ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
-      - name: Test pushsync
+      - name: Test pushsync (bytes)
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
-      - name: Test pushsync (bzz-chunk API)
-        run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3 --bzz-chunk
+      - name: Test pushsync (chunks)
+        run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3 --upload-chunks
       - name: Test retrieval
         run: ./beekeeper check retrieval --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3

--- a/cmd/internal/file/io.go
+++ b/cmd/internal/file/io.go
@@ -116,7 +116,7 @@ func NewApiStore(host string, port int, ssl bool) putGetter {
 	u := &url.URL{
 		Host:   fmt.Sprintf("%s:%d", host, port),
 		Scheme: scheme,
-		Path:   "bzz-chunk",
+		Path:   "chunks",
 	}
 	return &ApiStore{
 		Client:  http.DefaultClient,

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -21,16 +21,16 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-type rawPostResponse struct {
-	Hash swarm.Address `json:"hash"`
+type bytesPostResponse struct {
+	Reference swarm.Address `json:"reference"`
 }
 
-// rawUploadHandler handles upload of raw binary data of arbitrary length.
-func (s *server) rawUploadHandler(w http.ResponseWriter, r *http.Request) {
+// bytesUploadHandler handles upload of raw binary data of arbitrary length.
+func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	responseObject, err := s.splitUpload(ctx, r.Body, r.ContentLength)
 	if err != nil {
-		s.Logger.Debugf("raw: %v", err)
+		s.Logger.Debugf("bytes upload: %v", err)
 		o := responseObject.(jsonhttp.StatusResponse)
 		jsonhttp.Respond(w, o.Code, o)
 	} else {
@@ -68,18 +68,18 @@ func (s *server) splitUpload(ctx context.Context, r io.ReadCloser, l int64) (int
 		err = fmt.Errorf("%s: %v", response.Message, err)
 		return response, err
 	}
-	return rawPostResponse{Hash: address}, nil
+	return bytesPostResponse{Reference: address}, nil
 }
 
-// rawGetHandler handles retrieval of raw binary data of arbitrary length.
-func (s *server) rawGetHandler(w http.ResponseWriter, r *http.Request) {
+// bytesGetHandler handles retrieval of raw binary data of arbitrary length.
+func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 	addressHex := mux.Vars(r)["address"]
 	ctx := r.Context()
 
 	address, err := swarm.ParseHexAddress(addressHex)
 	if err != nil {
-		s.Logger.Debugf("raw: parse address %s: %v", addressHex, err)
-		s.Logger.Error("raw: parse address error")
+		s.Logger.Debugf("bytes: parse address %s: %v", addressHex, err)
+		s.Logger.Error("bytes: parse address error")
 		jsonhttp.BadRequest(w, "invalid address")
 		return
 	}
@@ -89,13 +89,13 @@ func (s *server) rawGetHandler(w http.ResponseWriter, r *http.Request) {
 	dataSize, err := j.Size(ctx, address)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			s.Logger.Debugf("raw: not found %s: %v", address, err)
-			s.Logger.Error("raw: not found")
+			s.Logger.Debugf("bytes: not found %s: %v", address, err)
+			s.Logger.Error("bytes: not found")
 			jsonhttp.NotFound(w, "not found")
 			return
 		}
-		s.Logger.Debugf("raw: invalid root chunk %s: %v", address, err)
-		s.Logger.Error("raw: invalid root chunk")
+		s.Logger.Debugf("bytes: invalid root chunk %s: %v", address, err)
+		s.Logger.Error("bytes: invalid root chunk")
 		jsonhttp.BadRequest(w, "invalid root chunk")
 		return
 	}
@@ -104,8 +104,8 @@ func (s *server) rawGetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", dataSize))
 	c, err := file.JoinReadAll(j, address, w)
 	if err != nil && c == 0 {
-		s.Logger.Errorf("raw: data write %s: %v", address, err)
-		s.Logger.Error("raw: data input error")
+		s.Logger.Errorf("bytes: data write %s: %v", address, err)
+		s.Logger.Error("bytes: data input error")
 		jsonhttp.InternalServerError(w, "retrieval fail")
 	}
 }

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -20,11 +20,11 @@ import (
 	mockbytes "gitlab.com/nolash/go-mockbytes"
 )
 
-// TestRaw tests that the data upload api responds as expected when uploading,
+// TestBytes tests that the data upload api responds as expected when uploading,
 // downloading and requesting a resource that cannot be found.
-func TestRaw(t *testing.T) {
+func TestBytes(t *testing.T) {
 	var (
-		resource   = "/bzz-raw"
+		resource   = "/bytes"
 		expHash    = "29a5fb121ce96194ba8b7b823a1f9c6af87e1791f824940a53b5a7efe3f790d9"
 		mockStorer = mock.NewStorer()
 		client     = newTestServer(t, testServerOptions{
@@ -40,8 +40,8 @@ func TestRaw(t *testing.T) {
 	}
 
 	t.Run("upload", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource, bytes.NewReader(content), http.StatusOK, api.RawPostResponse{
-			Hash: swarm.MustParseHexAddress(expHash),
+		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource, bytes.NewReader(content), http.StatusOK, api.BytesPostResponse{
+			Reference: swarm.MustParseHexAddress(expHash),
 		})
 	})
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -34,8 +34,8 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	address, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("bzz-chunk: parse chunk address %s: %v", addr, err)
-		s.Logger.Error("bzz-chunk: parse chunk address")
+		s.Logger.Debugf("chunk upload: parse chunk address %s: %v", addr, err)
+		s.Logger.Error("chunk upload: parse chunk address")
 		jsonhttp.BadRequest(w, "invalid chunk address")
 		return
 	}
@@ -47,8 +47,8 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		tagName := fmt.Sprintf("unnamed_tag_%d", time.Now().Unix())
 		tag, err = s.Tags.Create(tagName, 0, false)
 		if err != nil {
-			s.Logger.Debugf("bzz-chunk: tag creation error: %v, addr %s", err, address)
-			s.Logger.Error("bzz-chunk: tag creation error")
+			s.Logger.Debugf("chunk upload: tag creation error: %v, addr %s", err, address)
+			s.Logger.Error("chunk upload: tag creation error")
 			jsonhttp.InternalServerError(w, "cannot create tag")
 			return
 		}
@@ -56,16 +56,16 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		// if the tag uid header is present, then use the tag sent
 		tagUid, err := strconv.ParseUint(tagUidStr, 10, 32)
 		if err != nil {
-			s.Logger.Debugf("bzz-chunk: parse taguid %s: %v", tagUidStr, err)
-			s.Logger.Error("bzz-chunk: parse taguid")
+			s.Logger.Debugf("chunk upload: parse taguid %s: %v", tagUidStr, err)
+			s.Logger.Error("chunk upload: parse taguid")
 			jsonhttp.BadRequest(w, "invalid taguid")
 			return
 		}
 
 		tag, err = s.Tags.Get(uint32(tagUid))
 		if err != nil {
-			s.Logger.Debugf("bzz-chunk: tag get error: %v, addr %s", err, address)
-			s.Logger.Error("bzz-chunk: tag get error")
+			s.Logger.Debugf("chunk upload: tag get error: %v, addr %s", err, address)
+			s.Logger.Error("chunk upload: tag get error")
 			jsonhttp.InternalServerError(w, "cannot create tag")
 			return
 		}
@@ -77,8 +77,8 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		s.Logger.Debugf("bzz-chunk: read chunk data error: %v, addr %s", err, address)
-		s.Logger.Error("bzz-chunk: read chunk data error")
+		s.Logger.Debugf("chunk upload: read chunk data error: %v, addr %s", err, address)
+		s.Logger.Error("chunk upload: read chunk data error")
 		jsonhttp.InternalServerError(w, "cannot read chunk data")
 		return
 
@@ -86,8 +86,8 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	seen, err := s.Storer.Put(ctx, storage.ModePutUpload, swarm.NewChunk(address, data))
 	if err != nil {
-		s.Logger.Debugf("bzz-chunk: chunk write error: %v, addr %s", err, address)
-		s.Logger.Error("bzz-chunk: chunk write error")
+		s.Logger.Debugf("chunk upload: chunk write error: %v, addr %s", err, address)
+		s.Logger.Error("chunk upload: chunk write error")
 		jsonhttp.BadRequest(w, "chunk write error")
 		return
 	} else if len(seen) > 0 && seen[0] {
@@ -102,8 +102,8 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if pinHeaderValues != "" && strings.ToLower(pinHeaderValues) == "true" {
 		err = s.Storer.Set(ctx, storage.ModeSetPin, address)
 		if err != nil {
-			s.Logger.Debugf("bzz-chunk: chunk pinning error: %v, addr %s", err, address)
-			s.Logger.Error("bzz-chunk: chunk pinning error")
+			s.Logger.Debugf("chunk upload: chunk pinning error: %v, addr %s", err, address)
+			s.Logger.Error("chunk upload: chunk pinning error")
 			jsonhttp.InternalServerError(w, "cannot pin chunk")
 			return
 		}
@@ -120,8 +120,8 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 
 	address, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("bzz-chunk: parse chunk address %s: %v", addr, err)
-		s.Logger.Error("bzz-chunk: parse chunk address error")
+		s.Logger.Debugf("chunk: parse chunk address %s: %v", addr, err)
+		s.Logger.Error("chunk: parse chunk address error")
 		jsonhttp.BadRequest(w, "invalid chunk address")
 		return
 	}
@@ -129,13 +129,13 @@ func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 	chunk, err := s.Storer.Get(ctx, storage.ModeGetRequest, address)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			s.Logger.Trace("bzz-chunk: chunk not found. addr %s", address)
+			s.Logger.Trace("chunk: chunk not found. addr %s", address)
 			jsonhttp.NotFound(w, "chunk not found")
 			return
 
 		}
-		s.Logger.Debugf("bzz-chunk: chunk read error: %v ,addr %s", err, address)
-		s.Logger.Error("bzz-chunk: chunk read error")
+		s.Logger.Debugf("chunk: chunk read error: %v ,addr %s", err, address)
+		s.Logger.Error("chunk: chunk read error")
 		jsonhttp.InternalServerError(w, "chunk read error")
 		return
 	}

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -27,7 +27,7 @@ import (
 func TestChunkUploadDownload(t *testing.T) {
 
 	var (
-		resource             = func(addr swarm.Address) string { return "/bzz-chunk/" + addr.String() }
+		resource             = func(addr swarm.Address) string { return "/chunks/" + addr.String() }
 		validHash            = swarm.MustParseHexAddress("aabbcc")
 		invalidHash          = swarm.MustParseHexAddress("bbccdd")
 		validContent         = []byte("bbaatt")

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -120,7 +120,7 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 }
 
-func request(t *testing.T, client *http.Client, method string, resource string, body io.Reader, responseCode int) *http.Response {
+func request(t *testing.T, client *http.Client, method, resource string, body io.Reader, responseCode int) *http.Response {
 	t.Helper()
 
 	req, err := http.NewRequest(method, resource, body)

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -5,6 +5,6 @@
 package api
 
 type (
-	RawPostResponse = rawPostResponse
-	TagResponse     = tagResponse
+	BytesPostResponse = bytesPostResponse
+	TagResponse       = tagResponse
 )

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -17,6 +17,13 @@ import (
 )
 
 func (s *server) setupRouting() {
+	apiVersion := "v1" // only one api version exists, this should be configurable with more
+
+	handle := func(router *mux.Router, path string, handler http.Handler) {
+		router.Handle(path, handler)
+		router.Handle("/"+apiVersion+path, handler)
+	}
+
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 
@@ -28,15 +35,14 @@ func (s *server) setupRouting() {
 		fmt.Fprintln(w, "User-agent: *\nDisallow: /")
 	})
 
-	router.Handle("/bzz-raw", jsonhttp.MethodHandler{
-		"POST": http.HandlerFunc(s.rawUploadHandler),
+	handle(router, "/bytes", jsonhttp.MethodHandler{
+		"POST": http.HandlerFunc(s.bytesUploadHandler),
+	})
+	handle(router, "/bytes/{address}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.bytesGetHandler),
 	})
 
-	router.Handle("/bzz-raw/{address}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.rawGetHandler),
-	})
-
-	router.Handle("/bzz-chunk/{addr}", jsonhttp.MethodHandler{
+	handle(router, "/chunks/{addr}", jsonhttp.MethodHandler{
 		"GET":  http.HandlerFunc(s.chunkGetHandler),
 		"POST": http.HandlerFunc(s.chunkUploadHandler),
 	})

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestTags(t *testing.T) {
 	var (
-		resource             = func(addr swarm.Address) string { return "/bzz-chunk/" + addr.String() }
+		resource             = func(addr swarm.Address) string { return "/chunks/" + addr.String() }
 		tagResourceUidCreate = func(name string) string { return "/bzz-tag/name/" + name }
 		tagResourceUUid      = func(uuid uint64) string { return "/bzz-tag/uuid/" + strconv.FormatUint(uuid, 10) }
 		validHash            = swarm.MustParseHexAddress("aabbcc")

--- a/pkg/debugapi/pin_test.go
+++ b/pkg/debugapi/pin_test.go
@@ -23,7 +23,7 @@ import (
 // invalid chunk address case etc. This test case has to be run in sequence and
 // it assumes some state of the DB before another case is run.
 func TestPinChunkHandler(t *testing.T) {
-	resource := func(addr swarm.Address) string { return "/bzz-chunk/" + addr.String() }
+	resource := func(addr swarm.Address) string { return "/chunks/" + addr.String() }
 	hash := swarm.MustParseHexAddress("aabbcc")
 	data := []byte("bbaatt")
 	mockValidator := validator.NewMockValidator(hash, data)


### PR DESCRIPTION
This PR addresses some of the points discussed about API design for the alpha release.

- [renames](https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#Chunk-proposal-by-Louis) `bzz-chunk` endpoint to `chunks`
- [renames](https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#Raw-content) `bzz-raw` endpoint to `bytes`
- adds support for `/v1` [prefix to endpoints](https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#Translation-of-versioned-paths)
- [renames](https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#POST-v1bytes) `bzz-raw` (now `bytes`) POST json response field from `hash` to `reference`
- updates log message accordingly with the changes above
- updates tests to work with the new endpoints

This PR does not address points in [Other section](https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#Other). That will be done in the followup PR. This includes `bzz-tag` endpoint which is left as it is here, but will move to Debug API as per meeting notes.

@svetomir these changes has to be reflected in beekeeper. Fortunately they are just renames.