### PR TITLE
Disable QUIC and WS libp2p transports by default

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -33,8 +33,8 @@ func (c *command) initStartCmd() (err error) {
 		optionNameAPIAddr            = "api-addr"
 		optionNameP2PAddr            = "p2p-addr"
 		optionNameNATAddr            = "nat-addr"
-		optionNameP2PDisableWS       = "p2p-disable-ws"
-		optionNameP2PDisableQUIC     = "p2p-disable-quic"
+		optionNameP2PEnableWS        = "p2p-enable-ws"
+		optionNameP2PEnableQUIC      = "p2p-enable-quic"
 		optionNameEnableDebugAPI     = "enable-debug-api"
 		optionNameDebugAPIAddr       = "debug-api-addr"
 		optionNameBootnodes          = "bootnode"
@@ -119,8 +119,8 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 				DebugAPIAddr:       debugAPIAddr,
 				Addr:               c.config.GetString(optionNameP2PAddr),
 				NATAddr:            c.config.GetString(optionNameNATAddr),
-				DisableWS:          c.config.GetBool(optionNameP2PDisableWS),
-				DisableQUIC:        c.config.GetBool(optionNameP2PDisableQUIC),
+				EnableWS:           c.config.GetBool(optionNameP2PEnableWS),
+				EnableQUIC:         c.config.GetBool(optionNameP2PEnableQUIC),
 				NetworkID:          c.config.GetUint64(optionNameNetworkID),
 				WelcomeMessage:     c.config.GetString(optionWelcomeMessage),
 				Bootnodes:          c.config.GetStringSlice(optionNameBootnodes),
@@ -180,8 +180,8 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")
 	cmd.Flags().String(optionNameP2PAddr, ":7070", "P2P listen address")
 	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
-	cmd.Flags().Bool(optionNameP2PDisableWS, false, "disable P2P WebSocket protocol")
-	cmd.Flags().Bool(optionNameP2PDisableQUIC, false, "disable P2P QUIC protocol")
+	cmd.Flags().Bool(optionNameP2PEnableWS, false, "disable P2P WebSocket protocol")
+	cmd.Flags().Bool(optionNameP2PEnableQUIC, false, "disable P2P QUIC protocol")
 	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/bootnode.ethswarm.org"}, "initial nodes to connect to")
 	cmd.Flags().Bool(optionNameEnableDebugAPI, false, "enable debug HTTP API")
 	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -74,8 +74,8 @@ type Options struct {
 	DebugAPIAddr       string
 	Addr               string
 	NATAddr            string
-	DisableWS          bool
-	DisableQUIC        bool
+	EnableWS           bool
+	EnableQUIC         bool
 	NetworkID          uint64
 	WelcomeMessage     string
 	Bootnodes          []string
@@ -156,8 +156,8 @@ func NewBee(o Options) (*Bee, error) {
 	p2ps, err := libp2p.New(p2pCtx, signer, o.NetworkID, address, o.Addr, libp2p.Options{
 		PrivateKey:     libp2pPrivateKey,
 		NATAddr:        o.NATAddr,
-		DisableWS:      o.DisableWS,
-		DisableQUIC:    o.DisableQUIC,
+		EnableWS:       o.EnableWS,
+		EnableQUIC:     o.EnableQUIC,
 		Addressbook:    addressbook,
 		WelcomeMessage: o.WelcomeMessage,
 		Logger:         logger,

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -240,18 +240,18 @@ func TestDifferentNetworkIDs(t *testing.T) {
 	expectPeers(t, s2)
 }
 
-func TestConnectWithDisabledQUICAndWSTransports(t *testing.T) {
+func TestConnectWithEnabledQUICAndWSTransports(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	s1, overlay1 := newService(t, 1, libp2p.Options{
-		DisableQUIC: true,
-		DisableWS:   true,
+		EnableQUIC: true,
+		EnableWS:   true,
 	})
 
 	s2, overlay2 := newService(t, 1, libp2p.Options{
-		DisableQUIC: true,
-		DisableWS:   true,
+		EnableQUIC: true,
+		EnableWS:   true,
 	})
 
 	addr := serviceUnderlayAddress(t, s1)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -62,8 +62,8 @@ type Service struct {
 type Options struct {
 	PrivateKey     *ecdsa.PrivateKey
 	NATAddr        string
-	DisableWS      bool
-	DisableQUIC    bool
+	EnableWS       bool
+	EnableQUIC     bool
 	LightNode      bool
 	WelcomeMessage string
 	Addressbook    addressbook.Putter
@@ -95,20 +95,20 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	var listenAddrs []string
 	if ip4Addr != "" {
 		listenAddrs = append(listenAddrs, fmt.Sprintf("/ip4/%s/tcp/%s", ip4Addr, port))
-		if !o.DisableWS {
+		if o.EnableWS {
 			listenAddrs = append(listenAddrs, fmt.Sprintf("/ip4/%s/tcp/%s/ws", ip4Addr, port))
 		}
-		if !o.DisableQUIC {
+		if o.EnableQUIC {
 			listenAddrs = append(listenAddrs, fmt.Sprintf("/ip4/%s/udp/%s/quic", ip4Addr, port))
 		}
 	}
 
 	if ip6Addr != "" {
 		listenAddrs = append(listenAddrs, fmt.Sprintf("/ip6/%s/tcp/%s", ip6Addr, port))
-		if !o.DisableWS {
+		if o.EnableWS {
 			listenAddrs = append(listenAddrs, fmt.Sprintf("/ip6/%s/tcp/%s/ws", ip6Addr, port))
 		}
-		if !o.DisableQUIC {
+		if o.EnableQUIC {
 			listenAddrs = append(listenAddrs, fmt.Sprintf("/ip6/%s/udp/%s/quic", ip6Addr, port))
 		}
 	}
@@ -144,11 +144,11 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		libp2p.Transport(tcp.NewTCPTransport),
 	}
 
-	if !o.DisableWS {
+	if o.EnableWS {
 		transports = append(transports, libp2p.Transport(ws.New))
 	}
 
-	if !o.DisableQUIC {
+	if o.EnableQUIC {
 		transports = append(transports, libp2p.Transport(libp2pquic.NewTransport))
 	}
 


### PR DESCRIPTION
This PR makes QUIC and WS transports disabled by default. It was observed that quic may introduce problems, and it is still an experimental feature. We should keep the transport on tcp only as the safest one, and enable other transports if needed and for testing.

This PR is important for infrastructure and documentation also as it changes command line parameters:

- `--p2p-disable-quic` to `--p2p-enable-quic`
- `--p2p-disable-ws` to `--p2p-enable-ws`