### PR TITLE
Revert "Disconnect on headers error (#333)"

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -285,8 +285,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
-				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
-				_ = s.disconnect(peerID)
 				return
 			}
 
@@ -442,8 +440,6 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
-		s.logger.Debugf("send headers: returned error %s: %v", peerID, err)
-		_ = s.disconnect(peerID)
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 


### PR DESCRIPTION
This PR reverts the change from https://github.com/ethersphere/bee/pull/333 as it creates a deadlock by calling pslice Remove on disconnect in kademlia.go:446 from the inside of pslice EachBinRev.

This can be seen in the goroutine:

```
goroutine 151 [semacquire]:
sync.runtime_SemacquireMutex(0xc00243f618, 0xc002243400, 0x0)
	runtime/sema.go:71 +0x47
sync.(*RWMutex).Lock(0xc00243f610)
	sync/rwmutex.go:103 +0x88
github.com/ethersphere/bee/pkg/kademlia/pslice.(*PSlice).Remove(0xc00243f5e0, 0xc0002b59e0, 0x20, 0x20, 0x0)
	github.com/ethersphere/bee/pkg/kademlia/pslice/pslice.go:162 +0x5e
github.com/ethersphere/bee/pkg/kademlia.(*Kad).Disconnected(0xc000e22000, 0xc0002b59e0, 0x20, 0x20)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:371 +0xb3
github.com/ethersphere/bee/pkg/p2p/libp2p.(*peerRegistry).remove(0xc0002354a0, 0xc004ac39e0, 0x27)
	github.com/ethersphere/bee/pkg/p2p/libp2p/peer.go:131 +0x1da
github.com/ethersphere/bee/pkg/p2p/libp2p.(*Service).disconnect(0xc00024a380, 0xc004ac39e0, 0x27, 0xc003c093e0, 0x2)
	github.com/ethersphere/bee/pkg/p2p/libp2p/libp2p.go:409 +0xac
github.com/ethersphere/bee/pkg/p2p/libp2p.(*Service).NewStream(0xc00024a380, 0x1e09700, 0xc0000b2ac0, 0xc0001f7c80, 0x20, 0x40, 0xc0022436e0, 0x1b649b8, 0x4, 0x1b64ef2, ...)
	github.com/ethersphere/bee/pkg/p2p/libp2p/libp2p.go:446 +0x366
github.com/ethersphere/bee/pkg/hive.(*Service).sendPeers(0xc00244d2c0, 0x1e09700, 0xc0000b2ac0, 0xc0001f7c80, 0x20, 0x40, 0xc003e83b20, 0x1, 0x1, 0x0, ...)
	github.com/ethersphere/bee/pkg/hive/hive.go:87 +0xf2
github.com/ethersphere/bee/pkg/hive.(*Service).BroadcastPeers(0xc00244d2c0, 0x1e09700, 0xc0000b2ac0, 0xc0001f7c80, 0x20, 0x40, 0xc003e83b20, 0x1, 0x1, 0xc00028eb30, ...)
	github.com/ethersphere/bee/pkg/hive/hive.go:72 +0x156
github.com/ethersphere/bee/pkg/kademlia.(*Kad).announce.func1(0xc0001f7c80, 0x20, 0x40, 0x0, 0xc002243c30, 0x19135e4, 0xc00028eaf0)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:302 +0x17e
github.com/ethersphere/bee/pkg/kademlia/pslice.(*PSlice).EachBinRev(0xc00243f5e0, 0xc002243bf0, 0x0, 0x0)
	github.com/ethersphere/bee/pkg/kademlia/pslice/pslice.go:83 +0x133
github.com/ethersphere/bee/pkg/kademlia.(*Kad).announce(0xc000e22000, 0x1e09700, 0xc0000b2ac0, 0xc0001f7b40, 0x20, 0x40, 0x0, 0x0)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:297 +0xf9
github.com/ethersphere/bee/pkg/kademlia.(*Kad).connect(0xc000e22000, 0x1e09700, 0xc0000b2ac0, 0xc0001f7b40, 0x20, 0x40, 0x1e16e20, 0xc005e2f100, 0xc005a06d00, 0x0, ...)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:289 +0x6b9
github.com/ethersphere/bee/pkg/kademlia.(*Kad).manage.func2(0xc0001f7b40, 0x20, 0x40, 0xc005a06e00, 0x1050000, 0x0, 0x0)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:150 +0x5a8
github.com/ethersphere/bee/pkg/kademlia/pslice.(*PSlice).EachBinRev(0xc00243f630, 0xc002243f40, 0x0, 0x0)
	github.com/ethersphere/bee/pkg/kademlia/pslice/pslice.go:83 +0x133
github.com/ethersphere/bee/pkg/kademlia.(*Kad).manage(0xc000e22000)
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:119 +0x22b
created by github.com/ethersphere/bee/pkg/kademlia.New
	github.com/ethersphere/bee/pkg/kademlia/kademlia.go:94 +0x342
```