### PR TITLE
k3d set v1.7.0 version

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install k3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v1.7.0 bash
       - name: Install latest beekeeper
         run: |
           export TAG=$(curl -s https://api.github.com/repos/ethersphere/beekeeper/releases/latest | jq -r .tag_name)


### PR DESCRIPTION
K3d did two things, renamed master to main and released new version, new version is still not feature complete for our usecase, setting previous version.
DNS infra tests already [passed](https://github.com/ethersphere/bee/runs/896990514).