### PR TITLE
Stream reset initial implementation

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/mock/stream.go
+++ b/pkg/p2p/libp2p/internal/handshake/mock/stream.go
@@ -63,3 +63,7 @@ func (s *Stream) Close() error {
 func (s *Stream) FullClose() error {
 	return nil
 }
+
+func (s *Stream) Reset() error {
+	return nil
+}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -216,7 +216,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		if err != nil {
 			s.logger.Debugf("handshake: handle %s: %v", peerID, err)
 			s.logger.Errorf("unable to handshake with peer %v", peerID)
-			_ = stream.Reset()
+			_ = handshakeStream.Reset()
 			_ = s.disconnect(peerID)
 			return
 		}
@@ -376,7 +376,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 	handshakeStream := NewStream(stream)
 	i, err := s.handshakeService.Handshake(handshakeStream, stream.Conn().RemoteMultiaddr(), stream.Conn().RemotePeer())
 	if err != nil {
-		_ = stream.Reset()
+		_ = handshakeStream.Reset()
 		_ = s.disconnect(info.ID)
 		return nil, fmt.Errorf("handshake: %w", err)
 	}

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -35,6 +35,7 @@ type Stream interface {
 	io.Closer
 	Headers() Headers
 	FullClose() error
+	Reset() error
 }
 
 // ProtocolSpec defines a collection of Stream specifications with handlers.

--- a/pkg/p2p/protobuf/protobuf_test.go
+++ b/pkg/p2p/protobuf/protobuf_test.go
@@ -387,6 +387,10 @@ func (noopWriteCloser) FullClose() error {
 	return nil
 }
 
+func (noopWriteCloser) Reset() error {
+	return nil
+}
+
 type noopReadCloser struct {
 	io.Writer
 }
@@ -408,5 +412,9 @@ func (noopReadCloser) Close() error {
 }
 
 func (noopReadCloser) FullClose() error {
+	return nil
+}
+
+func (noopReadCloser) Reset() error {
 	return nil
 }

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -236,7 +236,7 @@ func (s *stream) FullClose() error {
 }
 
 func (s *stream) Reset() error {
-	//todo: :implement appropriatly after all protocols are migrated and tested
+	//todo: :implement appropriately after all protocols are migrated and tested
 	return s.Close()
 }
 

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -235,6 +235,11 @@ func (s *stream) FullClose() error {
 	return nil
 }
 
+func (s *stream) Reset() error {
+	//todo: :implement appropriatly after all protocols are migrated and tested
+	return s.Close()
+}
+
 type record struct {
 	b      []byte
 	c      int


### PR DESCRIPTION
This is a first PR in the set of PRs that will introduce usage of `stream.Reset()` into the protocols in order to:
1. Signalize errors between both sides of the stream instead of silencing them with `stream.Close()`
2. Not to timeout on `awaitEOF` in the case of an errors

Together with the usage of `FullClose` it should attempt to solve: https://github.com/ethersphere/bee/issues/403.

In order to have completely valid unit-test we would need to update `streamtest` to support `Reset` in a valid way. However, this would require us to change all the protocols at once. In order to avoid this, me and @janos have decided to dummy implement `Reset()` in `streamtest` for now, and test protocols behavior on the clusters. If everything goes well `streamtest` will be updated as well. 
