### PR TITLE
support binary upload to api files endpoint

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -27,45 +27,40 @@ type bytesPostResponse struct {
 // bytesUploadHandler handles upload of raw binary data of arbitrary length.
 func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	responseObject, err := s.splitUpload(ctx, r.Body, r.ContentLength)
+	address, err := s.splitUpload(ctx, r.Body, r.ContentLength)
 	if err != nil {
 		s.Logger.Debugf("bytes upload: %v", err)
-		var response jsonhttp.StatusResponse
-		response.Message = "upload error"
-		response.Code = http.StatusInternalServerError
-		jsonhttp.Respond(w, response.Code, response)
-	} else {
-		jsonhttp.OK(w, responseObject)
+		jsonhttp.InternalServerError(w, nil)
+		return
 	}
+	jsonhttp.OK(w, bytesPostResponse{
+		Reference: address,
+	})
 }
 
-func (s *server) splitUpload(ctx context.Context, r io.ReadCloser, l int64) (interface{}, error) {
+func (s *server) splitUpload(ctx context.Context, r io.Reader, l int64) (swarm.Address, error) {
 	chunkPipe := file.NewChunkPipe()
 	go func() {
 		buf := make([]byte, swarm.ChunkSize)
 		c, err := io.CopyBuffer(chunkPipe, r, buf)
 		if err != nil {
 			s.Logger.Debugf("split upload: io error %d: %v", c, err)
-			s.Logger.Error("io error")
+			s.Logger.Error("split upload: io error")
 			return
 		}
 		if c != l {
 			s.Logger.Debugf("split upload: read count mismatch %d: %v", c, err)
-			s.Logger.Error("read count mismatch")
+			s.Logger.Error("split upload: read count mismatch")
 			return
 		}
 		err = chunkPipe.Close()
 		if err != nil {
-			s.Logger.Errorf("split upload: incomplete file write close %v", err)
-			s.Logger.Error("incomplete file write close")
+			s.Logger.Debugf("split upload: incomplete file write close %v", err)
+			s.Logger.Error("split upload: incomplete file write close")
 		}
 	}()
 	sp := splitter.NewSimpleSplitter(s.Storer)
-	address, err := sp.Split(ctx, chunkPipe, l)
-	if err != nil {
-		return swarm.ZeroAddress, err
-	}
-	return bytesPostResponse{Reference: address}, nil
+	return sp.Split(ctx, chunkPipe, l)
 }
 
 // bytesGetHandler handles retrieval of raw binary data of arbitrary length.

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -5,5 +5,6 @@
 package api
 
 type (
-	BytesPostResponse = bytesPostResponse
+	BytesPostResponse  = bytesPostResponse
+	FileUploadResponse = fileUploadResponse
 )

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const multipartFormDataContentType = "multipart/form-data"
+const multipartFormDataMediaType = "multipart/form-data"
 
 type fileUploadResponse struct {
 	Reference swarm.Address `json:"reference"`
@@ -37,11 +37,11 @@ type fileUploadResponse struct {
 // - multipart http message
 // - other content types as complete file body
 func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
-	contentTypeHeader := r.Header.Get("Content-Type")
-	contentType, params, err := mime.ParseMediaType(contentTypeHeader)
+	contentType := r.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		s.Logger.Debugf("file upload: parse content type header %q: %v", contentTypeHeader, err)
-		s.Logger.Errorf("file upload: parse content type header %q", contentTypeHeader)
+		s.Logger.Debugf("file upload: parse content type header %q: %v", contentType, err)
+		s.Logger.Errorf("file upload: parse content type header %q", contentType)
 		jsonhttp.BadRequest(w, "invalid content-type header")
 		return
 	}
@@ -51,7 +51,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	var fileName, contentLength string
 	var fileSize uint64
 
-	if contentType == multipartFormDataContentType {
+	if mediaType == multipartFormDataMediaType {
 		mr := multipart.NewReader(r.Body, params["boundary"])
 
 		// read only the first part, as only one file upload is supported
@@ -140,7 +140,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If filename is still empty, use the file hash the filename
+	// If filename is still empty, use the file hash as the filename
 	if fileName == "" {
 		fileName = fr.String()
 	}

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -67,8 +67,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		// 1) in part header params
 		// 2) as formname
 		// 3) file reference hash (after uploading the file)
-		fileName = part.FileName()
-		if fileName == "" {
+		if fileName = part.FileName(); fileName == "" {
 			fileName = part.FormName()
 		}
 

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/api"
@@ -21,29 +22,29 @@ import (
 	"github.com/ethersphere/bee/pkg/tags"
 )
 
-func TestBzz(t *testing.T) {
+func TestFiles(t *testing.T) {
 	var (
-		simpleResource  = func() string { return "/files" }
-		addressResource = func(addr string) string { return "/files/" + addr }
-		simpleData      = []byte("this is a simple text")
-		mockStorer      = mock.NewStorer()
-		client          = newTestServer(t, testServerOptions{
-			Storer: mockStorer,
+		fileUploadResource   = "/files"
+		fileDownloadResource = func(addr string) string { return "/files/" + addr }
+		simpleData           = []byte("this is a simple text")
+		client               = newTestServer(t, testServerOptions{
+			Storer: mock.NewStorer(),
 			Tags:   tags.NewTags(),
 			Logger: logging.New(ioutil.Discard, 5),
 		})
 	)
+
 	t.Run("invalid-content-type", func(t *testing.T) {
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, simpleResource(), bytes.NewReader(simpleData), http.StatusBadRequest, jsonhttp.StatusResponse{
+		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource, bytes.NewReader(simpleData), http.StatusBadRequest, jsonhttp.StatusResponse{
 			Message: "invalid content-type header",
 			Code:    http.StatusBadRequest,
 		}, nil)
 	})
 
-	t.Run("simple-upload", func(t *testing.T) {
+	t.Run("multipart-upload", func(t *testing.T) {
 		fileName := "simple_file.txt"
 		rootHash := "295673cf7aa55d119dd6f82528c91d45b53dd63dc2e4ca4abf4ed8b3a0788085"
-		_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, simpleResource(), fileName, simpleData, http.StatusOK, "", api.FileUploadResponse{
+		_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, simpleData, http.StatusOK, "", api.FileUploadResponse{
 			Reference: swarm.MustParseHexAddress(rootHash),
 		})
 	})
@@ -51,22 +52,47 @@ func TestBzz(t *testing.T) {
 	t.Run("check-content-type-detection", func(t *testing.T) {
 		fileName := "my-pictures.jpeg"
 		rootHash := "f2e761160deda91c1fbfab065a5abf530b0766b3e102b51fbd626ba37c3bc581"
-		_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, simpleResource(), fileName, simpleData, http.StatusOK, "image/jpeg; charset=utf-8", api.FileUploadResponse{
-			Reference: swarm.MustParseHexAddress(rootHash),
+
+		t.Run("binary", func(t *testing.T) {
+			headers := make(http.Header)
+			headers.Add("Content-Type", "image/jpeg; charset=utf-8")
+
+			_ = jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, bytes.NewReader(simpleData), http.StatusOK, api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			}, headers)
+
+			rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, simpleData, nil)
+			cd := rcvdHeader.Get("Content-Disposition")
+			_, params, err := mime.ParseMediaType(cd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if params["filename"] != fileName {
+				t.Fatal("Invalid file name detected")
+			}
+			if rcvdHeader.Get("Content-Type") != "image/jpeg; charset=utf-8" {
+				t.Fatal("Invalid content type detected")
+			}
 		})
 
-		rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, addressResource(rootHash), nil, http.StatusOK, simpleData, nil)
-		cd := rcvdHeader.Get("Content-Disposition")
-		_, params, err := mime.ParseMediaType(cd)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if params["filename"] != fileName {
-			t.Fatal("Invalid file name detected")
-		}
-		if rcvdHeader.Get("Content-Type") != "image/jpeg; charset=utf-8" {
-			t.Fatal("Invalid content type detected")
-		}
+		t.Run("multipart", func(t *testing.T) {
+			_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, simpleData, http.StatusOK, "image/jpeg; charset=utf-8", api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			})
+
+			rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, simpleData, nil)
+			cd := rcvdHeader.Get("Content-Disposition")
+			_, params, err := mime.ParseMediaType(cd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if params["filename"] != fileName {
+				t.Fatal("Invalid file name detected")
+			}
+			if rcvdHeader.Get("Content-Type") != "image/jpeg; charset=utf-8" {
+				t.Fatal("Invalid content type detected")
+			}
+		})
 	})
 
 	t.Run("upload-then-download-and-check-data", func(t *testing.T) {
@@ -83,28 +109,60 @@ func TestBzz(t *testing.T) {
 		</body>
 		</html>`
 
-		rcvdHeader := jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, simpleResource(), fileName, []byte(sampleHtml), http.StatusOK, "", api.FileUploadResponse{
-			Reference: swarm.MustParseHexAddress(rootHash),
+		t.Run("binary", func(t *testing.T) {
+			headers := make(http.Header)
+			headers.Add("Content-Type", "text/html; charset=utf-8")
+
+			rcvdHeader := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, strings.NewReader(sampleHtml), http.StatusOK, api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			}, headers)
+
+			if rcvdHeader.Get("ETag") != fmt.Sprintf("%q", rootHash) {
+				t.Fatal("Invalid ETags header received")
+			}
+
+			// try to fetch the same file and check the data
+			rcvdHeader = jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, []byte(sampleHtml), nil)
+
+			// check the headers
+			cd := rcvdHeader.Get("Content-Disposition")
+			_, params, err := mime.ParseMediaType(cd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if params["filename"] != fileName {
+				t.Fatal("Invalid filename detected")
+			}
+			if rcvdHeader.Get("Content-Type") != "text/html; charset=utf-8" {
+				t.Fatal("Invalid content type detected")
+			}
 		})
 
-		if rcvdHeader.Get("ETag") != fmt.Sprintf("%q", rootHash) {
-			t.Fatal("Invalid ETags header received")
-		}
+		t.Run("multipart", func(t *testing.T) {
+			rcvdHeader := jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, []byte(sampleHtml), http.StatusOK, "", api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			})
 
-		// try to fetch the same file and check the data
-		rcvdHeader = jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, addressResource(rootHash), nil, http.StatusOK, []byte(sampleHtml), nil)
+			if rcvdHeader.Get("ETag") != fmt.Sprintf("%q", rootHash) {
+				t.Fatal("Invalid ETags header received")
+			}
 
-		// check the headers
-		cd := rcvdHeader.Get("Content-Disposition")
-		_, params, err := mime.ParseMediaType(cd)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if params["filename"] != fileName {
-			t.Fatal("Invalid filename detected")
-		}
-		if rcvdHeader.Get("Content-Type") != "text/html; charset=utf-8" {
-			t.Fatal("Invalid content type detected")
-		}
+			// try to fetch the same file and check the data
+			rcvdHeader = jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, []byte(sampleHtml), nil)
+
+			// check the headers
+			cd := rcvdHeader.Get("Content-Disposition")
+			_, params, err := mime.ParseMediaType(cd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if params["filename"] != fileName {
+				t.Fatal("Invalid filename detected")
+			}
+			if rcvdHeader.Get("Content-Type") != "text/html; charset=utf-8" {
+				t.Fatal("Invalid content type detected")
+			}
+		})
 	})
+
 }

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -33,7 +33,7 @@ func TestBzz(t *testing.T) {
 			Logger: logging.New(ioutil.Discard, 5),
 		})
 	)
-	t.Run("simple-upload", func(t *testing.T) {
+	t.Run("invalid-content-type", func(t *testing.T) {
 		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, simpleResource(), bytes.NewReader(simpleData), http.StatusBadRequest, jsonhttp.StatusResponse{
 			Message: "invalid content-type header",
 			Code:    http.StatusBadRequest,

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -35,7 +35,7 @@ func TestBzz(t *testing.T) {
 	)
 	t.Run("simple-upload", func(t *testing.T) {
 		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, simpleResource(), bytes.NewReader(simpleData), http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "not a mutlipart/form-data",
+			Message: "invalid content-type header",
 			Code:    http.StatusBadRequest,
 		}, nil)
 	})

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -35,18 +35,16 @@ func (s *server) setupRouting() {
 		fmt.Fprintln(w, "User-agent: *\nDisallow: /")
 	})
 
+	handle(router, "/files", jsonhttp.MethodHandler{
+		"POST": http.HandlerFunc(s.fileUploadHandler),
+	})
+	handle(router, "/files/{addr}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.fileDownloadHandler),
+	})
+
 	handle(router, "/bytes", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.bytesUploadHandler),
 	})
-
-	handle(router, "/files", jsonhttp.MethodHandler{
-		"POST": http.HandlerFunc(s.bzzFileUploadHandler),
-	})
-
-	handle(router, "/files/{addr}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.bzzFileDownloadHandler),
-	})
-
 	handle(router, "/bytes/{address}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.bytesGetHandler),
 	})


### PR DESCRIPTION
This PR adds a support to upload a file in its binary form, get its `content-type` from request header and name from `name` query parameter. This is done beside the regular multipart/form-data upload.

https://hackmd.io/fGoeV1n2QficZwuHnYmb-g?both#POST-v1files-typestringamp-namestring

- fileUploadHandler is reorganized to support binary data uploads, content type detection from header and filename detection from query parameter (Content-Disposition is only response header and is not used in requests)
- splitUpload returns only address to simplify its usage
- splitUpload removes requirement for io.ReadCloser as Close is never used, just io.Reader is required
- bytesUploadHandler structure is more consistent with other handlers
- minor adjustments to exported variables
- existing tests are extended to test for two types of uploading
- router decelerations are just reordered to group similar routes