### PR TITLE
add balance debug api to openapi

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -29,6 +29,21 @@ components:
           items:
             $ref: '#/components/schemas/P2PUnderlay'
 
+    Balance:
+      type: object
+      properties:
+        peer:
+          $ref: '#/components/schemas/SwarmAddress'
+        balance:
+          type: integer
+    
+    Balances:
+      type: object
+      properties:
+        balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/Balance'
      
     BzzChunksPinned:
       type: object

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -76,7 +76,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balance'
         '404':
           $ref: 'SwarmCommon.yaml#/components/responses/404'
         '500':

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -41,6 +41,49 @@ paths:
         default:
           description: Default response
 
+  '/balances':
+    get:
+      summary: Get the balances with all known peers
+      tags:
+        - Swarm Debug Endpoints
+      responses:
+        '200':
+          description: Own balances with all known peers
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/balances/{address}':
+    get:
+      summary: Get the balances with a specific peer
+      tags:
+        - Swarm Debug Endpoints
+      parameters:
+        - in: path
+          name: address
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      responses:
+        '200':
+          description: Peer is known
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
+        '400':
+          $ref: 'SwarmCommon.yaml#/components/responses/400'
+        '404':
+          $ref: 'SwarmCommon.yaml#/components/responses/404'
+        default:
+          description: Default response
+
   '/chunks/{address}':
     get:
       summary: Check if chunk at address exists locally

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -77,10 +77,10 @@ paths:
             application/json:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
-        '400':
-          $ref: 'SwarmCommon.yaml#/components/responses/400'
         '404':
           $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
           description: Default response
 


### PR DESCRIPTION
adds the `/balances` and `/balances/{peer}` calls to the openapi spec.