### PR TITLE
remove peer from kademlia on peer not found in peer registry

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -433,3 +433,8 @@ func mockNotifier(c cFunc, d dFunc) topology.Notifier {
 
 type cFunc func(context.Context, swarm.Address) error
 type dFunc func(swarm.Address)
+
+var noopNotifier = mockNotifier(
+	func(_ context.Context, _ swarm.Address) error { return nil },
+	func(_ swarm.Address) {},
+)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -392,6 +392,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 func (s *Service) Disconnect(overlay swarm.Address) error {
 	peerID, found := s.peers.peerID(overlay)
 	if !found {
+		s.peers.disconnecter.Disconnected(overlay)
 		return p2p.ErrPeerNotFound
 	}
 
@@ -418,6 +419,7 @@ func (s *Service) SetNotifier(n topology.Notifier) {
 func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers p2p.Headers, protocolName, protocolVersion, streamName string) (p2p.Stream, error) {
 	peerID, found := s.peers.peerID(overlay)
 	if !found {
+		s.peers.disconnecter.Disconnected(overlay)
 		return nil, p2p.ErrPeerNotFound
 	}
 

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -62,6 +62,8 @@ func newService(t *testing.T, networkID uint64, o libp2p.Options) (s *libp2p.Ser
 		t.Fatal(err)
 	}
 
+	s.SetNotifier(noopNotifier)
+
 	t.Cleanup(func() {
 		cancel()
 		s.Close()


### PR DESCRIPTION
This PR cleans up kademlia when the peer is not found in peer registry. This PR is dependent on https://github.com/ethersphere/bee/pull/350, as it currently creates a deadlock on pslice lock.