### PR TITLE
Fallback to bootnodes

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -27,11 +27,11 @@ const (
 )
 
 type Service struct {
-	streamer         p2p.Streamer
-	addressBook      addressbook.GetPutter
-	peerAddedHandler func(context.Context, ...swarm.Address) error
-	networkID        uint64
-	logger           logging.Logger
+	streamer        p2p.Streamer
+	addressBook     addressbook.GetPutter
+	addPeersHandler func(context.Context, ...swarm.Address) error
+	networkID       uint64
+	logger          logging.Logger
 }
 
 type Options struct {
@@ -79,8 +79,8 @@ func (s *Service) BroadcastPeers(ctx context.Context, addressee swarm.Address, p
 	return nil
 }
 
-func (s *Service) SetPeersAddedHandler(h func(ctx context.Context, addr ...swarm.Address) error) {
-	s.peerAddedHandler = h
+func (s *Service) SetAddPeersHandler(h func(ctx context.Context, addr ...swarm.Address) error) {
+	s.addPeersHandler = h
 }
 
 func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swarm.Address) (err error) {
@@ -151,8 +151,8 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 		peers = append(peers, bzzAddress.Overlay)
 	}
 
-	if s.peerAddedHandler != nil {
-		if err := s.peerAddedHandler(ctx, peers...); err != nil {
+	if s.addPeersHandler != nil {
+		if err := s.addPeersHandler(ctx, peers...); err != nil {
 			return err
 		}
 	}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -151,7 +151,7 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 		peers = append(peers, bzzAddress.Overlay)
 	}
 
-	if s.peerAddedHandler != nil && len(peers) > 0 {
+	if s.peerAddedHandler != nil {
 		if err := s.peerAddedHandler(ctx, peers...); err != nil {
 			return err
 		}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -134,6 +134,7 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 	// but we still want to handle not closed stream from the other side to avoid zombie stream
 	go stream.FullClose()
 
+	var peers []swarm.Address
 	for _, newPeer := range peersReq.Peers {
 		bzzAddress, err := bzz.ParseAddress(newPeer.Underlay, newPeer.Overlay, newPeer.Signature, s.networkID)
 		if err != nil {
@@ -147,10 +148,12 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 			continue
 		}
 
-		if s.peerHandler != nil {
-			if err := s.peerHandler(ctx, bzzAddress.Overlay); err != nil {
-				return err
-			}
+		peers = append(peers, bzzAddress.Overlay)
+	}
+
+	if s.peerHandler != nil && len(peers) > 0 {
+		if err := s.peerHandler(ctx, peers...); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -27,11 +27,11 @@ const (
 )
 
 type Service struct {
-	streamer    p2p.Streamer
-	addressBook addressbook.GetPutter
-	peerHandler func(context.Context, ...swarm.Address) error
-	networkID   uint64
-	logger      logging.Logger
+	streamer         p2p.Streamer
+	addressBook      addressbook.GetPutter
+	peerAddedHandler func(context.Context, ...swarm.Address) error
+	networkID        uint64
+	logger           logging.Logger
 }
 
 type Options struct {
@@ -79,8 +79,8 @@ func (s *Service) BroadcastPeers(ctx context.Context, addressee swarm.Address, p
 	return nil
 }
 
-func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr ...swarm.Address) error) {
-	s.peerHandler = h
+func (s *Service) SetPeersAddedHandler(h func(ctx context.Context, addr ...swarm.Address) error) {
+	s.peerAddedHandler = h
 }
 
 func (s *Service) sendPeers(ctx context.Context, peer swarm.Address, peers []swarm.Address) (err error) {
@@ -151,8 +151,8 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 		peers = append(peers, bzzAddress.Overlay)
 	}
 
-	if s.peerHandler != nil && len(peers) > 0 {
-		if err := s.peerHandler(ctx, peers...); err != nil {
+	if s.peerAddedHandler != nil && len(peers) > 0 {
+		if err := s.peerAddedHandler(ctx, peers...); err != nil {
 			return err
 		}
 	}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -29,7 +29,7 @@ const (
 type Service struct {
 	streamer    p2p.Streamer
 	addressBook addressbook.GetPutter
-	peerHandler func(context.Context, swarm.Address) error
+	peerHandler func(context.Context, ...swarm.Address) error
 	networkID   uint64
 	logger      logging.Logger
 }
@@ -79,7 +79,7 @@ func (s *Service) BroadcastPeers(ctx context.Context, addressee swarm.Address, p
 	return nil
 }
 
-func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr swarm.Address) error) {
+func (s *Service) SetPeerAddedHandler(h func(ctx context.Context, addr ...swarm.Address) error) {
 	s.peerHandler = h
 }
 

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -15,7 +15,7 @@ was persisted in the address book and the node has been restarted).
 
 So the information has been changed, and potentially upon disconnection,
 the depth can travel to a shallower depth in result.
-If a peer gets added through AddPeer, this does not necessarily infer
+If a peer gets added through AddPeers , this does not necessarily infer
 an immediate depth change, since the peer might end up in the backlog for
 a long time until we actually need to connect to her.
 

--- a/pkg/kademlia/doc.go
+++ b/pkg/kademlia/doc.go
@@ -15,7 +15,7 @@ was persisted in the address book and the node has been restarted).
 
 So the information has been changed, and potentially upon disconnection,
 the depth can travel to a shallower depth in result.
-If a peer gets added through AddPeers , this does not necessarily infer
+If a peer gets added through AddPeers, this does not necessarily infer
 an immediate depth change, since the peer might end up in the backlog for
 a long time until we actually need to connect to her.
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -241,7 +241,7 @@ func (k *Kad) connectBootnodes(ctx context.Context) {
 		go func(a ma.Multiaddr) {
 			defer wg.Done()
 			var count int
-			if _, err := p2p.Discover(ctx, addr, func(addr ma.Multiaddr) (stop bool, err error) {
+			if _, err := p2p.Discover(ctx, a, func(addr ma.Multiaddr) (stop bool, err error) {
 				k.logger.Tracef("connecting to bootnode %s", addr)
 				_, err = k.p2p.ConnectNotify(ctx, addr)
 				if err != nil {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -412,7 +412,7 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 	return err
 }
 
-// AddPeers s adds peers to the knownPeers list.
+// AddPeers adds peers to the knownPeers list.
 // This does not guarantee that a connection will immediately
 // be made to the peer.
 func (k *Kad) AddPeers(ctx context.Context, addrs ...swarm.Address) error {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -98,8 +98,7 @@ func New(o Options) *Kad {
 		done:           make(chan struct{}),
 		wg:             sync.WaitGroup{},
 	}
-	k.wg.Add(1)
-	go k.manage()
+
 	return k
 }
 
@@ -226,6 +225,9 @@ func (k *Kad) manage() {
 }
 
 func (k *Kad) Start(ctx context.Context) error {
+	k.wg.Add(1)
+	go k.manage()
+
 	addresses, err := k.addressBook.Overlays()
 	if err != nil {
 		return fmt.Errorf("addressbook overlays: %w", err)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -416,7 +416,6 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 // This does not guarantee that a connection will immediately
 // be made to the peer.
 func (k *Kad) AddPeers(ctx context.Context, addrs ...swarm.Address) error {
-	peerAdded := false
 	for _, addr := range addrs {
 		if k.knownPeers.Exists(addr) {
 			continue
@@ -424,14 +423,11 @@ func (k *Kad) AddPeers(ctx context.Context, addrs ...swarm.Address) error {
 
 		po := swarm.Proximity(k.base.Bytes(), addr.Bytes())
 		k.knownPeers.Add(addr, po)
-		peerAdded = true
 	}
 
-	if peerAdded {
-		select {
-		case k.manageC <- struct{}{}:
-		default:
-		}
+	select {
+	case k.manageC <- struct{}{}:
+	default:
 	}
 
 	return nil

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -292,10 +292,10 @@ func TestDiscoveryHooks(t *testing.T) {
 	)
 	defer kad.Close()
 
-	// first add a peer from AddPeer, wait for the connection
+	// first add a peer from AddPeers , wait for the connection
 	addOne(t, signer, kad, ab, p1)
 	waitConn(t, &conns)
-	// add another peer from AddPeer, wait for the connection
+	// add another peer from AddPeers , wait for the connection
 	// then check that peers are gossiped to each other via discovery
 	addOne(t, signer, kad, ab, p2)
 	waitConn(t, &conns)
@@ -374,7 +374,7 @@ func TestAddressBookPrune(t *testing.T) {
 	}
 
 	// add non connectable peer, check connection and failed connection counters
-	_ = kad.AddPeer(context.Background(), nonConnPeer.Overlay)
+	_ = kad.AddPeers(context.Background(), nonConnPeer.Overlay)
 	waitCounter(t, &conns, 0)
 	waitCounter(t, &failedConns, 1)
 
@@ -703,7 +703,7 @@ func addOne(t *testing.T, signer beeCrypto.Signer, k *kademlia.Kad, ab addressbo
 	if err := ab.Put(peer, *bzzAddr); err != nil {
 		t.Fatal(err)
 	}
-	_ = k.AddPeer(context.Background(), peer)
+	_ = k.AddPeers(context.Background(), peer)
 }
 
 func add(t *testing.T, signer beeCrypto.Signer, k *kademlia.Kad, ab addressbook.Putter, peers []swarm.Address, offset, number int) {

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -292,10 +292,10 @@ func TestDiscoveryHooks(t *testing.T) {
 	)
 	defer kad.Close()
 
-	// first add a peer from AddPeers , wait for the connection
+	// first add a peer from AddPeers, wait for the connection
 	addOne(t, signer, kad, ab, p1)
 	waitConn(t, &conns)
-	// add another peer from AddPeers , wait for the connection
+	// add another peer from AddPeers, wait for the connection
 	// then check that peers are gossiped to each other via discovery
 	addOne(t, signer, kad, ab, p2)
 	waitConn(t, &conns)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -46,7 +46,7 @@ var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cT
 func TestNeighborhoodDepth(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil)
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil, nil)
 		peers                    []swarm.Address
 		binEight                 []swarm.Address
 	)
@@ -163,7 +163,7 @@ func TestManage(t *testing.T) {
 		saturationFunc = func(bin uint8, peers, connected *pslice.PSlice) bool {
 			return saturationVal
 		}
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc)
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc, nil)
 	)
 	defer kad.Close()
 	// first, saturationFunc returns always false, this means that the bin is not saturated,
@@ -208,7 +208,7 @@ func TestBinSaturation(t *testing.T) {
 
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil)
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil, nil)
 		peers                    []swarm.Address
 	)
 
@@ -256,7 +256,7 @@ func TestBinSaturation(t *testing.T) {
 // result in the correct behavior once called.
 func TestNotifierHooks(t *testing.T) {
 	var (
-		base, kad, ab, _, signer = newTestKademlia(nil, nil, nil)
+		base, kad, ab, _, signer = newTestKademlia(nil, nil, nil, nil)
 		peer                     = test.RandomAddressAt(base, 3)
 		addr                     = test.RandomAddressAt(peer, 4) // address which is closer to peer
 	)
@@ -287,7 +287,7 @@ func TestNotifierHooks(t *testing.T) {
 func TestDiscoveryHooks(t *testing.T) {
 	var (
 		conns                    int32
-		_, kad, ab, disc, signer = newTestKademlia(&conns, nil, nil)
+		_, kad, ab, disc, signer = newTestKademlia(&conns, nil, nil, nil)
 		p1, p2, p3               = test.RandomAddress(), test.RandomAddress(), test.RandomAddress()
 	)
 	defer kad.Close()
@@ -322,7 +322,7 @@ func TestBackoff(t *testing.T) {
 
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil)
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil, nil)
 	)
 	defer kad.Close()
 
@@ -361,7 +361,7 @@ func TestAddressBookPrune(t *testing.T) {
 
 	var (
 		conns, failedConns       int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(&conns, &failedConns, nil)
+		base, kad, ab, _, signer = newTestKademlia(&conns, &failedConns, nil, nil)
 	)
 	defer kad.Close()
 
@@ -512,7 +512,6 @@ func TestClosestPeer(t *testing.T) {
 }
 
 func TestKademlia_SubscribePeersChange(t *testing.T) {
-
 	testSignal := func(t *testing.T, k *kademlia.Kad, c <-chan struct{}) {
 		t.Helper()
 
@@ -527,7 +526,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 	}
 
 	t.Run("single subscription", func(t *testing.T) {
-		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil)
+		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -540,7 +539,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 	})
 
 	t.Run("single subscription, remove peer", func(t *testing.T) {
-		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil)
+		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -556,7 +555,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 	})
 
 	t.Run("multiple subscriptions", func(t *testing.T) {
-		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil)
+		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
 		defer kad.Close()
 
 		c1, u1 := kad.SubscribePeersChange()
@@ -574,7 +573,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 	})
 
 	t.Run("multiple changes", func(t *testing.T) {
-		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil)
+		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -596,7 +595,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 	})
 
 	t.Run("no depth change", func(t *testing.T) {
-		_, kad, _, _, _ := newTestKademlia(nil, nil, nil)
+		_, kad, _, _, _ := newTestKademlia(nil, nil, nil, nil)
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -615,7 +614,7 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
-	_, kad, ab, _, signer := newTestKademlia(nil, nil, nil)
+	_, kad, ab, _, signer := newTestKademlia(nil, nil, nil, nil)
 	defer kad.Close()
 
 	a := test.RandomAddress()
@@ -626,14 +625,73 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin uint8, peers, connected *pslice.PSlice) bool) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+func TestStart(t *testing.T) {
+	var bootnodes []ma.Multiaddr
+
+	for i := 0; i < 5; i++ {
+		multiaddr, err := ma.NewMultiaddr(underlayBase + test.RandomAddress().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		bootnodes = append(bootnodes, multiaddr)
+	}
+
+	t.Run("non-empty addressbook", func(t *testing.T) {
+		var conns, failedConns int32 // how many connect calls were made to the p2p mock
+		_, kad, ab, _, signer := newTestKademlia(&conns, &failedConns, nil, bootnodes)
+
+		defer kad.Close()
+
+		for i := 0; i < 3; i++ {
+			peer := test.RandomAddress()
+			multiaddr, err := ma.NewMultiaddr(underlayBase + peer.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			bzzAddr, err := bzz.NewAddress(signer, multiaddr, peer, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := ab.Put(peer, *bzzAddr); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		waitCounter(t, &conns, 3)
+		waitCounter(t, &failedConns, 0)
+		return
+	})
+
+	t.Run("empty addressbook", func(t *testing.T) {
+		var conns, failedConns int32 // how many connect calls were made to the p2p mock
+		_, kad, _, _, _ := newTestKademlia(&conns, &failedConns, nil, bootnodes)
+
+		defer kad.Close()
+
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		waitCounter(t, &conns, 5)
+		waitCounter(t, &failedConns, 0)
+
+		return
+	})
+}
+
+func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin uint8, peers, connected *pslice.PSlice) bool, bootnodes []ma.Multiaddr) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
 	var (
 		base   = test.RandomAddress()                       // base address
 		ab     = addressbook.New(mockstate.NewStateStore()) // address book
 		p2p    = p2pMock(ab, connCounter, failedConnCounter)
-		logger = logging.New(ioutil.Discard, 0)                                                                                            // logger
-		disc   = mock.NewDiscovery()                                                                                                       // mock discovery
-		kad    = kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f}) // kademlia instance
+		logger = logging.New(ioutil.Discard, 0) // logger
+		disc   = mock.NewDiscovery()
+		kad    = kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2p, Logger: logger, SaturationFunc: f, Bootnodes: bootnodes}) // kademlia instance
 	)
 
 	pk, _ := crypto.GenerateSecp256k1Key()

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -664,7 +664,6 @@ func TestStart(t *testing.T) {
 
 		waitCounter(t, &conns, 3)
 		waitCounter(t, &failedConns, 0)
-		return
 	})
 
 	t.Run("empty addressbook", func(t *testing.T) {
@@ -679,8 +678,6 @@ func TestStart(t *testing.T) {
 
 		waitCounter(t, &conns, 5)
 		waitCounter(t, &failedConns, 0)
-
-		return
 	})
 }
 

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -51,6 +51,9 @@ func TestNeighborhoodDepth(t *testing.T) {
 		binEight                 []swarm.Address
 	)
 
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	for i := 0; i < 8; i++ {
@@ -165,6 +168,10 @@ func TestManage(t *testing.T) {
 		}
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc, nil)
 	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 	// first, saturationFunc returns always false, this means that the bin is not saturated,
 	// hence we expect that every peer we add to kademlia will be connected to
@@ -212,6 +219,9 @@ func TestBinSaturation(t *testing.T) {
 		peers                    []swarm.Address
 	)
 
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	// add two peers in a few bins to generate some depth >= 0, this will
@@ -260,6 +270,10 @@ func TestNotifierHooks(t *testing.T) {
 		peer                     = test.RandomAddressAt(base, 3)
 		addr                     = test.RandomAddressAt(peer, 4) // address which is closer to peer
 	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	connectOne(t, signer, kad, ab, peer)
@@ -290,6 +304,10 @@ func TestDiscoveryHooks(t *testing.T) {
 		_, kad, ab, disc, signer = newTestKademlia(&conns, nil, nil, nil)
 		p1, p2, p3               = test.RandomAddress(), test.RandomAddress(), test.RandomAddress()
 	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	// first add a peer from AddPeers, wait for the connection
@@ -324,6 +342,10 @@ func TestBackoff(t *testing.T) {
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, nil, nil)
 	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	// add one peer, wait for connection
@@ -363,6 +385,10 @@ func TestAddressBookPrune(t *testing.T) {
 		conns, failedConns       int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(&conns, &failedConns, nil, nil)
 	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	nonConnPeer, err := bzz.NewAddress(signer, nonConnectableAddress, test.RandomAddressAt(base, 1), 0)
@@ -454,6 +480,9 @@ func TestClosestPeer(t *testing.T) {
 	var conns int32
 
 	kad := kademlia.New(kademlia.Options{Base: base, Discovery: disc, AddressBook: ab, P2P: p2pMock(ab, &conns, nil), Logger: logger})
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	pk, _ := crypto.GenerateSecp256k1Key()
@@ -527,6 +556,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 	t.Run("single subscription", func(t *testing.T) {
 		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -540,6 +572,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 	t.Run("single subscription, remove peer", func(t *testing.T) {
 		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -556,6 +591,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 	t.Run("multiple subscriptions", func(t *testing.T) {
 		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 		defer kad.Close()
 
 		c1, u1 := kad.SubscribePeersChange()
@@ -574,6 +612,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 	t.Run("multiple changes", func(t *testing.T) {
 		base, kad, ab, _, sg := newTestKademlia(nil, nil, nil, nil)
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -596,6 +637,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 	t.Run("no depth change", func(t *testing.T) {
 		_, kad, _, _, _ := newTestKademlia(nil, nil, nil, nil)
+		if err := kad.Start(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 		defer kad.Close()
 
 		c, u := kad.SubscribePeersChange()
@@ -615,6 +659,9 @@ func TestKademlia_SubscribePeersChange(t *testing.T) {
 
 func TestMarshal(t *testing.T) {
 	_, kad, ab, _, signer := newTestKademlia(nil, nil, nil, nil)
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	defer kad.Close()
 
 	a := test.RandomAddress()
@@ -640,7 +687,6 @@ func TestStart(t *testing.T) {
 	t.Run("non-empty addressbook", func(t *testing.T) {
 		var conns, failedConns int32 // how many connect calls were made to the p2p mock
 		_, kad, ab, _, signer := newTestKademlia(&conns, &failedConns, nil, bootnodes)
-
 		defer kad.Close()
 
 		for i := 0; i < 3; i++ {
@@ -669,7 +715,6 @@ func TestStart(t *testing.T) {
 	t.Run("empty addressbook", func(t *testing.T) {
 		var conns, failedConns int32 // how many connect calls were made to the p2p mock
 		_, kad, _, _, _ := newTestKademlia(&conns, &failedConns, nil, bootnodes)
-
 		defer kad.Close()
 
 		if err := kad.Start(context.Background()); err != nil {

--- a/pkg/kademlia/mock/kademlia.go
+++ b/pkg/kademlia/mock/kademlia.go
@@ -58,9 +58,9 @@ func NewMockKademlia(o ...Option) *Mock {
 	return m
 }
 
-// AddPeer is called when a peer is added to the topology backlog
+// AddPeers  is called when a peers are added to the topology backlog
 // for further processing by connectivity strategy.
-func (m *Mock) AddPeer(ctx context.Context, addr swarm.Address) error {
+func (m *Mock) AddPeers(ctx context.Context, addr ...swarm.Address) error {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/kademlia/mock/kademlia.go
+++ b/pkg/kademlia/mock/kademlia.go
@@ -58,7 +58,7 @@ func NewMockKademlia(o ...Option) *Mock {
 	return m
 }
 
-// AddPeers  is called when a peers are added to the topology backlog
+// AddPeers is called when a peers are added to the topology backlog
 // for further processing by connectivity strategy.
 func (m *Mock) AddPeers(ctx context.Context, addr ...swarm.Address) error {
 	panic("not implemented") // TODO: Implement

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -204,7 +204,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 		addr, err := ma.NewMultiaddr(a)
 		if err != nil {
 			logger.Debugf("multiaddress fail %s: %v", a, err)
-			logger.Warningf("connect to bootnode %s", a)
+			logger.Warningf("invalid bootnode address %s", a)
 			continue
 		}
 
@@ -213,7 +213,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 
 	kad := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Bootnodes: bootnodes, Logger: logger})
 	b.topologyCloser = kad
-	hive.SetPeersAddedHandler(kad.AddPeers)
+	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.AddNotifier(kad)
 	addrs, err := p2ps.Addresses()
 	if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -204,7 +204,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 
 	topologyDriver := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Logger: logger})
 	b.topologyCloser = topologyDriver
-	hive.SetPeerAddedHandler(topologyDriver.AddPeer)
+	hive.SetPeerAddedHandler(topologyDriver.AddPeers)
 	p2ps.AddNotifier(topologyDriver)
 	addrs, err := p2ps.Addresses()
 	if err != nil {
@@ -396,7 +396,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 
 	// add the peers to topology and allow it to connect independently
 	for _, o := range addresses {
-		err = topologyDriver.AddPeer(p2pCtx, o)
+		err = topologyDriver.AddPeers(p2pCtx, o)
 		if err != nil {
 			logger.Debugf("topology add peer from addressbook: %v", err)
 		} else {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -213,7 +213,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 
 	kad := kademlia.New(kademlia.Options{Base: address, Discovery: hive, AddressBook: addressbook, P2P: p2ps, Bootnodes: bootnodes, Logger: logger})
 	b.topologyCloser = kad
-	hive.SetPeerAddedHandler(kad.AddPeers)
+	hive.SetPeersAddedHandler(kad.AddPeers)
 	p2ps.AddNotifier(kad)
 	addrs, err := p2ps.Addresses()
 	if err != nil {

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -414,7 +414,7 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			return
 		}
-		err = p.AddPeerInterval(peer, bin, s, top)
+		err = p.addPeerInterval(peer, bin, s, top)
 		if err != nil {
 			p.metrics.HistWorkerErrCounter.Inc()
 			p.logger.Errorf("error persisting interval for peer, quitting")
@@ -461,7 +461,7 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		if top == 0 {
 			return //TODO need to deal with this somehow. not right
 		}
-		err = p.AddPeerInterval(peer, bin, from, top)
+		err = p.addPeerInterval(peer, bin, from, top)
 		if err != nil {
 			p.metrics.LiveWorkerErrCounter.Inc()
 			p.logger.Errorf("liveSyncWorker exit on add peer interval. peer %s bin %d from %d err %v", peer, bin, from, err)
@@ -500,7 +500,7 @@ func (p *Puller) Close() error {
 	return nil
 }
 
-func (p *Puller) AddPeerInterval(peer swarm.Address, bin uint8, start, end uint64) (err error) {
+func (p *Puller) addPeerInterval(peer swarm.Address, bin uint8, start, end uint64) (err error) {
 	p.intervalMtx.Lock()
 	defer p.intervalMtx.Unlock()
 

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -414,7 +414,7 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			return
 		}
-		err = p.addPeerInterval(peer, bin, s, top)
+		err = p.AddPeerInterval(peer, bin, s, top)
 		if err != nil {
 			p.metrics.HistWorkerErrCounter.Inc()
 			p.logger.Errorf("error persisting interval for peer, quitting")
@@ -461,7 +461,7 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		if top == 0 {
 			return //TODO need to deal with this somehow. not right
 		}
-		err = p.addPeerInterval(peer, bin, from, top)
+		err = p.AddPeerInterval(peer, bin, from, top)
 		if err != nil {
 			p.metrics.LiveWorkerErrCounter.Inc()
 			p.logger.Errorf("liveSyncWorker exit on add peer interval. peer %s bin %d from %d err %v", peer, bin, from, err)
@@ -500,7 +500,7 @@ func (p *Puller) Close() error {
 	return nil
 }
 
-func (p *Puller) addPeerInterval(peer swarm.Address, bin uint8, start, end uint64) (err error) {
+func (p *Puller) AddPeerInterval(peer swarm.Address, bin uint8, start, end uint64) (err error) {
 	p.intervalMtx.Lock()
 	defer p.intervalMtx.Unlock()
 

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -124,7 +124,7 @@ func (d *driver) manage() {
 	}
 }
 
-// AddPeers  adds a new peer to the topology driver.
+// AddPeers adds a new peer to the topology driver.
 // The peer would be subsequently broadcasted to all connected peers.
 // All connected peers are also broadcasted to the new peer.
 func (d *driver) AddPeers(ctx context.Context, addrs ...swarm.Address) error {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -40,75 +40,99 @@ type driver struct {
 	backoffActive bool
 	logger        logging.Logger
 	mtx           sync.Mutex
+	addPeerCh     chan swarm.Address
 	quit          chan struct{}
 }
 
 func New(disc discovery.Driver, addressBook addressbook.Interface, p2pService p2p.Service, logger logging.Logger, baseAddress swarm.Address) topology.Driver {
-	return &driver{
+	d := &driver{
 		base:          baseAddress,
 		discovery:     disc,
 		addressBook:   addressBook,
 		p2pService:    p2pService,
 		receivedPeers: make(map[string]struct{}),
 		logger:        logger,
+		addPeerCh:     make(chan swarm.Address, 64),
 		quit:          make(chan struct{}),
+	}
+
+	go d.manage()
+	return d
+}
+
+func (d *driver) manage() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-d.quit
+		cancel()
+	}()
+
+	for {
+		select {
+		case <-d.quit:
+			return
+		case addr := <-d.addPeerCh:
+			d.mtx.Lock()
+			if _, ok := d.receivedPeers[addr.ByteString()]; ok {
+				d.mtx.Unlock()
+				return
+			}
+
+			d.receivedPeers[addr.ByteString()] = struct{}{}
+			d.mtx.Unlock()
+			connectedPeers := d.p2pService.Peers()
+			bzzAddress, err := d.addressBook.Get(addr)
+			if err != nil {
+				return
+			}
+
+			if !isConnected(addr, connectedPeers) {
+				_, err := d.p2pService.Connect(ctx, bzzAddress.Underlay)
+				if err != nil {
+					d.mtx.Lock()
+					delete(d.receivedPeers, addr.ByteString())
+					d.mtx.Unlock()
+					var e *p2p.ConnectionBackoffError
+					if errors.As(err, &e) {
+						d.backoff(e.TryAfter())
+					}
+
+					return
+				}
+			}
+
+			connectedAddrs := []swarm.Address{}
+			for _, addressee := range connectedPeers {
+				// skip newly added peer
+				if addressee.Address.Equal(addr) {
+					continue
+				}
+
+				connectedAddrs = append(connectedAddrs, addressee.Address)
+				if err := d.discovery.BroadcastPeers(ctx, addressee.Address, addr); err != nil {
+					return
+				}
+			}
+
+			if len(connectedAddrs) == 0 {
+				return
+			}
+
+			_ = d.discovery.BroadcastPeers(ctx, addr, connectedAddrs...)
+
+		}
 	}
 }
 
-// AddPeer adds a new peer to the topology driver.
+// AddPeers  adds a new peer to the topology driver.
 // The peer would be subsequently broadcasted to all connected peers.
 // All connected peers are also broadcasted to the new peer.
-func (d *driver) AddPeer(ctx context.Context, addr swarm.Address) error {
-	d.mtx.Lock()
-	if _, ok := d.receivedPeers[addr.ByteString()]; ok {
-		d.mtx.Unlock()
-		return nil
+func (d *driver) AddPeers(ctx context.Context, addrs ...swarm.Address) error {
+	for _, addr := range addrs {
+		d.addPeerCh <- addr
 	}
 
-	d.receivedPeers[addr.ByteString()] = struct{}{}
-	d.mtx.Unlock()
-	connectedPeers := d.p2pService.Peers()
-	bzzAddress, err := d.addressBook.Get(addr)
-	if err != nil {
-		if err == addressbook.ErrNotFound {
-			return topology.ErrNotFound
-		}
-		return err
-	}
-
-	if !isConnected(addr, connectedPeers) {
-		_, err := d.p2pService.Connect(ctx, bzzAddress.Underlay)
-		if err != nil {
-			d.mtx.Lock()
-			delete(d.receivedPeers, addr.ByteString())
-			d.mtx.Unlock()
-			var e *p2p.ConnectionBackoffError
-			if errors.As(err, &e) {
-				d.backoff(e.TryAfter())
-				return err
-			}
-			return err
-		}
-	}
-
-	connectedAddrs := []swarm.Address{}
-	for _, addressee := range connectedPeers {
-		// skip newly added peer
-		if addressee.Address.Equal(addr) {
-			continue
-		}
-
-		connectedAddrs = append(connectedAddrs, addressee.Address)
-		if err := d.discovery.BroadcastPeers(ctx, addressee.Address, addr); err != nil {
-			return err
-		}
-	}
-
-	if len(connectedAddrs) == 0 {
-		return nil
-	}
-
-	return d.discovery.BroadcastPeers(ctx, addr, connectedAddrs...)
+	return nil
 }
 
 // ClosestPeer returns the closest connected peer we have in relation to a
@@ -147,7 +171,7 @@ func (d *driver) ClosestPeer(addr swarm.Address) (swarm.Address, error) {
 }
 
 func (d *driver) Connected(ctx context.Context, addr swarm.Address) error {
-	return d.AddPeer(ctx, addr)
+	return d.AddPeers(ctx, addr)
 }
 
 func (_ *driver) Disconnected(swarm.Address) {
@@ -223,7 +247,7 @@ func (d *driver) backoff(tryAfter time.Time) {
 				case <-d.quit:
 					return
 				default:
-					if err := d.AddPeer(ctx, addr); err != nil {
+					if err := d.AddPeers(ctx, addr); err != nil {
 						var e *p2p.ConnectionBackoffError
 						if errors.As(err, &e) {
 							d.backoff(e.TryAfter())

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -16,14 +16,14 @@ type mock struct {
 	peers           []swarm.Address
 	closestPeer     swarm.Address
 	closestPeerErr  error
-	AddPeersErr     error
+	addPeersErr     error
 	marshalJSONFunc func() ([]byte, error)
 	mtx             sync.Mutex
 }
 
 func WithAddPeersErr(err error) Option {
 	return optionFunc(func(d *mock) {
-		d.AddPeersErr = err
+		d.addPeersErr = err
 	})
 }
 
@@ -54,8 +54,8 @@ func NewTopologyDriver(opts ...Option) topology.Driver {
 }
 
 func (d *mock) AddPeers(_ context.Context, addrs ...swarm.Address) error {
-	if d.AddPeersErr != nil {
-		return d.AddPeersErr
+	if d.addPeersErr != nil {
+		return d.addPeersErr
 	}
 
 	for _, addr := range addrs {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -16,14 +16,14 @@ type mock struct {
 	peers           []swarm.Address
 	closestPeer     swarm.Address
 	closestPeerErr  error
-	addPeerErr      error
+	AddPeersErr     error
 	marshalJSONFunc func() ([]byte, error)
 	mtx             sync.Mutex
 }
 
-func WithAddPeerErr(err error) Option {
+func WithAddPeersErr(err error) Option {
 	return optionFunc(func(d *mock) {
-		d.addPeerErr = err
+		d.AddPeersErr = err
 	})
 }
 
@@ -53,18 +53,21 @@ func NewTopologyDriver(opts ...Option) topology.Driver {
 	return d
 }
 
-func (d *mock) AddPeer(_ context.Context, addr swarm.Address) error {
-	if d.addPeerErr != nil {
-		return d.addPeerErr
+func (d *mock) AddPeers(_ context.Context, addrs ...swarm.Address) error {
+	if d.AddPeersErr != nil {
+		return d.AddPeersErr
 	}
 
-	d.mtx.Lock()
-	d.peers = append(d.peers, addr)
-	d.mtx.Unlock()
+	for _, addr := range addrs {
+		d.mtx.Lock()
+		d.peers = append(d.peers, addr)
+		d.mtx.Unlock()
+	}
+
 	return nil
 }
 func (d *mock) Connected(ctx context.Context, addr swarm.Address) error {
-	return d.AddPeer(ctx, addr)
+	return d.AddPeers(ctx, addr)
 }
 
 func (d *mock) Disconnected(swarm.Address) {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -33,7 +33,7 @@ type Notifier interface {
 }
 
 type PeerAdder interface {
-	// AddPeers s is called when a peer is added to the topology backlog
+	// AddPeers s is called when peers are added to the topology backlog
 	AddPeers(ctx context.Context, addr ...swarm.Address) error
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -33,7 +33,7 @@ type Notifier interface {
 }
 
 type PeerAdder interface {
-	// AddPeers s is called when peers are added to the topology backlog
+	// AddPeers is called when peers are added to the topology backlog
 	AddPeers(ctx context.Context, addr ...swarm.Address) error
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -33,8 +33,8 @@ type Notifier interface {
 }
 
 type PeerAdder interface {
-	// AddPeer is called when a peer is added to the topology backlog
-	AddPeer(ctx context.Context, addr swarm.Address) error
+	// AddPeers s is called when a peer is added to the topology backlog
+	AddPeers(ctx context.Context, addr ...swarm.Address) error
 }
 
 type Connecter interface {


### PR DESCRIPTION
https://github.com/ethersphere/bee/issues/521

I have left `Start()` method only on kademlia for now, so I did not extract any extra interfaces. This is probably ok, as there is no other implementation of topology driver at the moment, and full connectivity does not need it.