### PR TITLE
remove disconnect threshold argument

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -45,7 +45,6 @@ func (c *command) initStartCmd() (err error) {
 		optionNameTracingEndpoint      = "tracing-endpoint"
 		optionNameTracingServiceName   = "tracing-service-name"
 		optionNameVerbosity            = "verbosity"
-		optionNameDisconnectThreshold  = "disconnect-threshold"
 		optionNameGlobalPinningEnabled = "global-pinning-enable"
 		optionNamePaymentThreshold     = "payment-threshold"
 		optionNamePaymentTolerance     = "payment-tolerance"
@@ -133,7 +132,6 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 				TracingEndpoint:      c.config.GetString(optionNameTracingEndpoint),
 				TracingServiceName:   c.config.GetString(optionNameTracingServiceName),
 				Logger:               logger,
-				DisconnectThreshold:  c.config.GetUint64(optionNameDisconnectThreshold),
 				GlobalPinningEnabled: c.config.GetBool(optionNameGlobalPinningEnabled),
 				PaymentThreshold:     c.config.GetUint64(optionNamePaymentThreshold),
 				PaymentTolerance:     c.config.GetUint64(optionNamePaymentTolerance),

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -85,7 +85,6 @@ type Options struct {
 	TracingEnabled       bool
 	TracingEndpoint      string
 	TracingServiceName   string
-	DisconnectThreshold  uint64
 	GlobalPinningEnabled bool
 	PaymentThreshold     uint64
 	PaymentTolerance     uint64


### PR DESCRIPTION
This PR removes the `--disconnect-treshold` command line argument which seems to have been reintroduced by mistake in the unrelated #479.