### PR TITLE
Remove error log from add protocol

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -275,9 +275,8 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			peerID := streamlibp2p.Conn().RemotePeer()
 			overlay, found := s.peers.overlay(peerID)
 			if !found {
-				// todo: this should never happen
 				_ = s.disconnect(peerID)
-				s.logger.Errorf("overlay address for peer %q not found", peerID)
+				s.logger.Debugf("overlay address for peer %q not found", peerID)
 				return
 			}
 


### PR DESCRIPTION
This was a very old todo message. This can actually happen when the node is disconnected or something similar, so it is not valid anymore. So, I removed the todo and added this as a debug, cuz I think it pollutes the user output. We will watch this case and guard against it more if needed.