### PR TITLE
kademlia: dont connect to the same peer again in short interval

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -30,6 +30,7 @@ const (
 var (
 	errMissingAddressBookEntry = errors.New("addressbook underlay entry not found")
 	timeToRetry                = 60 * time.Second
+	shortRetry                 = 30 * time.Second
 )
 
 type binSaturationFunc func(bin, depth uint8, peers *pslice.PSlice) bool
@@ -155,11 +156,11 @@ func (k *Kad) manage() {
 					return false, false, nil
 				}
 
-				k.connectedPeers.Add(peer, po)
-
 				k.waitNextMu.Lock()
-				delete(k.waitNext, peer.String())
+				k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
 				k.waitNextMu.Unlock()
+
+				k.connectedPeers.Add(peer, po)
 
 				k.depthMu.Lock()
 				k.depth = k.recalcDepth()


### PR DESCRIPTION
We should not try to connect to the same peer over and over again, since iterator on pslice does not prioritize peers, it might get stuck on the same problematic peer over and over again, causing other bins not to optimize correctly