### PR TITLE
Fix one of the test case in local pinning

### DIFF
--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -698,18 +698,24 @@ func addRandomChunks(t *testing.T, count int, db *DB, pin bool) []swarm.Chunk {
 			if err != nil {
 				t.Fatal(err)
 			}
-		}
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = db.Set(context.Background(), storage.ModeSetAccess, ch.Address())
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
-		if err != nil {
-			t.Fatal(err)
+			err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = db.Set(context.Background(), storage.ModeSetAccess, ch.Address())
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			// Non pinned chunks could be GC'd by the time they reach here.
+			// so it is okay to ignore the error
+			_ = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+			_ = db.Set(context.Background(), storage.ModeSetAccess, ch.Address())
+			_, _ = db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		}
 		chunks = append(chunks, ch)
 	}


### PR DESCRIPTION
Local pinning fix introduced a testcase TestPinSyncAndAccessPutSetChunkMultipleTimes. Some times in coverage report the test fails because few chunks that we are bombarding might have been GC'd before they are accessed . 

This fix is to ignore those errors which are valid cases. 