### PR TITLE
Dynamic welcome message

### DIFF
--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -32,7 +32,7 @@ type server struct {
 
 type Options struct {
 	Overlay        swarm.Address
-	P2P            p2p.Service
+	P2P            p2p.DebugService
 	Pingpong       pingpong.Interface
 	TopologyDriver topology.PeerAdder
 	Storer         storage.Storer

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -13,4 +13,5 @@ type (
 	PinnedChunk              = pinnedChunk
 	ListPinnedChunksResponse = listPinnedChunksResponse
 	TagResponse              = tagResponse
+	WelcomeMessageResponse   = welcomeMessageResponse
 )

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -16,5 +16,3 @@ type (
 	WelcomeMessageRequest    = welcomeMessageRequest
 	WelcomeMessageResponse   = welcomeMessageResponse
 )
-
-const WelcomeMessageMaxRequestSize = welcomeMessageMaxRequestSize

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -13,5 +13,6 @@ type (
 	PinnedChunk              = pinnedChunk
 	ListPinnedChunksResponse = listPinnedChunksResponse
 	TagResponse              = tagResponse
+	WelcomeMessageRequest    = welcomeMessageRequest
 	WelcomeMessageResponse   = welcomeMessageResponse
 )

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -16,3 +16,5 @@ type (
 	WelcomeMessageRequest    = welcomeMessageRequest
 	WelcomeMessageResponse   = welcomeMessageResponse
 )
+
+const WelcomeMessageMaxRequestSize = welcomeMessageMaxRequestSize

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -86,6 +86,10 @@ func (s *server) setupRouting() {
 	router.Handle("/topology", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.topologyHandler),
 	})
+	router.Handle("/welcome-message", jsonhttp.MethodHandler{
+		"GET":  http.HandlerFunc(s.welcomeMessageSyncedHandler),
+		"POST": http.HandlerFunc(s.setWelcomeMessageHandler),
+	})
 
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -87,7 +87,7 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.topologyHandler),
 	})
 	router.Handle("/welcome-message", jsonhttp.MethodHandler{
-		"GET":  http.HandlerFunc(s.welcomeMessageSyncedHandler),
+		"GET":  http.HandlerFunc(s.getWelcomeMessageHandler),
 		"POST": http.HandlerFunc(s.setWelcomeMessageHandler),
 	})
 

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -87,8 +87,11 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.topologyHandler),
 	})
 	router.Handle("/welcome-message", jsonhttp.MethodHandler{
-		"GET":  http.HandlerFunc(s.getWelcomeMessageHandler),
-		"POST": http.HandlerFunc(s.setWelcomeMessageHandler),
+		"GET": http.HandlerFunc(s.getWelcomeMessageHandler),
+		"POST": web.ChainHandlers(
+			jsonhttp.NewMaxBodyBytesHandler(welcomeMessageMaxRequestSize),
+			web.FinalHandlerFunc(s.setWelcomeMessageHandler),
+		),
 	})
 
 	baseRouter.Handle("/", web.ChainHandlers(

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -27,8 +27,6 @@ func (s *server) getWelcomeMessageHandler(w http.ResponseWriter, r *http.Request
 }
 
 func (s *server) setWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
-	const maxBodySize = 256 // TODO: limit this on all requests?
-
 	var data welcomeMessageRequest
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+)
+
+type welcomeMessageResponse struct {
+	WelcomeMesssage string `json:"welcome_message"`
+}
+
+func (s *server) welcomeMessageSyncedHandler(w http.ResponseWriter, r *http.Request) {
+	val := s.P2P.WelcomeMessageSynced()
+	jsonhttp.OK(w, welcomeMessageResponse{
+		WelcomeMesssage: val,
+	})
+}
+
+func (s *server) setWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		s.Logger.Debugf("welcome message: request error: %v", err)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+	if err := s.P2P.SetWelcomeMessage(string(data)); err != nil {
+		s.Logger.Debugf("welcome message: set error: %v", err)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+	jsonhttp.OK(w, nil)
+}

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
+const welcomeMessageMaxRequestSize = 512
+
 type welcomeMessageRequest struct {
 	WelcomeMesssage string `json:"welcome_message"`
 }

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -30,7 +30,6 @@ func (s *server) setWelcomeMessageHandler(w http.ResponseWriter, r *http.Request
 	const maxBodySize = 256 // TODO: limit this on all requests?
 
 	var data welcomeMessageRequest
-	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
 		s.Logger.Debugf("debugapi: welcome message: failed to read request: %v", err)

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -15,8 +15,8 @@ type welcomeMessageResponse struct {
 	WelcomeMesssage string `json:"welcome_message"`
 }
 
-func (s *server) welcomeMessageSyncedHandler(w http.ResponseWriter, r *http.Request) {
-	val := s.P2P.WelcomeMessageSynced()
+func (s *server) getWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
+	val := s.P2P.GetWelcomeMessage()
 	jsonhttp.OK(w, welcomeMessageResponse{
 		WelcomeMesssage: val,
 	})

--- a/pkg/debugapi/welcome_message_test.go
+++ b/pkg/debugapi/welcome_message_test.go
@@ -56,6 +56,23 @@ func TestSetWelcomeMessage(t *testing.T) {
 				Code:    http.StatusOK,
 			},
 		},
+		{
+			desc: "fails - request entity too large",
+			message: `zZZbzbzbzbBzBBZbBbZbbbBzzzZBZBbzzBBBbBzBzzZbbBzBBzBBbZz
+			bZZZBBbbZbbZzBbzBbzbZBZzBZZbZzZzZzbbZZBZzzbBZBzZzzBBzZZzzZbZZZzbbbzz
+			bBzZZBbBZBzZzBZBzbzBBbzBBzbzzzBbBbZzZBZBZzBZZbbZZBZZBzZzBZbzZBzZbBzZ
+			bbbBbbZzZbzbZzZzbzzzbzzbzZZzbbzbBZZbBbBZBBZzZzzbBBBBBZbZzBzzBbzBbbbz
+			BBzbbZBbzbzBZbzzBzbZBzzbzbbbBZBzBZzBZbzBzZzBZZZBzZZBzBZZzbzZbzzZzBBz
+			ZZzbZzzZZZBZBBbZZbZzBBBzbzZZbbZZBZZBBBbBZzZbZBZBBBzzZBbbbbzBzbbzBBBz
+			bZBBbZzBbZZBzbBbZZBzBzBzBBbzzzZBbzbZBbzBbZzbbBZBBbbZbBBbbBZbzbZzbBzB
+			bBbbZZbzZzbbBbzZbZZZZbzzZZbBzZZbZzZzzBzbZZ`, // 513 characters
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantResponse: jsonhttp.StatusResponse{
+				Message: "Request Entity Too Large",
+				Code:    http.StatusRequestEntityTooLarge,
+			},
+			wantFail: true,
+		},
 	}
 	testURL := "/welcome-message"
 

--- a/pkg/debugapi/welcome_message_test.go
+++ b/pkg/debugapi/welcome_message_test.go
@@ -1,0 +1,66 @@
+package debugapi_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/p2p/mock"
+)
+
+func TestGetWelcomeMessage(t *testing.T) {
+	const DefaultTestWelcomeMessage = "Hello World!"
+
+	srv := newTestServer(t, testServerOptions{
+		P2P: mock.New(mock.WithWelcomeMessageHandlerFunc(nil, func() string {
+			return DefaultTestWelcomeMessage
+		})),
+	})
+
+	jsonhttptest.ResponseDirect(t, srv.Client, http.MethodGet, "/welcome-message", nil, http.StatusOK, debugapi.WelcomeMessageResponse{
+		WelcomeMesssage: DefaultTestWelcomeMessage,
+	})
+}
+
+func TestSetWelcomeMessage(t *testing.T) {
+	const NewWelcomeMessage = "Changed value"
+
+	t.Run("OK", func(t *testing.T) {
+		testWelcomeMessage := ""
+		srv := newTestServer(t, testServerOptions{
+			P2P: mock.New(mock.WithWelcomeMessageHandlerFunc(func(val string) error {
+				testWelcomeMessage = val
+				return nil
+			}, nil)),
+		})
+
+		jsonhttptest.ResponseDirect(t, srv.Client, http.MethodPost, "/welcome-message", bytes.NewReader([]byte(NewWelcomeMessage)), http.StatusOK, jsonhttp.StatusResponse{
+			Message: "OK",
+			Code:    http.StatusOK,
+		})
+
+		if testWelcomeMessage != NewWelcomeMessage {
+			t.Fatalf("Bad welcome message: want %s, got %s", NewWelcomeMessage, testWelcomeMessage)
+		}
+	})
+
+	t.Run("internal server error - failed to store", func(t *testing.T) {
+		testError := errors.New("Failed to store")
+
+		srv := newTestServer(t, testServerOptions{
+			P2P: mock.New(mock.WithWelcomeMessageHandlerFunc(func(val string) error {
+				return testError
+			}, nil)),
+		})
+
+		jsonhttptest.ResponseDirect(t, srv.Client, http.MethodPost, "/welcome-message", bytes.NewReader([]byte(NewWelcomeMessage)), http.StatusInternalServerError, jsonhttp.StatusResponse{
+			Message: testError.Error(),
+			Code:    http.StatusInternalServerError,
+		})
+	})
+
+}

--- a/pkg/debugapi/welcome_message_test.go
+++ b/pkg/debugapi/welcome_message_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package debugapi_test
 
 import (

--- a/pkg/debugapi/welcome_message_test.go
+++ b/pkg/debugapi/welcome_message_test.go
@@ -56,21 +56,6 @@ func TestSetWelcomeMessage(t *testing.T) {
 				Code:    http.StatusOK,
 			},
 		},
-		{
-			desc: "bad request - request length too long",
-			message: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-			Nam vitae enim finibus, posuere tellus eu, cursus risus. Nullam varius justo eget suscipit rhoncus. 
-			Fusce euismod, nisi non auctor posuere, lorem tortor tristique ligula, quis porta nulla lectus in magna. 
-			Duis commodo non diam non tincidunt. 
-			Nulla egestas, quam vel imperdiet dapibus, tellus sem porta nisi, nec tincidunt nunc nulla eget mauris.
-			Quisque at purus sed urna tincidunt rutrum. Fusce sit amet enim lobortis, consequat libero id, pretium morbi.`,
-			wantStatus: http.StatusBadRequest,
-			wantResponse: jsonhttp.StatusResponse{
-				Message: "http: request body too large",
-				Code:    http.StatusBadRequest,
-			},
-			wantFail: true,
-		},
 	}
 	testURL := "/welcome-message"
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -155,7 +155,7 @@ func (s *Service) Handshake(stream p2p.Stream, peerMultiaddr ma.Multiaddr, peerI
 	}
 
 	// Synced read:
-	welcomeMessage := s.WelcomeMessageSynced()
+	welcomeMessage := s.GetWelcomeMessage()
 	if err := w.WriteMsgWithTimeout(messageTimeout, &pb.Ack{
 		Address: &pb.BzzAddress{
 			Underlay:  advertisableUnderlayBytes,
@@ -226,8 +226,7 @@ func (s *Service) Handle(stream p2p.Stream, remoteMultiaddr ma.Multiaddr, remote
 		return nil, err
 	}
 
-	// SyncedRead:
-	welcomeMessage := s.WelcomeMessageSynced()
+	welcomeMessage := s.GetWelcomeMessage()
 
 	if err := w.WriteMsgWithTimeout(messageTimeout, &pb.SynAck{
 		Syn: &pb.Syn{
@@ -283,8 +282,8 @@ func (s *Service) SetWelcomeMessage(msg string) (err error) {
 	return nil
 }
 
-// WelcomeMessageSynced returns the synced value of the current welcome message.
-func (s *Service) WelcomeMessageSynced() string {
+// GetWelcomeMessage returns the the current handshake welcome message.
+func (s *Service) GetWelcomeMessage() string {
 	s.welcomeMessage.mu.Lock()
 	defer s.welcomeMessage.mu.Unlock()
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -165,6 +165,29 @@ func TestHandshake(t *testing.T) {
 		}
 	})
 
+	t.Run("Handshake - dynamic welcome message too long", func(t *testing.T) {
+		const LongMessage = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi consectetur urna ut lorem sollicitudin posuere. Donec sagittis laoreet sapien."
+
+		expectedErr := handshake.ErrWelcomeMessageLength
+		err := handshakeService.SetWelcomeMessage(LongMessage)
+		if err == nil || err.Error() != expectedErr.Error() {
+			t.Fatal("expected:", expectedErr, "got:", err)
+		}
+	})
+
+	t.Run("Handshake - set welcome message", func(t *testing.T) {
+		const TestMessage = "Hi im the new test message"
+
+		err := handshakeService.SetWelcomeMessage(TestMessage)
+		if err != nil {
+			t.Fatal("Got error:", err)
+		}
+		got := handshakeService.WelcomeMessageSynced()
+		if got != TestMessage {
+			t.Fatal("expected:", TestMessage, ", got:", got)
+		}
+	})
+
 	t.Run("Handshake - Syn write error", func(t *testing.T) {
 		testErr := errors.New("test error")
 		expectedErr := fmt.Errorf("write syn message: %w", testErr)

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -182,7 +182,7 @@ func TestHandshake(t *testing.T) {
 		if err != nil {
 			t.Fatal("Got error:", err)
 		}
-		got := handshakeService.WelcomeMessageSynced()
+		got := handshakeService.GetWelcomeMessage()
 		if got != TestMessage {
 			t.Fatal("expected:", TestMessage, ", got:", got)
 		}

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -509,7 +509,7 @@ func (s *Service) SetWelcomeMessage(val string) error {
 	return s.handshakeService.SetWelcomeMessage(val)
 }
 
-// GetWelcomeMessage returns the synced value of the welcome message.
+// GetWelcomeMessage returns the value of the welcome message.
 func (s *Service) GetWelcomeMessage() string {
 	return s.handshakeService.GetWelcomeMessage()
 }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -39,7 +39,8 @@ import (
 )
 
 var (
-	_ p2p.Service = (*Service)(nil)
+	_ p2p.Service      = (*Service)(nil)
+	_ p2p.DebugService = (*Service)(nil)
 )
 
 type Service struct {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -509,7 +509,7 @@ func (s *Service) SetWelcomeMessage(val string) error {
 	return s.handshakeService.SetWelcomeMessage(val)
 }
 
-// WelcomeMessageSynced returns the synced value of the welcome message.
-func (s *Service) WelcomeMessageSynced() string {
-	return s.handshakeService.WelcomeMessageSynced()
+// GetWelcomeMessage returns the synced value of the welcome message.
+func (s *Service) GetWelcomeMessage() string {
+	return s.handshakeService.GetWelcomeMessage()
 }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -503,3 +503,13 @@ func (s *Service) Close() error {
 	}
 	return s.host.Close()
 }
+
+// SetWelcomeMessage sets the welcome message for the handshake protocol.
+func (s *Service) SetWelcomeMessage(val string) error {
+	return s.handshakeService.SetWelcomeMessage(val)
+}
+
+// WelcomeMessageSynced returns the synced value of the welcome message.
+func (s *Service) WelcomeMessageSynced() string {
+	return s.handshakeService.WelcomeMessageSynced()
+}

--- a/pkg/p2p/libp2p/welcome_message_test.go
+++ b/pkg/p2p/libp2p/welcome_message_test.go
@@ -1,0 +1,32 @@
+package libp2p_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/p2p/libp2p"
+)
+
+func TestDynamicWelcomeMessage(t *testing.T) {
+	const TestWelcomeMessage = "Hello World!"
+	svc, _ := newService(t, 1, libp2p.Options{WelcomeMessage: TestWelcomeMessage})
+
+	t.Run("Get current message - OK", func(t *testing.T) {
+		got := svc.WelcomeMessageSynced()
+		if got != TestWelcomeMessage {
+			t.Fatalf("expected %s, got %s", TestWelcomeMessage, got)
+		}
+	})
+
+	t.Run("Set new message - OK", func(t *testing.T) {
+		const NewTestMessage = "I'm the new message!"
+
+		err := svc.SetWelcomeMessage(NewTestMessage)
+		if err != nil {
+			t.Fatal("got error:", err)
+		}
+		got := svc.WelcomeMessageSynced()
+		if got != NewTestMessage {
+			t.Fatalf("expected: %s. got %s", NewTestMessage, got)
+		}
+	})
+}

--- a/pkg/p2p/libp2p/welcome_message_test.go
+++ b/pkg/p2p/libp2p/welcome_message_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
+	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 )
 
 func TestDynamicWelcomeMessage(t *testing.T) {
@@ -20,16 +21,29 @@ func TestDynamicWelcomeMessage(t *testing.T) {
 		}
 	})
 
-	t.Run("Set new message - OK", func(t *testing.T) {
-		const NewTestMessage = "I'm the new message!"
+	t.Run("Set new message", func(t *testing.T) {
+		t.Run("OK", func(t *testing.T) {
+			const testMessage = "I'm the new message!"
 
-		err := svc.SetWelcomeMessage(NewTestMessage)
-		if err != nil {
-			t.Fatal("got error:", err)
-		}
-		got := svc.GetWelcomeMessage()
-		if got != NewTestMessage {
-			t.Fatalf("expected: %s. got %s", NewTestMessage, got)
-		}
+			err := svc.SetWelcomeMessage(testMessage)
+			if err != nil {
+				t.Fatal("got error:", err)
+			}
+			got := svc.GetWelcomeMessage()
+			if got != testMessage {
+				t.Fatalf("expected: %s. got %s", testMessage, got)
+			}
+		})
+		t.Run("fails - message too long", func(t *testing.T) {
+			const testMessage = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+			Maecenas eu aliquam enim. Nulla tincidunt arcu nec nulla condimentum nullam sodales` // 141 characters
+
+			want := handshake.ErrWelcomeMessageLength
+			got := svc.SetWelcomeMessage(testMessage)
+			if got != want {
+				t.Fatalf("wrong error: want %v, got %v", want, got)
+			}
+		})
+
 	})
 }

--- a/pkg/p2p/libp2p/welcome_message_test.go
+++ b/pkg/p2p/libp2p/welcome_message_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 package libp2p_test
 
 import (

--- a/pkg/p2p/libp2p/welcome_message_test.go
+++ b/pkg/p2p/libp2p/welcome_message_test.go
@@ -14,7 +14,7 @@ func TestDynamicWelcomeMessage(t *testing.T) {
 	svc, _ := newService(t, 1, libp2p.Options{WelcomeMessage: TestWelcomeMessage})
 
 	t.Run("Get current message - OK", func(t *testing.T) {
-		got := svc.WelcomeMessageSynced()
+		got := svc.GetWelcomeMessage()
 		if got != TestWelcomeMessage {
 			t.Fatalf("expected %s, got %s", TestWelcomeMessage, got)
 		}
@@ -27,7 +27,7 @@ func TestDynamicWelcomeMessage(t *testing.T) {
 		if err != nil {
 			t.Fatal("got error:", err)
 		}
-		got := svc.WelcomeMessageSynced()
+		got := svc.GetWelcomeMessage()
 		if got != NewTestMessage {
 			t.Fatalf("expected: %s. got %s", NewTestMessage, got)
 		}

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -16,6 +16,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+// Service is the mock of a P2P Service
 type Service struct {
 	addProtocolFunc       func(p2p.ProtocolSpec) error
 	connectFunc           func(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
@@ -25,52 +26,67 @@ type Service struct {
 	addressesFunc         func() ([]ma.Multiaddr, error)
 	setWelcomeMessageFunc func(string) error
 	getWelcomeMessageFunc func() string
+	welcomeMessage        string
 	notifyCalled          int32
 }
 
+// WithAddProtocolFunc sets the mock implementation of the AddProtocol function
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
 	return optionFunc(func(s *Service) {
 		s.addProtocolFunc = f
 	})
 }
 
+// WithConnectFunc sets the mock implementation of the Connect function
 func WithConnectFunc(f func(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)) Option {
 	return optionFunc(func(s *Service) {
 		s.connectFunc = f
 	})
 }
 
+// WithDisconnectFunc sets the mock implementation of the Disconnect function
 func WithDisconnectFunc(f func(overlay swarm.Address) error) Option {
 	return optionFunc(func(s *Service) {
 		s.disconnectFunc = f
 	})
 }
 
+// WithPeersFunc sets the mock implementation of the Peers function
 func WithPeersFunc(f func() []p2p.Peer) Option {
 	return optionFunc(func(s *Service) {
 		s.peersFunc = f
 	})
 }
 
+// WithSetNotifierFunc sets the mock implementation of the SetNotifier function
 func WithSetNotifierFunc(f func(topology.Notifier)) Option {
 	return optionFunc(func(s *Service) {
 		s.setNotifierFunc = f
 	})
 }
 
+// WithAddressesFunc sets the mock implementation of the Adresses function
 func WithAddressesFunc(f func() ([]ma.Multiaddr, error)) Option {
 	return optionFunc(func(s *Service) {
 		s.addressesFunc = f
 	})
 }
 
-func WithWelcomeMessageHandlerFunc(fSet func(string) error, fGet func() string) Option {
+// WithGetWelcomeMessageFunc sets the mock implementation of the GetWelcomeMessage function
+func WithGetWelcomeMessageFunc(f func() string) Option {
 	return optionFunc(func(s *Service) {
-		s.setWelcomeMessageFunc = fSet
-		s.getWelcomeMessageFunc = fGet
+		s.getWelcomeMessageFunc = f
 	})
 }
 
+// WithSetWelcomeMessageFunc sets the mock implementation of the SetWelcomeMessage function
+func WithSetWelcomeMessageFunc(f func(string) error) Option {
+	return optionFunc(func(s *Service) {
+		s.setWelcomeMessageFunc = f
+	})
+}
+
+// New will create a new mock P2P Service with the given options
 func New(opts ...Option) *Service {
 	s := new(Service)
 	for _, o := range opts {
@@ -136,17 +152,18 @@ func (s *Service) ConnectNotifyCalls() int32 {
 }
 
 func (s *Service) SetWelcomeMessage(val string) error {
-	if s.setWelcomeMessageFunc == nil {
-		return nil
+	if s.setWelcomeMessageFunc != nil {
+		return s.setWelcomeMessageFunc(val)
 	}
-	return s.setWelcomeMessageFunc(val)
+	s.welcomeMessage = val
+	return nil
 }
 
 func (s *Service) GetWelcomeMessage() string {
-	if s.getWelcomeMessageFunc == nil {
-		return ""
+	if s.getWelcomeMessageFunc != nil {
+		return s.getWelcomeMessageFunc()
 	}
-	return s.getWelcomeMessageFunc()
+	return s.welcomeMessage
 }
 
 type Option interface {

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -17,15 +17,15 @@ import (
 )
 
 type Service struct {
-	addProtocolFunc          func(p2p.ProtocolSpec) error
-	connectFunc              func(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
-	disconnectFunc           func(overlay swarm.Address) error
-	peersFunc                func() []p2p.Peer
-	setNotifierFunc          func(topology.Notifier)
-	addressesFunc            func() ([]ma.Multiaddr, error)
-	setWelcomeMessageFunc    func(string) error
-	welcomeMessageSyncedFunc func() string
-	notifyCalled             int32
+	addProtocolFunc       func(p2p.ProtocolSpec) error
+	connectFunc           func(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
+	disconnectFunc        func(overlay swarm.Address) error
+	peersFunc             func() []p2p.Peer
+	setNotifierFunc       func(topology.Notifier)
+	addressesFunc         func() ([]ma.Multiaddr, error)
+	setWelcomeMessageFunc func(string) error
+	getWelcomeMessageFunc func() string
+	notifyCalled          int32
 }
 
 func WithAddProtocolFunc(f func(p2p.ProtocolSpec) error) Option {
@@ -67,7 +67,7 @@ func WithAddressesFunc(f func() ([]ma.Multiaddr, error)) Option {
 func WithWelcomeMessageHandlerFunc(fSet func(string) error, fGet func() string) Option {
 	return optionFunc(func(s *Service) {
 		s.setWelcomeMessageFunc = fSet
-		s.welcomeMessageSyncedFunc = fGet
+		s.getWelcomeMessageFunc = fGet
 	})
 }
 
@@ -142,11 +142,11 @@ func (s *Service) SetWelcomeMessage(val string) error {
 	return s.setWelcomeMessageFunc(val)
 }
 
-func (s *Service) WelcomeMessageSynced() string {
-	if s.welcomeMessageSyncedFunc == nil {
+func (s *Service) GetWelcomeMessage() string {
+	if s.getWelcomeMessageFunc == nil {
 		return ""
 	}
-	return s.welcomeMessageSyncedFunc()
+	return s.getWelcomeMessageFunc()
 }
 
 type Option interface {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -26,6 +26,8 @@ type Service interface {
 	Peers() []Peer
 	SetNotifier(topology.Notifier)
 	Addresses() ([]ma.Multiaddr, error)
+	SetWelcomeMessage(val string) error
+	WelcomeMessageSynced() string
 }
 
 // Streamer is able to create a new Stream.

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -27,7 +27,7 @@ type Service interface {
 	SetNotifier(topology.Notifier)
 	Addresses() ([]ma.Multiaddr, error)
 	SetWelcomeMessage(val string) error
-	WelcomeMessageSynced() string
+	GetWelcomeMessage() string
 }
 
 // Streamer is able to create a new Stream.

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -26,6 +26,11 @@ type Service interface {
 	Peers() []Peer
 	SetNotifier(topology.Notifier)
 	Addresses() ([]ma.Multiaddr, error)
+}
+
+// DebugService extends the Service with method used for debugging.
+type DebugService interface {
+	Service
 	SetWelcomeMessage(val string) error
 	GetWelcomeMessage() string
 }


### PR DESCRIPTION
## Set dynamic welcome message

The purpose of this PR is twofold:

- One: to enable runtime changes of the welcome message for the handshake
- Two: to establish a pattern for runtime change of select configuration parameters through the debug API