### PR TITLE
implement http.CloseNotifier to responseLogger for gorilla compress

### DIFF
--- a/pkg/logging/http_access.go
+++ b/pkg/logging/http_access.go
@@ -92,7 +92,7 @@ func (l *responseLogger) Flush() {
 func (l *responseLogger) CloseNotify() <-chan bool {
 	// staticcheck SA1019 CloseNotifier interface is required by gorilla compress handler
 	// nolint:staticcheck
-	return l.w.(http.CloseNotifier).CloseNotify()
+	return l.w.(http.CloseNotifier).CloseNotify() // skipcq: SCC-SA1019
 }
 
 func (l *responseLogger) Push(target string, opts *http.PushOptions) error {

--- a/pkg/logging/http_access.go
+++ b/pkg/logging/http_access.go
@@ -89,6 +89,12 @@ func (l *responseLogger) Flush() {
 	l.w.(http.Flusher).Flush()
 }
 
+func (l *responseLogger) CloseNotify() <-chan bool {
+	// staticcheck SA1019 CloseNotifier interface is required by gorilla compress handler
+	// nolint:staticcheck
+	return l.w.(http.CloseNotifier).CloseNotify()
+}
+
 func (l *responseLogger) Push(target string, opts *http.PushOptions) error {
 	return l.w.(http.Pusher).Push(target, opts)
 }


### PR DESCRIPTION
This PR fixes the panic observed on making a request to debug api pprof /debug/pprof/profile endpoint.

responseLogger needs to implement a CloseNotifier interface as required by github.com/gorilla/handlers.compressResponseWriter.

It adds a linter ignore as http.CloseNotifier is considered deprecated.

```
http: panic serving [::1]:63564: runtime error: invalid memory address or nil pointer dereference
goroutine 41 [running]:                      
net/http.(*conn).serve.func1(0xc0002defa0)   
	net/http/server.go:1772 +0x139              
panic(0x1a16940, 0x25360e0)                  
	runtime/panic.go:975 +0x3e3                 
github.com/gorilla/handlers.(*compressResponseWriter).CloseNotify(0xc0000c6e10, 0x1de1de0) 
	<autogenerated>:1 +0x2f                     
net/http/pprof.sleep(0x1de1de0, 0xc0000c6e10, 0x6fc23ac00) 
	net/http/pprof/pprof.go:95 +0x120           
net/http/pprof.Profile(0x1de1de0, 0xc0000c6e10, 0xc00012cf00) 
	net/http/pprof/pprof.go:141 +0x468          
net/http.HandlerFunc.ServeHTTP(0x1cb4070, 0x1de1de0, 0xc0000c6e10, 0xc00012cf00) 
	net/http/server.go:2012 +0x44               
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0024b6000, 0x1de1de0, 0xc0000c6e10, 0xc00012c400) 
	github.com/gorilla/mux@v1.7.3/mux.go:212 +0xe2 
resenje.org/web.NewSetHeadersHandler.func1(0x1de1de0, 0xc0000c6e10, 0xc00012c400) 
	resenje.org/web@v0.4.0/set_headers.go:28 +0x1ff 
net/http.HandlerFunc.ServeHTTP(0xc0024a2b00, 0x1de1de0, 0xc0000c6e10, 0xc00012c400) 
	net/http/server.go:2012 +0x44               
github.com/gorilla/handlers.CompressHandlerLevel.func1(0x1de1720, 0xc0000cdb00, 0xc00012c400) 
	github.com/gorilla/handlers@v1.4.2/compress.go:148 +0x17b 
net/http.HandlerFunc.ServeHTTP(0xc0024a2b20, 0x1de1720, 0xc0000cdb00, 0xc00012c400) 
	net/http/server.go:2012 +0x44               
github.com/ethersphere/bee/pkg/logging.NewHTTPAccessLogHandler.func1.1(0x1de3d20, 0xc001918000, 0xc00012c400) 
	github.com/ethersphere/bee/pkg/logging/http_access.go:23 +0x11e 
net/http.HandlerFunc.ServeHTTP(0xc0000a0200, 0x1de3d20, 0xc001918000, 0xc00012c400) 
	net/http/server.go:2012 +0x44               
net/http.(*ServeMux).ServeHTTP(0xc0000a0040, 0x1de3d20, 0xc001918000, 0xc00012c400) 
	net/http/server.go:2387 +0x1a5              
net/http.serverHandler.ServeHTTP(0xc0024ea000, 0x1de3d20, 0xc001918000, 0xc00012c400) 
	net/http/server.go:2807 +0xa3               
net/http.(*conn).serve(0xc0002defa0, 0x1de6e60, 0xc0000d50c0) 
	net/http/server.go:1895 +0x86c              
created by net/http.(*Server).Serve          
	net/http/server.go:2933 +0x35c
```