### PR TITLE
manifest, jsonmanifest, api, node: add encoding marshaling to manifest interface

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/logging"
-	"github.com/ethersphere/bee/pkg/manifest"
 	m "github.com/ethersphere/bee/pkg/metrics"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -29,7 +28,6 @@ type server struct {
 type Options struct {
 	Tags               *tags.Tags
 	Storer             storage.Storer
-	ManifestParser     manifest.Parser
 	CORSAllowedOrigins []string
 	Logger             logging.Logger
 	Tracer             *tracing.Tracer

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/logging"
-	"github.com/ethersphere/bee/pkg/manifest"
 	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -21,11 +20,10 @@ import (
 )
 
 type testServerOptions struct {
-	Pingpong       pingpong.Interface
-	Storer         storage.Storer
-	ManifestParser manifest.Parser
-	Tags           *tags.Tags
-	Logger         logging.Logger
+	Pingpong pingpong.Interface
+	Storer   storage.Storer
+	Tags     *tags.Tags
+	Logger   logging.Logger
 }
 
 func newTestServer(t *testing.T, o testServerOptions) *http.Client {
@@ -33,10 +31,9 @@ func newTestServer(t *testing.T, o testServerOptions) *http.Client {
 		o.Logger = logging.New(ioutil.Discard, 0)
 	}
 	s := api.New(api.Options{
-		Tags:           o.Tags,
-		Storer:         o.Storer,
-		ManifestParser: o.ManifestParser,
-		Logger:         o.Logger,
+		Tags:   o.Tags,
+		Storer: o.Storer,
+		Logger: o.Logger,
 	})
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file"
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/manifest/jsonmanifest"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
 )
@@ -98,7 +99,8 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.NotFound(w, nil)
 		return
 	}
-	manifest, err := s.ManifestParser.Parse(buf.Bytes())
+	manifest := &jsonmanifest.JSONManifest{}
+	err = manifest.UnmarshalBinary(buf.Bytes())
 	if err != nil {
 		s.Logger.Debugf("bzz download: unmarshal manifest %s: %v", address, err)
 		s.Logger.Errorf("bzz download: unmarshal manifest %s", address)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -99,7 +99,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.NotFound(w, nil)
 		return
 	}
-	manifest := &jsonmanifest.JSONManifest{}
+	manifest := jsonmanifest.NewManifest()
 	err = manifest.UnmarshalBinary(buf.Bytes())
 	if err != nil {
 		s.Logger.Debugf("bzz download: unmarshal manifest %s: %v", address, err)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -108,7 +108,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	me, err := manifest.FindEntry(path)
+	me, err := manifest.Entry(path)
 	if err != nil {
 		s.Logger.Debugf("bzz download: invalid path %s/%s: %v", address, path, err)
 		s.Logger.Error("bzz download: invalid path")
@@ -116,20 +116,20 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	manifestEntryAddress := me.GetReference()
+	manifestEntryAddress := me.Reference()
 
 	var additionalHeaders http.Header
 
 	// copy headers from manifest
-	if me.GetHeaders() != nil {
-		additionalHeaders = me.GetHeaders().Clone()
+	if me.Headers() != nil {
+		additionalHeaders = me.Headers().Clone()
 	} else {
 		additionalHeaders = http.Header{}
 	}
 
 	// include filename
-	if me.GetName() != "" {
-		additionalHeaders.Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", me.GetName()))
+	if me.Name() != "" {
+		additionalHeaders.Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", me.Name()))
 	}
 
 	// read file entry

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -101,7 +101,7 @@ func TestBzz(t *testing.T) {
 			},
 		})
 
-		manifestFileBytes, err := jsonManifest.Serialize()
+		manifestFileBytes, err := jsonManifest.MarshalBinary()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -34,10 +34,9 @@ func TestBzz(t *testing.T) {
 		storer              = smock.NewStorer()
 		sp                  = splitter.NewSimpleSplitter(storer)
 		client              = newTestServer(t, testServerOptions{
-			Storer:         storer,
-			ManifestParser: jsonmanifest.NewParser(),
-			Tags:           tags.NewTags(),
-			Logger:         logging.New(ioutil.Discard, 5),
+			Storer: storer,
+			Tags:   tags.NewTags(),
+			Logger: logging.New(ioutil.Discard, 5),
 		})
 	)
 

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -92,13 +92,8 @@ func TestBzz(t *testing.T) {
 
 		jsonManifest := jsonmanifest.NewManifest()
 
-		jsonManifest.Add(filePath, jsonmanifest.JSONEntry{
-			Reference: fileReference,
-			Name:      fileName,
-			Headers: http.Header{
-				"Content-Type": {"text/html", "charset=utf-8"},
-			},
-		})
+		e := jsonmanifest.NewEntry(fileReference, fileName, http.Header{"Content-Type": {"text/html", "charset=utf-8"}})
+		jsonManifest.Add(filePath, e)
 
 		manifestFileBytes, err := jsonManifest.MarshalBinary()
 		if err != nil {

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -134,7 +134,7 @@ func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, logge
 
 	// upload manifest
 	// first, serialize into byte array
-	b, err := dirManifest.Serialize()
+	b, err := dirManifest.MarshalBinary()
 	if err != nil {
 		return swarm.ZeroAddress, fmt.Errorf("manifest serialize error: %w", err)
 	}

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -117,11 +117,7 @@ func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, logge
 		// create manifest entry for uploaded file
 		headers := http.Header{}
 		headers.Set("Content-Type", contentType)
-		fileEntry := &jsonmanifest.JSONEntry{
-			Reference: fileReference,
-			Name:      fileName,
-			Headers:   headers,
-		}
+		fileEntry := jsonmanifest.NewEntry(fileReference, fileName, headers)
 
 		// add entry to dir manifest
 		dirManifest.Add(filePath, fileEntry)

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -146,11 +146,7 @@ func TestDirs(t *testing.T) {
 			// create expected manifest
 			expectedManifest := jsonmanifest.NewManifest()
 			for _, file := range tc.files {
-				e := &jsonmanifest.JSONEntry{
-					Reference: file.reference,
-					Name:      file.name,
-					Headers:   file.headers,
-				}
+				e := jsonmanifest.NewEntry(file.reference, file.name, file.headers)
 				expectedManifest.Add(path.Join(file.dir, file.name), e)
 			}
 

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -154,7 +154,7 @@ func TestDirs(t *testing.T) {
 				expectedManifest.Add(path.Join(file.dir, file.name), e)
 			}
 
-			b, err := expectedManifest.Serialize()
+			b, err := expectedManifest.MarshalBinary()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package jsonmanifest
+
+import (
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/manifest"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// JSONEntry is a JSON representation of a file entry for a JSONManifest
+type JSONEntry struct {
+	Reference swarm.Address `json:"reference"`
+	Name      string        `json:"name"`
+	Headers   http.Header   `json:"headers"`
+}
+
+// verify JSONEntry implements manifest.Entry
+var _ manifest.Entry = (*JSONEntry)(nil)
+
+// GetReference returns the address of the entry for a file
+func (me JSONEntry) GetReference() swarm.Address {
+	return me.Reference
+}
+
+// GetName returns the name of the file for the entry
+func (me JSONEntry) GetName() string {
+	return me.Name
+}
+
+// GetHeaders returns the headers for manifest entry for a file
+func (me JSONEntry) GetHeaders() http.Header {
+	return me.Headers
+}

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -62,7 +62,7 @@ func (me *JSONEntry) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON implements the json.Marshaler interface.
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (me *JSONEntry) UnmarshalJSON(b []byte) error {
 	e := exportEntry{}
 	if err := json.Unmarshal(b, &e); err != nil {

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -11,27 +11,27 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// verify JSONEntry implements manifest.Entry
+// verify JSONEntry implements manifest.Entry.
 var _ manifest.Entry = (*JSONEntry)(nil)
 
-// JSONEntry is a JSON representation of a single manifest entry for a JSONManifest
+// JSONEntry is a JSON representation of a single manifest entry for a JSONManifest.
 type JSONEntry struct {
 	Reference swarm.Address `json:"reference"`
 	Name      string        `json:"name"`
 	Headers   http.Header   `json:"headers"`
 }
 
-// GetReference returns the address of the file in the entry
+// GetReference returns the address of the file in the entry.
 func (me JSONEntry) GetReference() swarm.Address {
 	return me.Reference
 }
 
-// GetName returns the name of the file in the entry
+// GetName returns the name of the file in the entry.
 func (me JSONEntry) GetName() string {
 	return me.Name
 }
 
-// GetHeaders returns the headers for the file in the manifest entry
+// GetHeaders returns the headers for the file in the manifest entry.
 func (me JSONEntry) GetHeaders() http.Header {
 	return me.Headers
 }

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -11,27 +11,27 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// JSONEntry is a JSON representation of a file entry for a JSONManifest
+// verify JSONEntry implements manifest.Entry
+var _ manifest.Entry = (*JSONEntry)(nil)
+
+// JSONEntry is a JSON representation of a single manifest entry for a JSONManifest
 type JSONEntry struct {
 	Reference swarm.Address `json:"reference"`
 	Name      string        `json:"name"`
 	Headers   http.Header   `json:"headers"`
 }
 
-// verify JSONEntry implements manifest.Entry
-var _ manifest.Entry = (*JSONEntry)(nil)
-
-// GetReference returns the address of the entry for a file
+// GetReference returns the address of the file in the entry
 func (me JSONEntry) GetReference() swarm.Address {
 	return me.Reference
 }
 
-// GetName returns the name of the file for the entry
+// GetName returns the name of the file in the entry
 func (me JSONEntry) GetName() string {
 	return me.Name
 }
 
-// GetHeaders returns the headers for manifest entry for a file
+// GetHeaders returns the headers for the file in the manifest entry
 func (me JSONEntry) GetHeaders() http.Header {
 	return me.Headers
 }

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -16,22 +16,31 @@ var _ manifest.Entry = (*JSONEntry)(nil)
 
 // JSONEntry is a JSON representation of a single manifest entry for a JSONManifest.
 type JSONEntry struct {
-	Reference swarm.Address `json:"reference"`
-	Name      string        `json:"name"`
-	Headers   http.Header   `json:"headers"`
+	reference swarm.Address
+	name      string
+	headers   http.Header
 }
 
-// GetReference returns the address of the file in the entry.
-func (me JSONEntry) GetReference() swarm.Address {
-	return me.Reference
+// NewEntry creates a new JSONEntry struct and returns it.
+func NewEntry(reference swarm.Address, name string, headers http.Header) JSONEntry {
+	return JSONEntry{
+		reference: reference,
+		name:      name,
+		headers:   headers,
+	}
 }
 
-// GetName returns the name of the file in the entry.
-func (me JSONEntry) GetName() string {
-	return me.Name
+// Reference returns the address of the file in the entry.
+func (me JSONEntry) Reference() swarm.Address {
+	return me.reference
 }
 
-// GetHeaders returns the headers for the file in the manifest entry.
-func (me JSONEntry) GetHeaders() http.Header {
-	return me.Headers
+// Name returns the name of the file in the entry.
+func (me JSONEntry) Name() string {
+	return me.name
+}
+
+// Headers returns the headers for the file in the manifest entry.
+func (me JSONEntry) Headers() http.Header {
+	return me.headers
 }

--- a/pkg/manifest/jsonmanifest/entry.go
+++ b/pkg/manifest/jsonmanifest/entry.go
@@ -5,6 +5,7 @@
 package jsonmanifest
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/manifest"
@@ -22,8 +23,8 @@ type JSONEntry struct {
 }
 
 // NewEntry creates a new JSONEntry struct and returns it.
-func NewEntry(reference swarm.Address, name string, headers http.Header) JSONEntry {
-	return JSONEntry{
+func NewEntry(reference swarm.Address, name string, headers http.Header) *JSONEntry {
+	return &JSONEntry{
 		reference: reference,
 		name:      name,
 		headers:   headers,
@@ -31,16 +32,44 @@ func NewEntry(reference swarm.Address, name string, headers http.Header) JSONEnt
 }
 
 // Reference returns the address of the file in the entry.
-func (me JSONEntry) Reference() swarm.Address {
+func (me *JSONEntry) Reference() swarm.Address {
 	return me.reference
 }
 
 // Name returns the name of the file in the entry.
-func (me JSONEntry) Name() string {
+func (me *JSONEntry) Name() string {
 	return me.name
 }
 
 // Headers returns the headers for the file in the manifest entry.
-func (me JSONEntry) Headers() http.Header {
+func (me *JSONEntry) Headers() http.Header {
 	return me.headers
+}
+
+// exportEntry is a struct used for marshaling and unmarshaling JSONEntry structs.
+type exportEntry struct {
+	Reference swarm.Address `json:"reference"`
+	Name      string        `json:"name"`
+	Headers   http.Header   `json:"headers"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (me *JSONEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(exportEntry{
+		Reference: me.reference,
+		Name:      me.name,
+		Headers:   me.headers,
+	})
+}
+
+// UnmarshalJSON implements the json.Marshaler interface.
+func (me *JSONEntry) UnmarshalJSON(b []byte) error {
+	e := exportEntry{}
+	if err := json.Unmarshal(b, &e); err != nil {
+		return err
+	}
+	me.reference = e.Reference
+	me.name = e.Name
+	me.headers = e.Headers
+	return nil
 }

--- a/pkg/manifest/jsonmanifest/json.go
+++ b/pkg/manifest/jsonmanifest/json.go
@@ -12,18 +12,22 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var _ manifest.Interface = (*JSONManifest)(nil)
-
+// JSONManifest stores JSON manifest entries
 type JSONManifest struct {
 	Entries map[string]JSONEntry `json:"entries,omitempty"`
 }
 
+// verify JSONManifest implements manifest.Interface
+var _ manifest.Interface = (*JSONManifest)(nil)
+
+// NewManifest creates a new JSONManifest struct and returns a pointer to it
 func NewManifest() *JSONManifest {
 	return &JSONManifest{
 		Entries: make(map[string]JSONEntry),
 	}
 }
 
+// Add adds a manifest entry to the specified path
 func (m *JSONManifest) Add(path string, entry manifest.Entry) {
 	m.Entries[path] = JSONEntry{
 		Reference: entry.GetReference(),
@@ -32,10 +36,12 @@ func (m *JSONManifest) Add(path string, entry manifest.Entry) {
 	}
 }
 
+// Remove removes an entry on the specified path
 func (m *JSONManifest) Remove(path string) {
 	delete(m.Entries, path)
 }
 
+// FindEntry returns a manifest entry if one is found on the specified path
 func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	if entry, ok := m.Entries[path]; ok {
 		return entry, nil
@@ -44,30 +50,37 @@ func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	return nil, manifest.ErrNotFound
 }
 
+// MarshalBinary implements encoding.BinaryMarshaler
 func (m *JSONManifest) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(m)
 }
 
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
 func (m *JSONManifest) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
+// verify JSONEntry implements manifest.Entry
 var _ manifest.Entry = (*JSONEntry)(nil)
 
+// JSONEntry is a JSON representation of a file entry for a JSONManifest
 type JSONEntry struct {
 	Reference swarm.Address `json:"reference"`
 	Name      string        `json:"name"`
 	Headers   http.Header   `json:"headers"`
 }
 
+// GetReference returns the address of the entry for a file
 func (me JSONEntry) GetReference() swarm.Address {
 	return me.Reference
 }
 
+// GetName returns the name of the file for the entry
 func (me JSONEntry) GetName() string {
 	return me.Name
 }
 
+// GetHeaders returns the headers for manifest entry for a file
 func (me JSONEntry) GetHeaders() http.Header {
 	return me.Headers
 }

--- a/pkg/manifest/jsonmanifest/json.go
+++ b/pkg/manifest/jsonmanifest/json.go
@@ -12,21 +12,6 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var _ manifest.Parser = (*JSONParser)(nil)
-
-type JSONParser struct{}
-
-func NewParser() *JSONParser {
-	return &JSONParser{}
-}
-
-func (m *JSONParser) Parse(bytes []byte) (manifest.Interface, error) {
-	mi := &JSONManifest{}
-	err := json.Unmarshal(bytes, mi)
-
-	return mi, err
-}
-
 var _ manifest.Interface = (*JSONManifest)(nil)
 
 type JSONManifest struct {

--- a/pkg/manifest/jsonmanifest/json.go
+++ b/pkg/manifest/jsonmanifest/json.go
@@ -59,8 +59,12 @@ func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	return nil, manifest.ErrNotFound
 }
 
-func (m *JSONManifest) Serialize() ([]byte, error) {
+func (m *JSONManifest) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(m)
+}
+
+func (m *JSONManifest) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, m)
 }
 
 var _ manifest.Entry = (*JSONEntry)(nil)

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -10,13 +10,14 @@ import (
 	"github.com/ethersphere/bee/pkg/manifest"
 )
 
-// JSONManifest stores JSON manifest entries
+// verify JSONManifest implements manifest.Interface
+var _ manifest.Interface = (*JSONManifest)(nil)
+
+// JSONManifest is a JSON representation of a manifest
+// it stores manifest entries in a map based on string keys
 type JSONManifest struct {
 	Entries map[string]JSONEntry `json:"entries,omitempty"`
 }
-
-// verify JSONManifest implements manifest.Interface
-var _ manifest.Interface = (*JSONManifest)(nil)
 
 // NewManifest creates a new JSONManifest struct and returns a pointer to it
 func NewManifest() *JSONManifest {
@@ -39,7 +40,7 @@ func (m *JSONManifest) Remove(path string) {
 	delete(m.Entries, path)
 }
 
-// FindEntry returns a manifest entry if one is found on the specified path
+// FindEntry returns a manifest entry if one is found in the specified path
 func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	if entry, ok := m.Entries[path]; ok {
 		return entry, nil

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -28,11 +28,7 @@ func NewManifest() *JSONManifest {
 
 // Add adds a manifest entry to the specified path.
 func (m *JSONManifest) Add(path string, entry manifest.Entry) {
-	m.Entries[path] = JSONEntry{
-		Reference: entry.GetReference(),
-		Name:      entry.GetName(),
-		Headers:   entry.GetHeaders(),
-	}
+	m.Entries[path] = NewEntry(entry.Reference(), entry.Name(), entry.Headers())
 }
 
 // Remove removes a manifest entry on the specified path.
@@ -40,8 +36,8 @@ func (m *JSONManifest) Remove(path string) {
 	delete(m.Entries, path)
 }
 
-// FindEntry returns a manifest entry if one is found in the specified path.
-func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
+// Entry returns a manifest entry if one is found in the specified path.
+func (m *JSONManifest) Entry(path string) (manifest.Entry, error) {
 	if entry, ok := m.Entries[path]; ok {
 		return entry, nil
 	}

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -6,10 +6,8 @@ package jsonmanifest
 
 import (
 	"encoding/json"
-	"net/http"
 
 	"github.com/ethersphere/bee/pkg/manifest"
-	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // JSONManifest stores JSON manifest entries
@@ -58,29 +56,4 @@ func (m *JSONManifest) MarshalBinary() (data []byte, err error) {
 // UnmarshalBinary implements encoding.BinaryUnmarshaler
 func (m *JSONManifest) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
-}
-
-// verify JSONEntry implements manifest.Entry
-var _ manifest.Entry = (*JSONEntry)(nil)
-
-// JSONEntry is a JSON representation of a file entry for a JSONManifest
-type JSONEntry struct {
-	Reference swarm.Address `json:"reference"`
-	Name      string        `json:"name"`
-	Headers   http.Header   `json:"headers"`
-}
-
-// GetReference returns the address of the entry for a file
-func (me JSONEntry) GetReference() swarm.Address {
-	return me.Reference
-}
-
-// GetName returns the name of the file for the entry
-func (me JSONEntry) GetName() string {
-	return me.Name
-}
-
-// GetHeaders returns the headers for manifest entry for a file
-func (me JSONEntry) GetHeaders() http.Header {
-	return me.Headers
 }

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -10,23 +10,23 @@ import (
 	"github.com/ethersphere/bee/pkg/manifest"
 )
 
-// verify JSONManifest implements manifest.Interface
+// verify JSONManifest implements manifest.Interface.
 var _ manifest.Interface = (*JSONManifest)(nil)
 
-// JSONManifest is a JSON representation of a manifest
-// it stores manifest entries in a map based on string keys
+// JSONManifest is a JSON representation of a manifest.
+// It stores manifest entries in a map based on string keys.
 type JSONManifest struct {
 	Entries map[string]JSONEntry `json:"entries,omitempty"`
 }
 
-// NewManifest creates a new JSONManifest struct and returns a pointer to it
+// NewManifest creates a new JSONManifest struct and returns a pointer to it.
 func NewManifest() *JSONManifest {
 	return &JSONManifest{
 		Entries: make(map[string]JSONEntry),
 	}
 }
 
-// Add adds a manifest entry to the specified path
+// Add adds a manifest entry to the specified path.
 func (m *JSONManifest) Add(path string, entry manifest.Entry) {
 	m.Entries[path] = JSONEntry{
 		Reference: entry.GetReference(),
@@ -35,12 +35,12 @@ func (m *JSONManifest) Add(path string, entry manifest.Entry) {
 	}
 }
 
-// Remove removes a manifest entry on the specified path
+// Remove removes a manifest entry on the specified path.
 func (m *JSONManifest) Remove(path string) {
 	delete(m.Entries, path)
 }
 
-// FindEntry returns a manifest entry if one is found in the specified path
+// FindEntry returns a manifest entry if one is found in the specified path.
 func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	if entry, ok := m.Entries[path]; ok {
 		return entry, nil
@@ -49,12 +49,12 @@ func (m *JSONManifest) FindEntry(path string) (manifest.Entry, error) {
 	return nil, manifest.ErrNotFound
 }
 
-// MarshalBinary implements encoding.BinaryMarshaler
+// MarshalBinary implements encoding.BinaryMarshaler.
 func (m *JSONManifest) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(m)
 }
 
-// UnmarshalBinary implements encoding.BinaryUnmarshaler
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
 func (m *JSONManifest) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
 }

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -34,7 +34,7 @@ func (m *JSONManifest) Add(path string, entry manifest.Entry) {
 	}
 }
 
-// Remove removes an entry on the specified path
+// Remove removes a manifest entry on the specified path
 func (m *JSONManifest) Remove(path string) {
 	delete(m.Entries, path)
 }

--- a/pkg/manifest/jsonmanifest/manifest.go
+++ b/pkg/manifest/jsonmanifest/manifest.go
@@ -16,13 +16,13 @@ var _ manifest.Interface = (*JSONManifest)(nil)
 // JSONManifest is a JSON representation of a manifest.
 // It stores manifest entries in a map based on string keys.
 type JSONManifest struct {
-	Entries map[string]JSONEntry `json:"entries,omitempty"`
+	Entries map[string]*JSONEntry `json:"entries,omitempty"`
 }
 
 // NewManifest creates a new JSONManifest struct and returns a pointer to it.
 func NewManifest() *JSONManifest {
 	return &JSONManifest{
-		Entries: make(map[string]JSONEntry),
+		Entries: make(map[string]*JSONEntry),
 	}
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -15,12 +15,6 @@ import (
 // ErrNotFound is returned when an Entry is not found in the manifest
 var ErrNotFound = errors.New("manifest: not found")
 
-// Parser for manifest
-type Parser interface {
-	// Parse parses the encoded manifest data and returns the result
-	Parse(bytes []byte) (Interface, error)
-}
-
 // Interface for operations with manifest
 type Interface interface {
 	// Add a manifest entry to specified path
@@ -29,7 +23,9 @@ type Interface interface {
 	Remove(string)
 	// FindEntry returns manifest entry if one is found on specified path
 	FindEntry(string) (Entry, error)
+	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form
 	encoding.BinaryMarshaler
+	// BinaryUnmarshaler is the interface implemented by an object that can unmarshal a binary representation of itself
 	encoding.BinaryUnmarshaler
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -23,9 +23,7 @@ type Interface interface {
 	Remove(string)
 	// FindEntry returns a manifest entry if one is found in the specified path.
 	FindEntry(string) (Entry, error)
-	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form.
 	encoding.BinaryMarshaler
-	// BinaryUnmarshaler is the interface implemented by an object that can unmarshal a binary representation of itself.
 	encoding.BinaryUnmarshaler
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -19,7 +19,7 @@ var ErrNotFound = errors.New("manifest: not found")
 type Interface interface {
 	// Add a manifest entry to the specified path
 	Add(string, Entry)
-	// Remove an entry on the specified path
+	// Remove a manifest entry on the specified path
 	Remove(string)
 	// FindEntry returns a manifest entry if one is found on the specified path
 	FindEntry(string) (Entry, error)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -17,11 +17,11 @@ var ErrNotFound = errors.New("manifest: not found")
 
 // Interface for operations with manifest
 type Interface interface {
-	// Add a manifest entry to specified path
+	// Add a manifest entry to the specified path
 	Add(string, Entry)
-	// Remove reference from file on specified path
+	// Remove an entry on the specified path
 	Remove(string)
-	// FindEntry returns manifest entry if one is found on specified path
+	// FindEntry returns a manifest entry if one is found on the specified path
 	FindEntry(string) (Entry, error)
 	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form
 	encoding.BinaryMarshaler
@@ -29,12 +29,12 @@ type Interface interface {
 	encoding.BinaryUnmarshaler
 }
 
-// Entry represents single manifest entry
+// Entry represents a single manifest entry
 type Entry interface {
-	// GetReference returns address of the entry file
+	// GetReference returns the address of the entry for a file
 	GetReference() swarm.Address
-	// GetName returns the name of the file for the entry, if added
+	// GetName returns the name of the file for the entry
 	GetName() string
-	// GetHeaders returns the headers for manifest entry, if configured
+	// GetHeaders returns the headers for manifest entry for a file
 	GetHeaders() http.Header
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -21,7 +21,7 @@ type Interface interface {
 	Add(string, Entry)
 	// Remove a manifest entry on the specified path
 	Remove(string)
-	// FindEntry returns a manifest entry if one is found on the specified path
+	// FindEntry returns a manifest entry if one is found in the specified path
 	FindEntry(string) (Entry, error)
 	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form
 	encoding.BinaryMarshaler
@@ -31,10 +31,10 @@ type Interface interface {
 
 // Entry represents a single manifest entry
 type Entry interface {
-	// GetReference returns the address of the entry for a file
+	// GetReference returns the address of the file in the entry
 	GetReference() swarm.Address
-	// GetName returns the name of the file for the entry
+	// GetName returns the name of the file in the entry
 	GetName() string
-	// GetHeaders returns the headers for manifest entry for a file
+	// GetHeaders returns the headers for the file in the manifest entry
 	GetHeaders() http.Header
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -21,18 +21,18 @@ type Interface interface {
 	Add(string, Entry)
 	// Remove a manifest entry on the specified path.
 	Remove(string)
-	// FindEntry returns a manifest entry if one is found in the specified path.
-	FindEntry(string) (Entry, error)
+	// Entry returns a manifest entry if one is found in the specified path.
+	Entry(string) (Entry, error)
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 }
 
 // Entry represents a single manifest entry.
 type Entry interface {
-	// GetReference returns the address of the file in the entry.
-	GetReference() swarm.Address
-	// GetName returns the name of the file in the entry.
-	GetName() string
-	// GetHeaders returns the headers for the file in the manifest entry.
-	GetHeaders() http.Header
+	// Reference returns the address of the file in the entry.
+	Reference() swarm.Address
+	// Name returns the name of the file in the entry.
+	Name() string
+	// Headers returns the headers for the file in the manifest entry.
+	Headers() http.Header
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -5,12 +5,14 @@
 package manifest
 
 import (
+	"encoding"
 	"errors"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
+// ErrNotFound is returned when an Entry is not found in the manifest
 var ErrNotFound = errors.New("manifest: not found")
 
 // Parser for manifest
@@ -27,8 +29,8 @@ type Interface interface {
 	Remove(string)
 	// FindEntry returns manifest entry if one is found on specified path
 	FindEntry(string) (Entry, error)
-	// Serialize return encoded manifest
-	Serialize() ([]byte, error)
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
 }
 
 // Entry represents single manifest entry

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -12,29 +12,29 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// ErrNotFound is returned when an Entry is not found in the manifest
+// ErrNotFound is returned when an Entry is not found in the manifest.
 var ErrNotFound = errors.New("manifest: not found")
 
-// Interface for operations with manifest
+// Interface for operations with manifest.
 type Interface interface {
-	// Add a manifest entry to the specified path
+	// Add a manifest entry to the specified path.
 	Add(string, Entry)
-	// Remove a manifest entry on the specified path
+	// Remove a manifest entry on the specified path.
 	Remove(string)
-	// FindEntry returns a manifest entry if one is found in the specified path
+	// FindEntry returns a manifest entry if one is found in the specified path.
 	FindEntry(string) (Entry, error)
-	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form
+	// BinaryMarshaler is the interface implemented by an object that can marshal itself into a binary form.
 	encoding.BinaryMarshaler
-	// BinaryUnmarshaler is the interface implemented by an object that can unmarshal a binary representation of itself
+	// BinaryUnmarshaler is the interface implemented by an object that can unmarshal a binary representation of itself.
 	encoding.BinaryUnmarshaler
 }
 
-// Entry represents a single manifest entry
+// Entry represents a single manifest entry.
 type Entry interface {
-	// GetReference returns the address of the file in the entry
+	// GetReference returns the address of the file in the entry.
 	GetReference() swarm.Address
-	// GetName returns the name of the file in the entry
+	// GetName returns the name of the file in the entry.
 	GetName() string
-	// GetHeaders returns the headers for the file in the manifest entry
+	// GetHeaders returns the headers for the file in the manifest entry.
 	GetHeaders() http.Header
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -29,7 +29,6 @@ import (
 	memkeystore "github.com/ethersphere/bee/pkg/keystore/mem"
 	"github.com/ethersphere/bee/pkg/localstore"
 	"github.com/ethersphere/bee/pkg/logging"
-	"github.com/ethersphere/bee/pkg/manifest/jsonmanifest"
 	"github.com/ethersphere/bee/pkg/metrics"
 	"github.com/ethersphere/bee/pkg/netstore"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -302,15 +301,12 @@ func NewBee(o Options) (*Bee, error) {
 
 	b.pullerCloser = puller
 
-	manifestParser := jsonmanifest.NewParser()
-
 	var apiService api.Service
 	if o.APIAddr != "" {
 		// API server
 		apiService = api.New(api.Options{
 			Tags:               tagg,
 			Storer:             ns,
-			ManifestParser:     manifestParser,
 			CORSAllowedOrigins: o.CORSAllowedOrigins,
 			Logger:             logger,
 			Tracer:             tracer,


### PR DESCRIPTION
This PR removes the `manifest` parser-related structures, interfaces and functions and embeds the `encoding` binary marshaller and unmarshaller interfaces in its stead.

It also:
- updates the `jsonmanifest` implementation to comply with the new interface.
- piggybacks the splitting of `jsonmanifest/manifest.go` into 2 files (one for `jsonmanifest.Entry`) for easier maintainability.
- removes the word `Get` from `manifest.Entry` func names
  - as a result, `jsonmanifest.JSONEntry` fields had to be unexported, a constructor added, and custom marshalling/unmarshalling funcs were added as well. this struct now uses pointer semantics
- updates some `manifest` and `jsonmanifest` comments.

We are still eventually migrating all of this out of the codebase, through #476.

closes #494 