### PR TITLE
fix lint and vet go github workflow condition

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,10 +49,10 @@ jobs:
         GO111MODULE: on
       working-directory: ~
     - name: Lint
-      if: matrix.os == 'linux-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: make lint
     - name: Vet
-      if: matrix.os == 'linux-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: make vet
     - name: Build
       run: make build


### PR DESCRIPTION
This change fixes the problem with CI configuration where Lint and Vet steps were disabled on all targets.