### PR TITLE
Added translation from chunks to bytes in help and log

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -151,7 +151,7 @@ func (c *command) initStartCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
-	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, "db capacity in chunks")
+	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, "db capacity in chunks, multiply by 4096 to get bytes")
 	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
 	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
 	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/node"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -151,7 +152,7 @@ func (c *command) initStartCmd() (err error) {
 	}
 
 	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
-	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, "db capacity in chunks, multiply by 4096 to get bytes")
+	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, fmt.Sprintf("db capacity in chunks, multiply by %d to get approximate capacity in bytes", swarm.ChunkSize))
 	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
 	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
 	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -166,7 +166,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if db.capacity == 0 {
 		db.capacity = defaultCapacity
 	}
-	db.logger.Infof("database capacity in chunks (and in Bytes): %v (%v)", db.capacity, db.capacity*swarm.ChunkSize)
+	db.logger.Infof("database capacity: %d chunks, %d bytes, %.2f megabytes.", db.capacity, db.capacity*swarm.ChunkSize, float64(db.capacity*swarm.ChunkSize)*9.5367431640625e-7)
 	if maxParallelUpdateGC > 0 {
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -166,7 +166,15 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if db.capacity == 0 {
 		db.capacity = defaultCapacity
 	}
-	db.logger.Infof("database capacity: %d chunks (approximately %0.1fMB)", db.capacity, float64(db.capacity*swarm.ChunkSize)*9.5367431640625e-7)
+
+	capacityMB := float64(db.capacity*swarm.ChunkSize) * 9.5367431640625e-7
+
+	if capacityMB <= 1000 {
+		db.logger.Infof("database capacity: %d chunks (approximately %fMB)", db.capacity, capacityMB)
+	} else {
+		db.logger.Infof("database capacity: %d chunks (approximately %0.1fGB)", db.capacity, capacityMB/1000)
+	}
+
 	if maxParallelUpdateGC > 0 {
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -166,7 +166,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if db.capacity == 0 {
 		db.capacity = defaultCapacity
 	}
-	db.logger.Infof("database capacity: %d chunks, %d bytes, %.2f megabytes.", db.capacity, db.capacity*swarm.ChunkSize, float64(db.capacity*swarm.ChunkSize)*9.5367431640625e-7)
+	db.logger.Infof("database capacity: %d chunks (approximately %0.1fMB)", db.capacity, float64(db.capacity*swarm.ChunkSize)*9.5367431640625e-7)
 	if maxParallelUpdateGC > 0 {
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -166,7 +166,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if db.capacity == 0 {
 		db.capacity = defaultCapacity
 	}
-	db.logger.Infof("db capacity: %v", db.capacity)
+	db.logger.Infof("database capacity in chunks (and in Bytes): %v (%v)", db.capacity, db.capacity*swarm.ChunkSize)
 	if maxParallelUpdateGC > 0 {
 		db.updateGCSem = make(chan struct{}, maxParallelUpdateGC)
 	}


### PR DESCRIPTION
I believe that we should never use the metric "chunks" when we communicate about database size to our users, however I can image that doing such a change is debated (as @mortelli convincingly argued, in some tests it is good to have fine-grained control over the gc with chunks as metric) and it might be too big of a change for now. 

At a minimum, we should give the user a translation from db capacity (as measured in chunks) to db capacity (measured in bytes). 
