### PR TITLE
change http header names per BOS / Standard

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,7 +35,7 @@ type Options struct {
 
 const (
 	// TargetsRecoveryHeader defines the Header for Recovery targets in Global Pinning
-	TargetsRecoveryHeader = "swarm-recovery-targets"
+	TargetsRecoveryHeader = "SWARM-RECOVERY-TARGETS"
 )
 
 func New(o Options) Service {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,7 +35,7 @@ type Options struct {
 
 const (
 	// TargetsRecoveryHeader defines the Header for Recovery targets in Global Pinning
-	TargetsRecoveryHeader = "SWARM-RECOVERY-TARGETS"
+	TargetsRecoveryHeader = "Swarm-Recovery-Targets"
 )
 
 func New(o Options) Service {

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -22,10 +22,10 @@ import (
 )
 
 // Presence of this header means that it needs to be tagged using the uid
-const TagHeaderUid = "SWARM-TAG"
+const TagHeaderUid = "Swarm-Tag"
 
 // Presence of this header in the HTTP request indicates the chunk needs to be pinned.
-const PinHeaderName = "SWARM-PIN"
+const PinHeaderName = "Swarm-Pin"
 
 func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["addr"]

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -22,10 +22,10 @@ import (
 )
 
 // Presence of this header means that it needs to be tagged using the uid
-const TagHeaderUid = "swarm-tag-uid"
+const TagHeaderUid = "SWARM-TAG"
 
 // Presence of this header in the HTTP request indicates the chunk needs to be pinned.
-const PinHeaderName = "swarm-pin"
+const PinHeaderName = "SWARM-PIN"
 
 func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["addr"]

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	multiPartFormData = "multipart/form-data"
-	EncryptHeader     = "SWARM-ENCRYPTION"
+	EncryptHeader     = "Swarm-Encryption"
 )
 
 type targetsContextKey struct{}

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -38,7 +38,7 @@ const (
 
 const (
 	multiPartFormData = "multipart/form-data"
-	EncryptHeader     = "swarm-encrypt"
+	EncryptHeader     = "SWARM-ENCRYPTION"
 )
 
 type targetsContextKey struct{}


### PR DESCRIPTION
This PR alighn's the http header names used in the code as per the BOS.
The BOS says that the header should start with capitalised SWARM and hyphen and the the feature name.
like SWARM-XXXX where XXXX is the feature name.

This affects the following features
- tags
- local pinning
- encryption
- global pinning targets