### PR TITLE
run lint and vet only for ubuntu

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,8 +49,10 @@ jobs:
         GO111MODULE: on
       working-directory: ~
     - name: Lint
+      if: matrix.os == 'linux-latest'
       run: make lint
     - name: Vet
+      if: matrix.os == 'linux-latest'
       run: make vet
     - name: Build
       run: make build


### PR DESCRIPTION
this pr tries to shorten workflow time and reduce false positives
quite often lint is failing on windows and it can take too much time
for vet and linting it doesn't matter what base os we are using