### PR TITLE
improve discover log messages and errors

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -375,33 +375,35 @@ func NewBee(o Options) (*Bee, error) {
 				}
 				var count int
 				if _, err := p2p.Discover(p2pCtx, addr, func(addr ma.Multiaddr) (stop bool, err error) {
+					logger.Tracef("connecting to peer %s", addr)
 					bzzAddr, err := p2ps.Connect(p2pCtx, addr)
 					if err != nil {
-						logger.Debugf("connect fail %s: %v", a, err)
-						logger.Errorf("connect to bootnode %s", a)
+						logger.Debugf("connect fail %s: %v", addr, err)
+						logger.Errorf("connect to bootnode %s", addr)
 						return false, nil
 					}
+					logger.Tracef("connected to peer %s", addr)
 
 					err = addressbook.Put(bzzAddr.Overlay, *bzzAddr)
 					if err != nil {
 						_ = p2ps.Disconnect(bzzAddr.Overlay)
-						logger.Debugf("addressbook error persisting %s %s: %v", a, bzzAddr.Overlay, err)
-						logger.Errorf("connect to bootnode %s", a)
+						logger.Debugf("addressbook error persisting %s %s: %v", addr, bzzAddr.Overlay, err)
+						logger.Errorf("connect to bootnode %s", addr)
 						return false, nil
 					}
 
 					if err := topologyDriver.Connected(p2pCtx, bzzAddr.Overlay); err != nil {
 						_ = p2ps.Disconnect(bzzAddr.Overlay)
-						logger.Debugf("topology connected fail %s %s: %v", a, bzzAddr.Overlay, err)
-						logger.Errorf("connect to bootnode %s", a)
+						logger.Debugf("topology connected fail %s %s: %v", addr, bzzAddr.Overlay, err)
+						logger.Errorf("connect to bootnode %s", addr)
 						return false, nil
 					}
 					count++
 					// connect to max 3 bootnodes
 					return count > 3, nil
 				}); err != nil {
-					logger.Debugf("connect fail %s: %v", a, err)
-					logger.Errorf("connect to bootnode %s", a)
+					logger.Debugf("discover fail %s: %v", a, err)
+					logger.Errorf("discover to bootnode %s", a)
 					return
 				}
 			}(a)

--- a/pkg/p2p/discover.go
+++ b/pkg/p2p/discover.go
@@ -7,6 +7,7 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -21,7 +22,7 @@ func Discover(ctx context.Context, addr ma.Multiaddr, f func(ma.Multiaddr) (stop
 	dnsResolver := madns.DefaultResolver
 	addrs, err := dnsResolver.Resolve(ctx, addr)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("dns resolve address %s: %w", addr, err)
 	}
 	if len(addrs) == 0 {
 		return false, errors.New("non-resolvable API endpoint")
@@ -33,7 +34,7 @@ func Discover(ctx context.Context, addr ma.Multiaddr, f func(ma.Multiaddr) (stop
 	for _, addr := range addrs {
 		stopped, err = Discover(ctx, addr, f)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("discover %s: %w", addr, err)
 		}
 		if stopped {
 			break


### PR DESCRIPTION
This PR improves logs when calling dns discover and logs correct address, not the provided bootnode.