### PR TITLE
Fullclose on incoming connection + stream close on send/handle headers

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -286,9 +286,7 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
-				if err := stream.Close(); err != nil {
-					s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers close stream: %v", p.Name, p.Version, ss.Name, overlay, err)
-				}
+				_ = s.disconnect(peerID)
 				return
 			}
 
@@ -443,9 +441,7 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
 		s.logger.Debugf("send headers %s: %w", peerID, err)
-		if err := stream.Close(); err != nil {
-			s.logger.Debugf("send headers %s: close stream %w", peerID, err)
-		}
+		_ = s.disconnect(peerID)
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -220,7 +220,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		}
 
 		if exists := s.peers.addIfNotExists(stream.Conn(), i.BzzAddress.Overlay); exists {
-			if err = stream.Close(); err != nil {
+			if err = helpers.FullClose(stream); err != nil {
 				s.logger.Debugf("handshake: could not close stream %s: %v", peerID, err)
 				s.logger.Errorf("unable to handshake with peer %v", peerID)
 				_ = s.disconnect(peerID)
@@ -228,7 +228,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if err = stream.Close(); err != nil {
+		if err = helpers.FullClose(stream); err != nil {
 			s.logger.Debugf("handshake: could not close stream %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
 			_ = s.disconnect(peerID)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -285,7 +285,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
-				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
 				if err := stream.Close(); err != nil {
 					s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers close stream: %v", p.Name, p.Version, ss.Name, overlay, err)
 				}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -286,7 +286,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
-				_ = s.disconnect(peerID)
 				return
 			}
 
@@ -440,7 +439,6 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
-		_ = s.disconnect(peerID)
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -286,6 +286,9 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
 				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
+				if err := stream.Close(); err != nil {
+					s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers close stream: %v", p.Name, p.Version, ss.Name, overlay, err)
+				}
 				return
 			}
 
@@ -439,6 +442,9 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
+		if err := stream.Close(); err != nil {
+			s.logger.Debugf("send headers %s: close stream %v", peerID, err)
+		}
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -285,6 +285,10 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			// exchange headers
 			if err := handleHeaders(ss.Headler, stream); err != nil {
 				s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers: %v", p.Name, p.Version, ss.Name, overlay, err)
+				s.logger.Errorf("handle protocol %s/%s: peer %s", p.Name, p.Version, overlay)
+				if err := stream.Close(); err != nil {
+					s.logger.Debugf("handle protocol %s/%s: stream %s: peer %s: handle headers close stream: %v", p.Name, p.Version, ss.Name, overlay, err)
+				}
 				return
 			}
 
@@ -440,6 +444,10 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
+		s.logger.Debugf("send headers %s: %w", peerID, err)
+		if err := stream.Close(); err != nil {
+			s.logger.Debugf("send headers %s: close stream %w", peerID, err)
+		}
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -440,7 +440,6 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
-		s.logger.Debugf("send headers %s: %w", peerID, err)
 		_ = s.disconnect(peerID)
 		return nil, fmt.Errorf("send headers: %w", err)
 	}


### PR DESCRIPTION
 - The both incoming and sending side should wait for each other after adding the node to the peer registry, so we have a consistent situation when initiating protocols.
- handle/send headers stream close per https://github.com/ethersphere/bee/pull/354
