### PR TITLE
return empty response when nothing is pinned

### DIFF
--- a/pkg/debugapi/pin_test.go
+++ b/pkg/debugapi/pin_test.go
@@ -47,6 +47,13 @@ func TestPinChunkHandler(t *testing.T) {
 		})
 	})
 
+	// list pins without anything pinned
+	t.Run("list-pins-zero-pins", func(t *testing.T) {
+		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodGet, "/chunks-pin", nil, http.StatusOK, debugapi.ListPinnedChunksResponse{
+			Chunks: []debugapi.PinnedChunk{},
+		})
+	})
+
 	// pin a chunk which is not existing
 	t.Run("pin-absent-chunk", func(t *testing.T) {
 		jsonhttptest.ResponseDirect(t, debugTestServer.Client, http.MethodPost, "/chunks-pin/123456", nil, http.StatusNotFound, jsonhttp.StatusResponse{

--- a/pkg/localstore/pin.go
+++ b/pkg/localstore/pin.go
@@ -30,6 +30,16 @@ func (db *DB) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChu
 		prefix = nil
 	}
 
+	c, err := db.pinIndex.Count()
+	if err != nil {
+		return nil, fmt.Errorf("list pinned chunks: %w", err)
+	}
+
+	// send empty response if there is nothing pinned
+	if c == 0 {
+		return pinnedChunks, nil
+	}
+
 	it, err := db.pinIndex.First(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("get first pin: %w", err)

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -263,6 +263,9 @@ func (m *MockStorer) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, s
 func (m *MockStorer) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChunks []*storage.Pinner, err error) {
 	m.pinSetMu.Lock()
 	defer m.pinSetMu.Unlock()
+	if m.pinnedAddress == nil || len(m.pinnedAddress) == 0 {
+		return pinnedChunks, nil
+	}
 	for i, addr := range m.pinnedAddress {
 		pi := &storage.Pinner{
 			Address:    swarm.NewAddress(addr.Bytes()),

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -263,7 +263,7 @@ func (m *MockStorer) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, s
 func (m *MockStorer) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChunks []*storage.Pinner, err error) {
 	m.pinSetMu.Lock()
 	defer m.pinSetMu.Unlock()
-	if m.pinnedAddress == nil || len(m.pinnedAddress) == 0 {
+	if len(m.pinnedAddress) == 0 {
 		return pinnedChunks, nil
 	}
 	for i, addr := range m.pinnedAddress {


### PR DESCRIPTION
When /chunks-pin (list pinned addresses) API is called and if nothing is pinned, the response is 
`{ "message": "get first pin: leveldb: not found", "code": 500 }`

Instead it would be good if an empty response is returned, like
`{"chunks":[]}`

This fixes the issue https://github.com/ethersphere/bee/issues/478