### PR TITLE
fix TestSocValidator test

### DIFF
--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -54,7 +54,7 @@ func TestSocValidator(t *testing.T) {
 	// check invalid address
 	sch.Data()[0] = 0x00
 	wrongAddressBytes := sch.Address().Bytes()
-	wrongAddressBytes[0] ^= wrongAddressBytes[0]
+	wrongAddressBytes[0] = 255 - wrongAddressBytes[0]
 	wrongAddress := swarm.NewAddress(wrongAddressBytes)
 	sch = swarm.NewChunk(wrongAddress, sch.Data())
 	if v.Validate(sch) {


### PR DESCRIPTION
This PR fixes the `TestSocValidator` test which fails sometimes.

The test attempts to manipulate a randomly generated address by xoring the first byte with itself. This always sets the first byte to zero which causes the test to fail if the first byte of the address was already zero. This PR replaces the xor with `255 - val` which guarantees that `wrongAddress` will always be different. 