### PR TITLE
golangci-lint binary install

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,11 +43,6 @@ jobs:
           ${{ runner.OS }}-build-${{ env.cache-name }}-
           ${{ runner.OS }}-build-
           ${{ runner.OS }}-
-    - name: Setup GolangCI-Lint
-      run: go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
-      env:
-        GO111MODULE: on
-      working-directory: ~
     - name: Lint
       if: matrix.os == 'ubuntu-latest'
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: linter
 
 .PHONY: linter
 linter:
-	which $(GOLANGCI_LINT) || ( cd /tmp && GO111MODULE=on $(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) )
+	which $(GOLANGCI_LINT) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$($(GO) env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
This PR fixes a problem when building golangci-lint fails with some of its linters create a breaking change. The solution is to install the prebuilt binary using the official install script. The unneeded step to setup golangci-lint is removed as it is done by the `lint` Makefile rule.