### PR TITLE
fix int conversion to string in statestore test

### DIFF
--- a/pkg/statestore/test/store.go
+++ b/pkg/statestore/test/store.go
@@ -160,7 +160,7 @@ func insert(t *testing.T, store storage.StateStorer, prefix string, count int) {
 	t.Helper()
 
 	for i := 0; i < count; i++ {
-		k := prefix + string(i)
+		k := prefix + fmt.Sprint(i)
 
 		err := store.Put(k, i)
 		if err != nil {


### PR DESCRIPTION
This pr fixes an error from Go 1.15 vet tool:

```
go vet ./...
# github.com/ethersphere/bee/pkg/statestore/test
pkg/statestore/test/store.go:163:17: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

This change is related to the correctness. No functional problems exist.