### PR TITLE
move tags endpoints to debug api

### DIFF
--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -6,5 +6,4 @@ package api
 
 type (
 	BytesPostResponse = bytesPostResponse
-	TagResponse       = tagResponse
 )

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -47,14 +47,6 @@ func (s *server) setupRouting() {
 		"POST": http.HandlerFunc(s.chunkUploadHandler),
 	})
 
-	router.Handle("/bzz-tag/name/{name}", jsonhttp.MethodHandler{
-		"POST": http.HandlerFunc(s.CreateTag),
-	})
-
-	router.Handle("/bzz-tag/uuid/{uuid}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.getTagInfoUsingUUid),
-	})
-
 	s.Handler = web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "api access"),
 		handlers.CompressHandler,

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -12,4 +12,5 @@ type (
 	AddressesResponse        = addressesResponse
 	PinnedChunk              = pinnedChunk
 	ListPinnedChunksResponse = listPinnedChunksResponse
+	TagResponse              = tagResponse
 )

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -77,6 +77,12 @@ func (s *server) setupRouting() {
 	router.Handle("/chunks-pin", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.listPinnedChunks),
 	})
+	router.Handle("/tags", jsonhttp.MethodHandler{
+		"POST": http.HandlerFunc(s.createTag),
+	})
+	router.Handle("/tags/{uid}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.getTag),
+	})
 	router.Handle("/topology", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.topologyHandler),
 	})

--- a/pkg/debugapi/tag.go
+++ b/pkg/debugapi/tag.go
@@ -2,9 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package api
+package debugapi
 
 import (
+	"errors"
+	"fmt"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -45,13 +48,17 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 		StartedAt: tag.StartedAt,
 	}
 }
-func (s *server) CreateTag(w http.ResponseWriter, r *http.Request) {
-	tagName := mux.Vars(r)["name"]
 
-	tag, err := s.Tags.Create(tagName, 0, false)
+func (s *server) createTag(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		name = fmt.Sprintf("tag-%v-%v", time.Now().UnixNano(), rand.Int())
+	}
+
+	tag, err := s.Tags.Create(name, 0, false)
 	if err != nil {
-		s.Logger.Debugf("bzz-chunk: tag create error: %v", err)
-		s.Logger.Error("bzz-chunk: tag create error")
+		s.Logger.Debugf("create tag: %s %v", name, err)
+		s.Logger.Errorf("create tag: %s error", name)
 		jsonhttp.InternalServerError(w, "cannot create tag")
 		return
 	}
@@ -60,22 +67,28 @@ func (s *server) CreateTag(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func (s *server) getTagInfoUsingUUid(w http.ResponseWriter, r *http.Request) {
-	uidStr := mux.Vars(r)["uuid"]
+func (s *server) getTag(w http.ResponseWriter, r *http.Request) {
+	uidStr := mux.Vars(r)["uid"]
 
-	uuid, err := strconv.ParseUint(uidStr, 10, 32)
+	uid, err := strconv.ParseUint(uidStr, 10, 32)
 	if err != nil {
-		s.Logger.Debugf("bzz-tag: parse uid  %s: %v", uidStr, err)
-		s.Logger.Error("bzz-tag: parse uid")
+		s.Logger.Debugf("get tag: parse uid  %s: %v", uidStr, err)
+		s.Logger.Error("get tag: parse uid")
 		jsonhttp.BadRequest(w, "invalid uid")
 		return
 	}
 
-	tag, err := s.Tags.Get(uint32(uuid))
+	tag, err := s.Tags.Get(uint32(uid))
 	if err != nil {
-		s.Logger.Debugf("bzz-tag: tag not present : %v, uuid %s", err, uidStr)
-		s.Logger.Error("bzz-tag: tag not present")
-		jsonhttp.InternalServerError(w, "tag not present")
+		if errors.Is(err, tags.ErrNotFound) {
+			s.Logger.Debugf("get tag: tag %v not present: %v", uid, err)
+			s.Logger.Warningf("get tag: tag %v not present", uid)
+			jsonhttp.NotFound(w, "tag not present")
+			return
+		}
+		s.Logger.Debugf("get tag: tag %v: %v", uid, err)
+		s.Logger.Errorf("get tag: %v", uid)
+		jsonhttp.InternalServerError(w, nil)
 		return
 	}
 

--- a/pkg/tags/tag.go
+++ b/pkg/tags/tag.go
@@ -30,10 +30,9 @@ import (
 )
 
 var (
-	errExists      = errors.New("already exists")
-	errNA          = errors.New("not available yet")
-	errNoETA       = errors.New("unable to calculate ETA")
-	errTagNotFound = errors.New("tag not found")
+	errExists = errors.New("already exists")
+	errNA     = errors.New("not available yet")
+	errNoETA  = errors.New("unable to calculate ETA")
 )
 
 // State is the enum type for chunk states

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -31,8 +31,8 @@ import (
 )
 
 var (
-	TagUidFunc     = rand.Uint32
-	TagNotFoundErr = errors.New("tag not found")
+	TagUidFunc  = rand.Uint32
+	ErrNotFound = errors.New("tag not found")
 )
 
 // Tags hold tag information indexed by a unique random uint32
@@ -75,7 +75,7 @@ func (ts *Tags) All() (t []*Tag) {
 func (ts *Tags) Get(uid uint32) (*Tag, error) {
 	t, ok := ts.tags.Load(uid)
 	if !ok {
-		return nil, TagNotFoundErr
+		return nil, ErrNotFound
 	}
 	return t.(*Tag), nil
 }
@@ -94,7 +94,7 @@ func (ts *Tags) GetByAddress(address swarm.Address) (*Tag, error) {
 	})
 
 	if t == nil {
-		return nil, errTagNotFound
+		return nil, ErrNotFound
 	}
 	return t, nil
 }
@@ -104,7 +104,7 @@ func (ts *Tags) GetFromContext(ctx context.Context) (*Tag, error) {
 	uid := sctx.GetTag(ctx)
 	t, ok := ts.tags.Load(uid)
 	if !ok {
-		return nil, errTagNotFound
+		return nil, ErrNotFound
 	}
 	return t.(*Tag), nil
 }


### PR DESCRIPTION
This PR moves /bzz-tag endpoints to Debug API /tags as noted in https://hackmd.io/fGoeV1n2QficZwuHnYmb-g?view#Other, and updated per https://hackmd.io/fGoeV1n2QficZwuHnYmb-g?view#new-tags-api-design-after-alpha. Total increment feature is not implemented as it would require more changes (a separate i), but some improvements to the code is done.

The purpose of this change is not to expose the tags api for alpha release. It will be moved to the main API for next releases.