### PR TITLE
Remove invalid disconnected call

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -429,7 +429,6 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 func (s *Service) Disconnect(overlay swarm.Address) error {
 	peerID, found := s.peers.peerID(overlay)
 	if !found {
-		s.peers.disconnect(overlay)
 		return p2p.ErrPeerNotFound
 	}
 
@@ -456,7 +455,6 @@ func (s *Service) AddNotifier(n topology.Notifier) {
 func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers p2p.Headers, protocolName, protocolVersion, streamName string) (p2p.Stream, error) {
 	peerID, found := s.peers.peerID(overlay)
 	if !found {
-		s.peers.disconnect(overlay)
 		return nil, p2p.ErrPeerNotFound
 	}
 

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -185,6 +185,14 @@ func (r *peerRegistry) addDisconnecter(d topology.Disconnecter) {
 }
 
 func (r *peerRegistry) disconnect(address swarm.Address) {
+	r.mu.RLock()
+	_, found := r.underlays[address.ByteString()]
+	r.mu.RUnlock()
+
+	if !found {
+		return
+	}
+
 	for _, d := range r.disconnecters {
 		d.Disconnected(address)
 	}

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -183,17 +183,3 @@ func (r *peerRegistry) remove(peerID libp2ppeer.ID) {
 func (r *peerRegistry) addDisconnecter(d topology.Disconnecter) {
 	r.disconnecters = append(r.disconnecters, d)
 }
-
-func (r *peerRegistry) disconnect(address swarm.Address) {
-	r.mu.RLock()
-	_, found := r.underlays[address.ByteString()]
-	r.mu.RUnlock()
-
-	if !found {
-		return
-	}
-
-	for _, d := range r.disconnecters {
-		d.Disconnected(address)
-	}
-}


### PR DESCRIPTION
During investigation of https://github.com/ethersphere/bee/pull/new/disconncted-calls-fix I noticed that disconnected is called sometimes on the value that is not found in peer registry. 
The new change that @zbiljic added is calling registry disconnect which is a bit more guarded. 
The original code was calling `peers.disconnecter.Disconnected` handler explicitly,  and could actually pass the address that is not in a peer registry.

Anywayz, since the `peerregistry.remove` is used to signal disconnection, there is not need to call disconnected explicitly if the peer is not found in peer registry. If this signal is needed in this case for some reason, then the receiver of disconncted event should always parse overlay address and check if it is valid.
