### PR TITLE
prevent panic in proximity function with shorter second argument

### DIFF
--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -21,10 +21,6 @@ import (
 
 var chunkData = []byte("mockdata")
 
-type mockValidator struct{}
-
-func (_ mockValidator) Validate(_ swarm.Chunk) bool { return true }
-
 // TestNetstoreRetrieval verifies that a chunk is asked from the network whenever
 // it is not found locally
 func TestNetstoreRetrieval(t *testing.T) {

--- a/pkg/swarm/proximity.go
+++ b/pkg/swarm/proximity.go
@@ -19,8 +19,10 @@ package swarm
 // (0 farthest, 255 closest, 256 self)
 func Proximity(one, other []byte) (ret uint8) {
 	b := MaxPO/8 + 1
-	l := uint8(len(one))
-	if b > l {
+	if l := uint8(len(one)); b > l {
+		b = l
+	}
+	if l := uint8(len(other)); b > l {
 		b = l
 	}
 	var m uint8 = 8

--- a/pkg/swarm/proximity_test.go
+++ b/pkg/swarm/proximity_test.go
@@ -168,10 +168,30 @@ func TestProximity(t *testing.T) {
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000001},
 			po:   limitPO(31),
 		},
+		{
+			addr: nil,
+			po:   limitPO(31),
+		},
+		{
+			addr: []byte{0b00000001},
+			po:   limitPO(7),
+		},
+		{
+			addr: []byte{0b00000000},
+			po:   limitPO(31),
+		},
+		{
+			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000001},
+			po:   limitPO(31),
+		},
 	} {
 		got := Proximity(base, tc.addr)
 		if got != tc.po {
 			t.Errorf("got %v bin, want %v", got, tc.po)
+		}
+		got = Proximity(tc.addr, base)
+		if got != tc.po {
+			t.Errorf("got %v bin, want %v (reverse arguments)", got, tc.po)
 		}
 	}
 }


### PR DESCRIPTION
This PR is a proposal how to handle the symptom of the problem described in https://github.com/ethersphere/bee/issues/515. This changes the behaviour for proximity function to handle shorter second argument than the first one instead to panic. This behaviour would hide the root cause of the issue https://github.com/ethersphere/bee/issues/515, but the current implementation is not commutative binary function as it would handle shorter first argument, but not the second one.

The root cause of https://github.com/ethersphere/bee/issues/515 should be found, regardless of this PR being merged or not.

Additionally, mockValidator is removed in order to make the linter pass.