### PR TITLE
add initial accounting for retrieval

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -26,25 +26,26 @@ import (
 func (c *command) initStartCmd() (err error) {
 
 	const (
-		optionNameDataDir            = "data-dir"
-		optionNameDBCapacity         = "db-capacity"
-		optionNamePassword           = "password"
-		optionNamePasswordFile       = "password-file"
-		optionNameAPIAddr            = "api-addr"
-		optionNameP2PAddr            = "p2p-addr"
-		optionNameNATAddr            = "nat-addr"
-		optionNameP2PWSEnable        = "p2p-ws-enable"
-		optionNameP2PQUICEnable      = "p2p-quic-enable"
-		optionNameDebugAPIEnable     = "debug-api-enable"
-		optionNameDebugAPIAddr       = "debug-api-addr"
-		optionNameBootnodes          = "bootnode"
-		optionNameNetworkID          = "network-id"
-		optionWelcomeMessage         = "welcome-message"
-		optionCORSAllowedOrigins     = "cors-allowed-origins"
-		optionNameTracingEnabled     = "tracing-enable"
-		optionNameTracingEndpoint    = "tracing-endpoint"
-		optionNameTracingServiceName = "tracing-service-name"
-		optionNameVerbosity          = "verbosity"
+		optionNameDataDir             = "data-dir"
+		optionNameDBCapacity          = "db-capacity"
+		optionNamePassword            = "password"
+		optionNamePasswordFile        = "password-file"
+		optionNameAPIAddr             = "api-addr"
+		optionNameP2PAddr             = "p2p-addr"
+		optionNameNATAddr             = "nat-addr"
+		optionNameP2PWSEnable         = "p2p-ws-enable"
+		optionNameP2PQUICEnable       = "p2p-quic-enable"
+		optionNameDebugAPIEnable      = "debug-api-enable"
+		optionNameDebugAPIAddr        = "debug-api-addr"
+		optionNameBootnodes           = "bootnode"
+		optionNameNetworkID           = "network-id"
+		optionWelcomeMessage          = "welcome-message"
+		optionCORSAllowedOrigins      = "cors-allowed-origins"
+		optionNameTracingEnabled      = "tracing-enable"
+		optionNameTracingEndpoint     = "tracing-endpoint"
+		optionNameTracingServiceName  = "tracing-service-name"
+		optionNameVerbosity           = "verbosity"
+		optionNameDisconnectThreshold = "disconnect-threshold"
 	)
 
 	cmd := &cobra.Command{
@@ -112,23 +113,24 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 			}
 
 			b, err := node.NewBee(node.Options{
-				DataDir:            c.config.GetString(optionNameDataDir),
-				DBCapacity:         c.config.GetUint64(optionNameDBCapacity),
-				Password:           password,
-				APIAddr:            c.config.GetString(optionNameAPIAddr),
-				DebugAPIAddr:       debugAPIAddr,
-				Addr:               c.config.GetString(optionNameP2PAddr),
-				NATAddr:            c.config.GetString(optionNameNATAddr),
-				EnableWS:           c.config.GetBool(optionNameP2PWSEnable),
-				EnableQUIC:         c.config.GetBool(optionNameP2PQUICEnable),
-				NetworkID:          c.config.GetUint64(optionNameNetworkID),
-				WelcomeMessage:     c.config.GetString(optionWelcomeMessage),
-				Bootnodes:          c.config.GetStringSlice(optionNameBootnodes),
-				CORSAllowedOrigins: c.config.GetStringSlice(optionCORSAllowedOrigins),
-				TracingEnabled:     c.config.GetBool(optionNameTracingEnabled),
-				TracingEndpoint:    c.config.GetString(optionNameTracingEndpoint),
-				TracingServiceName: c.config.GetString(optionNameTracingServiceName),
-				Logger:             logger,
+				DataDir:             c.config.GetString(optionNameDataDir),
+				DBCapacity:          c.config.GetUint64(optionNameDBCapacity),
+				Password:            password,
+				APIAddr:             c.config.GetString(optionNameAPIAddr),
+				DebugAPIAddr:        debugAPIAddr,
+				Addr:                c.config.GetString(optionNameP2PAddr),
+				NATAddr:             c.config.GetString(optionNameNATAddr),
+				EnableWS:            c.config.GetBool(optionNameP2PWSEnable),
+				EnableQUIC:          c.config.GetBool(optionNameP2PQUICEnable),
+				NetworkID:           c.config.GetUint64(optionNameNetworkID),
+				WelcomeMessage:      c.config.GetString(optionWelcomeMessage),
+				Bootnodes:           c.config.GetStringSlice(optionNameBootnodes),
+				CORSAllowedOrigins:  c.config.GetStringSlice(optionCORSAllowedOrigins),
+				TracingEnabled:      c.config.GetBool(optionNameTracingEnabled),
+				TracingEndpoint:     c.config.GetString(optionNameTracingEndpoint),
+				TracingServiceName:  c.config.GetString(optionNameTracingServiceName),
+				Logger:              logger,
+				DisconnectThreshold: c.config.GetUint64(optionNameDisconnectThreshold),
 			})
 			if err != nil {
 				return err
@@ -192,6 +194,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
 	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
 	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
+	cmd.Flags().Uint64(optionNameDisconnectThreshold, 100000000000, "debt threshold at which to disconnect from a peer")
 
 	c.root.AddCommand(cmd)
 	return nil

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -194,7 +194,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
 	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
 	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
-	cmd.Flags().Uint64(optionNameDisconnectThreshold, 100000000000, "threshold in BZZ until which you allows peers to be indebted before disconnecting")
+	cmd.Flags().Uint64(optionNameDisconnectThreshold, 100000000000, "threshold in BZZ until which you allow peers to be indebted before disconnecting")
 
 	c.root.AddCommand(cmd)
 	return nil

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -194,7 +194,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
 	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
 	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
-	cmd.Flags().Uint64(optionNameDisconnectThreshold, 100000000000, "debt threshold at which to disconnect from a peer")
+	cmd.Flags().Uint64(optionNameDisconnectThreshold, 100000000000, "threshold in BZZ until which you allows peers to be indebted before disconnecting")
 
 	c.root.AddCommand(cmd)
 	return nil

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -1,0 +1,128 @@
+package accounting
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var _ Interface = (*Accounting)(nil)
+
+// Interface is the main interface for Accounting
+type Interface interface {
+	// Reserve reserves a portion of the balance for peer
+	Reserve(peer swarm.Address, price uint64) error
+	// Release releases reserved funds
+	Release(peer swarm.Address, price uint64)
+	// Apply a balance change to the peers balance
+	Add(peer swarm.Address, price int64) error
+}
+
+type PeerBalance struct {
+	lock     sync.Mutex
+	balance  int64 // positive amount is the nodes debt with us
+	reserved uint64
+}
+
+type Options struct {
+	DisconnectThreshold uint64
+	PaymentThreshold    uint64
+	Logger              logging.Logger
+}
+
+type Accounting struct {
+	balancesMu sync.Mutex
+	balances   map[string]*PeerBalance
+	logger     logging.Logger
+
+	disconnectThreshold uint64
+	paymentThreshold    uint64
+}
+
+var (
+	DisconnectError   = errors.New("DisconnectError")
+	CannotAffordError = errors.New("CannotAffordError")
+)
+
+func NewAccounting(o Options) *Accounting {
+	return &Accounting{
+		balances: make(map[string]*PeerBalance),
+
+		paymentThreshold:    o.PaymentThreshold,
+		disconnectThreshold: o.DisconnectThreshold,
+		logger:              o.Logger,
+	}
+}
+
+func (a *Accounting) Reserve(peer swarm.Address, price uint64) error {
+	balance := a.getPeerBalance(peer)
+	balance.lock.Lock()
+	defer balance.lock.Unlock()
+
+	if balance.balance-int64(balance.reserved+price) < -int64(a.disconnectThreshold) {
+		return CannotAffordError
+	}
+
+	balance.reserved += price
+
+	return nil
+}
+
+func (a *Accounting) Release(peer swarm.Address, price uint64) {
+	balance := a.getPeerBalance(peer)
+	balance.lock.Lock()
+	defer balance.lock.Unlock()
+
+	if price > balance.reserved {
+		a.logger.Error("Releasing more balance than was reserved for peer")
+		balance.reserved = 0
+	} else {
+		balance.reserved -= price
+	}
+}
+
+func (a *Accounting) Add(peer swarm.Address, price int64) error {
+	balance := a.getPeerBalance(peer)
+	balance.lock.Lock()
+	defer balance.lock.Unlock()
+
+	if price > 0 {
+		// we gain balannce ith the peer
+		if balance.balance+price > int64(a.disconnectThreshold) {
+			// peer to much in debt
+			return DisconnectError
+		}
+	}
+
+	balance.balance += price
+	// TODO: save to state store
+
+	// TODO: try to initiate payment if payment threshold is reached
+	// if balance.balance < -int64(a.paymentThreshold) { }
+
+	return nil
+}
+
+func (a *Accounting) GetPeerBalance(peer swarm.Address) int64 {
+	return a.getPeerBalance(peer).balance
+}
+
+func (a *Accounting) getPeerBalance(peer swarm.Address) *PeerBalance {
+	a.balancesMu.Lock()
+	defer a.balancesMu.Unlock()
+
+	peerInfo, ok := a.balances[peer.String()]
+	if !ok {
+		// TODO: try loading from state store
+		peerInfo = &PeerBalance{
+			balance:  0,
+			reserved: 0,
+		}
+		a.balances[peer.String()] = peerInfo
+		return peerInfo
+	}
+
+	return peerInfo
+}

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -83,7 +83,7 @@ func (a *Accounting) Reserve(peer swarm.Address, price uint64) error {
 	// the previously reserved balance plus the new price is the maximum amount paid if all current operations are successful
 	// since we pay this we have to reduce this (positive quantity) from the balance
 	// the disconnectThreshold is stored as a positive value which is why it must be negated prior to comparison
-	if balance.balance-int64(balance.reserved+price) < -int64(a.disconnectThreshold) {
+	if balance.freeBalance()-int64(price) < -int64(a.disconnectThreshold) {
 		return fmt.Errorf("%w with peer %v", ErrOverdraft, peer)
 	}
 
@@ -214,4 +214,8 @@ func (a *Accounting) getPeerBalance(peer swarm.Address) (*PeerBalance, error) {
 	}
 
 	return peerBalance, nil
+}
+
+func (pb *PeerBalance) freeBalance() int64 {
+	return pb.balance - int64(pb.reserved)
 }

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -112,7 +112,7 @@ func (a *Accounting) Release(peer swarm.Address, price uint64) {
 	}
 }
 
-// Credit increases the balance the peer has with us
+// Credit increases the amount of credit we have with the given peer (and decreases existing debt).
 func (a *Accounting) Credit(peer swarm.Address, price uint64) error {
 	balance, err := a.getPeerBalance(peer)
 	if err != nil {
@@ -139,7 +139,7 @@ func (a *Accounting) Credit(peer swarm.Address, price uint64) error {
 	return nil
 }
 
-// Debit increases the balance we have with the peer
+// Debit increases the amount of debt we have with the given peer (and decreases existing credit)
 func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 	balance, err := a.getPeerBalance(peer)
 	if err != nil {

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -108,7 +108,7 @@ func (a *Accounting) Add(peer swarm.Address, price int64) error {
 
 	if price > 0 {
 		// we gain balannce ith the peer
-		if nextBalance > int64(a.disconnectThreshold) {
+		if nextBalance >= int64(a.disconnectThreshold) {
 			// peer to much in debt
 			return p2p.NewDisconnectError(fmt.Errorf("disconnect threshold exceeded for peer %s", peer.String()))
 		}

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -1,10 +1,12 @@
 package accounting
 
 import (
-	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -16,35 +18,32 @@ type Interface interface {
 	Reserve(peer swarm.Address, price uint64) error
 	// Release releases reserved funds
 	Release(peer swarm.Address, price uint64)
-	// Apply a balance change to the peers balance
+	// Add applies a balance change to the peers balance
 	Add(peer swarm.Address, price int64) error
 }
 
 type PeerBalance struct {
 	lock     sync.Mutex
-	balance  int64 // positive amount is the nodes debt with us
-	reserved uint64
+	balance  int64  // amount that the peer owes us if positive, our debt if negative
+	reserved uint64 // amount currently reserved for active peer interaction
 }
 
 type Options struct {
 	DisconnectThreshold uint64
 	PaymentThreshold    uint64
 	Logger              logging.Logger
+	Store               storage.StateStorer
 }
 
 type Accounting struct {
 	balancesMu sync.Mutex
 	balances   map[string]*PeerBalance
 	logger     logging.Logger
+	store      storage.StateStorer
 
 	disconnectThreshold uint64
 	paymentThreshold    uint64
 }
-
-var (
-	DisconnectError   = errors.New("DisconnectError")
-	CannotAffordError = errors.New("CannotAffordError")
-)
 
 func NewAccounting(o Options) *Accounting {
 	return &Accounting{
@@ -53,16 +52,22 @@ func NewAccounting(o Options) *Accounting {
 		paymentThreshold:    o.PaymentThreshold,
 		disconnectThreshold: o.DisconnectThreshold,
 		logger:              o.Logger,
+		store:               o.Store,
 	}
 }
 
+// Reserve reserves a portion of the balance for peer
 func (a *Accounting) Reserve(peer swarm.Address, price uint64) error {
-	balance := a.getPeerBalance(peer)
+	balance, err := a.getPeerBalance(peer)
+	if err != nil {
+		return err
+	}
+
 	balance.lock.Lock()
 	defer balance.lock.Unlock()
 
 	if balance.balance-int64(balance.reserved+price) < -int64(a.disconnectThreshold) {
-		return CannotAffordError
+		return fmt.Errorf("cannot afford operation with peer %v", peer.String())
 	}
 
 	balance.reserved += price
@@ -70,8 +75,14 @@ func (a *Accounting) Reserve(peer swarm.Address, price uint64) error {
 	return nil
 }
 
+// Release releases reserved funds
 func (a *Accounting) Release(peer swarm.Address, price uint64) {
-	balance := a.getPeerBalance(peer)
+	balance, err := a.getPeerBalance(peer)
+	if err != nil {
+		a.logger.Error("Releasing balance for peer that is not loaded")
+		return
+	}
+
 	balance.lock.Lock()
 	defer balance.lock.Unlock()
 
@@ -83,8 +94,13 @@ func (a *Accounting) Release(peer swarm.Address, price uint64) {
 	}
 }
 
+// Add applies a balance change to the peers balance
 func (a *Accounting) Add(peer swarm.Address, price int64) error {
-	balance := a.getPeerBalance(peer)
+	balance, err := a.getPeerBalance(peer)
+	if err != nil {
+		return err
+	}
+
 	balance.lock.Lock()
 	defer balance.lock.Unlock()
 
@@ -92,12 +108,16 @@ func (a *Accounting) Add(peer swarm.Address, price int64) error {
 		// we gain balannce ith the peer
 		if balance.balance+price > int64(a.disconnectThreshold) {
 			// peer to much in debt
-			return DisconnectError
+			return p2p.NewDisconnectError(fmt.Errorf("disconnect threshold exceeded for peer %s", peer.String()))
 		}
 	}
 
+	err = a.store.Put(a.balanceKey(peer), balance.balance+price)
+	if err != nil {
+		return err
+	}
+
 	balance.balance += price
-	// TODO: save to state store
 
 	// TODO: try to initiate payment if payment threshold is reached
 	// if balance.balance < -int64(a.paymentThreshold) { }
@@ -105,24 +125,44 @@ func (a *Accounting) Add(peer swarm.Address, price int64) error {
 	return nil
 }
 
-func (a *Accounting) GetPeerBalance(peer swarm.Address) int64 {
-	return a.getPeerBalance(peer).balance
+// Balance returns the current balance for the given peer
+func (a *Accounting) Balance(peer swarm.Address) (int64, error) {
+	peerBalance, err := a.getPeerBalance(peer)
+	if err != nil {
+		return 0, err
+	}
+	return peerBalance.balance, nil
 }
 
-func (a *Accounting) getPeerBalance(peer swarm.Address) *PeerBalance {
+func (a *Accounting) balanceKey(peer swarm.Address) string {
+	return fmt.Sprintf("balance_%s", peer.String())
+}
+
+func (a *Accounting) getPeerBalance(peer swarm.Address) (*PeerBalance, error) {
 	a.balancesMu.Lock()
 	defer a.balancesMu.Unlock()
 
 	peerInfo, ok := a.balances[peer.String()]
 	if !ok {
-		// TODO: try loading from state store
-		peerInfo = &PeerBalance{
-			balance:  0,
-			reserved: 0,
+		var balance int64
+		err := a.store.Get(a.balanceKey(peer), &balance)
+		if err == nil {
+			peerInfo = &PeerBalance{
+				balance:  balance,
+				reserved: 0,
+			}
+		} else if err == storage.ErrNotFound {
+			peerInfo = &PeerBalance{
+				balance:  0,
+				reserved: 0,
+			}
+		} else {
+			return nil, err
 		}
+
 		a.balances[peer.String()] = peerInfo
-		return peerInfo
+		return peerInfo, nil
 	}
 
-	return peerInfo
+	return peerInfo, nil
 }

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -20,7 +20,7 @@ var _ Interface = (*Accounting)(nil)
 type Interface interface {
 	// Reserve reserves a portion of the balance for peer
 	// It returns an error if the operation would risk exceeding the disconnect threshold
-	// This should be called (always in combination with release) before a Credit action
+	// This should be called (always in combination with Release) before a Credit action to prevent overspending in case of concurrent requests
 	Reserve(peer swarm.Address, price uint64) error
 	// Release releases reserved funds
 	Release(peer swarm.Address, price uint64)
@@ -91,7 +91,7 @@ func (a *Accounting) Reserve(peer swarm.Address, price uint64) error {
 func (a *Accounting) Release(peer swarm.Address, price uint64) {
 	balance, err := a.getPeerBalance(peer)
 	if err != nil {
-		a.logger.Error("Releasing balance for peer that is not loaded")
+		a.logger.Error("attempting to release balance for peer that is not loaded")
 		return
 	}
 
@@ -100,7 +100,7 @@ func (a *Accounting) Release(peer swarm.Address, price uint64) {
 
 	if price > balance.reserved {
 		// If Reserve and Release calls are always paired this should never happen
-		a.logger.Error("Releasing more balance than was reserved for peer")
+		a.logger.Error("attempting to release more balance than was reserved for peer")
 		balance.reserved = 0
 	} else {
 		balance.reserved -= price

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -211,7 +211,6 @@ func (a *Accounting) getPeerBalance(peer swarm.Address) (*PeerBalance, error) {
 		}
 
 		a.balances[peer.String()] = peerBalance
-		return peerBalance, nil
 	}
 
 	return peerBalance, nil

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package accounting_test
 
 import (
@@ -13,16 +17,17 @@ import (
 
 const (
 	testDisconnectThreshold = 10000
-	testPaymentThreshold    = 1000
 	testPrice               = uint64(10)
 )
 
+// Booking represents an accounting action and the expected result afterwards
 type Booking struct {
 	peer            swarm.Address
-	price           int64
+	price           int64 // Credit if <0, Debit otherwise
 	expectedBalance int64
 }
 
+// TestAccountingAddBalance does several accounting actions and verifies the balance after each steep
 func TestAccountingAddBalance(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
@@ -31,7 +36,6 @@ func TestAccountingAddBalance(t *testing.T) {
 
 	acc := accounting.NewAccounting(accounting.Options{
 		DisconnectThreshold: testDisconnectThreshold,
-		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
 		Store:               store,
 	})
@@ -86,6 +90,9 @@ func TestAccountingAddBalance(t *testing.T) {
 	}
 }
 
+// TestAccountingAdd_persistentBalances tests that balances are actually persisted
+// It creates an accounting instance, does some accounting
+// Then it creates a new accounting instance with the same store and verifies the balances
 func TestAccountingAdd_persistentBalances(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
@@ -94,7 +101,6 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 
 	acc := accounting.NewAccounting(accounting.Options{
 		DisconnectThreshold: testDisconnectThreshold,
-		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
 		Store:               store,
 	})
@@ -123,7 +129,6 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 
 	acc = accounting.NewAccounting(accounting.Options{
 		DisconnectThreshold: testDisconnectThreshold,
-		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
 		Store:               store,
 	})
@@ -147,6 +152,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 	}
 }
 
+// TestAccountingReserve tests that reserve returns an error if the disconnect threshold would be exceeded
 func TestAccountingReserve(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
@@ -155,7 +161,6 @@ func TestAccountingReserve(t *testing.T) {
 
 	acc := accounting.NewAccounting(accounting.Options{
 		DisconnectThreshold: testDisconnectThreshold,
-		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
 		Store:               store,
 	})
@@ -176,6 +181,7 @@ func TestAccountingReserve(t *testing.T) {
 	}
 }
 
+// TestAccountingDisconnect tests that exceeding the disconnect threshold with Debit returns a p2p.DisconnectError
 func TestAccountingDisconnect(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
@@ -184,7 +190,6 @@ func TestAccountingDisconnect(t *testing.T) {
 
 	acc := accounting.NewAccounting(accounting.Options{
 		DisconnectThreshold: testDisconnectThreshold,
-		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
 		Store:               store,
 	})

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -3,22 +3,29 @@ package accounting_test
 import (
 	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"io/ioutil"
 	"testing"
 )
 
 const (
-	testPrice = 10
+	testDisconnectThreshold = 10000
+	testPaymentThreshold    = 1000
+	testPrice               = 10
 )
 
 func TestAccountingAddBalance(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
-	accounting := accounting.NewAccounting(accounting.Options{
-		DisconnectThreshold: 10000,
-		PaymentThreshold:    1000,
+	store := mock.NewStateStore()
+	defer store.Close()
+
+	acc := accounting.NewAccounting(accounting.Options{
+		DisconnectThreshold: testDisconnectThreshold,
+		PaymentThreshold:    testPaymentThreshold,
 		Logger:              logger,
+		Store:               store,
 	})
 
 	peer1Addr, err := swarm.ParseHexAddress("00112233")
@@ -31,33 +38,102 @@ func TestAccountingAddBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = accounting.Add(peer1Addr, testPrice)
+	err = acc.Add(peer1Addr, testPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	peer1Balance := accounting.GetPeerBalance(peer1Addr)
+	peer1Balance, err := acc.Balance(peer1Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if peer1Balance != testPrice {
 		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, testPrice)
 	}
 
-	err = accounting.Add(peer2Addr, testPrice)
+	err = acc.Add(peer2Addr, testPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	peer2Balance := accounting.GetPeerBalance(peer2Addr)
+	peer2Balance, err := acc.Balance(peer2Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if peer2Balance != testPrice {
 		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, testPrice)
 	}
 
-	err = accounting.Add(peer1Addr, testPrice)
+	err = acc.Add(peer1Addr, testPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	peer1Balance = accounting.GetPeerBalance(peer1Addr)
+	peer1Balance, err = acc.Balance(peer1Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if peer1Balance != 2*testPrice {
 		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, 2*testPrice)
 	}
+}
+
+func TestAccountingAdd_persistentBalances(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+
+	store := mock.NewStateStore()
+	defer store.Close()
+
+	acc := accounting.NewAccounting(accounting.Options{
+		DisconnectThreshold: testDisconnectThreshold,
+		PaymentThreshold:    testPaymentThreshold,
+		Logger:              logger,
+		Store:               store,
+	})
+
+	peer1Addr, err := swarm.ParseHexAddress("00112233")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer2Addr, err := swarm.ParseHexAddress("00112244")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = acc.Add(peer1Addr, testPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = acc.Add(peer2Addr, 2*testPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acc = accounting.NewAccounting(accounting.Options{
+		DisconnectThreshold: testDisconnectThreshold,
+		PaymentThreshold:    testPaymentThreshold,
+		Logger:              logger,
+		Store:               store,
+	})
+
+	peer1Balance, err := acc.Balance(peer1Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if peer1Balance != testPrice {
+		t.Fatalf("peer1Balance not loaded correctly. got %d, wanted %d", peer1Balance, testPrice)
+	}
+
+	peer2Balance, err := acc.Balance(peer2Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if peer2Balance != 2*testPrice {
+		t.Fatalf("peer2Balance not loaded correctly. got %d, wanted %d", peer2Balance, 2*testPrice)
+	}
+
 }

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -1,0 +1,63 @@
+package accounting_test
+
+import (
+	"github.com/ethersphere/bee/pkg/accounting"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"io/ioutil"
+	"testing"
+)
+
+const (
+	testPrice = 10
+)
+
+func TestAccountingAddBalance(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+
+	accounting := accounting.NewAccounting(accounting.Options{
+		DisconnectThreshold: 10000,
+		PaymentThreshold:    1000,
+		Logger:              logger,
+	})
+
+	peer1Addr, err := swarm.ParseHexAddress("00112233")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer2Addr, err := swarm.ParseHexAddress("00112244")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = accounting.Add(peer1Addr, testPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer1Balance := accounting.GetPeerBalance(peer1Addr)
+	if peer1Balance != testPrice {
+		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, testPrice)
+	}
+
+	err = accounting.Add(peer2Addr, testPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer2Balance := accounting.GetPeerBalance(peer2Addr)
+	if peer2Balance != testPrice {
+		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, testPrice)
+	}
+
+	err = accounting.Add(peer1Addr, testPrice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer1Balance = accounting.GetPeerBalance(peer1Addr)
+	if peer1Balance != 2*testPrice {
+		t.Fatalf("peer1Balance not equal to price. got %d, wanted %d", peer1Balance, 2*testPrice)
+	}
+}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -20,8 +20,8 @@ const (
 	testPrice               = uint64(10)
 )
 
-// Booking represents an accounting action and the expected result afterwards
-type Booking struct {
+// booking represents an accounting action and the expected result afterwards
+type booking struct {
 	peer            swarm.Address
 	price           int64 // Credit if <0, Debit otherwise
 	expectedBalance int64
@@ -50,7 +50,7 @@ func TestAccountingAddBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bookings := []Booking{
+	bookings := []booking{
 		{peer: peer1Addr, price: 100, expectedBalance: 100},
 		{peer: peer2Addr, price: 200, expectedBalance: 200},
 		{peer: peer1Addr, price: 300, expectedBalance: 400},
@@ -178,6 +178,10 @@ func TestAccountingReserve(t *testing.T) {
 	err = acc.Reserve(peer1Addr, 101)
 	if err == nil {
 		t.Fatal("expected error from reserve")
+	}
+
+	if !errors.Is(err, accounting.ErrOverdraft) {
+		t.Fatalf("expected overdraft error from reserve, got %v", err)
 	}
 }
 

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+	"sync"
+)
+
+type MockAccounting struct {
+	lock     sync.Mutex
+	balances map[string]int64
+}
+
+func (ma *MockAccounting) Reserve(peer swarm.Address, price uint64) error {
+	return nil
+}
+
+func (ma *MockAccounting) Release(peer swarm.Address, price uint64) {
+
+}
+
+func (ma *MockAccounting) Credit(peer swarm.Address, price uint64) error {
+	ma.lock.Lock()
+	defer ma.lock.Unlock()
+	ma.balances[peer.String()] -= int64(price)
+	return nil
+}
+
+func (ma *MockAccounting) Debit(peer swarm.Address, price uint64) error {
+	ma.lock.Lock()
+	defer ma.lock.Unlock()
+	ma.balances[peer.String()] += int64(price)
+	return nil
+}
+
+func (ma *MockAccounting) Balance(peer swarm.Address) (int64, error) {
+	ma.lock.Lock()
+	defer ma.lock.Unlock()
+	return ma.balances[peer.String()], nil
+}
+
+func NewAccounting() *MockAccounting {
+	return &MockAccounting{
+		balances: make(map[string]int64),
+	}
+}

--- a/pkg/accounting/mock/pricer.go
+++ b/pkg/accounting/mock/pricer.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type MockPricer struct {
+	peerPrice uint64
+	price     uint64
+}
+
+func NewPricer(price, peerPrice uint64) *MockPricer {
+	return &MockPricer{
+		peerPrice: peerPrice,
+		price:     price,
+	}
+}
+
+func (pricer *MockPricer) PeerPrice(peer, chunk swarm.Address) uint64 {
+	return pricer.peerPrice
+}
+
+func (pricer *MockPricer) Price(chunk swarm.Address) uint64 {
+	return pricer.price
+}

--- a/pkg/accounting/pricer.go
+++ b/pkg/accounting/pricer.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package accounting
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type Pricer interface {
+	// PeerPrice is the price the peer charges for a given chunk hash
+	PeerPrice(peer, chunk swarm.Address) uint64
+	// Price is the price we charge for a given chunk hash
+	Price(chunk swarm.Address) uint64
+}
+
+type FixedPricer struct {
+	overlay swarm.Address
+	poPrice uint64
+}
+
+func NewFixedPricer(overlay swarm.Address, poPrice uint64) *FixedPricer {
+	return &FixedPricer{
+		overlay: overlay,
+		poPrice: poPrice,
+	}
+}
+
+func (pricer *FixedPricer) PeerPrice(peer, chunk swarm.Address) uint64 {
+	return uint64(swarm.MaxPO-swarm.Proximity(peer.Bytes(), chunk.Bytes())) * pricer.poPrice
+}
+
+func (pricer *FixedPricer) Price(chunk swarm.Address) uint64 {
+	return pricer.PeerPrice(pricer.overlay, chunk)
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/crypto"
@@ -232,10 +233,18 @@ func NewBee(o Options) (*Bee, error) {
 	}
 	b.localstoreCloser = storer
 
+	acc := accounting.NewAccounting(accounting.Options{
+		Logger:              logger,
+		Store:               stateStore,
+		DisconnectThreshold: 1000000,
+	})
+
 	retrieve := retrieval.New(retrieval.Options{
 		Streamer:    p2ps,
 		ChunkPeerer: topologyDriver,
 		Logger:      logger,
+		Accounting:  acc,
+		Pricer:      accounting.NewFixedPricer(address, 10),
 	})
 	tagg := tags.NewTags()
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -66,23 +66,24 @@ type Bee struct {
 }
 
 type Options struct {
-	DataDir            string
-	DBCapacity         uint64
-	Password           string
-	APIAddr            string
-	DebugAPIAddr       string
-	Addr               string
-	NATAddr            string
-	EnableWS           bool
-	EnableQUIC         bool
-	NetworkID          uint64
-	WelcomeMessage     string
-	Bootnodes          []string
-	CORSAllowedOrigins []string
-	Logger             logging.Logger
-	TracingEnabled     bool
-	TracingEndpoint    string
-	TracingServiceName string
+	DataDir             string
+	DBCapacity          uint64
+	Password            string
+	APIAddr             string
+	DebugAPIAddr        string
+	Addr                string
+	NATAddr             string
+	EnableWS            bool
+	EnableQUIC          bool
+	NetworkID           uint64
+	WelcomeMessage      string
+	Bootnodes           []string
+	CORSAllowedOrigins  []string
+	Logger              logging.Logger
+	TracingEnabled      bool
+	TracingEndpoint     string
+	TracingServiceName  string
+	DisconnectThreshold uint64
 }
 
 func NewBee(o Options) (*Bee, error) {
@@ -236,7 +237,7 @@ func NewBee(o Options) (*Bee, error) {
 	acc := accounting.NewAccounting(accounting.Options{
 		Logger:              logger,
 		Store:               stateStore,
-		DisconnectThreshold: 1000000,
+		DisconnectThreshold: o.DisconnectThreshold,
 	})
 
 	retrieve := retrieval.New(retrieval.Options{

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -7,6 +7,7 @@ package retrieval
 import (
 	"context"
 	"fmt"
+	"github.com/ethersphere/bee/pkg/accounting"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -39,6 +40,8 @@ type Service struct {
 	storer        storage.Storer
 	singleflight  singleflight.Group
 	logger        logging.Logger
+	accounting    accounting.Interface
+	pricer        accounting.Pricer
 }
 
 type Options struct {
@@ -46,6 +49,8 @@ type Options struct {
 	ChunkPeerer topology.EachPeerer
 	Storer      storage.Storer
 	Logger      logging.Logger
+	Accounting  accounting.Interface
+	Pricer      accounting.Pricer
 }
 
 func New(o Options) *Service {
@@ -54,6 +59,8 @@ func New(o Options) *Service {
 		peerSuggester: o.ChunkPeerer,
 		storer:        o.Storer,
 		logger:        o.Logger,
+		accounting:    o.Accounting,
+		pricer:        o.Pricer,
 	}
 }
 
@@ -118,6 +125,14 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	if err != nil {
 		return nil, peer, fmt.Errorf("get closest: %w", err)
 	}
+
+	chunkPrice := s.pricer.PeerPrice(peer, addr)
+	err = s.accounting.Reserve(peer, chunkPrice)
+	if err != nil {
+		return nil, peer, err
+	}
+	defer s.accounting.Release(peer, chunkPrice)
+
 	s.logger.Tracef("retrieval: requesting chunk %s from peer %s", addr, peer)
 	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
@@ -142,6 +157,11 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 	var d pb.Delivery
 	if err := r.ReadMsgWithContext(ctx, &d); err != nil {
 		return nil, peer, fmt.Errorf("read delivery: %w peer %s", err, peer.String())
+	}
+
+	err = s.accounting.Credit(peer, chunkPrice)
+	if err != nil {
+		return nil, peer, err
 	}
 
 	return d.Data, peer, nil
@@ -210,6 +230,12 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		Data: chunk.Data(),
 	}); err != nil {
 		return fmt.Errorf("write delivery: %w peer %s", err, p.Address.String())
+	}
+
+	chunkPrice := s.pricer.Price(chunk.Address())
+	err = s.accounting.Debit(p.Address, chunkPrice)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -126,6 +126,7 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 		return nil, peer, fmt.Errorf("get closest: %w", err)
 	}
 
+	// compute the price we pay for this chunk and reserve it for the rest of this function
 	chunkPrice := s.pricer.PeerPrice(peer, addr)
 	err = s.accounting.Reserve(peer, chunkPrice)
 	if err != nil {
@@ -159,6 +160,7 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 		return nil, peer, fmt.Errorf("read delivery: %w peer %s", err, peer.String())
 	}
 
+	// credit the peer after successful delivery
 	err = s.accounting.Credit(peer, chunkPrice)
 	if err != nil {
 		return nil, peer, err
@@ -232,6 +234,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		return fmt.Errorf("write delivery: %w peer %s", err, p.Address.String())
 	}
 
+	// compute the price we charge for this chunk and debit it from p's balance
 	chunkPrice := s.pricer.Price(chunk.Address())
 	err = s.accounting.Debit(p.Address, chunkPrice)
 	if err != nil {

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -139,7 +139,7 @@ func TestDelivery(t *testing.T) {
 
 	clientBalance, _ := clientMockAccounting.Balance(peerID)
 	if clientBalance != -int64(price) {
-		t.Fatalf("unexpected balance on clieent. want %d got %d", -price, clientBalance)
+		t.Fatalf("unexpected balance on client. want %d got %d", -price, clientBalance)
 	}
 
 }

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
 	"github.com/ethersphere/bee/pkg/p2p/streamtest"
@@ -43,14 +44,23 @@ func TestDelivery(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	serverMockAccounting := accountingmock.NewAccounting()
+
+	price := uint64(10)
+	pricerMock := accountingmock.NewPricer(price, price)
+
 	// create the server that will handle the request and will serve the response
 	server := retrieval.New(retrieval.Options{
-		Storer: mockStorer,
-		Logger: logger,
+		Storer:     mockStorer,
+		Logger:     logger,
+		Accounting: serverMockAccounting,
+		Pricer:     pricerMock,
 	})
 	recorder := streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
 	)
+
+	clientMockAccounting := accountingmock.NewAccounting()
 
 	// client mock storer does not store any data at this point
 	// but should be checked at at the end of the test for the
@@ -68,6 +78,8 @@ func TestDelivery(t *testing.T) {
 		ChunkPeerer: ps,
 		Storer:      clientMockStorer,
 		Logger:      logger,
+		Accounting:  clientMockAccounting,
+		Pricer:      pricerMock,
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
@@ -118,6 +130,16 @@ func TestDelivery(t *testing.T) {
 
 	if len(gotDeliveries) != 1 {
 		t.Fatalf("got too many deliveries. want 1 got %d", len(gotDeliveries))
+	}
+
+	serverBalance, _ := serverMockAccounting.Balance(peerID)
+	if serverBalance != int64(price) {
+		t.Fatalf("unexpected balance on server. want %d got %d", price, serverBalance)
+	}
+
+	clientBalance, _ := clientMockAccounting.Balance(peerID)
+	if clientBalance != -int64(price) {
+		t.Fatalf("unexpected balance on clieent. want %d got %d", -price, clientBalance)
 	}
 
 }

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -132,11 +132,6 @@ func TestDelivery(t *testing.T) {
 		t.Fatalf("got too many deliveries. want 1 got %d", len(gotDeliveries))
 	}
 
-	serverBalance, _ := serverMockAccounting.Balance(peerID)
-	if serverBalance != int64(price) {
-		t.Fatalf("unexpected balance on server. want %d got %d", price, serverBalance)
-	}
-
 	clientBalance, _ := clientMockAccounting.Balance(peerID)
 	if clientBalance != -int64(price) {
 		t.Fatalf("unexpected balance on client. want %d got %d", -price, clientBalance)


### PR DESCRIPTION
This PR adds an initial accounting implementation.

It includes
* `Credit` and `Debit` functions to modify a peers balance (replacing the `Add` function from earlier accounting implementation) 
* `Reserve` / `Release` functionality to prevent overspending
* Returning a p2p disconnect error in `Debit` if the disconnect threshold is crossed
* A `Balances` function to query balances used for testing (and later APIs)
* Writing and loading balances from a state store (this version writes to the store on every request which is not good if there is a lot of traffic, debouncing should be added to the db writes)
* Integration with retrieval protocol using a simple fixed price strategy based on proximity
* Option for setting the disconnect threshold

It does not include integration with settlement.