### PR TITLE
readd server accounting check in retrieval test

### DIFF
--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -140,6 +140,10 @@ func TestDelivery(t *testing.T) {
 		t.Fatalf("unexpected balance on client. want %d got %d", -price, clientBalance)
 	}
 
+	serverBalance, _ := serverMockAccounting.Balance(peerID)
+	if serverBalance != int64(price) {
+		t.Fatalf("unexpected balance on server. want %d got %d", price, serverBalance)
+	}
 }
 
 type mockPeerSuggester struct {


### PR DESCRIPTION
This PR reintroduces the check in the server accounting in retrieval test which was removed from the first accounting PR due to being flaky. Due to the changes in #514 this check can now run reliably.