### PR TITLE
Improve code in api/bytes.go

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -5,10 +5,8 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/file"
@@ -27,7 +25,8 @@ type bytesPostResponse struct {
 // bytesUploadHandler handles upload of raw binary data of arbitrary length.
 func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	address, err := s.splitUpload(ctx, r.Body, r.ContentLength)
+	sp := splitter.NewSimpleSplitter(s.Storer)
+	address, err := file.SplitWriteAll(ctx, sp, r.Body, r.ContentLength)
 	if err != nil {
 		s.Logger.Debugf("bytes upload: %v", err)
 		jsonhttp.InternalServerError(w, nil)
@@ -38,30 +37,6 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *server) splitUpload(ctx context.Context, r io.Reader, l int64) (swarm.Address, error) {
-	chunkPipe := file.NewChunkPipe()
-	go func() {
-		buf := make([]byte, swarm.ChunkSize)
-		c, err := io.CopyBuffer(chunkPipe, r, buf)
-		if err != nil {
-			s.Logger.Debugf("split upload: io error %d: %v", c, err)
-			s.Logger.Error("split upload: io error")
-			return
-		}
-		if c != l {
-			s.Logger.Debugf("split upload: read count mismatch %d: %v", c, err)
-			s.Logger.Error("split upload: read count mismatch")
-			return
-		}
-		err = chunkPipe.Close()
-		if err != nil {
-			s.Logger.Debugf("split upload: incomplete file write close %v", err)
-			s.Logger.Error("split upload: incomplete file write close")
-		}
-	}()
-	sp := splitter.NewSimpleSplitter(s.Storer)
-	return sp.Split(ctx, chunkPipe, l)
-}
 
 // bytesGetHandler handles retrieval of raw binary data of arbitrary length.
 func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -37,7 +37,6 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-
 // bytesGetHandler handles retrieval of raw binary data of arbitrary length.
 func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 	addressHex := mux.Vars(r)["address"]

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/ethersphere/bee/pkg/collection/entry"
 	"github.com/ethersphere/bee/pkg/file"
-	"github.com/ethersphere/bee/pkg/file/splitter"
 	"github.com/ethersphere/bee/pkg/file/joiner"
+	"github.com/ethersphere/bee/pkg/file/splitter"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"

--- a/pkg/file/error.go
+++ b/pkg/file/error.go
@@ -49,25 +49,3 @@ func (e *HashError) Unwrap() error {
 func (e *HashError) Error() string {
 	return e.err.Error()
 }
-
-// SplitError should wrap any error returned from the splitter.
-type SplitError struct {
-	err error
-}
-
-// NewSplitError returns a new SplitError instance.
-func NewSplitError(err error) error {
-	return &SplitError{
-		err: err,
-	}
-}
-
-// Unwrap returns an underlying error.
-func (e *SplitError) Unwrap() error {
-	return e.err
-}
-
-// Error implements standard go error interface.
-func (e *SplitError) Error() string {
-	return e.err.Error()
-}

--- a/pkg/file/error.go
+++ b/pkg/file/error.go
@@ -22,7 +22,7 @@ func (e *AbortError) Unwrap() error {
 	return e.err
 }
 
-// Error implement standard go error interface.
+// Error implements standard go error interface.
 func (e *AbortError) Error() string {
 	return e.err.Error()
 }
@@ -45,27 +45,29 @@ func (e *HashError) Unwrap() error {
 	return e.err
 }
 
-// Error implement standard go error interface.
+// Error implements standard go error interface.
 func (e *HashError) Error() string {
 	return e.err.Error()
 }
 
-
-// SplitError 
+// SplitError should wrap any error returned from the splitter.
 type SplitError struct {
 	err error
 }
 
+// NewSplitError returns a new SplitError instance.
 func NewSplitError(err error) error {
 	return &SplitError{
 		err: err,
 	}
 }
 
+// Unwrap returns an underlying error.
 func (e *SplitError) Unwrap() error {
 	return e.err
 }
 
+// Error implements standard go error interface.
 func (e *SplitError) Error() string {
 	return e.err.Error()
 }

--- a/pkg/file/error.go
+++ b/pkg/file/error.go
@@ -49,3 +49,23 @@ func (e *HashError) Unwrap() error {
 func (e *HashError) Error() string {
 	return e.err.Error()
 }
+
+
+// SplitError 
+type SplitError struct {
+	err error
+}
+
+func NewSplitError(err error) error {
+	return &SplitError{
+		err: err,
+	}
+}
+
+func (e *SplitError) Unwrap() error {
+	return e.err
+}
+
+func (e *SplitError) Error() string {
+	return e.err.Error()
+}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -7,6 +7,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -63,4 +64,41 @@ func JoinReadAll(j Joiner, addr swarm.Address, outFile io.Writer) (int64, error)
 		return total, fmt.Errorf("received only %d of %d total bytes", total, l)
 	}
 	return total, nil
+}
+
+// SplitWriteAll writes all input from provided reader to the provided splitter
+func SplitWriteAll(ctx context.Context, s Splitter, r io.Reader, l int64) (swarm.Address, error) {
+	chunkPipe := NewChunkPipe()
+	errC := make(chan error)
+	go func() {
+		buf := make([]byte, swarm.ChunkSize)
+		c, err := io.CopyBuffer(chunkPipe, r, buf)
+		if err != nil {
+			errC <- NewSplitError(err)
+		}
+		if c != l {
+			splitError := errors.New("read count mismatch")
+			errC <- NewSplitError(splitError)
+		}
+		err = chunkPipe.Close()
+		if err != nil {
+			errC <- NewSplitError(err)
+		}
+		close(errC)
+	}()
+
+	addr, err := s.Split(ctx, chunkPipe, l)
+	if err != nil {
+		return swarm.ZeroAddress, err
+	}
+
+	select {
+	case err := <-errC:
+		if err != nil {
+			return swarm.ZeroAddress, err
+		}
+	case <-ctx.Done():
+		return swarm.ZeroAddress, ctx.Err()
+	}
+	return addr, nil
 }

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -74,15 +74,14 @@ func SplitWriteAll(ctx context.Context, s Splitter, r io.Reader, l int64) (swarm
 		buf := make([]byte, swarm.ChunkSize)
 		c, err := io.CopyBuffer(chunkPipe, r, buf)
 		if err != nil {
-			errC <- NewSplitError(err)
+			errC <- err
 		}
 		if c != l {
-			splitError := errors.New("read count mismatch")
-			errC <- NewSplitError(splitError)
+			errC <- errors.New("read count mismatch")
 		}
 		err = chunkPipe.Close()
 		if err != nil {
-			errC <- NewSplitError(err)
+			errC <- err
 		}
 		close(errC)
 	}()

--- a/pkg/file/splitter/splitter.go
+++ b/pkg/file/splitter/splitter.go
@@ -57,7 +57,7 @@ func (s *simpleSplitter) Split(ctx context.Context, r io.ReadCloser, dataLength 
 		}
 		cc, err := j.Write(data[:c])
 		if err != nil {
-				splitError := file.NewSplitError(err)
+			splitError := file.NewSplitError(err)
 			return swarm.ZeroAddress, splitError
 		}
 		if cc < c {

--- a/pkg/file/splitter/splitter.go
+++ b/pkg/file/splitter/splitter.go
@@ -46,19 +46,23 @@ func (s *simpleSplitter) Split(ctx context.Context, r io.ReadCloser, dataLength 
 		if err != nil {
 			if err == io.EOF {
 				if total < dataLength {
-					return swarm.ZeroAddress, fmt.Errorf("splitter only received %d bytes of data, expected %d bytes", total+int64(c), dataLength)
+					splitError := file.NewSplitError(fmt.Errorf("splitter only received %d bytes of data, expected %d bytes", total+int64(c), dataLength))
+					return swarm.ZeroAddress, splitError
 				}
 				eof = true
 			} else {
-				return swarm.ZeroAddress, err
+				splitError := file.NewSplitError(err)
+				return swarm.ZeroAddress, splitError
 			}
 		}
 		cc, err := j.Write(data[:c])
 		if err != nil {
-			return swarm.ZeroAddress, err
+				splitError := file.NewSplitError(err)
+			return swarm.ZeroAddress, splitError
 		}
 		if cc < c {
-			return swarm.ZeroAddress, fmt.Errorf("write count to file hasher component %d does not match read count %d", cc, c)
+			splitError := file.NewSplitError(fmt.Errorf("write count to file hasher component %d does not match read count %d", cc, c))
+			return swarm.ZeroAddress, splitError
 		}
 	}
 

--- a/pkg/file/splitter/splitter.go
+++ b/pkg/file/splitter/splitter.go
@@ -46,23 +46,19 @@ func (s *simpleSplitter) Split(ctx context.Context, r io.ReadCloser, dataLength 
 		if err != nil {
 			if err == io.EOF {
 				if total < dataLength {
-					splitError := file.NewSplitError(fmt.Errorf("splitter only received %d bytes of data, expected %d bytes", total+int64(c), dataLength))
-					return swarm.ZeroAddress, splitError
+					return swarm.ZeroAddress, fmt.Errorf("splitter only received %d bytes of data, expected %d bytes", total+int64(c), dataLength)
 				}
 				eof = true
 			} else {
-				splitError := file.NewSplitError(err)
-				return swarm.ZeroAddress, splitError
+				return swarm.ZeroAddress, err
 			}
 		}
 		cc, err := j.Write(data[:c])
 		if err != nil {
-			splitError := file.NewSplitError(err)
-			return swarm.ZeroAddress, splitError
+			return swarm.ZeroAddress, err
 		}
 		if cc < c {
-			splitError := file.NewSplitError(fmt.Errorf("write count to file hasher component %d does not match read count %d", cc, c))
-			return swarm.ZeroAddress, splitError
+			return swarm.ZeroAddress, fmt.Errorf("write count to file hasher component %d does not match read count %d", cc, c)
 		}
 	}
 


### PR DESCRIPTION
There are not really big changes here in this PR, more or less just:

* removing the loglines in the goroutine, replacing them with errors (that we perhaps could just drop is what I asked, simplifying quite a bit)
* moving the splitUpload to files a method SplitWriteAll, which mirrors the already existing facilitator JoinReadAll.
* ~~typed error from splitter~~