### PR TITLE
Trojan chunk support

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -56,14 +56,14 @@ func NewEthereumAddress(p ecdsa.PublicKey) ([]byte, error) {
 		return nil, errors.New("invalid public key")
 	}
 	pubBytes := elliptic.Marshal(btcec.S256(), p.X, p.Y)
-	pubHash, err := legacyKeccak256(pubBytes[1:])
+	pubHash, err := LegacyKeccak256(pubBytes[1:])
 	if err != nil {
 		return nil, err
 	}
 	return pubHash[12:], err
 }
 
-func legacyKeccak256(data []byte) ([]byte, error) {
+func LegacyKeccak256(data []byte) ([]byte, error) {
 	var err error
 	hasher := sha3.NewLegacyKeccak256()
 	_, err = hasher.Write(data)

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	ChunkWithLengthSize = swarm.ChunkSize + 8
+	ChunkWithSpanSize = swarm.ChunkSize + 8
 )
 
 // Joiner returns file data referenced by the given Swarm Address to the given io.Reader.

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -21,7 +21,7 @@ import (
 )
 
 // maximum amount of file tree levels this file hasher component can handle
-// (128 ^ (9 - 1)) * 4096 = 295147905179352825856 bytes
+// (128 ^ (9 - 1)) * 4096 = 295147905179352825856 bytesgit fetch origin
 const levelBufferLimit = 9
 
 // hashFunc is a hasher factory used by the bmt hasher
@@ -68,7 +68,7 @@ func NewSimpleSplitterJob(ctx context.Context, putter storage.Putter, spanLength
 		sumCounts:  make([]int, levelBufferLimit),
 		cursors:    make([]int, levelBufferLimit),
 		hasher:     bmtlegacy.New(p),
-		buffer:     make([]byte, file.ChunkWithLengthSize*levelBufferLimit*2), // double size as temp workaround for weak calculation of needed buffer space
+		buffer:     make([]byte, file.ChunkWithSpanSize*levelBufferLimit*2), // double size as temp workaround for weak calculation of needed buffer space
 		toEncrypt:  toEncrypt,
 		refSize:    refSize,
 	}

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -60,7 +60,7 @@ func NewSimpleSplitterJob(ctx context.Context, putter storage.Putter, spanLength
 		sumCounts:  make([]int, levelBufferLimit),
 		cursors:    make([]int, levelBufferLimit),
 		hasher:     bmtlegacy.New(p),
-		buffer:     make([]byte, file.ChunkWithLengthSize*levelBufferLimit*2), // double size as temp workaround for weak calculation of needed buffer space
+		buffer:     make([]byte, file.ChunkWithSpanSize*levelBufferLimit*2), // double size as temp workaround for weak calculation of needed buffer space
 	}
 }
 

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -385,11 +385,7 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		s, _, _, err := p.nextPeerInterval(peer, bin)
 		if err != nil {
 			p.logger.Debugf("histSyncWorker nextPeerInterval: %v", err)
-			// wait and retry? this is a local error
-			// maybe just quit the peer entirely.
-			// not sure how to do this
-			<-time.After(30 * time.Second)
-			continue
+			return
 		}
 		if s > cur {
 			if logMore {

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -15,16 +15,13 @@ import (
 )
 
 const (
-	SectionSize            = 32
-	Branches               = 128
-	ChunkSize              = SectionSize * Branches
-	HashSize               = 32
-	MaxPO            uint8 = 15
-	MaxBins                = MaxPO + 1
-	SpanSize               = 8
-	TrojanNonceSize        = 32
-	TrojanLengthSize       = 2
-	TrojanTopicSize        = 32
+	SectionSize       = 32
+	Branches          = 128
+	ChunkSize         = SectionSize * Branches
+	HashSize          = 32
+	MaxPO       uint8 = 15
+	MaxBins           = MaxPO + 1
+	SpanSize          = 8
 )
 
 var (

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -10,15 +10,24 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
-	SectionSize       = 32
-	Branches          = 128
-	ChunkSize         = SectionSize * Branches
-	HashSize          = 32
-	MaxPO       uint8 = 15
-	MaxBins           = MaxPO + 1
+	SectionSize            = 32
+	Branches               = 128
+	ChunkSize              = SectionSize * Branches
+	HashSize               = 32
+	MaxPO            uint8 = 15
+	MaxBins                = MaxPO + 1
+	SpanSize               = 8
+	TrojanNonceSize        = 32
+	TrojanLengthSize       = 2
+	TrojanTopicSize        = 32
+)
+
+var (
+	NewHasher = sha3.NewLegacyKeccak256
 )
 
 // Address represents an address in Swarm metric space of
@@ -119,7 +128,7 @@ type chunk struct {
 	sdata      []byte
 	pinCounter uint64
 	tagID      uint32
-	chunkType  Type
+	typ        Type
 }
 
 func NewChunk(addr Address, data []byte) Chunk {
@@ -164,11 +173,11 @@ func (c *chunk) Equal(cp Chunk) bool {
 }
 
 func (c *chunk) Type() Type {
-	return c.chunkType
+	return c.typ
 }
 
 func (c *chunk) WithType(t Type) Chunk {
-	c.chunkType = t
+	c.typ = t
 	return c
 }
 

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+
 	"golang.org/x/crypto/sha3"
 )
 

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -94,6 +94,14 @@ func (a Address) MarshalJSON() ([]byte, error) {
 // ZeroAddress is the address that has no value.
 var ZeroAddress = NewAddress(nil)
 
+// Type describes a kind of chunk, whether it is content-addressed or other
+type Type int
+
+const (
+	Unknown Type = iota
+	ContentAddressed
+)
+
 type Chunk interface {
 	Address() Address
 	Data() []byte
@@ -102,6 +110,8 @@ type Chunk interface {
 	TagID() uint32
 	WithTagID(t uint32) Chunk
 	Equal(Chunk) bool
+	Type() Type
+	WithType(t Type) Chunk
 }
 
 type chunk struct {
@@ -109,6 +119,7 @@ type chunk struct {
 	sdata      []byte
 	pinCounter uint64
 	tagID      uint32
+	chunkType  Type
 }
 
 func NewChunk(addr Address, data []byte) Chunk {
@@ -150,6 +161,15 @@ func (c *chunk) String() string {
 
 func (c *chunk) Equal(cp Chunk) bool {
 	return c.Address().Equal(cp.Address()) && bytes.Equal(c.Data(), cp.Data())
+}
+
+func (c *chunk) Type() Type {
+	return c.chunkType
+}
+
+func (c *chunk) WithType(t Type) Chunk {
+	c.chunkType = t
+	return c
 }
 
 type ChunkValidator interface {

--- a/pkg/trojan/error.go
+++ b/pkg/trojan/error.go
@@ -1,0 +1,23 @@
+package trojan
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrPayloadTooBig is returned when a given payload for a Message type is longer than the maximum amount allowed
+	ErrPayloadTooBig = fmt.Errorf("message payload size cannot be greater than %d bytes", MaxPayloadSize)
+
+	// ErrEmptyTargets is returned when the given target list for a trojan chunk is empty
+	ErrEmptyTargets = errors.New("target list cannot be empty")
+
+	// ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
+	ErrVarLenTargets = errors.New("target list cannot have targets of different length")
+
+	// ErrUnMarshallingTrojanMessage is returned when a trojan message could not be de-serialized
+	ErrUnMarshallingTrojanMessage = errors.New("trojan message unmarshall error")
+
+	// ErrMinerTimeout is returned when mining a new nonce takes more time than swarm.TrojanMinerTimeout seconds
+	ErrMinerTimeout = errors.New("miner timeout error")
+)

--- a/pkg/trojan/export_test.go
+++ b/pkg/trojan/export_test.go
@@ -1,8 +1,8 @@
 package trojan
 
 var (
-	Contains  = contains
-	HashBytes = hashBytes
-	PadBytes  = padBytesLeft
+	Contains    = contains
+	HashBytes   = hashBytes
+	PadBytes    = padBytesLeft
 	IsPotential = isPotential
 )

--- a/pkg/trojan/export_test.go
+++ b/pkg/trojan/export_test.go
@@ -4,4 +4,5 @@ var (
 	Contains  = contains
 	HashBytes = hashBytes
 	PadBytes  = padBytesLeft
+	IsPotential = isPotential
 )

--- a/pkg/trojan/export_test.go
+++ b/pkg/trojan/export_test.go
@@ -1,0 +1,7 @@
+package trojan
+
+var (
+	Contains  = contains
+	HashBytes = hashBytes
+	PadBytes  = padBytesLeft
+)

--- a/pkg/trojan/message.go
+++ b/pkg/trojan/message.go
@@ -8,8 +8,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -20,7 +18,8 @@ import (
 // Topic is an alias for a 32 byte fixed-size array which contains an encoding of a message topic
 type Topic [32]byte
 
-// Target is an alias for an address which can be mined to construct a trojan message
+// Target is an alias for an address which can be mined to construct a trojan message.
+// Target is like partial address which helps to send message to a particular PO.
 type Target []byte
 
 // Targets is an alias for a collection of targets
@@ -43,23 +42,6 @@ const (
 	LengthSize     = 2
 	TopicSize      = 32
 	MinerTimeout   = 2 // seconds
-)
-
-var (
-	// ErrPayloadTooBig is returned when a given payload for a Message type is longer than the maximum amount allowed
-	ErrPayloadTooBig = fmt.Errorf("message payload size cannot be greater than %d bytes", MaxPayloadSize)
-
-	// ErrEmptyTargets is returned when the given target list for a trojan chunk is empty
-	ErrEmptyTargets = errors.New("target list cannot be empty")
-
-	// ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
-	ErrVarLenTargets = errors.New("target list cannot have targets of different length")
-
-	// ErrUnMarshallingTrojanMessage is returned when a trojan message could not be de-serialized
-	ErrUnMarshallingTrojanMessage = errors.New("trojan message unmarshall error")
-
-	// ErrMinerTimeout is returned when mining a new nonce takes more time than swarm.TrojanMinerTimeout seconds
-	ErrMinerTimeout = errors.New("miner timeout error")
 )
 
 // NewTopic creates a new Topic variable with the given input string

--- a/pkg/trojan/message.go
+++ b/pkg/trojan/message.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	// ErrPayloadTooBig is returned when a given payload for a Message type is longer than the maximum amount allowed
-	ErrPayloadTooBig = errors.New(fmt.Sprintf("message payload size cannot be greater than %d bytes", MaxPayloadSize))
+	ErrPayloadTooBig = fmt.Errorf("message payload size cannot be greater than %d bytes", MaxPayloadSize)
 
 	// ErrEmptyTargets is returned when the given target list for a trojan chunk is empty
 	ErrEmptyTargets = errors.New("target list cannot be empty")

--- a/pkg/trojan/message.go
+++ b/pkg/trojan/message.go
@@ -1,0 +1,280 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package trojan
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+	"math/big"
+
+	"github.com/ethersphere/swarm/bmt"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// Topic is an alias for a 32 byte fixed-size array which contains an encoding of a message topic
+type Topic [32]byte
+
+// Target is an alias for an address which can be mined to construct a trojan message
+type Target []byte
+
+// Targets is an alias for a collection of targets
+type Targets []Target
+
+// Message represents a trojan message, which is a message that will be hidden within a chunk payload as part of its data
+type Message struct {
+	length  [2]byte // big-endian encoding of Message payload length
+	Topic   Topic
+	Payload []byte // contains the chunk address to be repaired
+	padding []byte
+}
+
+const (
+	// MaxPayloadSize is the maximum allowed payload size for the Message type, in bytes
+	MaxPayloadSize = 4030
+)
+
+var (
+	// ErrPayloadTooBig is returned when a given payload for a Message type is longer than the maximum amount allowed
+	ErrPayloadTooBig = fmt.Errorf("message payload size cannot be greater than %d bytes", MaxPayloadSize)
+
+	// ErrEmptyTargets is returned when the given target list for a trojan chunk is empty
+	ErrEmptyTargets = errors.New("target list cannot be empty")
+
+	// ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
+	ErrVarLenTargets = errors.New("target list cannot have targets of different length")
+
+	ErrInvalidHasher = errors.New("hasher pool not initialized")
+)
+
+// NewTopic creates a new Topic variable with the given input string
+// the input string is taken as a byte slice and hashed
+func NewTopic(topic string) Topic {
+	var tpc Topic
+	t, err := crypto.LegacyKeccak256([]byte(topic))
+	if err != nil {
+		return tpc
+	}
+	copy(tpc[:], t[:])
+	return tpc
+}
+
+func hashFunc() hash.Hash {
+	return sha3.NewLegacyKeccak256()
+}
+
+var hasher *bmt.Hasher
+
+// NewMessage creates a new Message variable with the given topic and payload
+// it finds a length and nonce for the message according to the given input and maximum payload size
+func NewMessage(topic Topic, payload []byte) (Message, error) {
+	if len(payload) > MaxPayloadSize {
+		return Message{}, ErrPayloadTooBig
+	}
+
+	// get length as array of 2 bytes
+	payloadSize := uint16(len(payload))
+	lengthBuf := make([]byte, 2)
+	binary.BigEndian.PutUint16(lengthBuf, payloadSize)
+
+	// set random bytes as padding
+	paddingLen := MaxPayloadSize - payloadSize
+	padding := make([]byte, paddingLen)
+	if _, err := rand.Read(padding); err != nil {
+		return Message{}, err
+	}
+
+	// create new Message var and set fields
+	m := new(Message)
+	copy(m.length[:], lengthBuf[:])
+	m.Topic = topic
+	m.Payload = payload
+	m.padding = padding
+
+	hashPool := bmt.NewTreePool(hashFunc, swarm.Branches, bmt.PoolSize)
+	hasher = bmt.New(hashPool)
+
+	return *m, nil
+}
+
+// Wrap creates a new trojan chunk for the given targets and Message
+// a trojan chunk is a content-addressed chunk made up of span, a nonce, and a payload which contains the Message
+// the chunk address will have one of the targets as its prefix and thus will be forwarded to the neighbourhood of the recipient overlay address the target is derived from
+func (m *Message) Wrap(targets Targets) (swarm.Chunk, error) {
+	if err := checkTargets(targets); err != nil {
+		return nil, err
+	}
+
+	span := make([]byte, 8)
+	// 4064 bytes for trojan message + 32 bytes for nonce = 4096 bytes as payload for resulting chunk
+	binary.LittleEndian.PutUint64(span, swarm.ChunkSize)
+
+	return m.toChunk(targets, span)
+}
+
+// Unwrap creates a new trojan message from the given chunk payload
+// this function assumes the chunk has been validated as a content-addressed chunk
+// it will return the resulting message if the unwrapping is successful, and an error otherwise
+func Unwrap(c swarm.Chunk) (*Message, error) {
+	d := c.Data()
+
+	// unmarshal chunk payload into message
+	m := new(Message)
+	// first 40 bytes are span + nonce
+	err := m.UnmarshalBinary(d[40:])
+
+	return m, err
+}
+
+// IsPotential returns true if the given chunk is a potential trojan
+func IsPotential(c swarm.Chunk) bool {
+	// chunk must be content-addressed to be trojan
+	if c.Type() != swarm.ContentAddressed {
+		return false
+	}
+
+	data := c.Data()
+	// check for minimum chunk data length
+	// span (8) + nonce (32) + length (2) + topic (32) = 74
+	if len(data) < 74 {
+		return false
+	}
+
+	// check for valid trojan message length in bytes #41 and #42
+	messageLen := int(binary.BigEndian.Uint16(data[40:42]))
+	return 74+messageLen <= len(data)
+}
+
+// checkTargets verifies that the list of given targets is non empty and with elements of matching size
+func checkTargets(targets Targets) error {
+	if len(targets) == 0 {
+		return ErrEmptyTargets
+	}
+	validLen := len(targets[0]) // take first element as allowed length
+	for i := 1; i < len(targets); i++ {
+		if len(targets[i]) != validLen {
+			return ErrVarLenTargets
+		}
+	}
+	return nil
+}
+
+// toChunk finds a nonce so that when the given trojan chunk fields are hashed, the result will fall in the neighbourhood of one of the given targets
+// this is done by iteratively enumerating different nonces until the BMT hash of the serialization of the trojan chunk fields results in a chunk address that has one of the targets as its prefix
+// the function returns a new chunk, with the found matching hash to be used as its address,
+// and its data set to the serialization of the trojan chunk fields which correctly hash into the matching address
+func (m *Message) toChunk(targets Targets, span []byte) (swarm.Chunk, error) {
+	// start out with random nonce
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	nonceInt := new(big.Int).SetBytes(nonce)
+	targetsLen := len(targets[0])
+
+	// serialize message
+	b, err := m.MarshalBinary() // TODO: this should be encrypted
+	if err != nil {
+		return nil, err
+	}
+
+	// hash chunk fields with different nonces until an acceptable one is found
+	// TODO: prevent infinite loop
+	for {
+		s := append(append(span, nonce...), b...) // serialize chunk fields
+		hash1, err := hashBytes(s)
+		if err != nil {
+			return nil, err
+		}
+
+		// take as much of the hash as the targets are long
+		if contains(targets, hash1[:targetsLen]) {
+			// if nonce found, stop loop and return chunk
+			return swarm.NewChunk(swarm.NewAddress(hash1), s), nil
+		}
+		// else, add 1 to nonce and try again
+		nonceInt.Add(nonceInt, big.NewInt(1))
+		// loop around in case of overflow
+		if nonceInt.BitLen() > 256 {
+			nonceInt = big.NewInt(0)
+		}
+		nonce = padBytes(nonceInt.Bytes()) // pad in case Bytes call is not 32 bytes long
+	}
+}
+
+// hashBytes hashes the given serialization of chunk fields with the hashing func
+func hashBytes(s []byte) ([]byte, error) {
+	if hasher == nil {
+		return nil, ErrInvalidHasher
+	}
+	hasher.Reset()
+	hasher.SetSpanBytes(s[:8])
+	if _, err := hasher.Write(s[8:]); err != nil {
+		return nil, err
+	}
+	return hasher.Sum(nil), nil
+}
+
+// contains returns whether the given collection contains the given elem
+func contains(col Targets, elem []byte) bool {
+	for i := range col {
+		if bytes.Equal(elem, col[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// padBytes adds 0s to the given byte slice as left padding,
+// returning this as a new byte slice with a length of exactly 32
+// given param is assumed to be at most 32 bytes long
+func padBytes(b []byte) []byte {
+	l := len(b)
+	if l == 32 {
+		return b
+	}
+	bb := make([]byte, 32)
+	copy(bb[32-l:], b)
+	return bb
+}
+
+// MarshalBinary serializes a message struct
+func (m *Message) MarshalBinary() (data []byte, err error) {
+	data = append(m.length[:], m.Topic[:]...)
+	data = append(data, m.Payload...)
+	data = append(data, m.padding...)
+	return data, nil
+}
+
+// UnmarshalBinary deserializes a message struct
+func (m *Message) UnmarshalBinary(data []byte) (err error) {
+	copy(m.length[:], data[:2])  // first 2 bytes are length
+	copy(m.Topic[:], data[2:34]) // following 32 bytes are topic
+
+	// rest of the bytes are payload and padding
+	length := binary.BigEndian.Uint16(m.length[:])
+	payloadEnd := 34 + length
+	m.Payload = data[34:payloadEnd]
+	m.padding = data[payloadEnd:]
+	return nil
+}

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -1,0 +1,248 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package trojan
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/big"
+	"reflect"
+	"testing"
+
+	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// arbitrary targets for tests
+var t1 = Target([]byte{57, 120})
+var t2 = Target([]byte{209, 156})
+var t3 = Target([]byte{156, 38})
+var t4 = Target([]byte{89, 19})
+var t5 = Target([]byte{22, 129})
+var testTargets = Targets([]Target{t1, t2, t3, t4, t5})
+
+// arbitrary topic for tests
+var testTopic = NewTopic("foo")
+
+// newTestMessage creates an arbitrary Message for tests
+func newTestMessage(t *testing.T) Message {
+	payload := []byte("foopayload")
+	m, err := NewMessage(testTopic, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return m
+}
+
+// TestNewMessage tests the correct and incorrect creation of a Message struct
+func TestNewMessage(t *testing.T) {
+	smallPayload := make([]byte, 32)
+	m, err := NewMessage(testTopic, smallPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify topic
+	if m.Topic != testTopic {
+		t.Fatalf("expected message topic to be %v but is %v instead", testTopic, m.Topic)
+	}
+
+	maxPayload := make([]byte, MaxPayloadSize)
+	if _, err := NewMessage(testTopic, maxPayload); err != nil {
+		t.Fatal(err)
+	}
+
+	// the creation should fail if the payload is too big
+	invalidPayload := make([]byte, MaxPayloadSize+1)
+	if _, err := NewMessage(testTopic, invalidPayload); err != ErrPayloadTooBig {
+		t.Fatalf("expected error when creating message of invalid payload size to be %q, but got %v", ErrPayloadTooBig, err)
+	}
+}
+
+// TestWrap tests the creation of a chunk from a list of targets
+// its address length and span should be correct
+// its resulting address should have a prefix which matches one of the given targets
+// its resulting data should have a hash that matches its address exactly
+func TestWrap(t *testing.T) {
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := c.Address()
+	addrLen := len(addr.Bytes())
+	if addrLen != swarm.HashSize {
+		t.Fatalf("chunk has an unexpected address length of %d rather than %d", addrLen, swarm.HashSize)
+	}
+
+	addrPrefix := addr.Bytes()[:len(testTargets[0])]
+	if !contains(testTargets, addrPrefix) {
+		t.Fatal("chunk address prefix does not match any of the targets")
+	}
+
+	data := c.Data()
+	dataSize := len(data)
+	expectedSize := 8 + swarm.ChunkSize // span + payload
+	if dataSize != expectedSize {
+		t.Fatalf("chunk data has an unexpected size of %d rather than %d", dataSize, expectedSize)
+	}
+
+	span := binary.LittleEndian.Uint64(data[:8])
+	remDataLen := len(data[8:])
+	if int(span) != remDataLen {
+		t.Fatalf("chunk span set to %d, but rest of chunk data is of size %d", span, remDataLen)
+	}
+
+	dataHash, err := hashBytes(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(addr.Bytes(), dataHash) {
+		t.Fatal("chunk address does not match its data hash")
+	}
+}
+
+// TestWrapFail tests that the creation of a chunk fails when given targets are invalid
+func TestWrapFail(t *testing.T) {
+	m := newTestMessage(t)
+
+	emptyTargets := Targets([]Target{})
+	if _, err := m.Wrap(emptyTargets); err != ErrEmptyTargets {
+		t.Fatalf("expected error when creating chunk for empty targets to be %q, but got %v", ErrEmptyTargets, err)
+	}
+
+	t1 := Target([]byte{34})
+	t2 := Target([]byte{25, 120})
+	t3 := Target([]byte{180, 18, 255})
+	varLenTargets := Targets([]Target{t1, t2, t3})
+	if _, err := m.Wrap(varLenTargets); err != ErrVarLenTargets {
+		t.Fatalf("expected error when creating chunk for variable-length targets to be %q, but got %v", ErrVarLenTargets, err)
+	}
+}
+
+// TestPadBytes tests that different types of byte slices are correctly padded with leading 0s
+// all slices are interpreted as big-endian
+func TestPadBytes(t *testing.T) {
+	s := make([]byte, 32)
+
+	// empty slice should be unchanged
+	p := padBytes(s)
+	if !bytes.Equal(p, s) {
+		t.Fatalf("expected byte padding to result in %x, but is %x", s, p)
+	}
+
+	// slice of length 3
+	s = []byte{255, 128, 64}
+	p = padBytes(s)
+	e := append(make([]byte, 29), s...) // 29 zeros plus the 3 original bytes
+	if !bytes.Equal(p, e) {
+		t.Fatalf("expected byte padding to result in %x, but is %x", e, p)
+	}
+
+	// simulate toChunk behavior
+	s = []byte{255, 255, 255}
+	i := new(big.Int).SetBytes(s) // byte slice to big.Int
+	i.Add(i, big.NewInt(1))       // add 1 to slice as big.Int
+	s = i.Bytes()                 // []byte{1, 0, 0, 0}
+
+	p = padBytes(s)
+	e = append(make([]byte, 28), s...) // 28 zeros plus the 4 original bytes
+	if !bytes.Equal(p, e) {
+		t.Fatalf("expected byte padding to result in %x, but is %x", e, p)
+	}
+}
+
+// TestUnwrap tests the correct unwrapping of a trojan chunk to obtain a message
+func TestUnwrap(t *testing.T) {
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	um, err := Unwrap(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(m, *um) {
+		t.Fatalf("original message does not match unwrapped one")
+	}
+}
+
+// TestIsPotential tests if chunks are correctly interpreted as potentially trojan
+func TestIsPotential(t *testing.T) {
+	c := chunktesting.GenerateTestRandomChunk()
+
+	// invalid type
+	c.WithType(swarm.Unknown)
+	if IsPotential(c) {
+		t.Fatal("non content-addressed chunk marked as potential trojan")
+	}
+
+	// valid type, but invalid trojan message length
+	c.WithType(swarm.ContentAddressed)
+	length := len(c.Data()) - 73 // go 1 byte over the maximum allowed
+	lengthBuf := make([]byte, 2)
+	binary.BigEndian.PutUint16(lengthBuf, uint16(length))
+	// put invalid length into bytes #41 and #42
+	copy(c.Data()[40:42], lengthBuf[:])
+	if IsPotential(c) {
+		t.Fatal("chunk with invalid trojan message length marked as potential trojan")
+	}
+
+	// valid type, but invalid chunk data length
+	data := make([]byte, 10)
+	c = swarm.NewChunk(swarm.ZeroAddress, data)
+	c.WithType(swarm.ContentAddressed)
+	if IsPotential(c) {
+		t.Fatal("chunk with invalid data length marked as potential trojan")
+	}
+
+	// valid potential trojan
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.WithType(swarm.ContentAddressed)
+	if !IsPotential(c) {
+		t.Fatal("valid test trojan chunk not marked as potential trojan")
+	}
+}
+
+// TestMessageSerialization tests that the Message type can be correctly serialized and deserialized
+func TestMessageSerialization(t *testing.T) {
+	m := newTestMessage(t)
+
+	sm, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dsm := new(Message)
+	err = dsm.UnmarshalBinary(sm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(m, *dsm) {
+		t.Fatalf("original message does not match deserialized one")
+	}
+}

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -1,20 +1,8 @@
-// Copyright 2020 The Swarm Authors
-// This file is part of the Swarm library.
-//
-// The Swarm library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The Swarm library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
-package trojan
+package trojan_test
 
 import (
 	"bytes"
@@ -25,23 +13,24 @@ import (
 
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/trojan"
 )
 
 // arbitrary targets for tests
-var t1 = Target([]byte{57, 120})
-var t2 = Target([]byte{209, 156})
-var t3 = Target([]byte{156, 38})
-var t4 = Target([]byte{89, 19})
-var t5 = Target([]byte{22, 129})
-var testTargets = Targets([]Target{t1, t2, t3, t4, t5})
+var t1 = trojan.Target([]byte{57, 120})
+var t2 = trojan.Target([]byte{209, 156})
+var t3 = trojan.Target([]byte{156, 38})
+var t4 = trojan.Target([]byte{89, 19})
+var t5 = trojan.Target([]byte{22, 129})
+var testTargets = trojan.Targets([]trojan.Target{t1, t2, t3, t4, t5})
 
 // arbitrary topic for tests
-var testTopic = NewTopic("foo")
+var testTopic = trojan.NewTopic("foo")
 
 // newTestMessage creates an arbitrary Message for tests
-func newTestMessage(t *testing.T) Message {
+func newTestMessage(t *testing.T) trojan.Message {
 	payload := []byte("foopayload")
-	m, err := NewMessage(testTopic, payload)
+	m, err := trojan.NewMessage(testTopic, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +41,7 @@ func newTestMessage(t *testing.T) Message {
 // TestNewMessage tests the correct and incorrect creation of a Message struct
 func TestNewMessage(t *testing.T) {
 	smallPayload := make([]byte, 32)
-	m, err := NewMessage(testTopic, smallPayload)
+	m, err := trojan.NewMessage(testTopic, smallPayload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,15 +51,15 @@ func TestNewMessage(t *testing.T) {
 		t.Fatalf("expected message topic to be %v but is %v instead", testTopic, m.Topic)
 	}
 
-	maxPayload := make([]byte, MaxPayloadSize)
-	if _, err := NewMessage(testTopic, maxPayload); err != nil {
+	maxPayload := make([]byte, trojan.MaxPayloadSize)
+	if _, err := trojan.NewMessage(testTopic, maxPayload); err != nil {
 		t.Fatal(err)
 	}
 
 	// the creation should fail if the payload is too big
-	invalidPayload := make([]byte, MaxPayloadSize+1)
-	if _, err := NewMessage(testTopic, invalidPayload); err != ErrPayloadTooBig {
-		t.Fatalf("expected error when creating message of invalid payload size to be %q, but got %v", ErrPayloadTooBig, err)
+	invalidPayload := make([]byte, trojan.MaxPayloadSize+1)
+	if _, err := trojan.NewMessage(testTopic, invalidPayload); err != trojan.ErrPayloadTooBig {
+		t.Fatalf("expected error when creating message of invalid payload size to be %q, but got %v", trojan.ErrPayloadTooBig, err)
 	}
 }
 
@@ -92,7 +81,7 @@ func TestWrap(t *testing.T) {
 	}
 
 	addrPrefix := addr.Bytes()[:len(testTargets[0])]
-	if !contains(testTargets, addrPrefix) {
+	if !trojan.Contains(testTargets, addrPrefix) {
 		t.Fatal("chunk address prefix does not match any of the targets")
 	}
 
@@ -109,7 +98,7 @@ func TestWrap(t *testing.T) {
 		t.Fatalf("chunk span set to %d, but rest of chunk data is of size %d", span, remDataLen)
 	}
 
-	dataHash, err := hashBytes(data)
+	dataHash, err := trojan.HashBytes(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,17 +111,17 @@ func TestWrap(t *testing.T) {
 func TestWrapFail(t *testing.T) {
 	m := newTestMessage(t)
 
-	emptyTargets := Targets([]Target{})
-	if _, err := m.Wrap(emptyTargets); err != ErrEmptyTargets {
-		t.Fatalf("expected error when creating chunk for empty targets to be %q, but got %v", ErrEmptyTargets, err)
+	emptyTargets := trojan.Targets([]trojan.Target{})
+	if _, err := m.Wrap(emptyTargets); err != trojan.ErrEmptyTargets {
+		t.Fatalf("expected error when creating chunk for empty targets to be %q, but got %v", trojan.ErrEmptyTargets, err)
 	}
 
-	t1 := Target([]byte{34})
-	t2 := Target([]byte{25, 120})
-	t3 := Target([]byte{180, 18, 255})
-	varLenTargets := Targets([]Target{t1, t2, t3})
-	if _, err := m.Wrap(varLenTargets); err != ErrVarLenTargets {
-		t.Fatalf("expected error when creating chunk for variable-length targets to be %q, but got %v", ErrVarLenTargets, err)
+	t1 := trojan.Target([]byte{34})
+	t2 := trojan.Target([]byte{25, 120})
+	t3 := trojan.Target([]byte{180, 18, 255})
+	varLenTargets := trojan.Targets([]trojan.Target{t1, t2, t3})
+	if _, err := m.Wrap(varLenTargets); err != trojan.ErrVarLenTargets {
+		t.Fatalf("expected error when creating chunk for variable-length targets to be %q, but got %v", trojan.ErrVarLenTargets, err)
 	}
 }
 
@@ -142,14 +131,14 @@ func TestPadBytes(t *testing.T) {
 	s := make([]byte, 32)
 
 	// empty slice should be unchanged
-	p := padBytes(s)
+	p := trojan.PadBytes(s)
 	if !bytes.Equal(p, s) {
 		t.Fatalf("expected byte padding to result in %x, but is %x", s, p)
 	}
 
 	// slice of length 3
 	s = []byte{255, 128, 64}
-	p = padBytes(s)
+	p = trojan.PadBytes(s)
 	e := append(make([]byte, 29), s...) // 29 zeros plus the 3 original bytes
 	if !bytes.Equal(p, e) {
 		t.Fatalf("expected byte padding to result in %x, but is %x", e, p)
@@ -161,7 +150,7 @@ func TestPadBytes(t *testing.T) {
 	i.Add(i, big.NewInt(1))       // add 1 to slice as big.Int
 	s = i.Bytes()                 // []byte{1, 0, 0, 0}
 
-	p = padBytes(s)
+	p = trojan.PadBytes(s)
 	e = append(make([]byte, 28), s...) // 28 zeros plus the 4 original bytes
 	if !bytes.Equal(p, e) {
 		t.Fatalf("expected byte padding to result in %x, but is %x", e, p)
@@ -176,7 +165,7 @@ func TestUnwrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	um, err := Unwrap(c)
+	um, err := trojan.Unwrap(c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +181,7 @@ func TestIsPotential(t *testing.T) {
 
 	// invalid type
 	c.WithType(swarm.Unknown)
-	if IsPotential(c) {
+	if trojan.IsPotential(c) {
 		t.Fatal("non content-addressed chunk marked as potential trojan")
 	}
 
@@ -203,7 +192,7 @@ func TestIsPotential(t *testing.T) {
 	binary.BigEndian.PutUint16(lengthBuf, uint16(length))
 	// put invalid length into bytes #41 and #42
 	copy(c.Data()[40:42], lengthBuf)
-	if IsPotential(c) {
+	if trojan.IsPotential(c) {
 		t.Fatal("chunk with invalid trojan message length marked as potential trojan")
 	}
 
@@ -211,7 +200,7 @@ func TestIsPotential(t *testing.T) {
 	data := make([]byte, 10)
 	c = swarm.NewChunk(swarm.ZeroAddress, data)
 	c.WithType(swarm.ContentAddressed)
-	if IsPotential(c) {
+	if trojan.IsPotential(c) {
 		t.Fatal("chunk with invalid data length marked as potential trojan")
 	}
 
@@ -222,7 +211,7 @@ func TestIsPotential(t *testing.T) {
 		t.Fatal(err)
 	}
 	c.WithType(swarm.ContentAddressed)
-	if !IsPotential(c) {
+	if !trojan.IsPotential(c) {
 		t.Fatal("valid test trojan chunk not marked as potential trojan")
 	}
 }
@@ -236,7 +225,7 @@ func TestMessageSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dsm := new(Message)
+	dsm := new(trojan.Message)
 	err = dsm.UnmarshalBinary(sm)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -7,10 +7,10 @@ package trojan_test
 import (
 	"bytes"
 	"encoding/binary"
-	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/file"
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/trojan"
@@ -87,15 +87,15 @@ func TestWrap(t *testing.T) {
 
 	data := c.Data()
 	dataSize := len(data)
-	expectedSize := 8 + swarm.ChunkSize // span + payload
+	expectedSize := file.ChunkWithSpanSize // span + payload
 	if dataSize != expectedSize {
 		t.Fatalf("chunk data has an unexpected size of %d rather than %d", dataSize, expectedSize)
 	}
 
 	span := binary.LittleEndian.Uint64(data[:8])
-	remDataLen := len(data[8:])
-	if int(span) != remDataLen {
-		t.Fatalf("chunk span set to %d, but rest of chunk data is of size %d", span, remDataLen)
+	remainingDataLen := len(data[8:])
+	if int(span) != remainingDataLen {
+		t.Fatalf("chunk span set to %d, but rest of chunk data is of size %d", span, remainingDataLen)
 	}
 
 	dataHash, err := trojan.HashBytes(data)
@@ -145,10 +145,7 @@ func TestPadBytes(t *testing.T) {
 	}
 
 	// simulate toChunk behavior
-	s = []byte{255, 255, 255}
-	i := new(big.Int).SetBytes(s) // byte slice to big.Int
-	i.Add(i, big.NewInt(1))       // add 1 to slice as big.Int
-	s = i.Bytes()                 // []byte{1, 0, 0, 0}
+	s = []byte{1, 0, 0, 0}
 
 	p = trojan.PadBytes(s)
 	e = append(make([]byte, 28), s...) // 28 zeros plus the 4 original bytes

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -202,7 +202,7 @@ func TestIsPotential(t *testing.T) {
 	lengthBuf := make([]byte, 2)
 	binary.BigEndian.PutUint16(lengthBuf, uint16(length))
 	// put invalid length into bytes #41 and #42
-	copy(c.Data()[40:42], lengthBuf[:])
+	copy(c.Data()[40:42], lengthBuf)
 	if IsPotential(c) {
 		t.Fatal("chunk with invalid trojan message length marked as potential trojan")
 	}


### PR DESCRIPTION
Implements the trojan structures as described in the Book of Swarm.

The purpose of deploying trojan messages is to message another node in obscurity; hence they are embedded into trojan chunks, which are indistinguishable from regular data chunks.

This is pulled from the old swarm code base and refitted for the bee

### Task-related for improvements
#445 Add unsealing and sealing
#444 optimize trojan chunk mining
#443 make trojan chunks work as a bit vector