### PR TITLE
fix forever loop timeout issue

### DIFF
--- a/pkg/trojan/message.go
+++ b/pkg/trojan/message.go
@@ -41,7 +41,7 @@ const (
 	NonceSize               = 32
 	LengthSize              = 2
 	TopicSize               = 32
-	MinerTimeout            = 10   // seconds after which the wrap will fail
+	MinerTimeout            = 60  // seconds after which the wrap will fail
 	MaxTimerCheckIterations = 256 // no of iteration after which to check if timeout has happened
 )
 

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -125,6 +125,7 @@ func TestWrapFail(t *testing.T) {
 	}
 }
 
+// TestWrapTimeout tests for mining timeout and avoid forever loop
 func TestWrapTimeout(t *testing.T) {
 	m := newTestMessage(t)
 
@@ -135,8 +136,8 @@ func TestWrapTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t1 := trojan.Target(buf)
-	targets := trojan.Targets([]trojan.Target{t1})
+	target := trojan.Target(buf)
+	targets := trojan.Targets([]trojan.Target{target})
 	if _, err := m.Wrap(targets); err != trojan.ErrMinerTimeout {
 		t.Fatalf("expected error when having lengthy target to be %q, but got %v", trojan.ErrMinerTimeout, err)
 	}

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -6,6 +6,7 @@ package trojan_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"reflect"
 	"testing"
@@ -121,6 +122,23 @@ func TestWrapFail(t *testing.T) {
 	varLenTargets := trojan.Targets([]trojan.Target{t1, t2, t3})
 	if _, err := m.Wrap(varLenTargets); err != trojan.ErrVarLenTargets {
 		t.Fatalf("expected error when creating chunk for variable-length targets to be %q, but got %v", trojan.ErrVarLenTargets, err)
+	}
+}
+
+func TestWrapTimeout(t *testing.T) {
+	m := newTestMessage(t)
+
+	// a large target will take more than MinerTimeout seconds, so timeout error will be triggered
+	buf := make([]byte, swarm.SectionSize)
+	_, err := rand.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t1 := trojan.Target(buf)
+	targets := trojan.Targets([]trojan.Target{t1})
+	if _, err := m.Wrap(targets); err != trojan.ErrMinerTimeout {
+		t.Fatalf("expected error when having lengthy target to be %q, but got %v", trojan.ErrMinerTimeout, err)
 	}
 }
 

--- a/pkg/trojan/message_test.go
+++ b/pkg/trojan/message_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 // arbitrary targets for tests
-var t1 = trojan.Target([]byte{57, 120})
-var t2 = trojan.Target([]byte{209, 156})
-var t3 = trojan.Target([]byte{156, 38})
-var t4 = trojan.Target([]byte{89, 19})
-var t5 = trojan.Target([]byte{22, 129})
+var t1 = trojan.Target([]byte{57})
+var t2 = trojan.Target([]byte{209})
+var t3 = trojan.Target([]byte{156})
+var t4 = trojan.Target([]byte{89})
+var t5 = trojan.Target([]byte{22})
 var testTargets = trojan.Targets([]trojan.Target{t1, t2, t3, t4, t5})
 
 // arbitrary topic for tests


### PR DESCRIPTION
When a wrap takes time (race test) or is supplied a longer target, it gets stuck in a forever loop mining the trojan chunk.
This had a timeout which was inside the longest target loop (i.e. timeout will be checked after trojan reaches 255 bytes long ).
Now it is fixed to check the timeout every few(256) iterations.

The solution is to increase the timeout and bring down the target length from 2 bytes to 1 bytes in tests. 

Fixes https://github.com/ethersphere/bee/issues/509