### PR TITLE
Debounce statestore writes for Accounting

### DIFF
--- a/pkg/accounting/debouncer/debouncer.go
+++ b/pkg/accounting/debouncer/debouncer.go
@@ -1,0 +1,89 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debouncer
+
+import (
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/storage"
+	"sync"
+	"time"
+)
+
+type Interface interface {
+	Put(reference string, value int64)
+}
+
+type Debouncer struct {
+	logger logging.Logger
+	store  storage.StateStorer
+	lock   sync.Mutex
+	set    map[string]int64
+	wg     sync.WaitGroup
+	quit   chan struct{} // quit channel
+}
+
+type Options struct {
+	Logger logging.Logger
+	Store  storage.StateStorer
+}
+
+func (d *Debouncer) Close() error {
+	close(d.quit)
+	d.wg.Wait()
+	return nil
+}
+
+func NewDebouncer(o Options) *Debouncer {
+
+	d := &Debouncer{
+		logger: o.Logger,
+		store:  o.Store,
+		set:    make(map[string]int64),
+		quit:   make(chan struct{}),
+	}
+	d.wg.Add(1)
+	go d.manageWrites()
+
+	return d
+
+}
+
+func (d *Debouncer) manageWrites() {
+
+	for {
+		select {
+		case <-d.quit:
+			d.writeSet()
+			d.wg.Done()
+			return
+		case <-time.After(6 * time.Second):
+			// periodically clear set
+			d.writeSet()
+
+		}
+	}
+
+}
+
+func (d *Debouncer) writeSet() {
+	d.lock.Lock()
+	// use batch write from store
+	copySet := d.set
+	d.set = make(map[string]int64)
+	d.lock.Unlock()
+	//
+	for reference, value := range copySet {
+		err := d.store.Put(reference, value)
+		if err != nil {
+			d.logger.Errorf("error writing to store for peer %v in managed writes %v", reference, err)
+		}
+	}
+}
+
+func (d *Debouncer) Put(reference string, value int64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.set[reference] = value
+}

--- a/pkg/accounting/debouncer/mock/debouncer.go
+++ b/pkg/accounting/debouncer/mock/debouncer.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import ()
+
+type mockDebouncer struct {
+	set map[string]int64
+}
+
+func NewDebouncer() *mockDebouncer {
+	a := &mockDebouncer{
+		set: make(map[string]int64),
+	}
+	return a
+}
+
+func (md *mockDebouncer) Put(reference string, value int64) {
+	md.set[reference] = value
+}
+
+func (md *mockDebouncer) Get(reference string) (int64, bool) {
+	value, ok := md.set[reference]
+	return value, ok
+}

--- a/pkg/accounting/debouncer/mock/debouncer.go
+++ b/pkg/accounting/debouncer/mock/debouncer.go
@@ -6,22 +6,22 @@ package mock
 
 import ()
 
-type mockDebouncer struct {
+type MockDebouncer struct {
 	set map[string]int64
 }
 
-func NewDebouncer() *mockDebouncer {
-	a := &mockDebouncer{
+func NewDebouncer() *MockDebouncer {
+	a := &MockDebouncer{
 		set: make(map[string]int64),
 	}
 	return a
 }
 
-func (md *mockDebouncer) Put(reference string, value int64) {
+func (md *MockDebouncer) Put(reference string, value int64) {
 	md.set[reference] = value
 }
 
-func (md *mockDebouncer) Get(reference string) (int64, bool) {
+func (md *MockDebouncer) Get(reference string) (int64, bool) {
 	value, ok := md.set[reference]
 	return value, ok
 }

--- a/pkg/accounting/export_test.go
+++ b/pkg/accounting/export_test.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package accounting
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func BalanceKey(peer swarm.Address) string {
+	return balanceKey(peer)
+}


### PR DESCRIPTION
As part of this PR we create the accounting/debouncer package,
The debouncer package is meant to be a disk-write-bufferzone, that limits the number of disk writes for a store key within the time scope of the debouncer interval to 1 / interval.