### PR TITLE
Check for validity before concluding retrieving chunk

### DIFF
--- a/pkg/content/mock/validator.go
+++ b/pkg/content/mock/validator.go
@@ -8,14 +8,14 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var _ swarm.ChunkValidator = (*Validator)(nil)
+var _ swarm.Validator = (*Validator)(nil)
 
 type Validator struct {
 	rv bool
 }
 
 // NewValidator constructs a new Validator
-func NewValidator(rv bool) swarm.ChunkValidator {
+func NewValidator(rv bool) swarm.Validator {
 	return &Validator{rv: rv}
 }
 

--- a/pkg/content/mock/validator.go
+++ b/pkg/content/mock/validator.go
@@ -10,7 +10,6 @@ import (
 
 var _ swarm.ChunkValidator = (*Validator)(nil)
 
-//
 type Validator struct {
 	rv bool
 }

--- a/pkg/content/mock/validator.go
+++ b/pkg/content/mock/validator.go
@@ -10,17 +10,17 @@ import (
 
 var _ swarm.ChunkValidator = (*Validator)(nil)
 
-// ContentAddressValidator validates that the address of a given chunk
-// is the content address of its contents.
+//
 type Validator struct {
+	rv bool
 }
 
-// NewContentAddressValidator constructs a new ContentAddressValidator
-func NewValidator() swarm.ChunkValidator {
-	return &Validator{}
+// NewValidator constructs a new Validator
+func NewValidator(rv bool) swarm.ChunkValidator {
+	return &Validator{rv: rv}
 }
 
-// Validate performs the validation check.
+// Validate returns rv from mock struct
 func (v *Validator) Validate(ch swarm.Chunk) (valid bool) {
-	return true
+	return v.rv
 }

--- a/pkg/content/mock/validator.go
+++ b/pkg/content/mock/validator.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var _ swarm.ChunkValidator = (*Validator)(nil)
+
+// ContentAddressValidator validates that the address of a given chunk
+// is the content address of its contents.
+type Validator struct {
+}
+
+// NewContentAddressValidator constructs a new ContentAddressValidator
+func NewValidator() swarm.ChunkValidator {
+	return &Validator{}
+}
+
+// Validate performs the validation check.
+func (v *Validator) Validate(ch swarm.Chunk) (valid bool) {
+	return true
+}

--- a/pkg/content/validator.go
+++ b/pkg/content/validator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var _ swarm.ChunkValidator = (*Validator)(nil)
+var _ swarm.Validator = (*Validator)(nil)
 
 // ContentAddressValidator validates that the address of a given chunk
 // is the content address of its contents.
@@ -16,7 +16,7 @@ type Validator struct {
 }
 
 // NewContentAddressValidator constructs a new ContentAddressValidator
-func NewValidator() swarm.ChunkValidator {
+func NewValidator() swarm.Validator {
 	return &Validator{}
 }
 

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -40,11 +40,6 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 				return nil, fmt.Errorf("netstore retrieve chunk: %w", err)
 			}
 
-			if !s.valid(ch) {
-				// invalid retrieve handling
-				return nil, storage.ErrInvalidChunk
-			}
-
 			_, err = s.Storer.Put(ctx, storage.ModePutRequest, ch)
 			if err != nil {
 				return nil, fmt.Errorf("netstore retrieve put: %w", err)

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -35,13 +35,13 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			// request from network
-			data, err := s.retrieval.RetrieveChunk(ctx, addr)
+			ch, err := s.retrieval.RetrieveChunk(ctx, addr, s.valid)
 			if err != nil {
 				return nil, fmt.Errorf("netstore retrieve chunk: %w", err)
 			}
 
-			ch = swarm.NewChunk(addr, data)
 			if !s.valid(ch) {
+				// invalid retrieve handling
 				return nil, storage.ErrInvalidChunk
 			}
 

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -19,11 +19,11 @@ type store struct {
 	storage.Storer
 	retrieval retrieval.Interface
 	logger    logging.Logger
-	validator swarm.ChunkValidator
+	validator swarm.Validator
 }
 
 // New returns a new NetStore that wraps a given Storer.
-func New(s storage.Storer, r retrieval.Interface, logger logging.Logger, validator swarm.ChunkValidator) storage.Storer {
+func New(s storage.Storer, r retrieval.Interface, logger logging.Logger, validator swarm.Validator) storage.Storer {
 	return &store{Storer: s, retrieval: r, logger: logger, validator: validator}
 }
 

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -111,9 +111,10 @@ type retrievalMock struct {
 	addr      swarm.Address
 }
 
-func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address) (data []byte, err error) {
+func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error){
 	r.called = true
 	atomic.AddInt32(&r.callCount, 1)
 	r.addr = addr
-	return chunkData, nil
+	chunk = swarm.NewChunk(addr, chunkData)
+	return chunk, nil
 }

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -101,7 +101,7 @@ func newRetrievingNetstore() (ret *retrievalMock, mockStore, ns storage.Storer) 
 	retrieve := &retrievalMock{}
 	store := mock.NewStorer()
 	logger := logging.New(ioutil.Discard, 0)
-	validator := swarm.NewChunkValidators(validatormock.NewValidator())
+	validator := swarm.NewChunkValidators(validatormock.NewValidator(true))
 	nstore := netstore.New(store, retrieve, logger, validator)
 
 	return retrieve, store, nstore

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	validatormock "github.com/ethersphere/bee/pkg/content/mock"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/netstore"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -100,7 +101,8 @@ func newRetrievingNetstore() (ret *retrievalMock, mockStore, ns storage.Storer) 
 	retrieve := &retrievalMock{}
 	store := mock.NewStorer()
 	logger := logging.New(ioutil.Discard, 0)
-	nstore := netstore.New(store, retrieve, logger, mockValidator{})
+	validator := swarm.NewChunkValidators(validatormock.NewValidator())
+	nstore := netstore.New(store, retrieve, logger, validator)
 
 	return retrieve, store, nstore
 }
@@ -111,7 +113,7 @@ type retrievalMock struct {
 	addr      swarm.Address
 }
 
-func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error) {
+func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk swarm.Chunk, err error) {
 	r.called = true
 	atomic.AddInt32(&r.callCount, 1)
 	r.addr = addr

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -101,7 +101,7 @@ func newRetrievingNetstore() (ret *retrievalMock, mockStore, ns storage.Storer) 
 	retrieve := &retrievalMock{}
 	store := mock.NewStorer()
 	logger := logging.New(ioutil.Discard, 0)
-	validator := swarm.NewChunkValidators(validatormock.NewValidator(true))
+	validator := swarm.NewChunkValidator(validatormock.NewValidator(true))
 	nstore := netstore.New(store, retrieve, logger, validator)
 
 	return retrieve, store, nstore
@@ -117,6 +117,5 @@ func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address) (
 	r.called = true
 	atomic.AddInt32(&r.callCount, 1)
 	r.addr = addr
-	chunk = swarm.NewChunk(addr, chunkData)
-	return chunk, nil
+	return swarm.NewChunk(addr, chunkData), nil
 }

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -111,7 +111,7 @@ type retrievalMock struct {
 	addr      swarm.Address
 }
 
-func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error){
+func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error) {
 	r.called = true
 	atomic.AddInt32(&r.callCount, 1)
 	r.addr = addr

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -242,7 +242,7 @@ func NewBee(o Options) (*Bee, error) {
 		DisconnectThreshold: o.DisconnectThreshold,
 	})
 
-	chunkvalidators := swarm.NewChunkValidators(soc.NewValidator(), content.NewValidator())
+	chunkvalidators := swarm.NewChunkValidator(soc.NewValidator(), content.NewValidator())
 
 	retrieve := retrieval.New(retrieval.Options{
 		Streamer:    p2ps,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
 	mockinmem "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/tracing"
 	ma "github.com/multiformats/go-multiaddr"
@@ -241,12 +242,15 @@ func NewBee(o Options) (*Bee, error) {
 		DisconnectThreshold: o.DisconnectThreshold,
 	})
 
+	chunkvalidators := swarm.NewChunkValidators(soc.NewValidator(), content.NewValidator())
+
 	retrieve := retrieval.New(retrieval.Options{
 		Streamer:    p2ps,
 		ChunkPeerer: topologyDriver,
 		Logger:      logger,
 		Accounting:  acc,
 		Pricer:      accounting.NewFixedPricer(address, 10),
+		Validator:   chunkvalidators,
 	})
 	tagg := tags.NewTags()
 
@@ -254,7 +258,7 @@ func NewBee(o Options) (*Bee, error) {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}
 
-	ns := netstore.New(storer, retrieve, logger, content.NewValidator(), soc.NewValidator())
+	ns := netstore.New(storer, retrieve, logger, chunkvalidators)
 
 	retrieve.SetStorer(ns)
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -100,7 +100,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, valid f
 				continue
 			}
 			s.logger.Tracef("retrieval: got chunk %s from peer %s", addr, peer)
-			//
 			chunk := swarm.NewChunk(addr, data)
 			if valid(chunk) {
 				return chunk, nil
@@ -127,7 +126,6 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	defer cancel()
 
 	peer, err = s.closestPeer(addr, skipPeers)
-
 	if err != nil {
 		return nil, peer, fmt.Errorf("get closest: %w", err)
 	}

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -144,9 +144,6 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	s.logger.Tracef("retrieval: requesting chunk %s from peer %s", addr, peer)
 	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
-		if stream != nil {
-			s.logger.Debugf("##1 Retrieve Chunk stream unexpectedly still open")
-		}
 		return nil, peer, fmt.Errorf("new stream: %w", err)
 	}
 	defer func() {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -171,13 +171,11 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	}
 
 	err = s.accounting.Credit(peer, chunkPrice)
-
 	if err != nil {
 		return nil, peer, err
 	}
 
 	return chunk, peer, err
-
 }
 
 func (s *Service) closestPeer(addr swarm.Address, skipPeers []swarm.Address) (swarm.Address, error) {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -31,7 +31,7 @@ const (
 var _ Interface = (*Service)(nil)
 
 type Interface interface {
-	RetrieveChunk(ctx context.Context, addr swarm.Address) (data []byte, err error)
+	RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error)
 }
 
 type Service struct {
@@ -82,7 +82,7 @@ const (
 	retrieveChunkTimeout = 10 * time.Second
 )
 
-func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (data []byte, err error) {
+func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, valid func(swarm.Chunk) bool) (chunk swarm.Chunk, err error) {
 	ctx, cancel := context.WithTimeout(ctx, maxPeers*retrieveChunkTimeout)
 	defer cancel()
 
@@ -90,7 +90,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (data [
 		var skipPeers []swarm.Address
 		for i := 0; i < maxPeers; i++ {
 			var peer swarm.Address
-			data, peer, err = s.retrieveChunk(ctx, addr, skipPeers)
+			data, peer, err := s.retrieveChunk(ctx, addr, skipPeers)
 			if err != nil {
 				if peer.IsZero() {
 					return nil, err
@@ -100,14 +100,19 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (data [
 				continue
 			}
 			s.logger.Tracef("retrieval: got chunk %s from peer %s", addr, peer)
-			return data, nil
+			//
+			chunk := swarm.NewChunk(addr, data)
+			if valid(chunk) {
+				return chunk, nil
+			}
 		}
 		return nil, err
 	})
 	if err != nil {
 		return nil, err
 	}
-	return v.([]byte), nil
+
+	return v.(swarm.Chunk), nil
 }
 
 func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPeers []swarm.Address) (data []byte, peer swarm.Address, err error) {
@@ -122,6 +127,8 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	defer cancel()
 
 	peer, err = s.closestPeer(addr, skipPeers)
+	// reserve ?? calculate ( peer_price(chunk), ) -> release : skip
+
 	if err != nil {
 		return nil, peer, fmt.Errorf("get closest: %w", err)
 	}
@@ -137,6 +144,9 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	s.logger.Tracef("retrieval: requesting chunk %s from peer %s", addr, peer)
 	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
+		if stream != nil {
+			s.logger.Debugf("##1 Retrieve Chunk stream unexpectedly still open")
+		}
 		return nil, peer, fmt.Errorf("new stream: %w", err)
 	}
 	defer func() {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -42,7 +42,7 @@ type Service struct {
 	logger        logging.Logger
 	accounting    accounting.Interface
 	pricer        accounting.Pricer
-	validator     swarm.ChunkValidator
+	validator     swarm.Validator
 }
 
 type Options struct {
@@ -52,7 +52,7 @@ type Options struct {
 	Logger      logging.Logger
 	Accounting  accounting.Interface
 	Pricer      accounting.Pricer
-	Validator   swarm.ChunkValidator
+	Validator   swarm.Validator
 }
 
 func New(o Options) *Service {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -127,7 +127,6 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	defer cancel()
 
 	peer, err = s.closestPeer(addr, skipPeers)
-	// reserve ?? calculate ( peer_price(chunk), ) -> release : skip
 
 	if err != nil {
 		return nil, peer, fmt.Errorf("get closest: %w", err)

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -32,7 +32,7 @@ var testTimeout = 5 * time.Second
 // TestDelivery tests that a naive request -> delivery flow works.
 func TestDelivery(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
-	mockValidator := swarm.NewChunkValidators(mock.NewValidator(true))
+	mockValidator := swarm.NewChunkValidator(mock.NewValidator(true))
 	mockStorer := storemock.NewStorer()
 	reqAddr, err := swarm.ParseHexAddress("00112233")
 	if err != nil {

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -151,4 +151,3 @@ func (s mockPeerSuggester) EachPeerRev(f topology.EachPeerFunc) error {
 }
 
 func FValidate(_ swarm.Chunk) bool { return true }
-

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
 	"github.com/ethersphere/bee/pkg/p2p/streamtest"
-
 	"github.com/ethersphere/bee/pkg/retrieval"
 	pb "github.com/ethersphere/bee/pkg/retrieval/pb"
 	"github.com/ethersphere/bee/pkg/storage"

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -83,11 +83,11 @@ func TestDelivery(t *testing.T) {
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
-	v, err := client.RetrieveChunk(ctx, reqAddr)
+	v, err := client.RetrieveChunk(ctx, reqAddr, FValidate)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(v, reqData) {
+	if !bytes.Equal(v.Data(), reqData) {
 		t.Fatalf("request and response data not equal. got %s want %s", v, reqData)
 	}
 	records, err := recorder.Records(peerID, "retrieval", "1.0.0", "retrieval")
@@ -149,3 +149,6 @@ func (s mockPeerSuggester) EachPeer(topology.EachPeerFunc) error {
 func (s mockPeerSuggester) EachPeerRev(f topology.EachPeerFunc) error {
 	return s.eachPeerRevFunc(f)
 }
+
+func FValidate(_ swarm.Chunk) bool { return true }
+

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -32,7 +32,7 @@ var testTimeout = 5 * time.Second
 // TestDelivery tests that a naive request -> delivery flow works.
 func TestDelivery(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
-	mockValidator := swarm.NewChunkValidators(mock.NewValidator())
+	mockValidator := swarm.NewChunkValidators(mock.NewValidator(true))
 	mockStorer := storemock.NewStorer()
 	reqAddr, err := swarm.ParseHexAddress("00112233")
 	if err != nil {

--- a/pkg/soc/validator.go
+++ b/pkg/soc/validator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var _ swarm.ChunkValidator = (*Validator)(nil)
+var _ swarm.Validator = (*Validator)(nil)
 
 // SocVaildator validates that the address of a given chunk
 // is a single-owner chunk.
@@ -15,7 +15,7 @@ type Validator struct {
 }
 
 // NewSocValidator creates a new SocValidator.
-func NewValidator() swarm.ChunkValidator {
+func NewValidator() swarm.Validator {
 	return &Validator{}
 }
 

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -25,7 +25,7 @@ type MockStorer struct {
 	pinSetMu        sync.Mutex
 	subpull         []storage.Descriptor
 	partialInterval bool
-	validator       swarm.ChunkValidator
+	validator       swarm.Validator
 	tags            *tags.Tags
 	morePull        chan struct{}
 	mtx             sync.Mutex
@@ -63,7 +63,7 @@ func NewStorer(opts ...Option) *MockStorer {
 	return s
 }
 
-func NewValidatingStorer(v swarm.ChunkValidator, tags *tags.Tags) *MockStorer {
+func NewValidatingStorer(v swarm.Validator, tags *tags.Tags) *MockStorer {
 	return &MockStorer{
 		store:     make(map[string][]byte),
 		modeSet:   make(map[string]storage.ModeSet),

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -182,22 +182,22 @@ func (c *chunk) WithType(t Type) Chunk {
 	return c
 }
 
-type ChunkValidator interface {
+type Validator interface {
 	Validate(ch Chunk) (valid bool)
 }
 
-type chunkValidators struct {
-	set []ChunkValidator
-	ChunkValidator
+type chunkValidator struct {
+	set []Validator
+	Validator
 }
 
-func NewChunkValidators(v ...ChunkValidator) ChunkValidator {
-	return &chunkValidators{
+func NewChunkValidator(v ...Validator) Validator {
+	return &chunkValidator{
 		set: v,
 	}
 }
 
-func (c *chunkValidators) Validate(ch Chunk) bool {
+func (c *chunkValidator) Validate(ch Chunk) bool {
 	for _, v := range c.set {
 		if v.Validate(ch) {
 			return true

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -185,3 +185,24 @@ func (c *chunk) WithType(t Type) Chunk {
 type ChunkValidator interface {
 	Validate(ch Chunk) (valid bool)
 }
+
+type chunkValidators struct {
+	set []ChunkValidator
+	ChunkValidator
+}
+
+func NewChunkValidators(v ...ChunkValidator) ChunkValidator {
+	return &chunkValidators{
+		set: v,
+	}
+}
+
+func (c *chunkValidators) Validate(ch Chunk) bool {
+	for _, v := range c.set {
+		if v.Validate(ch) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
In order to account only for valid chunks that are returned by others (i.e. not paying for junk) we need to check for chunk validity before we would change the account balance of the serving peer. 
As we want to do the accounting in for example retrieval, this required us to do the check before the end of retrieval, while the preexisting code only checked after retrieve returned. 

This also brought our attention to another possible issue, that if we were to recieve garbage chunk, we would not retrieve from another peer, as the verification takes place after the peer queries, so then we would probably fail, even if the valid chunk would be available from the next tried peer.

So we created the chunk in retrieve, and passed a validation function as an argument to retrieve that can do the validation and already return the chunk. This might cause performance issues because of the frequent passing of validation functions. 