### PR TITLE
Debug API endpoint for querying balances

### DIFF
--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -60,4 +60,6 @@ func (s *server) balancesPeerHandler(w http.ResponseWriter, r *http.Request) {
 		Balance: balance,
 	})
 
+	//
+
 }

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -1,0 +1,59 @@
+package debugapi
+
+import (
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/gorilla/mux"
+
+	"net/http"
+)
+
+type balanceResponse struct {
+	Peer    string `json:"peer"`
+	Balance int64  `json:"balance"`
+}
+
+func (s *server) balancesHandler(w http.ResponseWriter, r *http.Request) {
+
+	/*
+		ms, ok := s.balancesDriver.(json.Marshaler)
+		if !ok {
+			s.Logger.Error("balances driver cast to json marshaler")
+			jsonhttp.InternalServerError(w, "balances json marshal interface error")
+			return
+		}
+
+		b, err := ms.MarshalJSON()
+		if err != nil {
+			s.Logger.Errorf("balances marshal to json: %v", err)
+			jsonhttp.InternalServerError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", jsonhttp.DefaultContentTypeHeader)
+		_, _ = io.Copy(w, bytes.NewBuffer(b))
+	*/
+}
+
+func (s *server) balancesPeerHandler(w http.ResponseWriter, r *http.Request) {
+
+	peer, err := swarm.ParseHexAddress(mux.Vars(r)["peer"])
+	if err != nil {
+		s.Logger.Debugf("debug api: balances peer: parse peer address: %v", err)
+		jsonhttp.BadRequest(w, "bad address")
+		return
+	}
+	//
+	balance, err := s.Accounting.Balance(peer)
+
+	if err != nil {
+		s.Logger.Debugf("debug-api: balances peer: get peer balance: %v", err)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+
+	jsonhttp.OK(w, balanceResponse{
+		Peer:    peer.String(),
+		Balance: balance,
+	})
+
+}

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	topmock "github.com/ethersphere/bee/pkg/accounting/mock"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+)
+
+type balancesResponse struct {
+	balances string `json:"balances"`
+}
+
+func TestBalancesOK(t *testing.T) {
+
+	/*
+		marshalFunc := func() ([]byte, error) {
+			return json.Marshal(balancesResponse{balances: "abcd"})
+		}
+		testServer := newTestServer(t, testServerOptions{
+			balancesOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
+		})
+
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances", nil, http.StatusOK, balancesResponse{
+			balances: "abcd",
+		})
+	*/
+}
+
+func TestBalancesError(t *testing.T) {
+
+	/*
+		marshalFunc := func() ([]byte, error) {
+			return nil, errors.New("error")
+		}
+		testServer := newTestServer(t, testServerOptions{
+			balancesOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
+		})
+
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
+			Message: "error",
+			Code:    http.StatusInternalServerError,
+		})
+	*/
+}
+
+func TestBalancesPeersOK(t *testing.T) {
+
+}
+
+func TestBalancesPeersError(t *testing.T) {
+
+}

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -7,6 +7,7 @@ package debugapi
 import (
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/pingpong"
@@ -39,6 +40,7 @@ type Options struct {
 	Logger         logging.Logger
 	Tracer         *tracing.Tracer
 	Tags           *tags.Tags
+	Accounting     accounting.Interface
 }
 
 func New(o Options) Service {

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -86,6 +86,12 @@ func (s *server) setupRouting() {
 	router.Handle("/topology", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.topologyHandler),
 	})
+	router.Handle("/balances", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.balancesHandler),
+	})
+	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.balancesPeerHandler),
+	})
 
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),


### PR DESCRIPTION
The aim of this pull request is to create the
/balances
/balances/{peer}
endpoints, that return the swap balances associated with peers in json format