### PR TITLE
hive: clean up tests, allow for unordered response

### DIFF
--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"runtime/debug"
 	"strconv"
 	"testing"
 	"time"
@@ -202,6 +203,10 @@ func expectOverlaysEventually(t *testing.T, exporter ab.Interface, wantOverlays 
 			break
 		}
 	}
+	if len(overlays) != len(wantOverlays) {
+		debug.PrintStack()
+		t.Fatal("timed out waiting for overlays")
+	}
 
 	for _, v := range wantOverlays {
 		if !isIn(v, overlays) {
@@ -239,6 +244,10 @@ func expectBzzAddresessEventually(t *testing.T, exporter ab.Interface, wantBzzAd
 		if len(addresses) == len(wantBzzAddresses) {
 			break
 		}
+	}
+	if len(addresses) != len(wantBzzAddresses) {
+		debug.PrintStack()
+		t.Fatal("timed out waiting for bzz addresses")
 	}
 
 	for _, v := range wantBzzAddresses {

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -70,7 +70,11 @@ func TestBroadcastPeers(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantMsgs[i/hive.MaxBatchSize].Peers = append(wantMsgs[i/hive.MaxBatchSize].Peers, &pb.BzzAddress{Overlay: bzzAddresses[i].Overlay.Bytes(), Underlay: bzzAddresses[i].Underlay.Bytes(), Signature: bzzAddresses[i].Signature})
+		wantMsgs[i/hive.MaxBatchSize].Peers = append(wantMsgs[i/hive.MaxBatchSize].Peers, &pb.BzzAddress{
+			Overlay:   bzzAddresses[i].Overlay.Bytes(),
+			Underlay:  bzzAddresses[i].Underlay.Bytes(),
+			Signature: bzzAddresses[i].Signature,
+		})
 	}
 
 	testCases := map[string]struct {

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -70,6 +70,7 @@ func TestBroadcastPeers(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		wantMsgs[i/hive.MaxBatchSize].Peers = append(wantMsgs[i/hive.MaxBatchSize].Peers, &pb.BzzAddress{
 			Overlay:   bzzAddresses[i].Overlay.Bytes(),
 			Underlay:  bzzAddresses[i].Underlay.Bytes(),


### PR DESCRIPTION
The discovery test was flaking on a timeout to reach the correct number of entries in the address book. The timeout of the helper function was 1 second, however, it can be that the timeout was reached since the golang test suite is significantly slower with race detector on. I have added more verbose logging and goroutine printouts in case this flakes again, to see if some specific handler goroutine is taking too long due to whatever reason. Also, responses are now checked without constraint of ordering.


hopefully fixes #485