### PR TITLE
add decompressed-content-length header to be used for progress bar

### DIFF
--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -296,6 +296,7 @@ func (s *server) fileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", metaData.Filename))
 	w.Header().Set("Content-Type", metaData.MimeType)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", dataSize))
+	w.Header().Set("Decompressed-Content-Length", fmt.Sprintf("%d", dataSize))
 	if _, err = io.Copy(w, bpr); err != nil {
 		s.Logger.Debugf("file download: data read %s: %v", addr, err)
 		s.Logger.Errorf("file download: data read %s", addr)


### PR DESCRIPTION
As we are using gzip compressor for our responses. I am adding a custom header as suggested in this comment https://stackoverflow.com/questions/15097712/how-can-i-use-deflated-gzipped-content-with-an-xhr-onprogress-function/32799706#32799706 for progress bar support.