### PR TITLE
Handle zombie streams with fullclose - pingpong

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -212,8 +212,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	// handshake
 	s.host.SetStreamHandlerMatch(id, matcher, func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
-		handshakeStream := NewStream(stream)
-		i, err := s.handshakeService.Handle(handshakeStream, stream.Conn().RemoteMultiaddr(), peerID)
+		i, err := s.handshakeService.Handle(NewStream(stream), stream.Conn().RemoteMultiaddr(), peerID)
 		if err != nil {
 			s.logger.Debugf("handshake: handle %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
@@ -230,7 +229,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if err = handshakeStream.FullClose(); err != nil {
+		if err = helpers.FullClose(stream); err != nil { ; err != nil {
 			s.logger.Debugf("handshake: could not close stream %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
 			_ = s.disconnect(peerID)
@@ -373,8 +372,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return nil, fmt.Errorf("connect new stream: %w", err)
 	}
 
-	handshakeStream := NewStream(stream)
-	i, err := s.handshakeService.Handshake(handshakeStream, stream.Conn().RemoteMultiaddr(), stream.Conn().RemotePeer())
+	i, err := s.handshakeService.Handshake(NewStream(stream), stream.Conn().RemoteMultiaddr(), stream.Conn().RemotePeer())
 	if err != nil {
 		_ = s.disconnect(info.ID)
 		return nil, fmt.Errorf("handshake: %w", err)
@@ -389,7 +387,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return i.BzzAddress, nil
 	}
 
-	if err := handshakeStream.FullClose(); err != nil {
+	if err := helpers.FullClose(stream); err != nil {
 		_ = s.disconnect(info.ID)
 		return nil, fmt.Errorf("connect full close %w", err)
 	}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -212,7 +212,8 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	// handshake
 	s.host.SetStreamHandlerMatch(id, matcher, func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
-		i, err := s.handshakeService.Handle(NewStream(stream), stream.Conn().RemoteMultiaddr(), peerID)
+		handshakeStream := NewStream(stream)
+		i, err := s.handshakeService.Handle(handshakeStream, stream.Conn().RemoteMultiaddr(), peerID)
 		if err != nil {
 			s.logger.Debugf("handshake: handle %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
@@ -229,7 +230,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if err = helpers.FullClose(stream); err != nil {
+		if err = handshakeStream.FullClose(); err != nil {
 			s.logger.Debugf("handshake: could not close stream %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
 			_ = s.disconnect(peerID)
@@ -372,7 +373,8 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return nil, fmt.Errorf("connect new stream: %w", err)
 	}
 
-	i, err := s.handshakeService.Handshake(NewStream(stream), stream.Conn().RemoteMultiaddr(), stream.Conn().RemotePeer())
+	handshakeStream := NewStream(stream)
+	i, err := s.handshakeService.Handshake(handshakeStream, stream.Conn().RemoteMultiaddr(), stream.Conn().RemotePeer())
 	if err != nil {
 		_ = s.disconnect(info.ID)
 		return nil, fmt.Errorf("handshake: %w", err)
@@ -387,7 +389,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return i.BzzAddress, nil
 	}
 
-	if err := helpers.FullClose(stream); err != nil {
+	if err := handshakeStream.FullClose(); err != nil {
 		_ = s.disconnect(info.ID)
 		return nil, fmt.Errorf("connect full close %w", err)
 	}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -229,7 +229,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			return
 		}
 
-		if err = helpers.FullClose(stream); err != nil { ; err != nil {
+		if err = helpers.FullClose(stream); err != nil {
 			s.logger.Debugf("handshake: could not close stream %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
 			_ = s.disconnect(peerID)

--- a/pkg/pingpong/pingpong.go
+++ b/pkg/pingpong/pingpong.go
@@ -72,7 +72,9 @@ func (s *Service) Ping(ctx context.Context, address swarm.Address, msgs ...strin
 	if err != nil {
 		return 0, fmt.Errorf("new stream: %w", err)
 	}
-	defer stream.Close()
+	defer func() {
+		go stream.FullClose()
+	}()
 
 	w, r := protobuf.NewWriterAndReader(stream)
 
@@ -100,7 +102,7 @@ func (s *Service) Ping(ctx context.Context, address swarm.Address, msgs ...strin
 
 func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) error {
 	w, r := protobuf.NewWriterAndReader(stream)
-	defer stream.Close()
+	defer stream.FullClose()
 
 	span, logger, ctx := s.tracer.StartSpanFromContext(ctx, "pingpong-p2p-handler", s.logger)
 	defer span.Finish()


### PR DESCRIPTION
As @acud found, libp2p appears not to clean-up streams unless the stream is closed for both write and read: https://github.com/libp2p/go-libp2p/blob/master/NEWS.md. 

We are currently relying on `stream.Close()` to close one side of the stream, but don't check if the other side is closed, always. This can result in a half-closed stream in a case of an error. The quick fix is to use `FullClose` which will reset the stream on timeout, if other side did not close the stream.

This means that in order for stream to be cleaned up, one of the following must happen:
1. Stream must be closed by both sending and receiving side. There is no way to know this unless we wait for other side to close the stream,
2. If any error appears the stream should be reset, so it is closed for both writing and reading

In order to achieve this we should reset streams on errors, and this is already part of `helpers.FullClose()`.  Taking the example of https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/identify/id.go, we can do the following:
1. On the calling side, the one that creates the stream, we can call `FullClose` in a separate goroutine, possibly hanging until the timeout, and resseting the stream in a case of timeout or error. This is done in a separate goroutine in order to not the block the caller, because maybe we don't actually care if the stream was reset or closed.
2. On the handler side, there is not need for a separate gouroutine, as this is already a path that was initiated in the goroutine that initiates the handler

TODO:
This way we will reset the stream if the other side does not close the stream, but still we don't have a way to know that the error actually happened. The next step would be to introduce `stream.Reset()` on errors.