### PR TITLE
file: disable hanging tests

### DIFF
--- a/pkg/file/testing/vector.go
+++ b/pkg/file/testing/vector.go
@@ -14,27 +14,27 @@ import (
 var (
 	fileByteMod int = 255
 	fileLengths     = []int{
-		31,                           // 0
-		32,                           // 1
-		33,                           // 2
-		63,                           // 3
-		64,                           // 4
-		65,                           // 5
-		swarm.ChunkSize,              // 6
-		swarm.ChunkSize + 31,         // 7
-		swarm.ChunkSize + 32,         // 8
-		swarm.ChunkSize + 63,         // 9
-		swarm.ChunkSize + 64,         // 10
-		swarm.ChunkSize * 2,          // 11
-		swarm.ChunkSize*2 + 32,       // 12
-		swarm.ChunkSize * 128,        // 13
-		swarm.ChunkSize*128 + 31,     // 14
-		swarm.ChunkSize*128 + 32,     // 15
-		swarm.ChunkSize*128 + 64,     // 16
-		swarm.ChunkSize * 129,        // 17
-		swarm.ChunkSize * 130,        // 18
-		swarm.ChunkSize * 128 * 128,  // 19
-		swarm.ChunkSize*128*128 + 32, // 20
+		31,                       // 0
+		32,                       // 1
+		33,                       // 2
+		63,                       // 3
+		64,                       // 4
+		65,                       // 5
+		swarm.ChunkSize,          // 6
+		swarm.ChunkSize + 31,     // 7
+		swarm.ChunkSize + 32,     // 8
+		swarm.ChunkSize + 63,     // 9
+		swarm.ChunkSize + 64,     // 10
+		swarm.ChunkSize * 2,      // 11
+		swarm.ChunkSize*2 + 32,   // 12
+		swarm.ChunkSize * 128,    // 13
+		swarm.ChunkSize*128 + 31, // 14
+		swarm.ChunkSize*128 + 32, // 15
+		swarm.ChunkSize*128 + 64, // 16
+		swarm.ChunkSize * 129,    // 17
+		swarm.ChunkSize * 130,    // 18
+		//swarm.ChunkSize * 128 * 128,  // 19
+		//swarm.ChunkSize*128*128 + 32, // 20
 	}
 	fileExpectHashHex = []string{
 		"ece86edb20669cc60d142789d464d57bdf5e33cb789d443f608cbd81cfa5697d", // 0


### PR DESCRIPTION
the last two test vectors in `TestSplitThenJoin` take `t=eternity+1` to execute, which very often sends the CI to a halt, causing the test suite to fail, resulting in a slower feedback loop and a general slow-down of the workflow.
example dump observed yesterday:
```
2020-07-27T13:39:58.1569660Z === RUN   TestSplitThenJoin
2020-07-27T13:39:58.1603830Z === RUN   TestSplitThenJoin/0
2020-07-27T13:39:58.1703740Z === RUN   TestSplitThenJoin/1
2020-07-27T13:39:58.1733370Z === RUN   TestSplitThenJoin/2
2020-07-27T13:39:58.1740340Z === RUN   TestSplitThenJoin/3
2020-07-27T13:39:58.1845580Z === RUN   TestSplitThenJoin/4
2020-07-27T13:39:58.1849340Z === RUN   TestSplitThenJoin/5
2020-07-27T13:39:58.1854880Z === RUN   TestSplitThenJoin/6
2020-07-27T13:39:58.1883860Z === RUN   TestSplitThenJoin/7
2020-07-27T13:39:58.1986820Z === RUN   TestSplitThenJoin/8
2020-07-27T13:39:58.2089780Z === RUN   TestSplitThenJoin/9
2020-07-27T13:39:58.2201580Z === RUN   TestSplitThenJoin/10
2020-07-27T13:39:58.2282040Z === RUN   TestSplitThenJoin/11
2020-07-27T13:39:58.2385350Z === RUN   TestSplitThenJoin/12
2020-07-27T13:39:58.2449760Z === RUN   TestSplitThenJoin/13
2020-07-27T13:39:58.2482070Z === RUN   TestSplitThenJoin/14
2020-07-27T13:39:58.2528990Z === RUN   TestSplitThenJoin/15
2020-07-27T13:39:58.2549130Z === RUN   TestSplitThenJoin/16
2020-07-27T13:39:58.2574850Z === RUN   TestSplitThenJoin/17
2020-07-27T13:39:58.2591300Z === RUN   TestSplitThenJoin/18
2020-07-27T13:39:58.2602290Z === RUN   TestSplitThenJoin/19
2020-07-27T13:39:58.2605390Z === RUN   TestSplitThenJoin/20
2020-07-27T13:39:58.2676270Z panic: test timed out after 10m0s
2020-07-27T13:39:58.2678190Z 
2020-07-27T13:39:58.2680040Z goroutine 1243590 [running]:
2020-07-27T13:39:58.2696430Z testing.(*M).startAlarm.func1()
2020-07-27T13:39:58.2767830Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1509 +0x11c
2020-07-27T13:39:58.2792660Z created by time.goFunc
2020-07-27T13:39:58.2865060Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/time/sleep.go:168 +0x52
2020-07-27T13:39:58.2866840Z 
2020-07-27T13:39:58.2868580Z goroutine 1 [chan receive, 9 minutes]:
2020-07-27T13:39:58.2872260Z testing.(*T).Run(0xc0000de900, 0x18169c6, 0x11, 0x18318f8, 0x1)
2020-07-27T13:39:58.2875630Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1091 +0x739
2020-07-27T13:39:58.2978710Z testing.runTests.func1(0xc0000de900)
2020-07-27T13:39:58.3047570Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1334 +0xa7
2020-07-27T13:39:58.3085030Z testing.tRunner(0xc0000de900, 0xc0000bfd38)
2020-07-27T13:39:58.3103840Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1039 +0x1ec
2020-07-27T13:39:58.3106690Z testing.runTests(0xc0000b3020, 0x1cf4980, 0x3, 0x3, 0x0)
2020-07-27T13:39:58.3109820Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1332 +0x528
2020-07-27T13:39:58.3112550Z testing.(*M).Run(0xc000140300, 0x0)
2020-07-27T13:39:58.3126020Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1249 +0x440
2020-07-27T13:39:58.3132110Z main.main()
2020-07-27T13:39:58.3156940Z 	_testmain.go:50 +0x224
2020-07-27T13:39:58.3159100Z 
2020-07-27T13:39:58.3161660Z goroutine 55 [chan receive, 1 minutes]:
2020-07-27T13:39:58.3262610Z testing.(*T).Run(0xc0000df560, 0x182bf25, 0x2, 0x1831910, 0x1)
2020-07-27T13:39:58.3288950Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1091 +0x739
2020-07-27T13:39:58.3317210Z github.com/ethersphere/bee/pkg/file_test.TestSplitThenJoin(0xc0000df560)
2020-07-27T13:39:58.3327820Z 	/Users/runner/work/bee/bee/pkg/file/file_test.go:38 +0x89
2020-07-27T13:39:58.3339650Z testing.tRunner(0xc0000df560, 0x18318f8)
2020-07-27T13:39:58.3354580Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1039 +0x1ec
2020-07-27T13:39:58.3365520Z created by testing.(*T).Run
2020-07-27T13:39:58.3370570Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1090 +0x701
2020-07-27T13:39:58.3438910Z 
2020-07-27T13:39:58.3444720Z goroutine 1244514 [runnable]:
2020-07-27T13:39:58.3469400Z github.com/ethersphere/bmt/legacy.(*Hasher).writeSection(0xc00009d680, 0x38, 0xc001830fc0, 0x40, 0x40, 0x1)
2020-07-27T13:39:58.3542290Z 	/Users/runner/go/pkg/mod/github.com/ethersphere/bmt@v0.1.2/legacy/bmt.go:472
2020-07-27T13:39:58.3550030Z created by github.com/ethersphere/bmt/legacy.(*Hasher).write
2020-07-27T13:39:58.3581940Z 	/Users/runner/go/pkg/mod/github.com/ethersphere/bmt@v0.1.2/legacy/bmt.go:370 +0x41c
2020-07-27T13:39:58.3684790Z 
2020-07-27T13:39:58.3839630Z goroutine 1124315 [runnable]:
2020-07-27T13:39:58.3943040Z github.com/ethersphere/bmt/legacy.(*Hasher).write(0xc00009d680, 0xc004e00680, 0x1000, 0x11a10, 0xc000200168)
2020-07-27T13:39:58.4015120Z 	/Users/runner/go/pkg/mod/github.com/ethersphere/bmt@v0.1.2/legacy/bmt.go:372 +0x43b
2020-07-27T13:39:58.4031150Z github.com/ethersphere/bmt/legacy.(*Hasher).Write(0xc00009d680, 0xc004e00680, 0x1000, 0x11a10, 0x0, 0x0, 0x1)
2020-07-27T13:39:58.4076450Z 	/Users/runner/go/pkg/mod/github.com/ethersphere/bmt@v0.1.2/legacy/bmt.go:331 +0x57
2020-07-27T13:39:58.4097070Z github.com/ethersphere/bee/pkg/file/splitter/internal.(*SimpleSplitterJob).sumLevel(0xc0000d8a00, 0x0, 0x11a10, 0xc004dfc000, 0x1000, 0x1000, 0x1)
2020-07-27T13:39:58.4199590Z 	/Users/runner/work/bee/bee/pkg/file/splitter/internal/job.go:152 +0x4df
2020-07-27T13:39:58.4303790Z github.com/ethersphere/bee/pkg/file/splitter/internal.(*SimpleSplitterJob).writeToLevel(0xc0000d8a00, 0x0, 0xc004dfc000, 0x1000, 0x1000, 0x1000, 0x0)
2020-07-27T13:39:58.4344060Z 	/Users/runner/work/bee/bee/pkg/file/splitter/internal/job.go:119 +0x311
2020-07-27T13:39:58.4348640Z github.com/ethersphere/bee/pkg/file/splitter/internal.(*SimpleSplitterJob).Write(0xc0000d8a00, 0xc004dfc000, 0x1000, 0x1000, 0x1000, 0x0, 0x0)
2020-07-27T13:39:58.4353060Z 	/Users/runner/work/bee/bee/pkg/file/splitter/internal/job.go:87 +0x1cf
2020-07-27T13:39:58.4356780Z github.com/ethersphere/bee/pkg/file/splitter.(*simpleSplitter).Split(0xc000196090, 0x18ea2c0, 0xc000020040, 0x18e4300, 0xc00000e0a0, 0x4000020, 0x0, 0x40, 0x2, 0x11bffd0, ...)
2020-07-27T13:39:58.4486440Z 	/Users/runner/work/bee/bee/pkg/file/splitter/splitter.go:56 +0x421
2020-07-27T13:39:58.4598270Z github.com/ethersphere/bee/pkg/file_test.testSplitThenJoin(0xc0000de000)
2020-07-27T13:39:58.4701850Z 	/Users/runner/work/bee/bee/pkg/file/file_test.go:56 +0x417
2020-07-27T13:39:58.4805560Z testing.tRunner(0xc0000de000, 0x1831910)
2020-07-27T13:39:58.4901370Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1039 +0x1ec
2020-07-27T13:39:58.5010230Z created by testing.(*T).Run
2020-07-27T13:39:58.5199480Z 	/Users/runner/hostedtoolcache/go/1.14.6/x64/src/testing/testing.go:1090 +0x701
2020-07-27T13:39:58.5211200Z FAIL	github.com/ethersphere/bee/pkg/file	600.982s
```

disabling this until we have some bandwidth to deal with this.
cc @nolash 
related to https://github.com/ethersphere/bee/issues/392