### PR TITLE
update golangci-lint to the latest release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.OS }}-build-
           ${{ runner.OS }}-
     - name: Setup GolangCI-Lint
-      run: go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+      run: go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
       env:
         GO111MODULE: on
       working-directory: ~

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 GOLANGCI_LINT ?= golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.24.0
+GOLANGCI_LINT_VERSION ?= v1.30.0
 GOGOPROTOBUF ?= protoc-gen-gogofaster
 GOGOPROTOBUF_VERSION ?= v1.3.1
 


### PR DESCRIPTION
Some of the previous releases had problems with compilation, this one works fine.