### PR TITLE
Fix getting tags by address in pusher

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -237,7 +237,7 @@ func NewBee(o Options) (*Bee, error) {
 		ChunkPeerer: topologyDriver,
 		Logger:      logger,
 	})
-	tagger := tags.NewTags()
+	tagg := tags.NewTags()
 
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
@@ -251,7 +251,7 @@ func NewBee(o Options) (*Bee, error) {
 		Streamer:      p2ps,
 		Storer:        storer,
 		ClosestPeerer: topologyDriver,
-		Tagger:        tagger,
+		Tagger:        tagg,
 		Logger:        logger,
 	})
 
@@ -263,7 +263,7 @@ func NewBee(o Options) (*Bee, error) {
 		Storer:        storer,
 		PeerSuggester: topologyDriver,
 		PushSyncer:    pushSyncProtocol,
-		Tagger:        tagger,
+		Tagger:        tagg,
 		Logger:        logger,
 	})
 	b.pusherCloser = pushSyncPusher
@@ -293,7 +293,7 @@ func NewBee(o Options) (*Bee, error) {
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
-			Tags:               tagger,
+			Tags:               tagg,
 			Storer:             ns,
 			CORSAllowedOrigins: o.CORSAllowedOrigins,
 			Logger:             logger,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -292,7 +292,7 @@ func NewBee(o Options) (*Bee, error) {
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
-			Tags:               tag,
+			Tags:               tagger,
 			Storer:             ns,
 			CORSAllowedOrigins: o.CORSAllowedOrigins,
 			Logger:             logger,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -263,6 +263,7 @@ func NewBee(o Options) (*Bee, error) {
 		Storer:        storer,
 		PeerSuggester: topologyDriver,
 		PushSyncer:    pushSyncProtocol,
+		Tagger:        tagger,
 		Logger:        logger,
 	})
 	b.pusherCloser = pushSyncPusher

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -233,7 +233,7 @@ func NewBee(o Options) (*Bee, error) {
 		ChunkPeerer: topologyDriver,
 		Logger:      logger,
 	})
-	tag := tags.NewTags()
+	tagger := tags.NewTags()
 
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
@@ -247,6 +247,7 @@ func NewBee(o Options) (*Bee, error) {
 		Streamer:      p2ps,
 		Storer:        storer,
 		ClosestPeerer: topologyDriver,
+		Tagger:        tagger,
 		Logger:        logger,
 	})
 
@@ -258,7 +259,6 @@ func NewBee(o Options) (*Bee, error) {
 		Storer:        storer,
 		PeerSuggester: topologyDriver,
 		PushSyncer:    pushSyncProtocol,
-		Tags:          tag,
 		Logger:        logger,
 	})
 	b.pusherCloser = pushSyncPusher
@@ -288,7 +288,7 @@ func NewBee(o Options) (*Bee, error) {
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
-			Tags:   tag,
+			Tags:   tagger,
 			Storer: ns,
 			Logger: logger,
 			Tracer: tracer,

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -91,7 +91,7 @@ func (s *Service) chunksWorker() {
 
 			t, err := s.tag.Get(ch.TagID())
 			if err != nil {
-				s.logger.Debugf("pusher: get tag by uid %s: %v", ch.Address(), err)
+				s.logger.Tracef("pusher: get tag by uid %s: %v", ch.Address(), err)
 				//continue // // until bzz api implements tags, dont continue here
 			}
 
@@ -149,7 +149,7 @@ func (s *Service) setChunkAsSynced(ctx context.Context, addr swarm.Address) {
 		s.metrics.TotalChunksSynced.Inc()
 		uid, err := s.getUidFromPushed(addr.String())
 		if err != nil {
-			s.logger.Debugf("pusher: get uid from pusher: %v", err)
+			s.logger.Tracef("pusher: get uid from pusher: %v", err)
 			return // until bzz api implements tags, dont considers this err fatal
 		}
 		ta, err := s.tag.Get(uid)

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -22,7 +22,7 @@ type Service struct {
 	storer            storage.Storer
 	pushSyncer        pushsync.PushSyncer
 	logger            logging.Logger
-	tagger            *tags.Tags
+	tagg              *tags.Tags
 	metrics           metrics
 	quit              chan struct{}
 	chunksWorkerQuitC chan struct{}
@@ -42,7 +42,7 @@ func New(o Options) *Service {
 	service := &Service{
 		storer:            o.Storer,
 		pushSyncer:        o.PushSyncer,
-		tagger:            o.Tagger,
+		tagg:              o.Tagger,
 		logger:            o.Logger,
 		metrics:           newMetrics(),
 		quit:              make(chan struct{}),
@@ -178,7 +178,7 @@ func (s *Service) setChunkAsSynced(ctx context.Context, ch swarm.Chunk) {
 		s.logger.Errorf("pusher: error setting chunk as synced: %v", err)
 		s.metrics.ErrorSettingChunkToSynced.Inc()
 	}
-	t, err := s.tagger.Get(ch.TagID())
+	t, err := s.tagg.Get(ch.TagID())
 	if err == nil && t != nil {
 		t.Inc(tags.StateSynced)
 	}

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -194,7 +194,5 @@ func (s *Service) getUidFromPushed(address string) (uint32, error) {
 func (s *Service) deleteUidFromPushed(address string) {
 	s.pushedMu.Lock()
 	defer s.pushedMu.Unlock()
-	if _, ok := s.pushed[address]; ok {
-		delete(s.pushed, address)
-	}
+	delete(s.pushed, address)
 }

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -93,10 +93,6 @@ func (s *Service) chunksWorker() {
 			if err != nil {
 				s.logger.Debugf("pusher: get tag by uid %s: %v", ch.Address(), err)
 				//continue // // until bzz api implements tags, dont continue here
-			} else {
-				// update the tags only if we get it
-				t.Inc(tags.StateSent)
-				s.addUidToPushed(ch.Address().String(), t.Uid)
 			}
 
 			// Later when we process receipt, get the receipt and process it
@@ -107,6 +103,12 @@ func (s *Service) chunksWorker() {
 					s.logger.Errorf("pusher: error while sending chunk or receiving receipt: %v", err)
 				}
 				continue
+			}
+
+			if t != nil {
+				// update the tags only if we get it
+				t.Inc(tags.StateSent)
+				s.addUidToPushed(ch.Address().String(), t.Uid)
 			}
 
 			// set chunk status to synced

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -87,7 +87,7 @@ func TestSendChunkToPushSyncWithTag(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ta.Synced != 1 {
+	if ta.Get(tags.StateSynced) != 1 {
 		t.Fatalf("tags error")
 	}
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -255,11 +255,6 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 		return nil, fmt.Errorf("invalid receipt. peer %s", peer.String())
 	}
 
-	// If we get the receipt and have a valid tag, set it as synced
-	if t != nil {
-		t.Inc(tags.StateSynced)
-	}
-
 	rec := &Receipt{
 		Address: swarm.NewAddress(receipt.Address),
 	}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -143,7 +143,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	}
 	receiptRTTTimer := time.Now()
 
-	// Most of the times now you wont get a tag because
+	//TODO:  Most of the times now you wont get a tag because
 	// /bytes and /files API does not implement tags
 	// SO dont print any logs or returning error, if you dont find them
 	t, _ := ps.tagger.Get(chunk.TagID())
@@ -199,7 +199,7 @@ func (ps *PushSync) sendChunkDelivery(w protobuf.Writer, chunk swarm.Chunk) (err
 	//  if you manage to get a tag, just increment the respective counter
 	t, err := ps.tagger.Get(chunk.TagID())
 	if err == nil && t != nil {
-		// most of the times now you wont get a tag because
+		// TODO: most of the times now you wont get a tag because
 		// /bytes and /files API does not implement tags
 		// SO dont print any logs or returning error, if you dont find them
 		// if you find a tag, increment the respective counter

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -38,7 +38,7 @@ type PushSync struct {
 	streamer      p2p.Streamer
 	storer        storage.Putter
 	peerSuggester topology.ClosestPeerer
-	tagger        *tags.Tags
+	tagg          *tags.Tags
 	logger        logging.Logger
 	metrics       metrics
 }
@@ -58,7 +58,7 @@ func New(o Options) *PushSync {
 		streamer:      o.Streamer,
 		storer:        o.Storer,
 		peerSuggester: o.ClosestPeerer,
-		tagger:        o.Tagger,
+		tagg:          o.Tagger,
 		logger:        o.Logger,
 		metrics:       newMetrics(),
 	}
@@ -237,7 +237,7 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 		return nil, fmt.Errorf("chunk deliver to peer %s: %w", peer.String(), err)
 	}
 	//  if you manage to get a tag, just increment the respective counter
-	t, err := ps.tagger.Get(ch.TagID())
+	t, err := ps.tagg.Get(ch.TagID())
 	if err == nil && t != nil {
 		t.Inc(tags.StateSent)
 	}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -122,7 +122,7 @@ func TestPushChunkToClosest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ta2.Sent != 1 || ta2.Synced != 1 {
+	if ta2.Sent != 1 {
 		t.Fatalf("tags error")
 	}
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -98,7 +98,7 @@ func TestPushChunkToClosest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ta1.Sent != 0 || ta1.Synced != 0 {
+	if ta1.Get(tags.StateSent) != 0 || ta1.Get(tags.StateSynced) != 0 {
 		t.Fatalf("tags initialization error")
 	}
 
@@ -122,7 +122,7 @@ func TestPushChunkToClosest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ta2.Sent != 1 {
+	if ta2.Get(tags.StateSent) != 1 {
 		t.Fatalf("tags error")
 	}
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/pushsync"
 	"github.com/ethersphere/bee/pkg/pushsync/pb"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/topology/mock"
 )
@@ -128,10 +129,12 @@ func createPushSyncNode(t *testing.T, addr swarm.Address, recorder *streamtest.R
 	}
 
 	mockTopology := mock.NewTopologyDriver(mockOpts...)
+	mtag := tags.NewTags()
 
 	ps := pushsync.New(pushsync.Options{
 		Streamer:      recorder,
 		Storer:        storer,
+		Tagger:        mtag,
 		ClosestPeerer: mockTopology,
 		Logger:        logger,
 	})


### PR DESCRIPTION
tags are fetched by address in pusher which is wrong. They should be fetched by the uid in the chunk (if present, /bytes & /files api's don't have tags) and stored in a local map. When a receipt is received, the state in the local store should be synced and the tag counter for synced should be incremented.