### PR TITLE
full close timeout handle

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -118,7 +118,7 @@ func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swa
 	return stream.FullClose()
 }
 
-func (s *Service) peersHandler(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
+func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.Stream) error {
 	_, r := protobuf.NewWriterAndReader(stream)
 	var peersReq pb.Peers
 	if err := r.ReadMsgWithTimeout(messageTimeout, &peersReq); err != nil {
@@ -143,7 +143,7 @@ func (s *Service) peersHandler(_ context.Context, peer p2p.Peer, stream p2p.Stre
 		}
 
 		if s.peerHandler != nil {
-			if err := s.peerHandler(context.Background(), bzzAddress.Overlay); err != nil {
+			if err := s.peerHandler(ctx, bzzAddress.Overlay); err != nil {
 				return err
 			}
 		}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -309,7 +309,7 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 		return nil
 	}
 
-	err := k.discovery.BroadcastPeers(context.Background(), peer, addrs...)
+	err := k.discovery.BroadcastPeers(ctx, peer, addrs...)
 	if err != nil {
 		_ = k.p2p.Disconnect(peer)
 	}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -297,7 +297,7 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 			return false, false, nil
 		}
 		addrs = append(addrs, connectedPeer)
-		if err := k.discovery.BroadcastPeers(context.Background(), connectedPeer, peer); err != nil {
+		if err := k.discovery.BroadcastPeers(ctx, connectedPeer, peer); err != nil {
 			// we don't want to fail the whole process because of this, keep on gossiping
 			k.logger.Debugf("error gossiping peer %s to peer %s: %v", peer, connectedPeer, err)
 			return false, false, nil

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -100,7 +100,7 @@ func (d *driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 		}
 
 		connectedAddrs = append(connectedAddrs, addressee.Address)
-		if err := d.discovery.BroadcastPeers(context.Background(), addressee.Address, addr); err != nil {
+		if err := d.discovery.BroadcastPeers(ctx, addressee.Address, addr); err != nil {
 			return err
 		}
 	}
@@ -109,7 +109,7 @@ func (d *driver) AddPeer(ctx context.Context, addr swarm.Address) error {
 		return nil
 	}
 
-	return d.discovery.BroadcastPeers(context.Background(), addr, connectedAddrs...)
+	return d.discovery.BroadcastPeers(ctx, addr, connectedAddrs...)
 }
 
 // ClosestPeer returns the closest connected peer we have in relation to a


### PR DESCRIPTION
This PR properly disconnects peers on errors and propagates context instead creating a new ones.