### PR TITLE
limit max http body size and detect it

### DIFF
--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -51,6 +51,9 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
+		if jsonhttp.HandleBodyReadError(err, w) {
+			return
+		}
 		s.Logger.Debugf("chunk upload: read chunk data error: %v, addr %s", err, address)
 		s.Logger.Error("chunk upload: read chunk data error")
 		jsonhttp.InternalServerError(w, "cannot read chunk data")

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -54,8 +55,11 @@ func (s *server) setupRouting() {
 	})
 
 	handle(router, "/chunks/{addr}", jsonhttp.MethodHandler{
-		"GET":  http.HandlerFunc(s.chunkGetHandler),
-		"POST": http.HandlerFunc(s.chunkUploadHandler),
+		"GET": http.HandlerFunc(s.chunkGetHandler),
+		"POST": web.ChainHandlers(
+			jsonhttp.NewMaxBodyBytesHandler(swarm.ChunkWithSpanSize),
+			web.FinalHandlerFunc(s.chunkUploadHandler),
+		),
 	})
 
 	handle(router, "/bzz/{address}/{path:.*}", jsonhttp.MethodHandler{

--- a/pkg/jsonhttp/handlers.go
+++ b/pkg/jsonhttp/handlers.go
@@ -19,3 +19,37 @@ func (h MethodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func NotFoundHandler(w http.ResponseWriter, _ *http.Request) {
 	NotFound(w, nil)
 }
+
+// NewMaxBodyBytesHandler is an http middleware constructor that limits the
+// maximal number of bytes that can be read from the request body. When a body
+// is read, the error can be handled with a helper function HandleBodyReadError
+// in order to respond with Request Entity Too Large response.
+// See TestNewMaxBodyBytesHandler as an example.
+func NewMaxBodyBytesHandler(limit int64) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > limit {
+				RequestEntityTooLarge(w, nil)
+				return
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, limit)
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// HandleBodyReadError checks for particular errors and writes appropriate
+// response accordingly. If no known error is found, no response is written and
+// the function returns false.
+func HandleBodyReadError(err error, w http.ResponseWriter) (responded bool) {
+	if err == nil {
+		return false
+	}
+	// http.MaxBytesReader returns an unexported error,
+	// this is the only way to detect it
+	if err.Error() == "http: request body too large" {
+		RequestEntityTooLarge(w, nil)
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This PR adds a simple http middleware constructor NewMaxBodyBytesHandler that can be chained on various router paths to limit the maximal allowed body size. Since the error is returned by reading from the body it has to be handled in the handler where it happens so a helper function is added HandleBodyReadError, which can be used to serve an appropriate Request Entity Too Large response.

This handler is integrated into the chunks api endpoint and should be used in other handlers where the protection from large response bodies is required, like in https://github.com/ethersphere/bee/pull/439.