### PR TITLE
Makefile: Added build for other binaries in BEE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,24 @@ binary: dist FORCE
 	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee ./cmd/bee
 
+.PHONY: binary-file
+binary-file: export CGO_ENABLED=0
+binary-file: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-file ./cmd/bee-file
+
+.PHONY: binary-join
+binary-join: export CGO_ENABLED=0
+binary-join: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-join ./cmd/bee-file
+
+.PHONY: binary-split
+binary-split: export CGO_ENABLED=0
+binary-split: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-split ./cmd/bee-file
+
 dist:
 	mkdir $@
 

--- a/cmd/bee-file/main.go
+++ b/cmd/bee-file/main.go
@@ -59,7 +59,7 @@ func getEntry(cmd *cobra.Command, args []string) (err error) {
 	writeCloser := cmdfile.NopWriteCloser(buf)
 	limitBuf := cmdfile.NewLimitWriteCloser(writeCloser, limitMetadataLength)
 	j := joiner.NewSimpleJoiner(store)
-	_, err = file.JoinReadAll(j, addr, limitBuf, false)
+	_, err = file.JoinReadAll(cmd.Context(), j, addr, limitBuf, false)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func getEntry(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	buf = bytes.NewBuffer(nil)
-	_, err = file.JoinReadAll(j, e.Metadata(), buf, false)
+	_, err = file.JoinReadAll(cmd.Context(), j, e.Metadata(), buf, false)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func getEntry(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer outFile.Close()
-	_, err = file.JoinReadAll(j, e.Reference(), outFile, false)
+	_, err = file.JoinReadAll(cmd.Context(), j, e.Reference(), outFile, false)
 	return err
 }
 

--- a/cmd/bee-join/main.go
+++ b/cmd/bee-join/main.go
@@ -83,7 +83,7 @@ func Join(cmd *cobra.Command, args []string) (err error) {
 
 	// create the join and get its data reader
 	j := joiner.NewSimpleJoiner(store)
-	_, err = file.JoinReadAll(j, addr, outFile, false)
+	_, err = file.JoinReadAll(cmd.Context(), j, addr, outFile, false)
 	return err
 }
 

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -72,8 +73,12 @@ func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	targets := r.URL.Query().Get("targets")
+	r = r.WithContext(context.WithValue(r.Context(), "targets", targets))
+	ctx = r.Context()
+
 	outBuffer := bytes.NewBuffer(nil)
-	c, err := file.JoinReadAll(j, address, outBuffer, toDecrypt)
+	c, err := file.JoinReadAll(ctx, j, address, outBuffer, toDecrypt)
 	if err != nil && c == 0 {
 		s.Logger.Debugf("bytes download: data join %s: %v", address, err)
 		s.Logger.Errorf("bytes download: data join %s", address)

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -72,9 +72,11 @@ func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.BadRequest(w, "invalid root chunk")
 		return
 	}
+	type targetsContextKey string
+	k := targetsContextKey("targets")
 
 	targets := r.URL.Query().Get("targets")
-	r = r.WithContext(context.WithValue(r.Context(), "targets", targets))
+	r = r.WithContext(context.WithValue(r.Context(), k, targets))
 	ctx = r.Context()
 
 	outBuffer := bytes.NewBuffer(nil)

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -72,11 +72,9 @@ func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.BadRequest(w, "invalid root chunk")
 		return
 	}
-	type targetsContextKey string
-	k := targetsContextKey("targets")
 
 	targets := r.URL.Query().Get("targets")
-	r = r.WithContext(context.WithValue(r.Context(), k, targets))
+	r = r.WithContext(context.WithValue(r.Context(), targetsContextKey{}, targets))
 	ctx = r.Context()
 
 	outBuffer := bytes.NewBuffer(nil)

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -36,6 +36,8 @@ const (
 	EncryptHeader     = "swarm-encrypt"
 )
 
+type targetsContextKey struct{}
+
 type fileUploadResponse struct {
 	Reference swarm.Address `json:"reference"`
 }
@@ -207,11 +209,9 @@ func (s *server) fileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	toDecrypt := len(address.Bytes()) == (swarm.HashSize + encryption.KeyLength)
-	type targetsContextKey string
-	k := targetsContextKey("targets")
 	targets := r.URL.Query().Get("targets")
 
-	r = r.WithContext(context.WithValue(r.Context(), k, targets))
+	r = r.WithContext(context.WithValue(r.Context(), targetsContextKey{}, targets))
 
 	// read entry.
 	j := joiner.NewSimpleJoiner(s.Storer)

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -207,8 +207,11 @@ func (s *server) fileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	toDecrypt := len(address.Bytes()) == (swarm.HashSize + encryption.KeyLength)
+	type targetsContextKey string
+	k := targetsContextKey("targets")
 	targets := r.URL.Query().Get("targets")
-	r = r.WithContext(context.WithValue(r.Context(), "targets", targets))
+
+	r = r.WithContext(context.WithValue(r.Context(), k, targets))
 
 	// read entry.
 	j := joiner.NewSimpleJoiner(s.Storer)

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -38,8 +38,8 @@ type Splitter interface {
 }
 
 // JoinReadAll reads all output from the provided joiner.
-func JoinReadAll(j Joiner, addr swarm.Address, outFile io.Writer, toDecrypt bool) (int64, error) {
-	r, l, err := j.Join(context.Background(), addr, toDecrypt)
+func JoinReadAll(ctx context.Context, j Joiner, addr swarm.Address, outFile io.Writer, toDecrypt bool) (int64, error) {
+	r, l, err := j.Join(ctx, addr, toDecrypt)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -93,7 +93,7 @@ func TestJoinReadAll(t *testing.T) {
 	var dataLength int64 = swarm.ChunkSize + 2
 	j := newMockJoiner(dataLength)
 	buf := bytes.NewBuffer(nil)
-	c, err := file.JoinReadAll(j, swarm.ZeroAddress, buf, false)
+	c, err := file.JoinReadAll(context.Background(), j, swarm.ZeroAddress, buf, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -35,12 +35,7 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 			// request from network
 			data, err := s.retrieval.RetrieveChunk(ctx, addr)
 			if err != nil {
-				// START RECOVERY PROCESS
-				/*
-					if targets := ctx.Value("targets"); targets != "" {
-						//TODO: ADD RECOVERY PROCESS HERE
-					}
-				*/
+				//TODO: INVOKE RECOVERY PROCESS, obtain targets thru ctx
 				return nil, fmt.Errorf("netstore retrieve chunk: %w", err)
 			}
 

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -36,9 +36,11 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 			data, err := s.retrieval.RetrieveChunk(ctx, addr)
 			if err != nil {
 				// START RECOVERY PROCESS
-				if targets := ctx.Value("targets"); targets != "" {
-					//TODO: ADD RECOVERY PROCESS HERE
-				}
+				/*
+					if targets := ctx.Value("targets"); targets != "" {
+						//TODO: ADD RECOVERY PROCESS HERE
+					}
+				*/
 				return nil, fmt.Errorf("netstore retrieve chunk: %w", err)
 			}
 

--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -35,6 +35,10 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 			// request from network
 			data, err := s.retrieval.RetrieveChunk(ctx, addr)
 			if err != nil {
+				// START RECOVERY PROCESS
+				if targets := ctx.Value("targets"); targets != "" {
+					//TODO: ADD RECOVERY PROCESS HERE
+				}
 				return nil, fmt.Errorf("netstore retrieve chunk: %w", err)
 			}
 


### PR DESCRIPTION
This PR adds the build for  `bee-file`,`bee-split` and `bee-file`
Makefile added commands for
- `make binary-file`
- `make binary-split`
- `make binary-join`