### PR TITLE
expose remove chunk debug API

### DIFF
--- a/pkg/debugapi/chunk.go
+++ b/pkg/debugapi/chunk.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
 )
@@ -32,5 +33,33 @@ func (s *server) hasChunkHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonhttp.OK(w, nil)
+}
 
+func (s *server) removeChunk(w http.ResponseWriter, r *http.Request) {
+	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
+	if err != nil {
+		s.Logger.Debugf("debug api: parse chunk address: %v", err)
+		jsonhttp.BadRequest(w, "bad address")
+		return
+	}
+
+	has, err := s.Storer.Has(r.Context(), addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: localstore remove: %v", err)
+		jsonhttp.BadRequest(w, err)
+		return
+	}
+
+	if !has {
+		jsonhttp.OK(w, nil)
+		return
+	}
+
+	err = s.Storer.Set(r.Context(), storage.ModeSetRemove, addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: localstore remove: %v", err)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+	jsonhttp.OK(w, nil)
 }

--- a/pkg/debugapi/chunk_test.go
+++ b/pkg/debugapi/chunk_test.go
@@ -50,4 +50,33 @@ func TestHasChunkHandler(t *testing.T) {
 			Code:    http.StatusBadRequest,
 		})
 	})
+
+	t.Run("remove-chunk", func(t *testing.T) {
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/chunks/"+key.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
+			Message: http.StatusText(http.StatusOK),
+			Code:    http.StatusOK,
+		})
+		yes, err := mockStorer.Has(context.Background(), key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if yes {
+			t.Fatalf("The chunk %s is not deleted", key.String())
+		}
+	})
+
+	t.Run("remove-not-present-chunk", func(t *testing.T) {
+		notPresentChunkAddress := "deadbeef"
+		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/chunks/"+notPresentChunkAddress, nil, http.StatusOK, jsonhttp.StatusResponse{
+			Message: http.StatusText(http.StatusOK),
+			Code:    http.StatusOK,
+		})
+		yes, err := mockStorer.Has(context.Background(), swarm.NewAddress([]byte(notPresentChunkAddress)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if yes {
+			t.Fatalf("The chunk %s is not deleted", notPresentChunkAddress)
+		}
+	})
 }

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -67,7 +67,8 @@ func (s *server) setupRouting() {
 		"DELETE": http.HandlerFunc(s.peerDisconnectHandler),
 	})
 	router.Handle("/chunks/{address}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.hasChunkHandler),
+		"GET":    http.HandlerFunc(s.hasChunkHandler),
+		"DELETE": http.HandlerFunc(s.removeChunk),
 	})
 	router.Handle("/chunks-pin/{address}", jsonhttp.MethodHandler{
 		"GET":    http.HandlerFunc(s.getPinnedChunk),

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -137,9 +137,9 @@ func (m *MockStorer) Set(ctx context.Context, mode storage.ModeSet, addrs ...swa
 	defer m.pinSetMu.Unlock()
 	for _, addr := range addrs {
 		m.modeSet[addr.String()] = mode
-
-		// if mode is set pin, increment the pin counter
-		if mode == storage.ModeSetPin {
+		switch mode {
+		case storage.ModeSetPin:
+			// if mode is set pin, increment the pin counter
 			var found bool
 			for i, ad := range m.pinnedAddress {
 				if addr.String() == ad.String() {
@@ -151,11 +151,9 @@ func (m *MockStorer) Set(ctx context.Context, mode storage.ModeSet, addrs ...swa
 				m.pinnedAddress = append(m.pinnedAddress, addr)
 				m.pinnedCounter = append(m.pinnedCounter, uint64(1))
 			}
-		}
-
-		// if mode is set unpin, decrement the pin counter and remove the address
-		// once it reaches zero
-		if mode == storage.ModeSetUnpin {
+		case storage.ModeSetUnpin:
+			// if mode is set unpin, decrement the pin counter and remove the address
+			// once it reaches zero
 			for i, ad := range m.pinnedAddress {
 				if addr.String() == ad.String() {
 					m.pinnedCounter[i] = m.pinnedCounter[i] - 1
@@ -170,6 +168,9 @@ func (m *MockStorer) Set(ctx context.Context, mode storage.ModeSet, addrs ...swa
 					}
 				}
 			}
+		case storage.ModeSetRemove:
+			delete(m.store, addr.String())
+		default:
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds a debug API to remove a chunk from the local store and its associated indexes.
This will be useful to test global pinning in cluster setting.
the API is 

curl -X DELETE http://127.0.0.1:6060/chunks/<chunk reference>

Fixes https://github.com/ethersphere/bee/issues/555