### PR TITLE
Error -> warnings on connect calls

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -157,7 +157,7 @@ func (k *Kad) manage() {
 						}
 					}
 					k.logger.Debugf("error connecting to peer from kademlia %s: %v", bzzAddr.String(), err)
-					k.logger.Errorf("connecting to peer %s: %v", bzzAddr.ShortString(), err)
+					k.logger.Warningf("connecting to peer %s: %v", bzzAddr.ShortString(), err)
 					// continue to next
 					return false, false, nil
 				}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -381,7 +381,7 @@ func NewBee(o Options) (*Bee, error) {
 			defer wg.Done()
 			if err := topologyDriver.AddPeer(p2pCtx, overlay); err != nil {
 				logger.Debugf("topology add peer fail %s: %v", overlay, err)
-				logger.Errorf("topology add peer %s", overlay)
+				logger.Warningf("topology add peer fail %s", overlay)
 				return
 			}
 
@@ -400,7 +400,7 @@ func NewBee(o Options) (*Bee, error) {
 				addr, err := ma.NewMultiaddr(a)
 				if err != nil {
 					logger.Debugf("multiaddress fail %s: %v", a, err)
-					logger.Errorf("connect to bootnode %s", a)
+					logger.Warningf("connect to bootnode %s", a)
 					return
 				}
 				var count int
@@ -410,7 +410,7 @@ func NewBee(o Options) (*Bee, error) {
 					if err != nil {
 						if !errors.Is(err, p2p.ErrAlreadyConnected) {
 							logger.Debugf("connect fail %s: %v", addr, err)
-							logger.Errorf("connect to bootnode %s", addr)
+							logger.Warningf("connect to bootnode %s", addr)
 						}
 						return false, nil
 					}
@@ -420,14 +420,14 @@ func NewBee(o Options) (*Bee, error) {
 					if err != nil {
 						_ = p2ps.Disconnect(bzzAddr.Overlay)
 						logger.Debugf("addressbook error persisting %s %s: %v", addr, bzzAddr.Overlay, err)
-						logger.Errorf("connect to bootnode %s", addr)
+						logger.Warningf("connect to bootnode %s", addr)
 						return false, nil
 					}
 
 					if err := topologyDriver.Connected(p2pCtx, bzzAddr.Overlay); err != nil {
 						_ = p2ps.Disconnect(bzzAddr.Overlay)
 						logger.Debugf("topology connected fail %s %s: %v", addr, bzzAddr.Overlay, err)
-						logger.Errorf("connect to bootnode %s", addr)
+						logger.Warningf("connect to bootnode %s", addr)
 						return false, nil
 					}
 					count++
@@ -435,7 +435,7 @@ func NewBee(o Options) (*Bee, error) {
 					return count > 3, nil
 				}); err != nil {
 					logger.Debugf("discover fail %s: %v", a, err)
-					logger.Errorf("discover to bootnode %s", a)
+					logger.Warningf("discover to bootnode %s", a)
 					return
 				}
 			}(a)


### PR DESCRIPTION
We decided to change these to warnings as they can be part of a normal workflow of the app.