### PR TITLE
api: add pin on upload

### DIFF
--- a/cmd/bee-file/main.go
+++ b/cmd/bee-file/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	"github.com/ethersphere/bee/pkg/file/splitter"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/spf13/cobra"
 )
@@ -160,7 +161,7 @@ func putEntry(cmd *cobra.Command, args []string) (err error) {
 	logger.Debugf("metadata contents: %s", metadataBytes)
 
 	// set up splitter to process the metadata
-	s := splitter.NewSimpleSplitter(stores)
+	s := splitter.NewSimpleSplitter(stores, storage.ModePutUpload)
 	ctx := context.Background()
 
 	// first add metadata

--- a/cmd/bee-split/main.go
+++ b/cmd/bee-split/main.go
@@ -15,6 +15,7 @@ import (
 	cmdfile "github.com/ethersphere/bee/cmd/internal/file"
 	"github.com/ethersphere/bee/pkg/file/splitter"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -93,7 +94,7 @@ func Split(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// split and rule
-	s := splitter.NewSimpleSplitter(stores)
+	s := splitter.NewSimpleSplitter(stores, storage.ModePutUpload)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr, err := s.Split(ctx, infile, inputLength, false)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
@@ -47,4 +48,17 @@ func New(tags *tags.Tags, storer storage.Storer, corsAllowedOrigins []string, lo
 	s.setupRouting()
 
 	return s
+}
+
+const (
+	SwarmPinHeader = "Swarm-Pin"
+	TagHeaderUid   = "swarm-tag-uid"
+)
+
+// requestModePut returns the desired storage.ModePut for this request based on the request headers.
+func requestModePut(r *http.Request) storage.ModePut {
+	if h := strings.ToLower(r.Header.Get(SwarmPinHeader)); h == "true" {
+		return storage.ModePutUploadPin
+	}
+	return storage.ModePutUpload
 }

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -36,7 +36,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	toEncrypt := strings.ToLower(r.Header.Get(EncryptHeader)) == "true"
-	sp := splitter.NewSimpleSplitter(s.Storer)
+	sp := splitter.NewSimpleSplitter(s.Storer, requestModePut(r))
 	address, err := file.SplitWriteAll(ctx, sp, r.Body, r.ContentLength, toEncrypt)
 	if err != nil {
 		s.Logger.Debugf("bytes upload: %v", err)

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/manifest/jsonmanifest"
+	"github.com/ethersphere/bee/pkg/storage"
 	smock "github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -32,7 +33,7 @@ func TestBzz(t *testing.T) {
 	var (
 		bzzDownloadResource = func(addr, path string) string { return "/bzz/" + addr + "/" + path }
 		storer              = smock.NewStorer()
-		sp                  = splitter.NewSimpleSplitter(storer)
+		sp                  = splitter.NewSimpleSplitter(storer, storage.ModePutUpload)
 		client              = newTestServer(t, testServerOptions{
 			Storer: storer,
 			Tags:   tags.NewTags(),

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -83,7 +83,7 @@ func TestChunkUploadDownload(t *testing.T) {
 
 	t.Run("pin-invalid-value", func(t *testing.T) {
 		headers := make(map[string][]string)
-		headers[api.PinHeaderName] = []string{"hdgdh"}
+		headers[api.SwarmPinHeader] = []string{"hdgdh"}
 		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
 			Message: http.StatusText(http.StatusOK),
 			Code:    http.StatusOK,
@@ -108,14 +108,14 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 	t.Run("pin-ok", func(t *testing.T) {
 		headers := make(map[string][]string)
-		headers[api.PinHeaderName] = []string{"True"}
+		headers[api.SwarmPinHeader] = []string{"True"}
 		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
 			Message: http.StatusText(http.StatusOK),
 			Code:    http.StatusOK,
 		}, headers)
 
 		// Also check if the chunk is pinned
-		if mockValidatingStorer.GetModeSet(validHash) != storage.ModeSetPin {
+		if mockValidatingStorer.GetModePut(validHash) != storage.ModePutUploadPin {
 			t.Fatal("chunk is not pinned")
 		}
 

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -36,7 +36,7 @@ func TestChunkUploadDownload(t *testing.T) {
 		invalidContent       = []byte("bbaattss")
 		mockValidator        = validator.NewMockValidator(validHash, validContent)
 		tag                  = tags.NewTags()
-		mockValidatingStorer = mock.NewValidatingStorer(mockValidator, tag)
+		mockValidatingStorer = mock.NewStorer(mock.WithValidator(mockValidator))
 		client               = newTestServer(t, testServerOptions{
 			Storer: mockValidatingStorer,
 			Tags:   tag,

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -8,6 +8,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ethersphere/bee/pkg/collection/entry"
+	"github.com/ethersphere/bee/pkg/file"
+	"github.com/ethersphere/bee/pkg/file/splitter"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/manifest/jsonmanifest"
@@ -40,7 +44,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reference, err := storeDir(ctx, r.Body, s.Storer, s.Logger)
+	reference, err := storeDir(ctx, r.Body, s.Storer, requestModePut(r), s.Logger)
 	if err != nil {
 		s.Logger.Errorf("dir upload, store dir")
 		s.Logger.Debugf("dir upload, store dir err: %v", err)
@@ -74,7 +78,7 @@ func validateRequest(r *http.Request) (context.Context, error) {
 
 // storeDir stores all files recursively contained in the directory given as a tar
 // it returns the hash for the uploaded manifest corresponding to the uploaded dir
-func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, logger logging.Logger) (swarm.Address, error) {
+func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, mode storage.ModePut, logger logging.Logger) (swarm.Address, error) {
 	dirManifest := jsonmanifest.NewManifest()
 
 	// set up HTTP body reader
@@ -108,7 +112,7 @@ func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, logge
 			contentType: contentType,
 			reader:      tarReader,
 		}
-		fileReference, err := storeFile(ctx, fileInfo, s)
+		fileReference, err := storeFile(ctx, fileInfo, s, mode)
 		if err != nil {
 			return swarm.ZeroAddress, fmt.Errorf("store dir file error: %w", err)
 		}
@@ -144,10 +148,57 @@ func storeDir(ctx context.Context, reader io.ReadCloser, s storage.Storer, logge
 		contentType: ManifestContentType,
 		reader:      r,
 	}
-	manifestReference, err := storeFile(ctx, manifestFileInfo, s)
+	manifestReference, err := storeFile(ctx, manifestFileInfo, s, mode)
 	if err != nil {
 		return swarm.ZeroAddress, fmt.Errorf("store manifest error: %w", err)
 	}
 
 	return manifestReference, nil
+}
+
+// storeFile uploads the given file and returns its reference
+// this function was extracted from `fileUploadHandler` and should eventually replace its current code
+func storeFile(ctx context.Context, fileInfo *fileUploadInfo, s storage.Storer, mode storage.ModePut) (swarm.Address, error) {
+	v := ctx.Value(toEncryptContextKey{})
+	toEncrypt, _ := v.(bool) // default is false
+
+	// first store the file and get its reference
+	sp := splitter.NewSimpleSplitter(s, mode)
+	fr, err := file.SplitWriteAll(ctx, sp, fileInfo.reader, fileInfo.size, toEncrypt)
+	if err != nil {
+		return swarm.ZeroAddress, fmt.Errorf("split file error: %w", err)
+	}
+
+	// if filename is still empty, use the file hash as the filename
+	if fileInfo.name == "" {
+		fileInfo.name = fr.String()
+	}
+
+	// then store the metadata and get its reference
+	m := entry.NewMetadata(fileInfo.name)
+	m.MimeType = fileInfo.contentType
+	metadataBytes, err := json.Marshal(m)
+	if err != nil {
+		return swarm.ZeroAddress, fmt.Errorf("metadata marshal error: %w", err)
+	}
+
+	sp = splitter.NewSimpleSplitter(s, mode)
+	mr, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(metadataBytes), int64(len(metadataBytes)), toEncrypt)
+	if err != nil {
+		return swarm.ZeroAddress, fmt.Errorf("split metadata error: %w", err)
+	}
+
+	// now join both references (mr, fr) to create an entry and store it
+	e := entry.New(fr, mr)
+	fileEntryBytes, err := e.MarshalBinary()
+	if err != nil {
+		return swarm.ZeroAddress, fmt.Errorf("entry marshal error: %w", err)
+	}
+	sp = splitter.NewSimpleSplitter(s, mode)
+	reference, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)), toEncrypt)
+	if err != nil {
+		return swarm.ZeroAddress, fmt.Errorf("split entry error: %w", err)
+	}
+
+	return reference, nil
 }

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -51,8 +51,15 @@ type fileUploadResponse struct {
 // - multipart http message
 // - other content types as complete file body
 func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
-	toEncrypt := strings.ToLower(r.Header.Get(EncryptHeader)) == "true"
-	contentType := r.Header.Get("Content-Type")
+	var (
+		reader                  io.Reader
+		fileName, contentLength string
+		fileSize                uint64
+		mode                    = requestModePut(r)
+		toEncrypt               = strings.ToLower(r.Header.Get(EncryptHeader)) == "true"
+		contentType             = r.Header.Get("Content-Type")
+	)
+
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		s.Logger.Debugf("file upload: parse content type header %q: %v", contentType, err)
@@ -60,10 +67,6 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.BadRequest(w, "invalid content-type header")
 		return
 	}
-
-	var reader io.Reader
-	var fileName, contentLength string
-	var fileSize uint64
 
 	ta := s.createTag(w, r)
 	if ta == nil {
@@ -154,7 +157,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// first store the file and get its reference
-	sp := splitter.NewSimpleSplitter(s.Storer)
+	sp := splitter.NewSimpleSplitter(s.Storer, mode)
 	fr, err := file.SplitWriteAll(ctx, sp, reader, int64(fileSize), toEncrypt)
 	if err != nil {
 		s.Logger.Debugf("file upload: file store, file %q: %v", fileName, err)
@@ -178,7 +181,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, "metadata marshal error")
 		return
 	}
-	sp = splitter.NewSimpleSplitter(s.Storer)
+	sp = splitter.NewSimpleSplitter(s.Storer, mode)
 	mr, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(metadataBytes), int64(len(metadataBytes)), toEncrypt)
 	if err != nil {
 		s.Logger.Debugf("file upload: metadata store, file %q: %v", fileName, err)
@@ -196,7 +199,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, "entry marshal error")
 		return
 	}
-	sp = splitter.NewSimpleSplitter(s.Storer)
+	sp = splitter.NewSimpleSplitter(s.Storer, mode)
 	reference, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)), toEncrypt)
 	if err != nil {
 		s.Logger.Debugf("file upload: entry store, file %q: %v", fileName, err)
@@ -221,53 +224,6 @@ type fileUploadInfo struct {
 	size        int64  // file size
 	contentType string
 	reader      io.Reader
-}
-
-// storeFile uploads the given file and returns its reference
-// this function was extracted from `fileUploadHandler` and should eventually replace its current code
-func storeFile(ctx context.Context, fileInfo *fileUploadInfo, s storage.Storer) (swarm.Address, error) {
-	v := ctx.Value(toEncryptContextKey{})
-	toEncrypt, _ := v.(bool) // default is false
-
-	// first store the file and get its reference
-	sp := splitter.NewSimpleSplitter(s)
-	fr, err := file.SplitWriteAll(ctx, sp, fileInfo.reader, fileInfo.size, toEncrypt)
-	if err != nil {
-		return swarm.ZeroAddress, fmt.Errorf("split file error: %w", err)
-	}
-
-	// if filename is still empty, use the file hash as the filename
-	if fileInfo.name == "" {
-		fileInfo.name = fr.String()
-	}
-
-	// then store the metadata and get its reference
-	m := entry.NewMetadata(fileInfo.name)
-	m.MimeType = fileInfo.contentType
-	metadataBytes, err := json.Marshal(m)
-	if err != nil {
-		return swarm.ZeroAddress, fmt.Errorf("metadata marshal error: %w", err)
-	}
-
-	sp = splitter.NewSimpleSplitter(s)
-	mr, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(metadataBytes), int64(len(metadataBytes)), toEncrypt)
-	if err != nil {
-		return swarm.ZeroAddress, fmt.Errorf("split metadata error: %w", err)
-	}
-
-	// now join both references (mr, fr) to create an entry and store it
-	e := entry.New(fr, mr)
-	fileEntryBytes, err := e.MarshalBinary()
-	if err != nil {
-		return swarm.ZeroAddress, fmt.Errorf("entry marshal error: %w", err)
-	}
-	sp = splitter.NewSimpleSplitter(s)
-	reference, err := file.SplitWriteAll(ctx, sp, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)), toEncrypt)
-	if err != nil {
-		return swarm.ZeroAddress, fmt.Errorf("split entry error: %w", err)
-	}
-
-	return reference, nil
 }
 
 // fileDownloadHandler downloads the file given the entry's reference.

--- a/pkg/debugapi/pin_test.go
+++ b/pkg/debugapi/pin_test.go
@@ -23,21 +23,25 @@ import (
 // invalid chunk address case etc. This test case has to be run in sequence and
 // it assumes some state of the DB before another case is run.
 func TestPinChunkHandler(t *testing.T) {
-	resource := func(addr swarm.Address) string { return "/chunks/" + addr.String() }
-	hash := swarm.MustParseHexAddress("aabbcc")
-	data := []byte("bbaatt")
-	mockValidator := validator.NewMockValidator(hash, data)
-	tag := tags.NewTags()
-	mockValidatingStorer := mock.NewValidatingStorer(mockValidator, tag)
-	debugTestServer := newTestServer(t, testServerOptions{
-		Storer: mockValidatingStorer,
-		Tags:   tag,
-	})
-	// This server is used to store chunks
-	bzzTestServer := newBZZTestServer(t, testServerOptions{
-		Storer: mockValidatingStorer,
-		Tags:   tag,
-	})
+	var (
+		resource             = func(addr swarm.Address) string { return "/chunks/" + addr.String() }
+		hash                 = swarm.MustParseHexAddress("aabbcc")
+		data                 = []byte("bbaatt")
+		mockValidator        = validator.NewMockValidator(hash, data)
+		mockValidatingStorer = mock.NewStorer(mock.WithValidator(mockValidator))
+		tag                  = tags.NewTags()
+
+		debugTestServer = newTestServer(t, testServerOptions{
+			Storer: mockValidatingStorer,
+			Tags:   tag,
+		})
+
+		// This server is used to store chunks
+		bzzTestServer = newBZZTestServer(t, testServerOptions{
+			Storer: mockValidatingStorer,
+			Tags:   tag,
+		})
+	)
 
 	// bad chunk address
 	t.Run("pin-bad-address", func(t *testing.T) {

--- a/pkg/debugapi/tag_test.go
+++ b/pkg/debugapi/tag_test.go
@@ -34,7 +34,7 @@ func TestTags(t *testing.T) {
 		validHash            = swarm.MustParseHexAddress("aabbcc")
 		validContent         = []byte("bbaatt")
 		tag                  = tags.NewTags()
-		mockStorer           = mock.NewStorer(mock.WithTags(tag))
+		mockStorer           = mock.NewStorer()
 		mockPusher           = mp.NewMockPusher(tag)
 		ts                   = newTestServer(t, testServerOptions{
 			Storer: mockStorer,

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	"github.com/ethersphere/bee/pkg/file/splitter"
 	test "github.com/ethersphere/bee/pkg/file/testing"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -44,7 +45,7 @@ func testSplitThenJoin(t *testing.T) {
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
 		store       = mock.NewStorer()
-		s           = splitter.NewSimpleSplitter(store)
+		s           = splitter.NewSimpleSplitter(store, storage.ModePutUpload)
 		j           = joiner.NewSimpleJoiner(store)
 		data, _     = test.GetVector(t, int(dataIdx))
 	)

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -143,7 +143,7 @@ func TestEncryptionAndDecryption(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			s := splitter.NewSimpleSplitter(store)
+			s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
 			testDataReader := file.NewSimpleReadCloser(testData)
 			resultAddress, err := s.Split(context.Background(), testDataReader, int64(len(testData)), true)
 			if err != nil {

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -13,13 +13,16 @@ import (
 
 	"github.com/ethersphere/bee/pkg/encryption"
 	"github.com/ethersphere/bee/pkg/file"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bmt"
 	bmtlegacy "github.com/ethersphere/bmt/legacy"
 	"golang.org/x/crypto/sha3"
 )
+
+type Putter interface {
+	Put(context.Context, swarm.Chunk) ([]bool, error)
+}
 
 // maximum amount of file tree levels this file hasher component can handle
 // (128 ^ (9 - 1)) * 4096 = 295147905179352825856 bytes
@@ -41,7 +44,7 @@ func hashFunc() hash.Hash {
 // error and will may result in undefined result.
 type SimpleSplitterJob struct {
 	ctx        context.Context
-	putter     storage.Putter
+	putter     Putter
 	spanLength int64    // target length of data
 	length     int64    // number of bytes written to the data level of the hasher
 	sumCounts  []int    // number of sums performed, indexed per level
@@ -56,7 +59,7 @@ type SimpleSplitterJob struct {
 // NewSimpleSplitterJob creates a new SimpleSplitterJob.
 //
 // The spanLength is the length of the data that will be written.
-func NewSimpleSplitterJob(ctx context.Context, putter storage.Putter, spanLength int64, toEncrypt bool) *SimpleSplitterJob {
+func NewSimpleSplitterJob(ctx context.Context, putter Putter, spanLength int64, toEncrypt bool) *SimpleSplitterJob {
 	hashSize := swarm.HashSize
 	refSize := int64(hashSize)
 	if toEncrypt {
@@ -184,7 +187,7 @@ func (s *SimpleSplitterJob) sumLevel(lvl int) ([]byte, error) {
 		ch = swarm.NewChunk(addr, c)
 	}
 
-	seen, err := s.putter.Put(s.ctx, storage.ModePutUpload, ch)
+	seen, err := s.putter.Put(s.ctx, ch)
 	if err != nil {
 		return nil, err
 	} else if len(seen) > 0 && seen[0] {

--- a/pkg/file/splitter/internal/job_test.go
+++ b/pkg/file/splitter/internal/job_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/file/splitter/internal"
 	test "github.com/ethersphere/bee/pkg/file/testing"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -21,17 +22,30 @@ var (
 	end   = test.GetVectorCount()
 )
 
+type putWrapper struct {
+	putter func(context.Context, swarm.Chunk) ([]bool, error)
+}
+
+func (p putWrapper) Put(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
+	return p.putter(ctx, ch)
+}
+
 // TestSplitterJobPartialSingleChunk passes sub-chunk length data to the splitter,
 // verifies the correct hash is returned, and that write after Sum/complete Write
 // returns error.
 func TestSplitterJobPartialSingleChunk(t *testing.T) {
 	store := mock.NewStorer()
+	putter := putWrapper{
+		putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
+			return store.Put(ctx, storage.ModePutUpload, ch)
+		},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	data := []byte("foo")
-	j := internal.NewSimpleSplitterJob(ctx, store, int64(len(data)), false)
+	j := internal.NewSimpleSplitterJob(ctx, putter, int64(len(data)), false)
 
 	c, err := j.Write(data)
 	if err != nil {
@@ -69,12 +83,17 @@ func testSplitterJobVector(t *testing.T) {
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
 		store       = mock.NewStorer()
+		putter      = putWrapper{
+			putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
+				return store.Put(ctx, storage.ModePutUpload, ch)
+			},
+		}
 	)
 
 	data, expect := test.GetVector(t, int(dataIdx))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	j := internal.NewSimpleSplitterJob(ctx, store, int64(len(data)), false)
+	j := internal.NewSimpleSplitterJob(ctx, putter, int64(len(data)), false)
 
 	for i := 0; i < len(data); i += swarm.ChunkSize {
 		l := swarm.ChunkSize

--- a/pkg/file/splitter/splitter.go
+++ b/pkg/file/splitter/splitter.go
@@ -16,15 +16,27 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
+type putWrapper struct {
+	putter func(context.Context, swarm.Chunk) ([]bool, error)
+}
+
+func (p putWrapper) Put(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
+	return p.putter(ctx, ch)
+}
+
 // simpleSplitter wraps a non-optimized implementation of file.Splitter
 type simpleSplitter struct {
-	putter storage.Putter
+	putter internal.Putter
 }
 
 // NewSimpleSplitter creates a new SimpleSplitter
-func NewSimpleSplitter(putter storage.Putter) file.Splitter {
+func NewSimpleSplitter(storePutter storage.Putter, mode storage.ModePut) file.Splitter {
 	return &simpleSplitter{
-		putter: putter,
+		putter: putWrapper{
+			putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
+				return storePutter.Put(ctx, mode, ch)
+			},
+		},
 	}
 }
 

--- a/pkg/file/splitter/splitter_test.go
+++ b/pkg/file/splitter/splitter_test.go
@@ -23,7 +23,7 @@ import (
 func TestSplitIncomplete(t *testing.T) {
 	testData := make([]byte, 42)
 	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store)
+	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	_, err := s.Split(context.Background(), testDataReader, 41, false)
@@ -42,7 +42,7 @@ func TestSplitSingleChunk(t *testing.T) {
 	}
 
 	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store)
+	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	resultAddress, err := s.Split(context.Background(), testDataReader, int64(len(testData)), false)
@@ -74,7 +74,7 @@ func TestSplitThreeLevels(t *testing.T) {
 	}
 
 	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store)
+	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	resultAddress, err := s.Split(context.Background(), testDataReader, int64(len(testData)), false)
@@ -131,7 +131,7 @@ func TestUnalignedSplit(t *testing.T) {
 	}
 
 	// perform the split in a separate thread
-	sp := splitter.NewSimpleSplitter(storer)
+	sp := splitter.NewSimpleSplitter(storer, storage.ModePutUpload)
 	ctx := context.Background()
 	doneC := make(chan swarm.Address)
 	errC := make(chan error)

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -342,6 +342,24 @@ func newGCIndexTest(db *DB, chunk swarm.Chunk, storeTimestamp, accessTimestamp i
 	}
 }
 
+// newPinIndexTest returns a test function that validates if the right
+// chunk values are in the pin index.
+func newPinIndexTest(db *DB, chunk swarm.Chunk, wantError error) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		item, err := db.pinIndex.Get(shed.Item{
+			Address: chunk.Address().Bytes(),
+		})
+		if !errors.Is(err, wantError) {
+			t.Errorf("got error %v, want %v", err, wantError)
+		}
+		if err == nil {
+			validateItem(t, item, chunk.Address().Bytes(), nil, 0, 0)
+		}
+	}
+}
+
 // newItemsCountTest returns a test function that validates if
 // an index contains expected number of key/value pairs.
 func newItemsCountTest(i shed.Index, want int) func(t *testing.T) {

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -87,7 +87,7 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 			gcSizeChange += c
 		}
 
-	case storage.ModePutUpload:
+	case storage.ModePutUpload, storage.ModePutUploadPin:
 		for i, ch := range chs {
 			if containsChunk(ch.Address(), chs[:i]...) {
 				exist[i] = true
@@ -105,6 +105,12 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 				triggerPushFeed = true
 			}
 			gcSizeChange += c
+			if mode == storage.ModePutUploadPin {
+				err = db.setPin(batch, ch.Address())
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
 
 	case storage.ModePutSync:

--- a/pkg/localstore/pin.go
+++ b/pkg/localstore/pin.go
@@ -64,7 +64,7 @@ func (db *DB) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChu
 	return pinnedChunks, err
 }
 
-// Pinner returns the pin counter given a swarm address, provided that the
+// PinInfo returns the pin counter for a given swarm address, provided that the
 // address has been pinned.
 func (db *DB) PinInfo(address swarm.Address) (uint64, error) {
 	out, err := db.pinIndex.Get(shed.Item{

--- a/pkg/localstore/pin.go
+++ b/pkg/localstore/pin.go
@@ -65,12 +65,12 @@ func (db *DB) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChu
 }
 
 // Pinner returns the pin counter given a swarm address, provided that the
-// address has to be pinned already.
+// address has been pinned.
 func (db *DB) PinInfo(address swarm.Address) (uint64, error) {
-	it := shed.Item{
+	out, err := db.pinIndex.Get(shed.Item{
 		Address: address.Bytes(),
-	}
-	out, err := db.pinIndex.Get(it)
+	})
+
 	if err != nil {
 		if errors.Is(err, leveldb.ErrNotFound) {
 			return 0, storage.ErrNotFound

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/tags"
 )
 
 var _ storage.Storer = (*MockStorer)(nil)
@@ -25,7 +24,6 @@ type MockStorer struct {
 	subpull         []storage.Descriptor
 	partialInterval bool
 	validator       swarm.Validator
-	tags            *tags.Tags
 	morePull        chan struct{}
 	mtx             sync.Mutex
 	quit            chan struct{}
@@ -48,9 +46,9 @@ func WithBaseAddress(a swarm.Address) Option {
 	})
 }
 
-func WithTags(t *tags.Tags) Option {
+func WithValidator(v swarm.Validator) Option {
 	return optionFunc(func(m *MockStorer) {
-		m.tags = t
+		m.validator = v
 	})
 }
 
@@ -75,26 +73,6 @@ func NewStorer(opts ...Option) *MockStorer {
 	}
 
 	return s
-}
-
-func NewValidatingStorer(v swarm.Validator, tags *tags.Tags) *MockStorer {
-	return &MockStorer{
-		store:     make(map[string][]byte),
-		modePut:   make(map[string]storage.ModePut),
-		modeSet:   make(map[string]storage.ModeSet),
-		validator: v,
-		tags:      tags,
-	}
-}
-
-func NewTagsStorer(tags *tags.Tags) *MockStorer {
-	return &MockStorer{
-		store:     make(map[string][]byte),
-		modeSet:   make(map[string]storage.ModeSet),
-		modeSetMu: sync.Mutex{},
-		pinSetMu:  sync.Mutex{},
-		tags:      tags,
-	}
 }
 
 func (m *MockStorer) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address) (ch swarm.Chunk, err error) {

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -18,11 +18,10 @@ var _ storage.Storer = (*MockStorer)(nil)
 
 type MockStorer struct {
 	store           map[string][]byte
+	modePut         map[string]storage.ModePut
 	modeSet         map[string]storage.ModeSet
-	modeSetMu       sync.Mutex
 	pinnedAddress   []swarm.Address // Stores the pinned address
 	pinnedCounter   []uint64        // and its respective counter. These are stored as slices to preserve the order.
-	pinSetMu        sync.Mutex
 	subpull         []storage.Descriptor
 	partialInterval bool
 	validator       swarm.Validator
@@ -63,12 +62,12 @@ func WithPartialInterval(v bool) Option {
 
 func NewStorer(opts ...Option) *MockStorer {
 	s := &MockStorer{
-		store:     make(map[string][]byte),
-		modeSet:   make(map[string]storage.ModeSet),
-		modeSetMu: sync.Mutex{},
-		morePull:  make(chan struct{}),
-		quit:      make(chan struct{}),
-		bins:      make([]uint64, swarm.MaxBins),
+		store:    make(map[string][]byte),
+		modePut:  make(map[string]storage.ModePut),
+		modeSet:  make(map[string]storage.ModeSet),
+		morePull: make(chan struct{}),
+		quit:     make(chan struct{}),
+		bins:     make([]uint64, swarm.MaxBins),
 	}
 
 	for _, v := range opts {
@@ -81,9 +80,8 @@ func NewStorer(opts ...Option) *MockStorer {
 func NewValidatingStorer(v swarm.Validator, tags *tags.Tags) *MockStorer {
 	return &MockStorer{
 		store:     make(map[string][]byte),
+		modePut:   make(map[string]storage.ModePut),
 		modeSet:   make(map[string]storage.ModeSet),
-		modeSetMu: sync.Mutex{},
-		pinSetMu:  sync.Mutex{},
 		validator: v,
 		tags:      tags,
 	}
@@ -114,26 +112,23 @@ func (m *MockStorer) Put(ctx context.Context, mode storage.ModePut, chs ...swarm
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	for _, ch := range chs {
+	exist = make([]bool, len(chs))
+	for i, ch := range chs {
 		if m.validator != nil {
 			if !m.validator.Validate(ch) {
 				return nil, storage.ErrInvalidChunk
 			}
 		}
-		m.store[ch.Address().String()] = ch.Data()
-		yes, err := m.has(ctx, ch.Address())
+		exist[i], err = m.has(ctx, ch.Address())
 		if err != nil {
-			exist = append(exist, false)
-			continue
+			return exist, err
 		}
-		if yes {
-			exist = append(exist, true)
-		} else {
+		if !exist[i] {
 			po := swarm.Proximity(ch.Address().Bytes(), m.baseAddress)
 			m.bins[po]++
-			exist = append(exist, false)
 		}
-
+		m.store[ch.Address().String()] = ch.Data()
+		m.modePut[ch.Address().String()] = mode
 	}
 	return exist, nil
 }
@@ -158,10 +153,8 @@ func (m *MockStorer) HasMulti(ctx context.Context, addrs ...swarm.Address) (yes 
 }
 
 func (m *MockStorer) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Address) (err error) {
-	m.modeSetMu.Lock()
-	m.pinSetMu.Lock()
-	defer m.modeSetMu.Unlock()
-	defer m.pinSetMu.Unlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	for _, addr := range addrs {
 		m.modeSet[addr.String()] = mode
 		switch mode {
@@ -202,10 +195,18 @@ func (m *MockStorer) Set(ctx context.Context, mode storage.ModeSet, addrs ...swa
 	}
 	return nil
 }
+func (m *MockStorer) GetModePut(addr swarm.Address) (mode storage.ModePut) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	if mode, ok := m.modePut[addr.String()]; ok {
+		return mode
+	}
+	return mode
+}
 
 func (m *MockStorer) GetModeSet(addr swarm.Address) (mode storage.ModeSet) {
-	m.modeSetMu.Lock()
-	defer m.modeSetMu.Unlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	if mode, ok := m.modeSet[addr.String()]; ok {
 		return mode
 	}
@@ -289,8 +290,8 @@ func (m *MockStorer) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, s
 }
 
 func (m *MockStorer) PinnedChunks(ctx context.Context, cursor swarm.Address) (pinnedChunks []*storage.Pinner, err error) {
-	m.pinSetMu.Lock()
-	defer m.pinSetMu.Unlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	if len(m.pinnedAddress) == 0 {
 		return pinnedChunks, nil
 	}
@@ -308,8 +309,8 @@ func (m *MockStorer) PinnedChunks(ctx context.Context, cursor swarm.Address) (pi
 }
 
 func (m *MockStorer) PinInfo(address swarm.Address) (uint64, error) {
-	m.pinSetMu.Lock()
-	defer m.pinSetMu.Unlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	for i, addr := range m.pinnedAddress {
 		if addr.String() == address.String() {
 			return m.pinnedCounter[i], nil

--- a/pkg/storage/mock/storer_test.go
+++ b/pkg/storage/mock/storer_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/tags"
-
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/storage/mock/validator"
@@ -65,7 +63,7 @@ func TestMockValidatingStorer(t *testing.T) {
 	validContent := []byte("bbaatt")
 	invalidContent := []byte("bbaattss")
 
-	s := mock.NewValidatingStorer(validator.NewMockValidator(validAddress, validContent), tags.NewTags())
+	s := mock.NewStorer(mock.WithValidator(validator.NewMockValidator(validAddress, validContent)))
 
 	ctx := context.Background()
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -59,6 +59,8 @@ func (m ModePut) String() string {
 		return "Sync"
 	case ModePutUpload:
 		return "Upload"
+	case ModePutUploadPin:
+		return "UploadPin"
 	default:
 		return "Unknown"
 	}
@@ -72,6 +74,8 @@ const (
 	ModePutSync
 	// ModePutUpload: when a chunk is created by local upload
 	ModePutUpload
+	// ModePutUploadPin: the same as ModePutUpload but also pin the chunk atomically with the put
+	ModePutUploadPin
 )
 
 // ModeSet enumerates different Setter modes.


### PR DESCRIPTION
This PR adds a `ModePutUploadPin` which allows to upload and pin content simultaneously in one atomic operation. `Swarm-Pin` header is also added to the API to enable pinning on all the relevant endpoints.