### PR TITLE
pusher: disable broken tags and make pusher push chunks in parallel

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -68,7 +68,7 @@ func (s *Service) chunksWorker() {
 		cancel()
 	}()
 
-	sem := make(chan struct{}, 5)
+	sem := make(chan struct{}, 10)
 	inflight := make(map[string]struct{})
 	var mtx sync.Mutex
 
@@ -87,6 +87,8 @@ func (s *Service) chunksWorker() {
 				break
 			}
 
+			// postpone a retry only after we've finished processing everything in index
+			timer.Reset(1 * time.Second)
 			chunksInBatch++
 			s.metrics.TotalChunksToBeSentCounter.Inc()
 			select {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -72,6 +72,7 @@ func (s *Service) chunksWorker() {
 	inflight := make(map[string]struct{})
 	var mtx sync.Mutex
 
+LOOP:
 	for {
 		select {
 		// handle incoming chunks
@@ -148,7 +149,7 @@ func (s *Service) chunksWorker() {
 			if unsubscribe != nil {
 				unsubscribe()
 			}
-			return
+			break LOOP
 		}
 	}
 


### PR DESCRIPTION
Tags are not working correctly and are polluting the terminal output.
Also, pusher pushes every chunk synchronously to NN, making the process painstakingly slow.
This PR adds some parallelism to the push process, therefore speeding it up.