### PR TITLE
node: remove var declaration for storer

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -219,10 +219,7 @@ func NewBee(o Options) (*Bee, error) {
 		logger.Debugf("p2p address: %s", addr)
 	}
 
-	var (
-		storer storage.Storer
-		path   = ""
-	)
+	var path string
 
 	if o.DataDir != "" {
 		path = filepath.Join(o.DataDir, "localstore")
@@ -230,7 +227,7 @@ func NewBee(o Options) (*Bee, error) {
 	lo := &localstore.Options{
 		Capacity: o.DBCapacity,
 	}
-	storer, err = localstore.New(path, address.Bytes(), lo, logger)
+	storer, err := localstore.New(path, address.Bytes(), lo, logger)
 	if err != nil {
 		return nil, fmt.Errorf("localstore: %w", err)
 	}


### PR DESCRIPTION
Removes the variable declaration for `storer` as it is increases indirection when reading the code.