### PR TITLE
use lazy chunk reader and langos to file download api

### DIFF
--- a/pkg/file/lcr/lcr.go
+++ b/pkg/file/lcr/lcr.go
@@ -1,0 +1,273 @@
+package lcr
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// LazyChunkReader implements LazySectionReader
+type LazyChunkReader struct {
+	ctx       context.Context
+	addr      swarm.Address // root address
+	chunkData []byte
+	off       int64 // offset
+	chunkSize int64 // inherit from chunker
+	branches  int64 // inherit from chunker
+	hashSize  int64 // inherit from chunker
+	depth     int
+	getter    storage.Getter
+}
+
+func Join(ctx context.Context, addr swarm.Address, getter storage.Getter, depth int) *LazyChunkReader {
+	hashSize := int64(len(addr.Bytes()))
+	return &LazyChunkReader{
+		addr:      addr,
+		chunkSize: swarm.ChunkSize,
+		branches:  swarm.ChunkSize / hashSize,
+		hashSize:  hashSize,
+		depth:     depth,
+		getter:    getter,
+		ctx:       ctx,
+	}
+}
+
+func (r *LazyChunkReader) Context() context.Context {
+	return r.ctx
+}
+
+// Size is meant to be called on the LazySectionReader
+func (r *LazyChunkReader) Size(ctx context.Context, quitC chan bool) (n int64, err error) {
+	// metrics.GetOrRegisterCounter("lazychunkreader/size", nil).Inc(1)
+
+	// var sp opentracing.Span
+	// var cctx context.Context
+	// cctx, sp = spancontext.StartSpan(
+	// 	ctx,
+	// 	"lcr.size")
+	// defer sp.Finish()
+
+	//log.Debug("lazychunkreader.size", "addr", r.addr)
+	if r.chunkData == nil {
+		//startTime := time.Now()
+		chunk, err := r.getter.Get(ctx, storage.ModeGetRequest, r.addr)
+		if err != nil {
+			//metrics.GetOrRegisterResettingTimer("lcr/getter/get/err", nil).UpdateSince(startTime)
+			return 0, err
+		}
+		//metrics.GetOrRegisterResettingTimer("lcr/getter/get", nil).UpdateSince(startTime)
+		r.chunkData = chunk.Data()
+	}
+
+	s := chunkSize(r.chunkData)
+	//log.Debug("lazychunkreader.size", "key", r.addr, "size", s)
+
+	return int64(s), nil
+}
+
+// read at can be called numerous times
+// concurrent reads are allowed
+// Size() needs to be called synchronously on the LazyChunkReader first
+func (r *LazyChunkReader) ReadAt(b []byte, off int64) (read int, err error) {
+	//metrics.GetOrRegisterCounter("lazychunkreader/readat", nil).Inc(1)
+
+	// var sp opentracing.Span
+	// var cctx context.Context
+	// cctx, sp = spancontext.StartSpan(
+	// 	r.ctx,
+	// 	"lcr.read")
+	// defer sp.Finish()
+
+	// defer func() {
+	// 	sp.LogFields(
+	// 		olog.Int("off", int(off)),
+	// 		olog.Int("read", read))
+	// }()
+
+	// this is correct, a swarm doc cannot be zero length, so no EOF is expected
+	if len(b) == 0 {
+		return 0, nil
+	}
+	quitC := make(chan bool)
+	size, err := r.Size(r.ctx, quitC)
+	if err != nil {
+		//log.Debug("lazychunkreader.readat.size", "size", size, "err", err)
+		return 0, err
+	}
+
+	errC := make(chan error)
+
+	// }
+	var treeSize int64
+	var depth int
+	// calculate depth and max treeSize
+	treeSize = r.chunkSize
+	for ; treeSize < size; treeSize *= r.branches {
+		depth++
+	}
+	wg := sync.WaitGroup{}
+	length := int64(len(b))
+	for d := 0; d < r.depth; d++ {
+		off *= r.chunkSize
+		length *= r.chunkSize
+	}
+	wg.Add(1)
+	go r.join(r.ctx, b, off, off+length, depth, treeSize/r.branches, r.chunkData, &wg, errC, quitC)
+	go func() {
+		wg.Wait()
+		close(errC)
+	}()
+
+	err = <-errC
+	if err != nil {
+		//log.Debug("lazychunkreader.readat.errc", "err", err)
+		close(quitC)
+		return 0, err
+	}
+	if off+int64(len(b)) >= size {
+		//log.Debug("lazychunkreader.readat.return at end", "size", size, "off", off)
+		return int(size - off), io.EOF
+	}
+	//log.Debug("lazychunkreader.readat.errc", "buff", len(b))
+	return len(b), nil
+}
+
+func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff int64, depth int, treeSize int64, chunkData []byte, parentWg *sync.WaitGroup, errC chan error, quitC chan bool) {
+	defer parentWg.Done()
+	// find appropriate block level
+	for chunkSize(chunkData) < uint64(treeSize) && depth > r.depth {
+		treeSize /= r.branches
+		depth--
+	}
+
+	// leaf chunk found
+	if depth == r.depth {
+		extra := 8 + eoff - int64(len(chunkData))
+		if extra > 0 {
+			eoff -= extra
+		}
+		copy(b, chunkData[8+off:8+eoff])
+		return // simply give back the chunks reader for content chunks
+	}
+
+	// subtree
+	start := off / treeSize
+	end := (eoff + treeSize - 1) / treeSize
+
+	// last non-leaf chunk can be shorter than default chunk size, let's not read it further then its end
+	currentBranches := int64(len(chunkData)-8) / r.hashSize
+	if end > currentBranches {
+		end = currentBranches
+	}
+
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+	for i := start; i < end; i++ {
+		soff := i * treeSize
+		roff := soff
+		seoff := soff + treeSize
+
+		if soff < off {
+			soff = off
+		}
+		if seoff > eoff {
+			seoff = eoff
+		}
+		if depth > 1 {
+			wg.Wait()
+		}
+		wg.Add(1)
+		go func(j int64) {
+			childAddress := swarm.NewAddress(chunkData[8+j*r.hashSize : 8+(j+1)*r.hashSize])
+			//startTime := time.Now()
+			chunk, err := r.getter.Get(ctx, storage.ModeGetRequest, childAddress)
+			if err != nil {
+				//metrics.GetOrRegisterResettingTimer("lcr/getter/get/err", nil).UpdateSince(startTime)
+				select {
+				case errC <- fmt.Errorf("chunk %v-%v not found; key: %s", off, off+treeSize, fmt.Sprintf("%x", childAddress)):
+				case <-quitC:
+				}
+				wg.Done()
+				return
+			}
+			chunkData = chunk.Data()
+			//metrics.GetOrRegisterResettingTimer("lcr/getter/get", nil).UpdateSince(startTime)
+			if l := len(chunkData); l < 9 {
+				select {
+				case errC <- fmt.Errorf("chunk %v-%v incomplete; key: %s, data length %v", off, off+treeSize, fmt.Sprintf("%x", childAddress), l):
+				case <-quitC:
+				}
+				wg.Done()
+				return
+			}
+			if soff < off {
+				soff = off
+			}
+			r.join(ctx, b[soff-off:seoff-off], soff-roff, seoff-roff, depth-1, treeSize/r.branches, chunkData, wg, errC, quitC)
+		}(i)
+	} //for
+}
+
+// Read keeps a cursor so cannot be called simulateously, see ReadAt
+func (r *LazyChunkReader) Read(b []byte) (read int, err error) {
+	//log.Trace("lazychunkreader.read", "key", r.addr)
+	//metrics.GetOrRegisterCounter("lazychunkreader/read", nil).Inc(1)
+
+	read, err = r.ReadAt(b, r.off)
+	if err != nil && err != io.EOF {
+		//log.Trace("lazychunkreader.readat", "read", read, "err", err)
+		//metrics.GetOrRegisterCounter("lazychunkreader/read/err", nil).Inc(1)
+		return read, err
+	}
+
+	//metrics.GetOrRegisterCounter("lazychunkreader/read/bytes", nil).Inc(int64(read))
+
+	r.off += int64(read)
+	return read, err
+}
+
+// completely analogous to standard SectionReader implementation
+var errWhence = errors.New("seek: invalid whence")
+var errOffset = errors.New("seek: invalid offset")
+
+func (r *LazyChunkReader) Seek(offset int64, whence int) (int64, error) {
+	// cctx, sp := spancontext.StartSpan(
+	// 	r.ctx,
+	// 	"lcr.seek")
+	// defer sp.Finish()
+
+	// log.Debug("lazychunkreader.seek", "key", r.addr, "offset", offset)
+	switch whence {
+	default:
+		return 0, errWhence
+	case 0:
+		offset += 0
+	case 1:
+		offset += r.off
+	case 2:
+
+		if r.chunkData == nil { //seek from the end requires rootchunk for size. call Size first
+			_, err := r.Size(r.ctx, nil)
+			if err != nil {
+				return 0, fmt.Errorf("chunk size: %w", err)
+			}
+		}
+		offset += int64(chunkSize(r.chunkData))
+	}
+
+	if offset < 0 {
+		return 0, errOffset
+	}
+	r.off = offset
+	return offset, nil
+}
+
+func chunkSize(data []byte) uint64 {
+	return binary.LittleEndian.Uint64(data[:8])
+}

--- a/pkg/file/lcr/lcr.go
+++ b/pkg/file/lcr/lcr.go
@@ -138,7 +138,7 @@ func (r *LazyChunkReader) ReadAt(b []byte, off int64) (read int, err error) {
 	return len(b), nil
 }
 
-func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff int64, depth int, treeSize int64, chunkData []byte, parentWg *sync.WaitGroup, errC chan error, quitC chan bool) {
+func (r *LazyChunkReader) join(ctx context.Context, b []byte, off, eoff int64, depth int, treeSize int64, chunkData []byte, parentWg *sync.WaitGroup, errC chan error, quitC chan bool) {
 	defer parentWg.Done()
 	// find appropriate block level
 	for chunkSize(chunkData) < uint64(treeSize) && depth > r.depth {

--- a/pkg/langos/buffered_reader.go
+++ b/pkg/langos/buffered_reader.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package langos
+
+import (
+	"bufio"
+	"io"
+)
+
+// BufferedReadSeeker wraps bufio.Reader to expose Seek method
+// from the provided io.ReadSeeker in NewBufferedReadSeeker.
+type BufferedReadSeeker struct {
+	r  *bufio.Reader
+	s  io.ReadSeeker
+	ra io.ReaderAt
+}
+
+// NewBufferedReadSeeker creates a new instance of BufferedReadSeeker,
+// out of io.ReadSeeker. Argument `size` is the size of the read buffer.
+func NewBufferedReadSeeker(readSeeker io.ReadSeeker, size int) BufferedReadSeeker {
+	ra, _ := readSeeker.(io.ReaderAt)
+	return BufferedReadSeeker{
+		r:  bufio.NewReaderSize(readSeeker, size),
+		s:  readSeeker,
+		ra: ra,
+	}
+}
+
+// Read reads to the byte slice from from buffered reader.
+func (b BufferedReadSeeker) Read(p []byte) (n int, err error) {
+	return b.r.Read(p)
+}
+
+// Seek moves the read position of the underlying ReadSeeker and resets the buffer.
+func (b BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	n, err := b.s.Seek(offset, whence)
+	b.r.Reset(b.s)
+	return n, err
+}
+
+// ReadAt implements io.ReaderAt if the provided ReadSeeker also implements it,
+// otherwise it returns no error and no bytes read.
+func (b BufferedReadSeeker) ReadAt(p []byte, off int64) (n int, err error) {
+	if b.ra == nil {
+		return 0, nil
+	}
+	return b.ra.ReadAt(p, off)
+}

--- a/pkg/langos/http_test.go
+++ b/pkg/langos/http_test.go
@@ -1,0 +1,319 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package langos_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/langos"
+)
+
+// TestHTTPResponse validates that the langos returns correct data
+// over http test server and ServeContent function.
+func TestHTTPResponse(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeContent(w, r, "test", time.Now(), langos.NewBufferedLangos(bytes.NewReader(data), bufferSize))
+		}))
+		defer ts.Close()
+
+		res, err := http.Get(ts.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer res.Body.Close()
+
+		got, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got invalid data (lengths: got %v, want %v)", len(got), len(data))
+		}
+	})
+}
+
+// TestHTTPResponse validates that the langos returns correct data
+// over http test server and ServeContent function for http range requests.
+func TestHTTPRangeResponse(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeContent(w, r, "test", time.Now(), langos.NewBufferedLangos(bytes.NewReader(data), bufferSize))
+		}))
+		defer ts.Close()
+
+		for i := 0; i < 12; i++ {
+			start := rand.Intn(dataSize)
+			var end int
+			if dataSize-1-start <= 0 {
+				end = dataSize - 1
+			} else {
+				end = rand.Intn(dataSize-1-start) + start
+			}
+			rangeHeader := fmt.Sprintf("bytes=%v-%v", start, end)
+			if i == 0 {
+				// test open ended range
+				end = dataSize - 1
+				rangeHeader = fmt.Sprintf("bytes=%v-", start)
+			}
+
+			gotRangs := httpRangeRequest(t, ts.URL, rangeHeader)
+			got := gotRangs[0]
+			want := data[start : end+1]
+			if !bytes.Equal(got, want) {
+				t.Fatalf("got invalid data for range %s (lengths: got %v, want %v)", rangeHeader, len(got), len(want))
+			}
+		}
+	})
+}
+
+// TestHTTPMultipleRangeResponse validates that the langos returns correct data
+// over http test server and ServeContent function for http requests with multiple ranges.
+func TestHTTPMultipleRangeResponse(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeContent(w, r, "test", time.Now(), langos.NewBufferedLangos(bytes.NewReader(data), bufferSize))
+		}))
+		defer ts.Close()
+
+		for i := 0; i < 12; i++ {
+			var ranges [][2]int
+
+			var wantParts [][2]int
+			for i := rand.Intn(5); i >= 0; i-- {
+				var beginning int
+				if l := len(ranges); l > 0 {
+					beginning = ranges[l-1][1] + 1
+				}
+				if beginning >= dataSize {
+					break
+				}
+				start := rand.Intn(dataSize-beginning) + beginning
+				var end int
+				if dataSize-1-start <= 0 {
+					end = dataSize - 1
+				} else {
+					end = rand.Intn(dataSize-1-start) + start
+				}
+				if l := len(wantParts); l > 0 && wantParts[l-1][0] == start && wantParts[l-1][1] == end {
+					continue
+				}
+				ranges = append(ranges, [2]int{start, end})
+				wantParts = append(wantParts, [2]int{start, end})
+			}
+
+			rangeHeader := "bytes="
+			for i, r := range ranges {
+				if i > 0 {
+					rangeHeader += ", "
+				}
+				rangeHeader += fmt.Sprintf("%v-%v", r[0], r[1])
+			}
+
+			gotParts := httpRangeRequest(t, ts.URL, rangeHeader)
+
+			if len(gotParts) != len(wantParts) {
+				t.Fatalf("got %v parts for range %q, want %v", len(gotParts), rangeHeader, len(wantParts))
+			}
+
+			for i, w := range wantParts {
+				got := gotParts[i]
+				want := data[w[0] : w[1]+1]
+				if !bytes.Equal(got, want) {
+					t.Fatalf("got invalid data for range #%v %s (lengths: got %v, want %v)", i+1, rangeHeader, len(got), len(want))
+				}
+			}
+		}
+	})
+}
+
+func parseDataSize(t *testing.T, v string) (s int) {
+	t.Helper()
+
+	multiplier := 1
+	for suffix, value := range map[string]int{
+		"k": 1024,
+		"M": 1024 * 1024,
+	} {
+		if strings.HasSuffix(v, suffix) {
+			v = strings.TrimSuffix(v, suffix)
+			multiplier = value
+			break
+		}
+	}
+	s, err := strconv.Atoi(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s * multiplier
+}
+
+func httpRangeRequest(t *testing.T, url, rangeHeader string) (parts [][]byte) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Add("Range", rangeHeader)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	mimetype, params, _ := mime.ParseMediaType(res.Header.Get("Content-Type"))
+	if mimetype == "multipart/byteranges" {
+		mr := multipart.NewReader(res.Body, params["boundary"])
+		for part, err := mr.NextPart(); err == nil; part, err = mr.NextPart() {
+			value, err := ioutil.ReadAll(part)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parts = append(parts, value)
+		}
+	} else {
+		value, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parts = append(parts, value)
+	}
+
+	return parts
+}
+
+// BenchmarkHTTPDelayedReaders measures time needed by test http server to serve the body
+// using different readers.
+//
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/ethersphere/swarm/api/http/langos
+// BenchmarkHTTPDelayedReaders/static_direct-8			         	       8	 128278515 ns/op	 8389878 B/op	      24 allocs/op
+// BenchmarkHTTPDelayedReaders/static_buffered-8			       	      43	  27465687 ns/op	 8389144 B/op	      22 allocs/op
+// BenchmarkHTTPDelayedReaders/static_langos-8			         	     441	   2578510 ns/op	10264076 B/op	      63 allocs/op
+// BenchmarkHTTPDelayedReaders/static_buffered_langos-8         	     493	   2591692 ns/op	10120822 B/op	      57 allocs/op
+// BenchmarkHTTPDelayedReaders/random_direct-8                  	       3	 351496566 ns/op	 8389416 B/op	      23 allocs/op
+// BenchmarkHTTPDelayedReaders/random_buffered-8                	      14	  90407289 ns/op	 8389294 B/op	      22 allocs/op
+// BenchmarkHTTPDelayedReaders/random_langos-8                  	     430	   2771827 ns/op	10256494 B/op	      62 allocs/op
+// BenchmarkHTTPDelayedReaders/random_buffered_langos-8         	     420	   2817784 ns/op	10115937 B/op	      57 allocs/op
+func BenchmarkHTTPDelayedReaders(b *testing.B) {
+	dataSize := 2 * 1024 * 1024
+	bufferSize := 4 * 32 * 1024
+
+	data := randomData(b, dataSize)
+
+	for _, bc := range []struct {
+		name      string
+		newReader func() langos.Reader
+	}{
+		{
+			name: "static direct",
+			newReader: func() langos.Reader {
+				return newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays)
+			},
+		},
+		{
+			name: "static buffered",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedReadSeeker(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "static langos",
+			newReader: func() langos.Reader {
+				return langos.NewLangos(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "static buffered langos",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedLangos(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "random direct",
+			newReader: func() langos.Reader {
+				return newDelayedReader(bytes.NewReader(data), randomDelaysFunc)
+			},
+		},
+		{
+			name: "random buffered",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedReadSeeker(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+		{
+			name: "random langos",
+			newReader: func() langos.Reader {
+				return langos.NewLangos(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+		{
+			name: "random buffered langos",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedLangos(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.StopTimer()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.ServeContent(w, r, "test", time.Now(), bc.newReader())
+			}))
+			defer ts.Close()
+
+			for i := 0; i < b.N; i++ {
+				res, err := http.Get(ts.URL)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.StartTimer()
+				got, err := ioutil.ReadAll(res.Body)
+				b.StopTimer()
+
+				res.Body.Close()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !bytes.Equal(got, data) {
+					b.Fatalf("%v got invalid data (lengths: got %v, want %v)", i, len(got), len(data))
+				}
+			}
+		})
+	}
+}

--- a/pkg/langos/langos.go
+++ b/pkg/langos/langos.go
@@ -1,0 +1,245 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package langos
+
+import (
+	"io"
+	"sync"
+)
+
+// Reader contains all methods that Langos needs to read data from.
+type Reader interface {
+	io.ReadSeeker
+	io.ReaderAt
+}
+
+// Langos is a reader with a lookahead peekBuffer
+// this is the most naive implementation of a lookahead peekBuffer
+// it should issue a lookahead Read when a Read is called, hence
+// the name - langos
+// |--->====>>------------|
+//    cur   topmost
+// the first read is not a lookahead but the rest are
+// so, it could be that a lookahead read might need to wait for a previous read to finish
+// due to resource pooling
+//
+// All Read and Seek method call must be synchronous.
+type Langos struct {
+	reader    Reader // reader needs to implement io.ReadSeeker and io.ReaderAt interfaces
+	size      int64
+	cursor    int64 // current read position
+	peeks     []*peek
+	peekSize  int
+	closed    chan struct{} // terminates peek goroutine and unblocks Read method
+	closeOnce sync.Once     // protects closed channel on multiple calls to Close method
+}
+
+// NewLangos bakes a new yummy langos that peeks
+// on provided reader when its Read method is called.
+// Argument peekSize defines the length of peeks.
+func NewLangos(r Reader, peekSize int) *Langos {
+	return &Langos{
+		reader:   r,
+		peeks:    make([]*peek, 0),
+		peekSize: peekSize,
+		closed:   make(chan struct{}),
+	}
+}
+
+// NewBufferedLangos wraps a new Langos with BufferedReadSeeker
+// and returns it.
+func NewBufferedLangos(r Reader, bufferSize int) Reader {
+	return NewBufferedReadSeeker(NewLangos(r, bufferSize), bufferSize)
+}
+
+// Read copies the data to the provided byte slice starting from the
+// current read position. The first read will wait for the underlaying
+// Reader to return all the data and start a peek on the next data segment.
+// All sequential reads will wait for peek to finish reading the data.
+// If the current peek is not finished when Read is called, a second peek
+// will be started to apprehend the following Read call.
+func (l *Langos) Read(p []byte) (n int, err error) {
+	pe := l.popPeek(l.cursor)
+
+	// no peek at current cursor
+	if pe == nil {
+		n, err := l.reader.Read(p)
+		if err != nil {
+			return n, err
+		}
+		l.cursor += int64(n)
+		// start the peek for the next read
+		l.peek(l.cursor)
+		return n, err
+	}
+
+	select {
+	// peek is done, continue to read it
+	case <-pe.done:
+	default:
+		// start the next peek while waiting for the current to finish
+		if len(l.peeks) == 0 { // ensure only one second peek
+			l.peek(l.cursor + int64(l.peekSize))
+		}
+	}
+
+	select {
+	case <-pe.done:
+		bufSize := int64(len(pe.buf))
+		// peek detected EOF, store the size if there is none
+		if l.size == 0 && pe.err == io.EOF {
+			l.size = pe.offset + bufSize
+		}
+
+		// peek got an error, return it, but do not pass EOF
+		if pe.err != nil && pe.err != io.EOF {
+			return 0, pe.err
+		}
+
+		// copy peeked data
+		start := l.cursor - pe.offset
+		n = copy(p, pe.buf[start:])
+		// set current cursor
+		n64 := int64(n)
+		l.cursor += n64
+		// preserve buffer tail as another peek
+		if l.cursor < pe.offset+bufSize {
+			pe.buf = pe.buf[start+n64:]
+			pe.offset = l.cursor
+			l.addPeek(pe)
+		}
+
+		// return EOF if it is reached
+		if l.size > 0 && l.cursor >= l.size {
+			return n, io.EOF
+		}
+
+		// peek from the current cursor
+		l.peek(l.cursor)
+
+		return n, nil
+	case <-l.closed:
+		return 0, io.EOF
+	}
+}
+
+// Seek moves the Read cursor to a specific position.
+func (l *Langos) Seek(offset int64, whence int) (int64, error) {
+	n, err := l.reader.Seek(offset, whence)
+	if err != nil {
+		return n, err
+	}
+	// seek got data size, store it
+	if whence == io.SeekEnd {
+		l.size = n
+	}
+	l.cursor = n
+	return n, err
+}
+
+// ReadAt reads the data on offset and does not add any optimizations.
+func (l *Langos) ReadAt(p []byte, off int64) (int, error) {
+	return l.reader.ReadAt(p, off)
+}
+
+// Close unblocks Read method calls that are waiting for peek to finish.
+func (l *Langos) Close() (err error) {
+	l.closeOnce.Do(func() {
+		close(l.closed)
+	})
+	return nil
+}
+
+// peek starts a new peek ad offset with peekSize data length. The peek
+// can be retrieved by popPeek Langos method.
+func (l *Langos) peek(offset int64) {
+	// if here already is a peek that
+	// contains data at this offset,
+	// do not create another one
+	if l.hasPeek(offset) {
+		return
+	}
+
+	p := &peek{
+		offset: offset,
+		done:   make(chan struct{}),
+		buf:    make([]byte, l.peekSize),
+	}
+	l.addPeek(p)
+
+	// start a goroutine to peek the data
+	go func() {
+		n, err := l.reader.ReadAt(p.buf, offset)
+
+		if n >= 0 && n < len(p.buf) { // protect from invalid n (from lazy chunk reader)
+			p.mu.Lock()
+			p.buf = p.buf[:n]
+			p.mu.Unlock()
+		}
+		p.err = err
+		close(p.done)
+	}()
+}
+
+func (l *Langos) addPeek(p *peek) {
+	l.peeks = append(l.peeks, p)
+}
+
+// popPeek returns a peek that includes the offset and removes it
+// from langos. Nil is returned if there is no peek.
+func (l *Langos) popPeek(offset int64) (p *peek) {
+	for i, p := range l.peeks {
+		if p.has(offset) {
+			l.peeks = append(l.peeks[:i], l.peeks[i+1:]...)
+			return p
+		}
+	}
+	return nil
+}
+
+// hasPeek returns true if there is a peek that includes the given offset.
+func (l *Langos) hasPeek(offset int64) (yes bool) {
+	for _, p := range l.peeks {
+		if p.has(offset) {
+			return true
+		}
+	}
+	return false
+}
+
+// peek holds the current state of a read at some offset. When the read is done,
+// done channel is closed and buffer is safe to read up to the size if error is not nil.
+type peek struct {
+	offset int64         // peek cursor position
+	buf    []byte        // peeked data
+	mu     sync.RWMutex  // protects buf length change and len read in has method
+	err    error         // error returned by ReadAt on peeking
+	done   chan struct{} // closed when the peek is done so that Read can copy buf data
+}
+
+// has returns whether the peek has, or should have after it is done,
+// data starting from the offset.
+func (p *peek) has(offset int64) (yes bool) {
+	// peek offset does not start from required offset
+	if offset < p.offset {
+		return false
+	}
+	p.mu.RLock()
+	bufSize := int64(len(p.buf))
+	p.mu.RUnlock()
+	return offset < p.offset+bufSize
+}

--- a/pkg/langos/langos_test.go
+++ b/pkg/langos/langos_test.go
@@ -1,0 +1,349 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package langos_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/langos"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// TestLangosNumberOfReadCalls validates that Read calls on the passed
+// Reader is correct in respect to Langos peek calls.
+func TestLangosNumberOfReadCalls(t *testing.T) {
+	testData := "sometestdata" // len 12
+
+	for _, tc := range []struct {
+		name     string
+		peekSize int
+		numReads int
+		expReads int
+		expErr   error
+	}{
+		{
+			name:     "2 seq reads, no error",
+			peekSize: 6,
+			numReads: 1,
+			expReads: 2,
+			expErr:   nil,
+		},
+		{
+			name:     "3 seq reads, EOF",
+			peekSize: 6,
+			numReads: 3,
+			expReads: 4,
+			expErr:   io.EOF,
+		},
+		{
+			name:     "2 seq reads, EOF",
+			peekSize: 7,
+			numReads: 2,
+			expReads: 3,
+			expErr:   io.EOF,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := newCounterReader(strings.NewReader(testData))
+			l := langos.NewLangos(cr, tc.peekSize)
+
+			b := make([]byte, tc.peekSize)
+			var err error
+			for i := 1; i <= tc.numReads; i++ {
+				var wantErr error
+				if i == tc.numReads {
+					wantErr = tc.expErr
+				}
+				var n int
+				n, err = l.Read(b)
+				if err != wantErr {
+					t.Fatalf("got read #%v error %v, want %v", i, err, wantErr)
+				}
+				end := i * tc.peekSize
+				if end > len(testData) {
+					end = len(testData)
+				}
+				want := testData[(i-1)*tc.peekSize : end]
+				if l := len(want); l != n {
+					t.Fatalf("got read count #%v %v, want %v", i, n, l)
+				}
+				got := string(b[:n])
+				if got != want {
+					t.Fatalf("got read data #%v %q, want %q", i, got, want)
+				}
+			}
+
+			testReadCount(t, cr, tc.expReads)
+		})
+	}
+}
+
+// TestLangosCallsPeek counts the number reads by Langos
+// for single read, validating that the peek is called.
+func TestLangosCallsPeek(t *testing.T) {
+	peekSize := 128
+	cr := newCounterReader(strings.NewReader("sometestdata"))
+	l := langos.NewLangos(cr, peekSize)
+
+	b := make([]byte, peekSize)
+	_, err := l.Read(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testReadCount(t, cr, 2)
+}
+
+// counterReader counts the number of Read or ReadAt calls.
+type counterReader struct {
+	langos.Reader
+	readCount int
+	mu        sync.Mutex
+}
+
+func newCounterReader(r langos.Reader) (cr *counterReader) {
+	return &counterReader{
+		Reader: r,
+	}
+}
+
+func (cr *counterReader) Read(p []byte) (n int, err error) {
+	cr.mu.Lock()
+	cr.readCount++
+	cr.mu.Unlock()
+	return cr.Reader.Read(p)
+}
+
+func (cr *counterReader) ReadAt(p []byte, off int64) (int, error) {
+	cr.mu.Lock()
+	cr.readCount++
+	cr.mu.Unlock()
+	return cr.Reader.ReadAt(p, off)
+}
+
+func (cr *counterReader) ReadCount() (c int) {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	return cr.readCount
+}
+
+func testReadCount(t *testing.T, cr *counterReader, want int) {
+	t.Helper()
+
+	var got int
+	// retry for 2s to give the peek goroutine time to finish
+	for i := 0; i < 400; i++ {
+		got = cr.ReadCount()
+		if got == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("got %d, want %d call to read func", got, want)
+}
+
+// BenchmarkDelayedReaders performs benchmarks on reader with deterministic and random
+// delays on every Read method call. Function ioutil.ReadAll is used for reading.
+//
+//  - direct: a baseline on plain reader
+//  - buffered: reading through bufio.Reader
+//  - langos: reading through regular langos
+//  - bufferd langos: reading through buffered langos
+//
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/ethersphere/swarm/api/http/langos
+// BenchmarkDelayedReaders/static_direct-8                      	      30	  36824643 ns/op	33552520 B/op	      18 allocs/op
+// BenchmarkDelayedReaders/static_buffered-8                    	      45	  27717528 ns/op	33683733 B/op	      21 allocs/op
+// BenchmarkDelayedReaders/static_langos-8                      	      81	  14409938 ns/op	44108067 B/op	     264 allocs/op
+// BenchmarkDelayedReaders/static_buffered_langos-8             	      93	  12466593 ns/op	44405518 B/op	     270 allocs/op
+// BenchmarkDelayedReaders/random_direct-8                      	      12	  92957186 ns/op	33552464 B/op	      17 allocs/op
+// BenchmarkDelayedReaders/random_buffered-8                    	      18	  58062327 ns/op	33683683 B/op	      20 allocs/op
+// BenchmarkDelayedReaders/random_langos-8                      	     100	  15663876 ns/op	44098568 B/op	     262 allocs/op
+// BenchmarkDelayedReaders/random_buffered_langos-8             	      66	  16711523 ns/op	44407221 B/op	     269 allocs/op
+func BenchmarkDelayedReaders(b *testing.B) {
+	dataSize := 10 * 1024 * 1024
+	bufferSize := 4 * 32 * 1024
+
+	data := randomData(b, dataSize)
+
+	for _, bc := range []struct {
+		name      string
+		newReader func() langos.Reader
+	}{
+		{
+			name: "static direct",
+			newReader: func() langos.Reader {
+				return newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays)
+			},
+		},
+		{
+			name: "static buffered",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedReadSeeker(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "static langos",
+			newReader: func() langos.Reader {
+				return langos.NewLangos(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "static buffered langos",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedLangos(newDelayedReaderStatic(bytes.NewReader(data), defaultStaticDelays), bufferSize)
+			},
+		},
+		{
+			name: "random direct",
+			newReader: func() langos.Reader {
+				return newDelayedReader(bytes.NewReader(data), randomDelaysFunc)
+			},
+		},
+		{
+			name: "random buffered",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedReadSeeker(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+		{
+			name: "random langos",
+			newReader: func() langos.Reader {
+				return langos.NewLangos(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+		{
+			name: "random buffered langos",
+			newReader: func() langos.Reader {
+				return langos.NewBufferedLangos(newDelayedReader(bytes.NewReader(data), randomDelaysFunc), bufferSize)
+			},
+		},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			b.StopTimer()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				got, err := ioutil.ReadAll(bc.newReader())
+				b.StopTimer()
+
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !bytes.Equal(got, data) {
+					b.Fatalf("got invalid data (lengths: got %v, want %v)", len(got), len(data))
+				}
+			}
+		})
+	}
+}
+
+type delayedReaderFunc func(i int) (delay time.Duration)
+
+type delayedReader struct {
+	langos.Reader
+	f delayedReaderFunc
+	i int
+}
+
+func newDelayedReader(r langos.Reader, f delayedReaderFunc) *delayedReader {
+	return &delayedReader{
+		Reader: r,
+		f:      f,
+	}
+}
+
+func newDelayedReaderStatic(r langos.Reader, delays []time.Duration) *delayedReader {
+	l := len(delays)
+	return &delayedReader{
+		Reader: r,
+		f: func(i int) (delay time.Duration) {
+			return delays[i%l]
+		},
+	}
+}
+
+func (d *delayedReader) Read(p []byte) (n int, err error) {
+	time.Sleep(d.f(d.i))
+	d.i++
+	return d.Reader.Read(p)
+}
+
+var (
+	defaultStaticDelays = []time.Duration{
+		2 * time.Millisecond,
+		0, 0, 0,
+		5 * time.Millisecond,
+		0, 0,
+		10 * time.Millisecond,
+		0, 0,
+	}
+	randomDelaysFunc = func(_ int) (delay time.Duration) {
+		// max delay 10ms
+		return time.Duration(rand.Intn(10 * int(time.Millisecond)))
+	}
+)
+
+// randomDataCache keeps random data in memory between tests
+// to avoid regenerating random data for every test or subtest.
+var randomDataCache []byte
+
+// randomData returns a byte slice with random data.
+// This function is not safe for concurrent use.
+func randomData(t testing.TB, size int) []byte {
+	t.Helper()
+
+	if cacheSize := len(randomDataCache); cacheSize < size {
+		data := make([]byte, size-cacheSize)
+		_, err := rand.Read(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		randomDataCache = append(randomDataCache, data...)
+	}
+
+	return randomDataCache[:size]
+}
+
+var (
+	testDataSizes   = []string{"100", "749", "1k", "128k", "749k", "1M", "10M"}
+	testBufferSizes = []string{"1k", "128k", "753k", "1M", "10M", "25M"}
+)
+
+// multiSizeTester performs a series of subtests with different data and buffer sizes.
+func multiSizeTester(t *testing.T, newTestFunc func(t *testing.T, dataSize, bufferSize int)) {
+	t.Helper()
+
+	for _, dataSize := range testDataSizes {
+		for _, bufferSize := range testBufferSizes {
+			t.Run(fmt.Sprintf("data %s buffer %s", dataSize, bufferSize), func(t *testing.T) {
+				newTestFunc(t, parseDataSize(t, dataSize), parseDataSize(t, bufferSize))
+			})
+		}
+	}
+}

--- a/pkg/langos/readseeker_test.go
+++ b/pkg/langos/readseeker_test.go
@@ -1,0 +1,139 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package langos_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/langos"
+)
+
+// TestBufferedReadSeeker runs a series of reads and seeks on
+// BufferedReadSeeker instances with various buffer sizes.
+func TestBufferedReadSeeker(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+		newReadSeekerTester(langos.NewBufferedReadSeeker(bytes.NewReader(data), bufferSize), data)(t)
+	})
+}
+
+// TestLangosReadSeeker runs a series of reads and seeks on
+// Langos instances with various buffer sizes.
+func TestLangosReadSeeker(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+		newReadSeekerTester(langos.NewLangos(bytes.NewReader(data), bufferSize), data)(t)
+	})
+}
+
+// TestBufferedLangosReadSeeker runs a series of reads and seeks on
+// buffered Langos instances with various buffer sizes.
+func TestBufferedLangosReadSeeker(t *testing.T) {
+	multiSizeTester(t, func(t *testing.T, dataSize, bufferSize int) {
+		data := randomData(t, dataSize)
+		newReadSeekerTester(langos.NewBufferedLangos(bytes.NewReader(data), bufferSize), data)(t)
+	})
+}
+
+// TestReadSeekerTester tests newReadSeekerTester steps against the stdlib's
+// bytes.Reader which is used as the reference implementation.
+func TestReadSeekerTester(t *testing.T) {
+	for _, size := range testDataSizes {
+		data := randomData(t, parseDataSize(t, size))
+		t.Run(size, newReadSeekerTester(bytes.NewReader(data), data))
+	}
+}
+
+// newReadSeekerTester returns a new test function that performs a series of
+// Read and Seek method calls to validate that provided io.ReadSeeker
+// provide the expected functionality while reading data and seeking on it.
+// Argument data must be the same as used in io.ReadSeeker as it is used
+// in validations.
+func newReadSeekerTester(rs io.ReadSeeker, data []byte) func(t *testing.T) {
+	return func(t *testing.T) {
+		read := func(t *testing.T, size int, want []byte, wantErr error) {
+			t.Helper()
+
+			b := make([]byte, size)
+			for count := 0; count < len(want); {
+				n, err := rs.Read(b[count:])
+				if err != wantErr {
+					t.Fatalf("got error %v, want %v", err, wantErr)
+				}
+				count += n
+			}
+			if !bytes.Equal(b, want) {
+				t.Fatal("invalid read data")
+			}
+		}
+
+		seek := func(t *testing.T, offset, whence, wantPosition int, wantErr error) {
+			t.Helper()
+
+			n, err := rs.Seek(int64(offset), whence)
+			if err != wantErr {
+				t.Fatalf("got error %v, want %v", err, wantErr)
+			}
+			if n != int64(wantPosition) {
+				t.Fatalf("got position %v, want %v", n, wantPosition)
+			}
+		}
+
+		l := len(data)
+
+		// Test sequential reads
+		readSize1 := l / 5
+		read(t, readSize1, data[:readSize1], nil)
+		readSize2 := l / 6
+		read(t, readSize2, data[readSize1:readSize1+readSize2], nil)
+		readSize3 := l / 4
+		read(t, readSize3, data[readSize1+readSize2:readSize1+readSize2+readSize3], nil)
+
+		// Test seek and read
+		seekSize1 := l / 4
+		seek(t, seekSize1, io.SeekStart, seekSize1, nil)
+		readSize1 = l / 5
+		read(t, readSize1, data[seekSize1:seekSize1+readSize1], nil)
+		readSize2 = l / 10
+		read(t, readSize2, data[seekSize1+readSize1:seekSize1+readSize1+readSize2], nil)
+
+		// Test get size and read from start
+		seek(t, 0, io.SeekEnd, l, nil)
+		seek(t, 0, io.SeekStart, 0, nil)
+		readSize1 = l / 6
+		read(t, readSize1, data[:readSize1], nil)
+
+		// Test read end
+		seek(t, 0, io.SeekEnd, l, nil)
+		read(t, 0, nil, io.EOF)
+
+		// Test read near end
+		seekOffset := 1 / 10
+		seek(t, seekOffset, io.SeekEnd, l-seekOffset, nil)
+		read(t, seekOffset, data[l-seekOffset:], io.EOF)
+
+		// Test seek from current with reads
+		seek(t, 0, io.SeekStart, 0, nil)
+		seekSize1 = l / 3
+		seek(t, seekSize1, io.SeekCurrent, seekSize1, nil)
+		readSize1 = l / 8
+		read(t, readSize1, data[seekSize1:seekSize1+readSize1], nil)
+
+	}
+}


### PR DESCRIPTION
WIP

This PR is an experiment to speedup file download by using lazy chunk reader from swarm and langos readahead buffer.

- lcr package is a copy of swarm/storage.LazyChunkReader with all instrumentation code commented out
- chunk retrievals starts to fail after the first buffer read with context deadline exceeded error, chunk addresses look very suspicious, as a pattern is obvious in them, probably adjustments to LazyChunkReader need to be done in respect to bee/pkg/file/splitter
- tests for LazyChunkReader are missing in respect to the chunks from bee/pkg/file/splitter
- langos is copied here as it is from swarm and can be moved to its own repo as it contains no code from other swarm packages