### PR TITLE
remove experimental -x http header prefix

### DIFF
--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -23,10 +23,10 @@ import (
 )
 
 // Presence of this header means that it needs to be tagged using the uid
-const TagHeaderUid = "x-swarm-tag-uid"
+const TagHeaderUid = "swarm-tag-uid"
 
 // Presence of this header in the HTTP request indicates the chunk needs to be pinned.
-const PinHeaderName = "x-swarm-pin"
+const PinHeaderName = "swarm-pin"
 
 func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["addr"]


### PR DESCRIPTION
This PR removes "X-" prefix in served http headers. This was suggested by @metacertain as no longer suggested practice. https://hackmd.io/fGoeV1n2QficZwuHnYmb-g#Other