### PR TITLE
puller: extract maxpo and shallow bin peers

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -280,13 +280,13 @@ func NewBee(o Options) (*Bee, error) {
 		return nil, fmt.Errorf("pullsync protocol: %w", err)
 	}
 
-	pullerOpts := puller.NewOptions()
-	pullerOpts.StateStore = stateStore
-	pullerOpts.Topology = topologyDriver
-	pullerOpts.PullSync = pullSync
-	pullerOpts.Logger = logger
+	puller := puller.New(puller.Options{
+		StateStore: stateStore,
+		Topology:   topologyDriver,
+		PullSync:   pullSync,
+		Logger:     logger,
+	})
 
-	puller := puller.New(pullerOpts)
 	b.pullerCloser = puller
 
 	var apiService api.Service

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -280,12 +280,13 @@ func NewBee(o Options) (*Bee, error) {
 		return nil, fmt.Errorf("pullsync protocol: %w", err)
 	}
 
-	puller := puller.New(puller.Options{
-		StateStore: stateStore,
-		Topology:   topologyDriver,
-		PullSync:   pullSync,
-		Logger:     logger,
-	})
+	pullerOpts := puller.NewOptions()
+	pullerOpts.StateStore = stateStore
+	pullerOpts.Topology = topologyDriver
+	pullerOpts.PullSync = pullSync
+	pullerOpts.Logger = logger
+
+	puller := puller.New(pullerOpts)
 	b.pullerCloser = puller
 
 	var apiService api.Service

--- a/pkg/puller/export_test.go
+++ b/pkg/puller/export_test.go
@@ -2,7 +2,5 @@ package puller
 
 var (
 	PeerIntervalKey = peerIntervalKey
-	Bins            = &bins
-	ShallowBinPeers = &shallowBinPeers
 	IsSyncing       = isSyncing
 )

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -557,12 +557,13 @@ func newPuller(ops opts) (*puller.Puller, storage.StateStorer, *mockk.Mock, *moc
 	kad := mockk.NewMockKademlia(ops.kad...)
 	logger := logging.New(ioutil.Discard, 6)
 
-	o := puller.NewOptions()
-	o.Topology = kad
-	o.StateStore = s
-	o.PullSync = ps
-	o.Logger = logger
-	o.Bins = ops.bins
+	o := puller.Options{
+		Topology:   kad,
+		StateStore: s,
+		PullSync:   ps,
+		Logger:     logger,
+		Bins:       ops.bins,
+	}
 	if ops.shallowBinPeers != nil {
 		o.ShallowBinPeers = *ops.shallowBinPeers
 	}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -18,6 +18,7 @@ const (
 	ChunkSize         = SectionSize * Branches
 	HashSize          = 32
 	MaxPO       uint8 = 15
+	MaxBins           = MaxPO + 1
 )
 
 // Address represents an address in Swarm metric space of


### PR DESCRIPTION
extract the max bins from puller to be easily injected from tests.
tried to also refactor `kademlia` to use `swarm.MaxBins` but I'm getting tests to hang for some reason.

as part of #329 
