### PR TITLE
Disconnect on headers error

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -285,6 +285,8 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
+				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
+				_ = s.disconnect(peerID)
 				return
 			}
 
@@ -440,6 +442,8 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
+		s.logger.Debugf("send headers: returned error %s: %v", peerID, err)
+		_ = s.disconnect(peerID)
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 


### PR DESCRIPTION
Currently, it seems that we are relying on headers logic timeout when errors happen in sending headers on both sending and receiving side (read will probably timeout). This is not a huge problem, but probably it's better to handle this explicitly as it will not wait for the whole timeout and we have a bit more control.

The solution is disconnect for now, as this is how we are handling most of errors of this kind, assuming that something is wrong with the peer in this case. Other solution could be closing or resetting the stream.