### PR TITLE
streamtest record err flaky test fix

### DIFF
--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -21,10 +21,6 @@ import (
 
 var chunkData = []byte("mockdata")
 
-type mockValidator struct{}
-
-func (_ mockValidator) Validate(_ swarm.Chunk) bool { return true }
-
 // TestNetstoreRetrieval verifies that a chunk is asked from the network whenever
 // it is not found locally
 func TestNetstoreRetrieval(t *testing.T) {


### PR DESCRIPTION
This PR fixes the problem found as flaky test in https://github.com/ethersphere/bee/issues/513. The problem is not with the test but within goroutine synchronization in stream test. The handler is returned allowing the test to continue while the hander goroutine may still did not set the error. This PR adds a done channel so that all goroutines are done before the records are returned by the Records method.

I was able to reproduce the error on master locally with:

```
go test github.com/ethersphere/bee/pkg/p2p/streamtest -failfast -count=100000 -race -run TestRecorder_recordErr
```

It is very rare, hence the large count value.

Unrelated to this fix, this error is removing unused `mockValidator` to avoid linter errors.

fixes: #513