### PR TITLE
suppress p2p.ErrAlreadyConnected log when connecting to bootnodes

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -149,7 +149,7 @@ func (k *Kad) manage() {
 
 				err = k.connect(ctx, peer, bzzAddr.Underlay, po)
 				if err != nil {
-					k.logger.Debugf("error connecting to peer from kademlia %s %s: %v", peer, bzzAddr, err)
+					k.logger.Debugf("error connecting to peer from kademlia %s: %v", bzzAddr.String(), err)
 					k.logger.Errorf("connecting to peer %s: %v", bzzAddr.ShortString(), err)
 					// continue to next
 					return false, false, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -6,6 +6,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -378,8 +379,10 @@ func NewBee(o Options) (*Bee, error) {
 					logger.Tracef("connecting to peer %s", addr)
 					bzzAddr, err := p2ps.Connect(p2pCtx, addr)
 					if err != nil {
-						logger.Debugf("connect fail %s: %v", addr, err)
-						logger.Errorf("connect to bootnode %s", addr)
+						if !errors.Is(err, p2p.ErrAlreadyConnected) {
+							logger.Debugf("connect fail %s: %v", addr, err)
+							logger.Errorf("connect to bootnode %s", addr)
+						}
 						return false, nil
 					}
 					logger.Tracef("connected to peer %s", addr)


### PR DESCRIPTION
This is just a cleanup of the not so useful log messages.

I also included one log fix in kademlia.