### PR TITLE
Fix panic in tags debug api

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -27,6 +27,9 @@ type bytesPostResponse struct {
 // bytesUploadHandler handles upload of raw binary data of arbitrary length.
 func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ta := s.createTag(w, r)
+	if ta == nil {
+		return
+	}
 
 	// Add the tag to the context
 	r = r.WithContext(context.WithValue(r.Context(), tags.TagsContextKey{}, ta))

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -67,6 +67,9 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	var fileSize uint64
 
 	ta := s.createTag(w, r)
+	if ta == nil {
+		return
+	}
 
 	// Add the tag to the context
 	r = r.WithContext(context.WithValue(r.Context(), tags.TagsContextKey{}, ta))

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -176,7 +176,13 @@ func (s *SimpleSplitterJob) sumLevel(lvl int) ([]byte, error) {
 	ref := s.hasher.Sum(nil)
 	addr = swarm.NewAddress(ref)
 
-	ch := swarm.NewChunk(addr, c)
+	var ch swarm.Chunk
+	if s.tagg != nil {
+		ch = swarm.NewChunk(addr, c).WithTagID(s.tagg.Uid)
+	} else {
+		ch = swarm.NewChunk(addr, c)
+	}
+
 	seen, err := s.putter.Put(s.ctx, storage.ModePutUpload, ch)
 	if err != nil {
 		return nil, err

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -176,6 +176,7 @@ func (s *SimpleSplitterJob) sumLevel(lvl int) ([]byte, error) {
 	ref := s.hasher.Sum(nil)
 	addr = swarm.NewAddress(ref)
 
+	// Add tag to the chunk if tag is valid
 	var ch swarm.Chunk
 	if s.tagg != nil {
 		ch = swarm.NewChunk(addr, c).WithTagID(s.tagg.Uid)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -347,6 +347,7 @@ func NewBee(o Options) (*Bee, error) {
 			Tracer:         tracer,
 			TopologyDriver: topologyDriver,
 			Storer:         storer,
+			Tags:           tagg,
 		})
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)


### PR DESCRIPTION
When the debug api is enabled,  /tags and /tags/{uid} api panic.
This is because the tag is not initialized in the debug server.
This was not caught in the unit tests as the test cases uses mock server and in real world we use the debug server which is initialized in "node" package
