### PR TITLE
shadow stream descriptor in libp2p

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -231,6 +231,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 
 func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 	for _, ss := range p.StreamSpecs {
+		ss := ss
 		id := protocol.ID(p2p.NewSwarmStreamName(p.Name, p.Version, ss.Name))
 		matcher, err := s.protocolSemverMatcher(id)
 		if err != nil {


### PR DESCRIPTION
wrong handlers are called when multiple stream descriptors are defined