### PR TITLE
retrieval: return chunk not found if max peers reached

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -7,9 +7,9 @@ package retrieval
 import (
 	"context"
 	"fmt"
-	"github.com/ethersphere/bee/pkg/accounting"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
@@ -85,11 +85,11 @@ const (
 	retrieveChunkTimeout = 10 * time.Second
 )
 
-func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk swarm.Chunk, err error) {
+func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.Chunk, error) {
 	ctx, cancel := context.WithTimeout(ctx, maxPeers*retrieveChunkTimeout)
 	defer cancel()
 
-	v, err, _ := s.singleflight.Do(addr.String(), func() (v interface{}, err error) {
+	v, err, _ := s.singleflight.Do(addr.String(), func() (interface{}, error) {
 		var skipPeers []swarm.Address
 		for i := 0; i < maxPeers; i++ {
 			var peer swarm.Address
@@ -105,7 +105,8 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk 
 			s.logger.Tracef("retrieval: got chunk %s from peer %s", addr, peer)
 			return chunk, nil
 		}
-		return nil, err
+		s.logger.Debugf("retrieval: failed to get chunk %s: reached max peers of %v", addr, maxPeers)
+		return nil, storage.ErrNotFound
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes the problem when maxPeers is reached while retrieving the chunk. In that case the error that is returned is nil, as well as the chunk, resulting in type assertion panic.

fixes: https://github.com/ethersphere/bee/issues/523