### PR TITLE
Addressbook get  - not found

### DIFF
--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -5,6 +5,7 @@
 package addressbook
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,8 @@ import (
 const keyPrefix = "addressbook_entry_"
 
 var _ Interface = (*store)(nil)
+
+var ErrNotFound = errors.New("addressbook: not found")
 
 type Interface interface {
 	GetPutter
@@ -57,7 +60,7 @@ func (s *store) Get(overlay swarm.Address) (*bzz.Address, error) {
 	err := s.store.Get(key, &v)
 	if err != nil {
 		if err == storage.ErrNotFound {
-			return nil, nil
+			return nil, ErrNotFound
 		}
 
 		return nil, err

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -30,7 +30,7 @@ type GetPutter interface {
 }
 
 type Getter interface {
-	Get(overlay swarm.Address) (addr bzz.Address, err error)
+	Get(overlay swarm.Address) (addr *bzz.Address, err error)
 }
 
 type Putter interface {
@@ -51,12 +51,16 @@ func New(storer storage.StateStorer) Interface {
 	}
 }
 
-func (s *store) Get(overlay swarm.Address) (bzz.Address, error) {
+func (s *store) Get(overlay swarm.Address) (*bzz.Address, error) {
 	key := keyPrefix + overlay.String()
-	v := bzz.Address{}
+	v := &bzz.Address{}
 	err := s.store.Get(key, &v)
 	if err != nil {
-		return bzz.Address{}, err
+		if err == storage.ErrNotFound {
+			return nil, nil
+		}
+
+		return nil, err
 	}
 	return v, nil
 }

--- a/pkg/addressbook/addressbook_test.go
+++ b/pkg/addressbook/addressbook_test.go
@@ -22,7 +22,6 @@ func TestInMem(t *testing.T) {
 	run(t, func(t *testing.T) addressbook.Interface {
 		store := mock.NewStateStore()
 		book := addressbook.New(store)
-
 		return book
 	})
 }
@@ -56,13 +55,17 @@ func run(t *testing.T, f bookFunc) {
 		t.Fatal(err)
 	}
 
-	_, err = store.Get(addr2)
-	if err == nil {
-		t.Fatal("value found in store but should not have been")
+	if !bzzAddr.Equal(v) {
+		t.Fatalf("expectted: %s, want %s", v, multiaddr)
 	}
 
-	if !bzzAddr.Equal(&v) {
-		t.Fatalf("value retrieved from store not equal to original stored address: %v, want %v", v, multiaddr)
+	notFound, err := store.Get(addr2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if notFound != nil {
+		t.Fatalf("expected nil got %s", v)
 	}
 
 	overlays, err := store.Overlays()

--- a/pkg/addressbook/addressbook_test.go
+++ b/pkg/addressbook/addressbook_test.go
@@ -60,7 +60,7 @@ func run(t *testing.T, f bookFunc) {
 	}
 
 	notFound, err := store.Get(addr2)
-	if err != nil {
+	if err != addressbook.ErrNotFound {
 		t.Fatal(err)
 	}
 

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -59,7 +59,7 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(&bzzAddr) {
+		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 	})
@@ -99,7 +99,7 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(&bzzAddr) {
+		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -58,7 +58,10 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && !bzzAddress.Equal(bzzAddr) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 	})
@@ -98,7 +101,10 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && !bzzAddress.Equal(bzzAddr) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/mock"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	topmock "github.com/ethersphere/bee/pkg/topology/mock"
 	ma "github.com/multiformats/go-multiaddr"
@@ -59,7 +58,7 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(bzzAddr) {
+		if err != nil && !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 	})
@@ -99,7 +98,7 @@ func TestConnect(t *testing.T) {
 		})
 
 		bzzAddr, err := testServer.Addressbook.Get(overlay)
-		if err != nil && errors.Is(err, storage.ErrNotFound) && !bzzAddress.Equal(bzzAddr) {
+		if err != nil && !bzzAddress.Equal(bzzAddr) {
 			t.Fatalf("found wrong underlay.  expected: %+v, found: %+v", bzzAddress, bzzAddr)
 		}
 

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -6,7 +6,6 @@ package hive
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -97,11 +95,12 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	for _, p := range peers {
 		addr, err := s.addressBook.Get(p)
 		if err != nil {
-			if errors.Is(err, storage.ErrNotFound) {
-				s.logger.Debugf("Peer not found %s", p)
-				continue
-			}
 			return err
+		}
+
+		if addr == nil {
+			s.logger.Debugf("Peer not found %s", p)
+			continue
 		}
 
 		peersRequest.Peers = append(peersRequest.Peers, &pb.BzzAddress{

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -95,12 +95,12 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	for _, p := range peers {
 		addr, err := s.addressBook.Get(p)
 		if err != nil {
-			return err
-		}
+			if err == addressbook.ErrNotFound {
+				s.logger.Debugf("hive broadcast peers: peer not found in the addressbook. Skipping peer %s", p)
+				continue
+			}
 
-		if addr == nil {
-			s.logger.Debugf("hive broadcast peers: peer not found in the addressbook. Skipping peer %s", p)
-			continue
+			return err
 		}
 
 		peersRequest.Peers = append(peersRequest.Peers, &pb.BzzAddress{

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -99,7 +99,7 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 		}
 
 		if addr == nil {
-			s.logger.Debugf("Peer not found %s", p)
+			s.logger.Debugf("hive broadcast peers: peer not found in the addressbook. Skipping peer %s", p)
 			continue
 		}
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -133,15 +133,14 @@ func (k *Kad) manage() {
 
 				bzzAddr, err := k.addressBook.Get(peer)
 				if err != nil {
+					if err == addressbook.ErrNotFound {
+						k.logger.Errorf("failed to get address book entry for peer: %s", peer.String())
+						peerToRemove = peer
+						return false, false, errMissingAddressBookEntry
+					}
 					// either a peer is not known in the address book, in which case it
 					// should be removed, or that some severe I/O problem is at hand
 					return false, false, err
-				}
-
-				if bzzAddr == nil {
-					k.logger.Errorf("failed to get address book entry for peer: %s", peer.String())
-					peerToRemove = peer
-					return false, false, errMissingAddressBookEntry
 				}
 
 				k.logger.Debugf("kademlia dialing to peer %s", peer.String())

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethersphere/bee/pkg/kademlia/pslice"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/topology"
 	ma "github.com/multiformats/go-multiaddr"
@@ -136,15 +135,15 @@ func (k *Kad) manage() {
 				if err != nil {
 					// either a peer is not known in the address book, in which case it
 					// should be removed, or that some severe I/O problem is at hand
-
-					if errors.Is(err, storage.ErrNotFound) {
-						k.logger.Errorf("failed to get address book entry for peer: %s", peer.String())
-						peerToRemove = peer
-						return false, false, errMissingAddressBookEntry
-					}
-
 					return false, false, err
 				}
+
+				if bzzAddr == nil {
+					k.logger.Errorf("failed to get address book entry for peer: %s", peer.String())
+					peerToRemove = peer
+					return false, false, errMissingAddressBookEntry
+				}
+
 				k.logger.Debugf("kademlia dialing to peer %s", peer.String())
 
 				err = k.connect(ctx, peer, bzzAddr.Underlay, po)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -418,12 +418,8 @@ func TestAddressBookPrune(t *testing.T) {
 	waitCounter(t, &failedConns, 1)
 
 	p, err = ab.Get(nonConnPeer.Overlay)
-	if err != nil {
+	if err != addressbook.ErrNotFound {
 		t.Fatal(err)
-	}
-
-	if p != nil {
-		t.Fatal("peer found in addressbook")
 	}
 }
 

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -377,7 +377,7 @@ func TestAddressBookPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !nonConnPeer.Equal(&p) {
+	if !nonConnPeer.Equal(p) {
 		t.Fatalf("expected %+v, got %+v", nonConnPeer, p)
 	}
 
@@ -392,7 +392,7 @@ func TestAddressBookPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !nonConnPeer.Equal(&p) {
+	if !nonConnPeer.Equal(p) {
 		t.Fatalf("expected %+v, got %+v", nonConnPeer, p)
 	}
 
@@ -407,7 +407,7 @@ func TestAddressBookPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !nonConnPeer.Equal(&p) {
+	if !nonConnPeer.Equal(p) {
 		t.Fatalf("expected %+v, got %+v", nonConnPeer, p)
 	}
 
@@ -418,11 +418,11 @@ func TestAddressBookPrune(t *testing.T) {
 	waitCounter(t, &failedConns, 1)
 
 	p, err = ab.Get(nonConnPeer.Overlay)
-	if err == nil {
-		t.Fatal("expected not found error")
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if nonConnPeer.Equal(&p) {
+	if p != nil {
 		t.Fatal("peer found in addressbook")
 	}
 }

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -417,7 +417,7 @@ func TestAddressBookPrune(t *testing.T) {
 	waitCounter(t, &conns, 1)
 	waitCounter(t, &failedConns, 1)
 
-	p, err = ab.Get(nonConnPeer.Overlay)
+	_, err = ab.Get(nonConnPeer.Overlay)
 	if err != addressbook.ErrNotFound {
 		t.Fatal(err)
 	}

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -70,11 +70,10 @@ func (d *driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 	connectedPeers := d.p2pService.Peers()
 	bzzAddress, err := d.addressBook.Get(addr)
 	if err != nil {
+		if err == addressbook.ErrNotFound {
+			return topology.ErrNotFound
+		}
 		return err
-	}
-
-	if bzzAddress == nil {
-		return topology.ErrNotFound
 	}
 
 	if !isConnected(addr, connectedPeers) {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethersphere/bee/pkg/discovery"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/topology"
 )
@@ -71,10 +70,11 @@ func (d *driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 	connectedPeers := d.p2pService.Peers()
 	bzzAddress, err := d.addressBook.Get(addr)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return topology.ErrNotFound
-		}
 		return err
+	}
+
+	if bzzAddress == nil {
+		return topology.ErrNotFound
 	}
 
 	if !isConnected(addr, connectedPeers) {


### PR DESCRIPTION
This PR addresses 2 minor issues:
1. In order to check the result of `addressbook.Get()` one must compare received error with `storage.NotFound` error, which is not in the same package and should not be used to check the result of the addressbook get function.
2. The returned `BzzAddress` is copied creating minor, but unnecessary overhead.
3. Makes the user of fetched `BzzAddress` pay attention to pass the address of BzzAddress on many places where it is convenient, such where  `Equal(), String()` methods are used and their appropriate interfaces