### PR TITLE
kademlia: saturate based on known peers

### DIFF
--- a/pkg/kademlia/export_test.go
+++ b/pkg/kademlia/export_test.go
@@ -4,5 +4,8 @@
 
 package kademlia
 
-var MaxBins = maxBins
-var TimeToRetry = &timeToRetry
+var (
+	MaxBins         = maxBins
+	TimeToRetry     = &timeToRetry
+	SaturationPeers = &saturationPeers
+)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -34,7 +34,7 @@ var (
 	shortRetry                 = 30 * time.Second
 )
 
-type binSaturationFunc func(bin, depth uint8, peers, connected *pslice.PSlice) bool
+type binSaturationFunc func(bin uint8, peers, connected *pslice.PSlice) bool
 
 // Options for injecting services to Kademlia.
 type Options struct {
@@ -141,7 +141,7 @@ func (k *Kad) manage() {
 				k.waitNextMu.Unlock()
 
 				currentDepth := k.NeighborhoodDepth()
-				if saturated := k.saturationFunc(po, currentDepth, k.knownPeers, k.connectedPeers); saturated {
+				if saturated := k.saturationFunc(po, k.knownPeers, k.connectedPeers); saturated {
 					return false, true, nil // bin is saturated, skip to next bin
 				}
 
@@ -214,7 +214,7 @@ func (k *Kad) manage() {
 // binSaturated indicates whether a certain bin is saturated or not.
 // when a bin is not saturated it means we would like to proactively
 // initiate connections to other peers in the bin.
-func binSaturated(bin, depth uint8, peers, connected *pslice.PSlice) bool {
+func binSaturated(bin uint8, peers, connected *pslice.PSlice) bool {
 	potentialDepth := recalcDepth(peers)
 
 	// short circuit for bins which are >= depth

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -216,7 +216,7 @@ func (k *Kad) manage() {
 // initiate connections to other peers in the bin.
 func binSaturated(bin, depth uint8, peers *pslice.PSlice) bool {
 	// short circuit for bins which are >= depth
-	if bin >= depth {
+	if bin > 0 && bin >= depth {
 		return false
 	}
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -237,7 +237,7 @@ func binSaturated(bin uint8, peers, connected *pslice.PSlice) bool {
 		return false, false, nil
 	})
 
-	return size >= 2
+	return size >= 4
 }
 
 // recalcDepth calculates and returns the kademlia depth.

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -200,6 +200,11 @@ func TestManage(t *testing.T) {
 // be true since depth is increasingly moving deeper, but then we add more peers
 // in shallower depth for the rest of the function to be executed
 func TestBinSaturation(t *testing.T) {
+	defer func(p int) {
+		*kademlia.SaturationPeers = p
+	}(*kademlia.SaturationPeers)
+	*kademlia.SaturationPeers = 2
+
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -160,7 +160,7 @@ func TestManage(t *testing.T) {
 		conns int32 // how many connect calls were made to the p2p mock
 
 		saturationVal  = false
-		saturationFunc = func(bin, depth uint8, peers, connected *pslice.PSlice) bool {
+		saturationFunc = func(bin uint8, peers, connected *pslice.PSlice) bool {
 			return saturationVal
 		}
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc)
@@ -610,7 +610,7 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin, depth uint8, peers, connected *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin uint8, peers, connected *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
 	var (
 		base   = test.RandomAddress()                       // base address
 		ab     = addressbook.New(mockstate.NewStateStore()) // address book

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -7,7 +7,6 @@ package kademlia_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"sync/atomic"
@@ -241,11 +240,7 @@ func TestBinSaturation(t *testing.T) {
 	waitCounter(t, &conns, 1)
 
 	// this is in order to hit the `if size < 2` in the saturation func
-	fmt.Printf("disconnecting 1 peer %s", peers[2].String())
 	removeOne(kad, peers[2])
-
-	time.Sleep(1 * time.Second)
-	fmt.Println(kad.String())
 	waitCounter(t, &conns, 1)
 }
 

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -165,6 +165,7 @@ func TestManage(t *testing.T) {
 		}
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc)
 	)
+	defer kad.Close()
 	// first, saturationFunc returns always false, this means that the bin is not saturated,
 	// hence we expect that every peer we add to kademlia will be connected to
 	for i := 0; i < 50; i++ {
@@ -210,6 +211,8 @@ func TestBinSaturation(t *testing.T) {
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil)
 		peers                    []swarm.Address
 	)
+
+	defer kad.Close()
 
 	// add two peers in a few bins to generate some depth >= 0, this will
 	// make the next iteration result in binSaturated==true, causing no new

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -7,6 +7,7 @@ package kademlia_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"sync/atomic"
@@ -160,7 +161,7 @@ func TestManage(t *testing.T) {
 		conns int32 // how many connect calls were made to the p2p mock
 
 		saturationVal  = false
-		saturationFunc = func(bin, depth uint8, peers *pslice.PSlice) bool {
+		saturationFunc = func(bin, depth uint8, peers, connected *pslice.PSlice) bool {
 			return saturationVal
 		}
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc)
@@ -240,7 +241,11 @@ func TestBinSaturation(t *testing.T) {
 	waitCounter(t, &conns, 1)
 
 	// this is in order to hit the `if size < 2` in the saturation func
+	fmt.Printf("disconnecting 1 peer %s", peers[2].String())
 	removeOne(kad, peers[2])
+
+	time.Sleep(1 * time.Second)
+	fmt.Println(kad.String())
 	waitCounter(t, &conns, 1)
 }
 
@@ -610,7 +615,7 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin, depth uint8, peers *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin, depth uint8, peers, connected *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
 	var (
 		base   = test.RandomAddress()                       // base address
 		ab     = addressbook.New(mockstate.NewStateStore()) // address book

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -81,7 +81,10 @@ func (r *peerRegistry) Disconnected(_ network.Network, c network.Conn) {
 func (r *peerRegistry) addStream(peerID libp2ppeer.ID, stream network.Stream, cancel context.CancelFunc) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
+	if _, ok := r.streams[peerID]; !ok {
+		// it is possible that an addStream will be called after a disconnect
+		return
+	}
 	r.streams[peerID][stream] = cancel
 }
 

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -11,8 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -427,15 +425,6 @@ func (s *Syncer) Close() error {
 	case <-cc:
 	case <-time.After(10 * time.Second):
 		s.logger.Warning("pull syncer shutting down with running goroutines")
-		f, _ := ioutil.TempFile("", "goroutine_dump")
-		stat, _ := f.Stat()
-		s.logger.Warningf("puller shutting down with running goroutines, file %s", stat.Name())
-
-		pprof.Lookup("goroutine").WriteTo(f, 2)
-
-		_ = f.Sync()
-		_ = f.Close()
-
 	}
 	return nil
 }

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -425,6 +427,15 @@ func (s *Syncer) Close() error {
 	case <-cc:
 	case <-time.After(10 * time.Second):
 		s.logger.Warning("pull syncer shutting down with running goroutines")
+		f, _ := ioutil.TempFile("", "goroutine_dump")
+		stat, _ := f.Stat()
+		s.logger.Warningf("puller shutting down with running goroutines, file %s", stat.Name())
+
+		pprof.Lookup("goroutine").WriteTo(f, 2)
+
+		_ = f.Sync()
+		_ = f.Close()
+
 	}
 	return nil
 }


### PR DESCRIPTION
This PR changes the saturation function to use both known and connected peers for depth calculation, avoiding piling up peers in shallow bins when initially bootstrapping the topology. This results in much more stable topology. We also after some experimentation raised the number of peers needed to saturate a bin to `4`, referred to as `saturationPeers` thereafter in kademlia.