### PR TITLE
Makefile: Added build for other binaries in BEE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,23 +18,23 @@ binary: dist FORCE
 	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee ./cmd/bee
 
-.PHONY: binary-file
-binary-file: export CGO_ENABLED=0
-binary-file: dist FORCE
+.PHONY: bee-file
+bee-file: export CGO_ENABLED=0
+bee-file: dist FORCE
 	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-file ./cmd/bee-file
 
-.PHONY: binary-join
-binary-join: export CGO_ENABLED=0
-binary-join: dist FORCE
+.PHONY: bee-join
+bee-join: export CGO_ENABLED=0
+bee-join: dist FORCE
 	$(GO) version
-	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-join ./cmd/bee-file
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-join ./cmd/bee-join
 
-.PHONY: binary-split
-binary-split: export CGO_ENABLED=0
-binary-split: dist FORCE
+.PHONY: bee-split
+bee-split: export CGO_ENABLED=0
+bee-split: dist FORCE
 	$(GO) version
-	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-split ./cmd/bee-file
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-split ./cmd/bee-split
 
 dist:
 	mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,24 @@ binary: dist FORCE
 	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee ./cmd/bee
 
+.PHONY: binary-file
+binary-file: export CGO_ENABLED=0
+binary-file: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-file ./cmd/bee-file
+
+.PHONY: binary-join
+binary-join: export CGO_ENABLED=0
+binary-join: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-join ./cmd/bee-file
+
+.PHONY: binary-split
+binary-split: export CGO_ENABLED=0
+binary-split: dist FORCE
+	$(GO) version
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-split ./cmd/bee-file
+
 dist:
 	mkdir $@
 

--- a/Makefile
+++ b/Makefile
@@ -18,22 +18,10 @@ binary: dist FORCE
 	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee ./cmd/bee
 
-.PHONY: bee-file
-bee-file: export CGO_ENABLED=0
-bee-file: dist FORCE
-	$(GO) version
+.PHONY: binaries
+binaries: binary
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-file ./cmd/bee-file
-
-.PHONY: bee-join
-bee-join: export CGO_ENABLED=0
-bee-join: dist FORCE
-	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-join ./cmd/bee-join
-
-.PHONY: bee-split
-bee-split: export CGO_ENABLED=0
-bee-split: dist FORCE
-	$(GO) version
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/bee-split ./cmd/bee-split
 
 dist:


### PR DESCRIPTION
This PR adds the build for  `bee-file`,`bee-split` and `bee-file`
Makefile adds a command for
- `make binaries`

This will compile and generate the binaries in the dist folder for:
- `bee`
- `bee-file`
- `bee-split`
- `bee-file`
