### PR TITLE
cleanup jsonhttptest package

### DIFF
--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -41,9 +41,12 @@ func TestBytes(t *testing.T) {
 	}
 
 	t.Run("upload", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource, bytes.NewReader(content), http.StatusOK, api.BytesPostResponse{
-			Reference: swarm.MustParseHexAddress(expHash),
-		})
+		jsonhttptest.Request(t, client, http.MethodPost, resource, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(content)),
+			jsonhttptest.WithExpectedJSONResponse(api.BytesPostResponse{
+				Reference: swarm.MustParseHexAddress(expHash),
+			}),
+		)
 	})
 
 	t.Run("download", func(t *testing.T) {
@@ -67,9 +70,11 @@ func TestBytes(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, resource+"/abcd", nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: "not found",
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, client, http.MethodGet, resource+"/abcd", http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "not found",
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 }

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -132,7 +132,9 @@ func TestBzz(t *testing.T) {
 
 		// read file from manifest path
 
-		rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, bzzDownloadResource(manifestFileReference.String(), filePath), nil, http.StatusOK, []byte(sampleHtml), nil)
+		rcvdHeader := jsonhttptest.Request(t, client, http.MethodGet, bzzDownloadResource(manifestFileReference.String(), filePath), http.StatusOK,
+			jsonhttptest.WithExpectedResponse([]byte(sampleHtml)),
+		)
 		cd := rcvdHeader.Get("Content-Disposition")
 		_, params, err := mime.ParseMediaType(cd)
 		if err != nil {
@@ -150,11 +152,12 @@ func TestBzz(t *testing.T) {
 
 		// check on invalid path
 
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodGet, bzzDownloadResource(manifestFileReference.String(), missingFilePath), nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "invalid path address",
-			Code:    http.StatusBadRequest,
-		}, nil)
-
+		jsonhttptest.Request(t, client, http.MethodGet, bzzDownloadResource(manifestFileReference.String(), missingFilePath), http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "invalid path address",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 	})
 
 }

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -97,7 +97,7 @@ func TestChunkUploadDownload(t *testing.T) {
 				Message: http.StatusText(http.StatusOK),
 				Code:    http.StatusOK,
 			}),
-			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "hdgdh"),
+			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "invalid-pin"),
 		)
 
 		// Also check if the chunk is NOT pinned

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -44,30 +44,39 @@ func TestChunkUploadDownload(t *testing.T) {
 	)
 
 	t.Run("invalid hash", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource(invalidHash), bytes.NewReader(validContent), http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "chunk write error",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, client, http.MethodPost, resource(invalidHash), http.StatusBadRequest,
+			jsonhttptest.WithRequestBody(bytes.NewReader(validContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "chunk write error",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 
 		// make sure chunk is not retrievable
 		_ = request(t, client, http.MethodGet, resource(invalidHash), nil, http.StatusNotFound)
 	})
 
 	t.Run("invalid content", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource(validHash), bytes.NewReader(invalidContent), http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "chunk write error",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, client, http.MethodPost, resource(invalidHash), http.StatusBadRequest,
+			jsonhttptest.WithRequestBody(bytes.NewReader(invalidContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "chunk write error",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 
 		// make sure not retrievable
 		_ = request(t, client, http.MethodGet, resource(validHash), nil, http.StatusNotFound)
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, client, http.MethodPost, resource(validHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(validContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 
 		// try to fetch the same chunk
 		resp := request(t, client, http.MethodGet, resource(validHash), nil, http.StatusOK)
@@ -82,12 +91,14 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 
 	t.Run("pin-invalid-value", func(t *testing.T) {
-		headers := make(map[string][]string)
-		headers[api.SwarmPinHeader] = []string{"hdgdh"}
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, headers)
+		jsonhttptest.Request(t, client, http.MethodPost, resource(validHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(validContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "hdgdh"),
+		)
 
 		// Also check if the chunk is NOT pinned
 		if mockValidatingStorer.GetModeSet(validHash) == storage.ModeSetPin {
@@ -95,11 +106,13 @@ func TestChunkUploadDownload(t *testing.T) {
 		}
 	})
 	t.Run("pin-header-missing", func(t *testing.T) {
-		headers := make(map[string][]string)
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, headers)
+		jsonhttptest.Request(t, client, http.MethodPost, resource(validHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(validContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 
 		// Also check if the chunk is NOT pinned
 		if mockValidatingStorer.GetModeSet(validHash) == storage.ModeSetPin {
@@ -107,12 +120,14 @@ func TestChunkUploadDownload(t *testing.T) {
 		}
 	})
 	t.Run("pin-ok", func(t *testing.T) {
-		headers := make(map[string][]string)
-		headers[api.SwarmPinHeader] = []string{"True"}
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, resource(validHash), bytes.NewReader(validContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, headers)
+		jsonhttptest.Request(t, client, http.MethodPost, resource(validHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(validContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "True"),
+		)
 
 		// Also check if the chunk is pinned
 		if mockValidatingStorer.GetModePut(validHash) != storage.ModePutUploadPin {

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -67,7 +67,7 @@ func TestFiles(t *testing.T) {
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithRequestHeader(api.EncryptHeader, "True"),
 			jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
-			jsonhttptest.WithUnmarshalResponse(&resp),
+			jsonhttptest.WithUnmarshalJSONResponse(&resp),
 		)
 
 		rootHash := resp.Reference.String()

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -6,7 +6,6 @@ package api_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,44 +34,46 @@ func TestFiles(t *testing.T) {
 		client               = newTestServer(t, testServerOptions{
 			Storer: mock.NewStorer(),
 			Tags:   tags.NewTags(),
-			Logger: logging.New(ioutil.Discard, 5),
 		})
 	)
 
 	t.Run("invalid-content-type", func(t *testing.T) {
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource, bytes.NewReader(simpleData), http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "invalid content-type header",
-			Code:    http.StatusBadRequest,
-		}, nil)
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusBadRequest,
+			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "invalid content-type header",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 	})
 
 	t.Run("multipart-upload", func(t *testing.T) {
 		fileName := "simple_file.txt"
 		rootHash := "295673cf7aa55d119dd6f82528c91d45b53dd63dc2e4ca4abf4ed8b3a0788085"
-		_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, simpleData, http.StatusOK, "", api.FileUploadResponse{
-			Reference: swarm.MustParseHexAddress(rootHash),
-		})
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusOK,
+			jsonhttptest.WithMultipartRequest(bytes.NewReader(simpleData), len(simpleData), fileName, ""),
+			jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			}),
+		)
 	})
 
 	t.Run("encrypt-decrypt", func(t *testing.T) {
 		t.Skip("reenable after crypto refactor")
 		fileName := "my-pictures.jpeg"
-		headers := make(http.Header)
-		headers.Add(api.EncryptHeader, "True")
-		headers.Add("Content-Type", "image/jpeg; charset=utf-8")
 
-		_, respBytes := jsonhttptest.ResponseDirectSendHeadersAndDontCheckResponse(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, bytes.NewReader(simpleData), http.StatusOK, headers)
-		read := bytes.NewReader(respBytes)
-
-		// get the reference as everytime it will change because of random encryption key
 		var resp api.FileUploadResponse
-		err := json.NewDecoder(read).Decode(&resp)
-		if err != nil {
-			t.Fatal(err)
-		}
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
+			jsonhttptest.WithRequestHeader(api.EncryptHeader, "True"),
+			jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
+			jsonhttptest.WithUnmarshalResponse(&resp),
+		)
 
 		rootHash := resp.Reference.String()
-		rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, simpleData, nil)
+		rcvdHeader := jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash), http.StatusOK,
+			jsonhttptest.WithExpectedResponse(simpleData),
+		)
 		cd := rcvdHeader.Get("Content-Disposition")
 		_, params, err := mime.ParseMediaType(cd)
 		if err != nil {
@@ -91,14 +92,17 @@ func TestFiles(t *testing.T) {
 		rootHash := "f2e761160deda91c1fbfab065a5abf530b0766b3e102b51fbd626ba37c3bc581"
 
 		t.Run("binary", func(t *testing.T) {
-			headers := make(http.Header)
-			headers.Add("Content-Type", "image/jpeg; charset=utf-8")
+			jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, http.StatusOK,
+				jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
+				jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+					Reference: swarm.MustParseHexAddress(rootHash),
+				}),
+				jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
+			)
 
-			_ = jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, bytes.NewReader(simpleData), http.StatusOK, api.FileUploadResponse{
-				Reference: swarm.MustParseHexAddress(rootHash),
-			}, headers)
-
-			rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, simpleData, nil)
+			rcvdHeader := jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash), http.StatusOK,
+				jsonhttptest.WithExpectedResponse(simpleData),
+			)
 			cd := rcvdHeader.Get("Content-Disposition")
 			_, params, err := mime.ParseMediaType(cd)
 			if err != nil {
@@ -113,11 +117,16 @@ func TestFiles(t *testing.T) {
 		})
 
 		t.Run("multipart", func(t *testing.T) {
-			_ = jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, simpleData, http.StatusOK, "image/jpeg; charset=utf-8", api.FileUploadResponse{
-				Reference: swarm.MustParseHexAddress(rootHash),
-			})
+			jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusOK,
+				jsonhttptest.WithMultipartRequest(bytes.NewReader(simpleData), len(simpleData), fileName, "image/jpeg; charset=utf-8"),
+				jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+					Reference: swarm.MustParseHexAddress(rootHash),
+				}),
+			)
 
-			rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, simpleData, nil)
+			rcvdHeader := jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash), http.StatusOK,
+				jsonhttptest.WithExpectedResponse(simpleData),
+			)
 			cd := rcvdHeader.Get("Content-Disposition")
 			_, params, err := mime.ParseMediaType(cd)
 			if err != nil {
@@ -147,19 +156,22 @@ func TestFiles(t *testing.T) {
 		</html>`
 
 		t.Run("binary", func(t *testing.T) {
-			headers := make(http.Header)
-			headers.Add("Content-Type", "text/html; charset=utf-8")
-
-			rcvdHeader := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, strings.NewReader(sampleHtml), http.StatusOK, api.FileUploadResponse{
-				Reference: swarm.MustParseHexAddress(rootHash),
-			}, headers)
+			rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, http.StatusOK,
+				jsonhttptest.WithRequestBody(strings.NewReader(sampleHtml)),
+				jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+					Reference: swarm.MustParseHexAddress(rootHash),
+				}),
+				jsonhttptest.WithRequestHeader("Content-Type", "text/html; charset=utf-8"),
+			)
 
 			if rcvdHeader.Get("ETag") != fmt.Sprintf("%q", rootHash) {
 				t.Fatal("Invalid ETags header received")
 			}
 
 			// try to fetch the same file and check the data
-			rcvdHeader = jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, []byte(sampleHtml), nil)
+			rcvdHeader = jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash), http.StatusOK,
+				jsonhttptest.WithExpectedResponse([]byte(sampleHtml)),
+			)
 
 			// check the headers
 			cd := rcvdHeader.Get("Content-Disposition")
@@ -176,16 +188,21 @@ func TestFiles(t *testing.T) {
 		})
 
 		t.Run("multipart", func(t *testing.T) {
-			rcvdHeader := jsonhttptest.ResponseDirectWithMultiPart(t, client, http.MethodPost, fileUploadResource, fileName, []byte(sampleHtml), http.StatusOK, "", api.FileUploadResponse{
-				Reference: swarm.MustParseHexAddress(rootHash),
-			})
+			rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusOK,
+				jsonhttptest.WithMultipartRequest(strings.NewReader(sampleHtml), len(sampleHtml), fileName, ""),
+				jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+					Reference: swarm.MustParseHexAddress(rootHash),
+				}),
+			)
 
 			if rcvdHeader.Get("ETag") != fmt.Sprintf("%q", rootHash) {
 				t.Fatal("Invalid ETags header received")
 			}
 
 			// try to fetch the same file and check the data
-			rcvdHeader = jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash), nil, http.StatusOK, []byte(sampleHtml), nil)
+			rcvdHeader = jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash), http.StatusOK,
+				jsonhttptest.WithExpectedResponse([]byte(sampleHtml)),
+			)
 
 			// check the headers
 			cd := rcvdHeader.Get("Content-Disposition")
@@ -205,14 +222,18 @@ func TestFiles(t *testing.T) {
 	t.Run("upload-then-download-with-targets", func(t *testing.T) {
 		fileName := "simple_file.txt"
 		rootHash := "19d2e82c076031ec4e456978f839472d2f1b1b969a765420404d8d315a0c6123"
-		headers := make(http.Header)
-		headers.Add("Content-Type", "text/html; charset=utf-8")
 
-		jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, bytes.NewReader(simpleData), http.StatusOK, api.FileUploadResponse{
-			Reference: swarm.MustParseHexAddress(rootHash),
-		}, headers)
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource+"?name="+fileName, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
+			jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+				Reference: swarm.MustParseHexAddress(rootHash),
+			}),
+			jsonhttptest.WithRequestHeader("Content-Type", "text/html; charset=utf-8"),
+		)
 
-		rcvdHeader := jsonhttptest.ResponseDirectCheckBinaryResponse(t, client, http.MethodGet, fileDownloadResource(rootHash)+"?targets="+targets, nil, http.StatusOK, simpleData, nil)
+		rcvdHeader := jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(rootHash)+"?targets="+targets, http.StatusOK,
+			jsonhttptest.WithExpectedResponse(simpleData),
+		)
 
 		if rcvdHeader.Get(api.TargetsRecoveryHeader) != targets {
 			t.Fatalf("targets mismatch. got %s, want %s", rcvdHeader.Get(api.TargetsRecoveryHeader), targets)
@@ -318,19 +339,23 @@ func TestRangeRequests(t *testing.T) {
 				Logger: logging.New(ioutil.Discard, 5),
 			})
 
-			jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, upload.uploadEndpoint, upload.reader, http.StatusOK, api.FileUploadResponse{
-				Reference: swarm.MustParseHexAddress(upload.reference),
-			}, http.Header{
-				"Content-Type": {upload.contentType},
-			})
+			jsonhttptest.Request(t, client, http.MethodPost, upload.uploadEndpoint, http.StatusOK,
+				jsonhttptest.WithRequestBody(upload.reader),
+				jsonhttptest.WithExpectedJSONResponse(api.FileUploadResponse{
+					Reference: swarm.MustParseHexAddress(upload.reference),
+				}),
+				jsonhttptest.WithRequestHeader("Content-Type", upload.contentType),
+			)
 
 			for _, tc := range ranges {
 				t.Run(tc.name, func(t *testing.T) {
 					rangeHeader, want := createRangeHeader(data, tc.ranges)
 
-					respHeaders, body := jsonhttptest.ResponseDirectSendHeadersAndDontCheckResponse(t, client, http.MethodGet, upload.downloadEndpoint+"/"+upload.reference+upload.filepath, nil, http.StatusPartialContent, http.Header{
-						"Range": {rangeHeader},
-					})
+					var body []byte
+					respHeaders := jsonhttptest.Request(t, client, http.MethodGet, upload.downloadEndpoint+"/"+upload.reference+upload.filepath, http.StatusPartialContent,
+						jsonhttptest.WithRequestHeader("Range", rangeHeader),
+						jsonhttptest.WithPutResponseBody(&body),
+					)
 
 					got := parseRangeParts(t, respHeaders.Get("Content-Type"), body)
 

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -6,7 +6,6 @@ package api_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -48,14 +47,11 @@ func TestTags(t *testing.T) {
 	)
 
 	t.Run("create-unnamed-tag", func(t *testing.T) {
-		tReq := &api.TagRequest{}
-		b, err := json.Marshal(tReq)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tr)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		if !strings.Contains(tr.Name, "unnamed_tag_") {
 			t.Fatalf("expected tag name to contain %s but is %s instead", "unnamed_tag_", tr.Name)
@@ -63,16 +59,13 @@ func TestTags(t *testing.T) {
 	})
 
 	t.Run("create-tag-with-name", func(t *testing.T) {
-		tReq := &api.TagRequest{
-			Name: someTagName,
-		}
-		b, err := json.Marshal(tReq)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tr)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		if tr.Name != someTagName {
 			t.Fatalf("expected tag name to be %s but is %s instead", someTagName, tr.Name)
@@ -80,85 +73,96 @@ func TestTags(t *testing.T) {
 	})
 
 	t.Run("create-tag-from-chunk-upload-with-invalid-id", func(t *testing.T) {
-		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, "invalid_id.jpg") // the value should be uint32
-		_ = jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Message: "cannot get or create tag",
-			Code:    http.StatusInternalServerError,
-		}, sentHeaders)
+		jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusInternalServerError,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "cannot get or create tag",
+				Code:    http.StatusInternalServerError,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, "invalid_id.jpg"), // the value should be uint32
+		)
 	})
 
 	t.Run("get-invalid-tags", func(t *testing.T) {
 		// invalid tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, tagsResource+"/foobar", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "invalid id",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, client, http.MethodGet, tagsResource+"/foobar", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "invalid id",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 
 		// non-existent tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, tagsWithIdResource(uint32(333)), nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: "tag not present",
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, client, http.MethodDelete, tagsWithIdResource(uint32(333)), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "tag not present",
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 
 	t.Run("get-tag-id-from-chunk-upload-without-tag", func(t *testing.T) {
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, nil)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 
 		isTagFoundInResponse(t, rcvdHeaders, nil)
 	})
 
 	t.Run("create-tag-and-use-it-to-upload-chunk", func(t *testing.T) {
 		// create a tag using the API
-		b, err := json.Marshal(api.TagResponse{
-			Name: someTagName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tr)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		if tr.Name != someTagName {
 			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
 		}
 
 		// now upload a chunk and see if we receive a tag with the same id
-		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10))
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, sentHeaders)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
+		)
 
 		isTagFoundInResponse(t, rcvdHeaders, &tr)
 	})
 
 	t.Run("create-tag-and-use-it-to-upload-multiple-chunks", func(t *testing.T) {
 		// create a tag using the API
-		b, err := json.Marshal(api.TagResponse{
-			Name: someTagName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tr)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		if tr.Name != someTagName {
 			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
 		}
 
 		// now upload a chunk and see if we receive a tag with the same id
-		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid))
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, sentHeaders)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid)),
+		)
 
 		isTagFoundInResponse(t, rcvdHeaders, &tr)
 
@@ -166,40 +170,51 @@ func TestTags(t *testing.T) {
 		secondValidHash := swarm.MustParseHexAddress("deadbeaf")
 		secondValidContent := []byte("123456")
 
-		sentHeaders = make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid))
-		rcvdHeaders = jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(secondValidHash), bytes.NewReader(secondValidContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, sentHeaders)
+		rcvdHeaders = jsonhttptest.Request(t, client, http.MethodPost, chunksResource(secondValidHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(secondValidContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid)),
+		)
 
 		isTagFoundInResponse(t, rcvdHeaders, &tr)
 	})
 
 	t.Run("get-tag-from-chunk-upload-and-use-it-again", func(t *testing.T) {
 		// upload a new chunk and get the generated tag id
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, nil)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 
 		id := isTagFoundInResponse(t, rcvdHeaders, nil)
 
 		// see if the tag id is present and has valid values
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(id), nil, http.StatusOK, &tr)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		// now upload another chunk using the same tag id
-		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid))
-		_ = jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, sentHeaders)
+		jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, fmt.Sprint(tr.Uid)),
+		)
 
 		// see if the tag id is present and has valid values
 		tr = api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(id), nil, http.StatusOK, &tr)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 
 		if id != tr.Uid {
 			t.Fatalf("expected tag id to be %d but is %d", id, tr.Uid)
@@ -210,25 +225,33 @@ func TestTags(t *testing.T) {
 	})
 
 	t.Run("get-tag-using-id", func(t *testing.T) {
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, nil)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 		id := isTagFoundInResponse(t, rcvdHeaders, nil)
 
 		// request the tag and see if the ID is the same
 		tr := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(id), nil, http.StatusOK, &tr)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 		if id != tr.Uid {
 			t.Fatalf("expected tag id to be %d but is %d", id, tr.Uid)
 		}
 	})
 
 	t.Run("tag-counters", func(t *testing.T) {
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		}, nil)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 		id := isTagFoundInResponse(t, rcvdHeaders, nil)
 
 		tagToVerify, err := tag.Get(id)
@@ -245,7 +268,9 @@ func TestTags(t *testing.T) {
 		}
 
 		finalTag := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(id), nil, http.StatusOK, &finalTag)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&finalTag),
+		)
 
 		if tagToVerify.Total != finalTag.Total {
 			t.Errorf("tag total count mismatch. got %d want %d", tagToVerify.Total, finalTag.Total)
@@ -266,92 +291,101 @@ func TestTags(t *testing.T) {
 
 	t.Run("delete-tag-error", func(t *testing.T) {
 		// try to delete invalid tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, tagsResource+"/foobar", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "invalid id",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, client, http.MethodDelete, tagsResource+"/foobar", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "invalid id",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 
 		// try to delete non-existent tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, tagsWithIdResource(uint32(333)), nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: "tag not present",
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, client, http.MethodDelete, tagsWithIdResource(uint32(333)), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "tag not present",
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 
 	t.Run("delete-tag", func(t *testing.T) {
 		// create a tag through API
-		b, err := json.Marshal(api.TagResponse{
-			Name: someTagName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 		tRes := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tRes)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 
 		// delete tag through API
-		jsonhttptest.ResponseDirect(t, client, http.MethodDelete, tagsWithIdResource(tRes.Uid), nil, http.StatusNoContent, nil)
+		jsonhttptest.Request(t, client, http.MethodDelete, tagsWithIdResource(tRes.Uid), http.StatusNoContent,
+			jsonhttptest.WithNoResponseBody(),
+		)
 
 		// try to get tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodGet, tagsWithIdResource(tRes.Uid), nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: "tag not present",
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(tRes.Uid), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "tag not present",
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 
 	t.Run("done-split-error", func(t *testing.T) {
-		b, err := json.Marshal(api.TagResponse{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		// invalid tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodPatch, tagsResource+"/foobar", bytes.NewReader(b), http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "invalid id",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, client, http.MethodPatch, tagsResource+"/foobar", http.StatusBadRequest,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{}),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "invalid id",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 
 		// non-existent tag
-		jsonhttptest.ResponseDirect(t, client, http.MethodPatch, tagsWithIdResource(uint32(333)), bytes.NewReader(b), http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: "tag not present",
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, client, http.MethodPatch, tagsWithIdResource(uint32(333)), http.StatusNotFound,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{}),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "tag not present",
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 
 	t.Run("done-split", func(t *testing.T) {
 		// create a tag through API
-		tResB, err := json.Marshal(api.TagResponse{
-			Name: someTagName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 		tRes := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(tResB), http.StatusCreated, &tRes)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 		tagId := tRes.Uid
 
 		// generate address to be supplied to the done split
 		addr := test.RandomAddress()
-		tReqB, err := json.Marshal(api.TagRequest{
-			Address: addr,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		// upload content with tag
-		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, fmt.Sprint(tagId))
-		jsonhttptest.ResponseDirectSendHeadersAndDontCheckResponse(t, client, http.MethodPost, chunksResource(someHash), bytes.NewReader(someContent), http.StatusOK, sentHeaders)
+		jsonhttptest.Request(t, client, http.MethodPost, chunksResource(someHash), http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(someContent)),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, fmt.Sprint(tagId)),
+		)
 
 		// call done split
-		jsonhttptest.ResponseDirect(t, client, http.MethodPatch, tagsWithIdResource(tagId), bytes.NewReader(tReqB), http.StatusOK, jsonhttp.StatusResponse{
-			Message: "ok",
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, client, http.MethodPatch, tagsWithIdResource(tagId), http.StatusOK,
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{
+				Address: addr,
+			}),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "ok",
+				Code:    http.StatusOK,
+			}),
+		)
 
 		// check tag data
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(tagId), nil, http.StatusOK, &tRes)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(tagId), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 		if !tRes.Address.Equal(addr) {
 			t.Fatalf("expected tag address to be %s but is %s", addr.String(), tRes.Address.String())
 		}
@@ -362,21 +396,22 @@ func TestTags(t *testing.T) {
 
 		// try different address value
 		addr = test.RandomAddress()
-		tReqB, err = json.Marshal(api.TagRequest{
-			Address: addr,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		// call done split
-		jsonhttptest.ResponseDirect(t, client, http.MethodPatch, tagsWithIdResource(tagId), bytes.NewReader(tReqB), http.StatusOK, jsonhttp.StatusResponse{
-			Message: "ok",
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, client, http.MethodPatch, tagsWithIdResource(tagId), http.StatusOK,
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{
+				Address: addr,
+			}),
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "ok",
+				Code:    http.StatusOK,
+			}),
+		)
 
 		// check tag data
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(tagId), nil, http.StatusOK, &tRes)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(tagId), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 		if !tRes.Address.Equal(addr) {
 			t.Fatalf("expected tag address to be %s but is %s", addr.String(), tRes.Address.String())
 		}
@@ -390,9 +425,11 @@ func TestTags(t *testing.T) {
 		expectedHash := swarm.MustParseHexAddress("8e27bb803ff049e8c2f4650357026723220170c15ebf9b635a7026539879a1a8")
 		expectedResponse := api.FileUploadResponse{Reference: expectedHash}
 
-		sentHeaders := make(http.Header)
-		sentHeaders.Set("Content-Type", "application/octet-stream")
-		respHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, filesResource, bytes.NewReader([]byte("some data")), http.StatusOK, expectedResponse, sentHeaders)
+		respHeaders := jsonhttptest.Request(t, client, http.MethodPost, filesResource, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader([]byte("some data"))),
+			jsonhttptest.WithExpectedJSONResponse(expectedResponse),
+			jsonhttptest.WithRequestHeader("Content-Type", "application/octet-stream"),
+		)
 
 		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagUidHeader))
 		if err != nil {
@@ -401,7 +438,9 @@ func TestTags(t *testing.T) {
 
 		// check tag data
 		tRes := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), nil, http.StatusOK, &tRes)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 
 		if !(tRes.Total > 0) {
 			t.Errorf("tag total should be greater than 0 but it is not")
@@ -424,9 +463,11 @@ func TestTags(t *testing.T) {
 		expectedHash := swarm.MustParseHexAddress("9e5acfbfeb7e074d4c79f5f9922e8a25990dad267d0ea7becaaad07b47fb2a87")
 		expectedResponse := api.FileUploadResponse{Reference: expectedHash}
 
-		sentHeaders := make(http.Header)
-		sentHeaders.Set("Content-Type", api.ContentTypeTar)
-		respHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, dirResource, tarReader, http.StatusOK, expectedResponse, sentHeaders)
+		respHeaders := jsonhttptest.Request(t, client, http.MethodPost, dirResource, http.StatusOK,
+			jsonhttptest.WithRequestBody(tarReader),
+			jsonhttptest.WithExpectedJSONResponse(expectedResponse),
+			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
+		)
 
 		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagUidHeader))
 		if err != nil {
@@ -435,7 +476,9 @@ func TestTags(t *testing.T) {
 
 		// check tag data
 		tRes := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), nil, http.StatusOK, &tRes)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&tRes),
+		)
 
 		if !(tRes.Total > 0) {
 			t.Errorf("tag total should be greater than 0 but it is not")
@@ -451,13 +494,12 @@ func TestTags(t *testing.T) {
 	t.Run("bytes-tags", func(t *testing.T) {
 		// create a tag using the API
 		tr := api.TagResponse{}
-		b, err := json.Marshal(api.TagResponse{
-			Name: someTagName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodPost, tagsResource, bytes.NewReader(b), http.StatusCreated, &tr)
+		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
+			jsonhttptest.WithJSONRequestBody(api.TagResponse{
+				Name: someTagName,
+			}),
+			jsonhttptest.WithUnmarshalResponse(&tr),
+		)
 		if tr.Name != someTagName {
 			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
 		}
@@ -477,9 +519,13 @@ func TestTags(t *testing.T) {
 		copy(content[swarm.ChunkSize:], dataChunk)
 		copy(content[:swarm.ChunkSize], dataChunk)
 
-		rcvdHeaders := jsonhttptest.ResponseDirectSendHeadersAndReceiveHeaders(t, client, http.MethodPost, bytesResource, bytes.NewReader(content), http.StatusOK, fileUploadResponse{
-			Reference: rootAddress,
-		}, sentHeaders)
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, bytesResource, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(content)),
+			jsonhttptest.WithExpectedJSONResponse(fileUploadResponse{
+				Reference: rootAddress,
+			}),
+			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
+		)
 		id := isTagFoundInResponse(t, rcvdHeaders, nil)
 
 		tagToVerify, err := tag.Get(id)
@@ -492,7 +538,9 @@ func TestTags(t *testing.T) {
 		}
 
 		finalTag := api.TagResponse{}
-		jsonhttptest.ResponseUnmarshal(t, client, http.MethodGet, tagsWithIdResource(id), nil, http.StatusOK, &finalTag)
+		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+			jsonhttptest.WithUnmarshalResponse(&finalTag),
+		)
 
 		if finalTag.Total != 0 {
 			t.Errorf("tag total count mismatch. got %d want %d", finalTag.Total, 0)

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -50,7 +50,7 @@ func TestTags(t *testing.T) {
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
 			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		if !strings.Contains(tr.Name, "unnamed_tag_") {
@@ -64,7 +64,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagRequest{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		if tr.Name != someTagName {
@@ -120,7 +120,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagResponse{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		if tr.Name != someTagName {
@@ -147,7 +147,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagResponse{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		if tr.Name != someTagName {
@@ -197,7 +197,7 @@ func TestTags(t *testing.T) {
 		// see if the tag id is present and has valid values
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		// now upload another chunk using the same tag id
@@ -213,7 +213,7 @@ func TestTags(t *testing.T) {
 		// see if the tag id is present and has valid values
 		tr = api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
 		if id != tr.Uid {
@@ -237,7 +237,7 @@ func TestTags(t *testing.T) {
 		// request the tag and see if the ID is the same
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 		if id != tr.Uid {
 			t.Fatalf("expected tag id to be %d but is %d", id, tr.Uid)
@@ -269,7 +269,7 @@ func TestTags(t *testing.T) {
 
 		finalTag := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&finalTag),
+			jsonhttptest.WithUnmarshalJSONResponse(&finalTag),
 		)
 
 		if tagToVerify.Total != finalTag.Total {
@@ -314,7 +314,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagResponse{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 
 		// delete tag through API
@@ -358,7 +358,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagResponse{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 		tagId := tRes.Uid
 
@@ -384,7 +384,7 @@ func TestTags(t *testing.T) {
 
 		// check tag data
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(tagId), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 		if !tRes.Address.Equal(addr) {
 			t.Fatalf("expected tag address to be %s but is %s", addr.String(), tRes.Address.String())
@@ -410,7 +410,7 @@ func TestTags(t *testing.T) {
 
 		// check tag data
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(tagId), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 		if !tRes.Address.Equal(addr) {
 			t.Fatalf("expected tag address to be %s but is %s", addr.String(), tRes.Address.String())
@@ -439,7 +439,7 @@ func TestTags(t *testing.T) {
 		// check tag data
 		tRes := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 
 		if !(tRes.Total > 0) {
@@ -477,7 +477,7 @@ func TestTags(t *testing.T) {
 		// check tag data
 		tRes := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(uint32(tagId)), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&tRes),
+			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 
 		if !(tRes.Total > 0) {
@@ -498,7 +498,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithJSONRequestBody(api.TagResponse{
 				Name: someTagName,
 			}),
-			jsonhttptest.WithUnmarshalResponse(&tr),
+			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 		if tr.Name != someTagName {
 			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
@@ -539,7 +539,7 @@ func TestTags(t *testing.T) {
 
 		finalTag := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
-			jsonhttptest.WithUnmarshalResponse(&finalTag),
+			jsonhttptest.WithUnmarshalJSONResponse(&finalTag),
 		)
 
 		if finalTag.Total != 0 {

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -49,7 +49,7 @@ func TestBalances(t *testing.T) {
 	// We expect a list of items unordered by peer:
 	var got *debugapi.BalancesResponse
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances", http.StatusOK,
-		jsonhttptest.WithUnmarshalResponse(&got),
+		jsonhttptest.WithUnmarshalJSONResponse(&got),
 	)
 
 	if !equalBalances(got, expected) {

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -48,7 +48,9 @@ func TestBalances(t *testing.T) {
 
 	// We expect a list of items unordered by peer:
 	var got *debugapi.BalancesResponse
-	jsonhttptest.ResponseUnmarshal(t, testServer.Client, http.MethodGet, "/balances", nil, http.StatusOK, &got)
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances", http.StatusOK,
+		jsonhttptest.WithUnmarshalResponse(&got),
+	)
 
 	if !equalBalances(got, expected) {
 		t.Errorf("got balances: %v, expected: %v", got, expected)
@@ -65,10 +67,12 @@ func TestBalancesError(t *testing.T) {
 		AccountingOpts: []mock.Option{mock.WithBalancesFunc(balancesFunc)},
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-		Message: debugapi.ErrCantBalances,
-		Code:    http.StatusInternalServerError,
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances", http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantBalances,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
 }
 
 func TestBalancesPeers(t *testing.T) {
@@ -80,10 +84,12 @@ func TestBalancesPeers(t *testing.T) {
 		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances/"+peer, nil, http.StatusOK, debugapi.BalanceResponse{
-		Peer:    peer,
-		Balance: 1000000000000000000,
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.BalanceResponse{
+			Peer:    peer,
+			Balance: 1000000000000000000,
+		}),
+	)
 }
 
 func TestBalancesPeersError(t *testing.T) {
@@ -96,10 +102,12 @@ func TestBalancesPeersError(t *testing.T) {
 		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances/"+peer, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-		Message: debugapi.ErrCantBalance,
-		Code:    http.StatusInternalServerError,
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantBalance,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
 }
 
 func TestBalancesInvalidAddress(t *testing.T) {
@@ -107,10 +115,12 @@ func TestBalancesInvalidAddress(t *testing.T) {
 
 	testServer := newTestServer(t, testServerOptions{})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/balances/"+peer, nil, http.StatusNotFound, jsonhttp.StatusResponse{
-		Message: debugapi.ErrInvaliAddress,
-		Code:    http.StatusNotFound,
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrInvaliAddress,
+			Code:    http.StatusNotFound,
+		}),
+	)
 }
 
 func equalBalances(a, b *debugapi.BalancesResponse) bool {

--- a/pkg/debugapi/chunk_test.go
+++ b/pkg/debugapi/chunk_test.go
@@ -31,31 +31,39 @@ func TestHasChunkHandler(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/chunks/"+key.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/chunks/"+key.String(), http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/chunks/abbbbb", nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusNotFound),
-			Code:    http.StatusNotFound,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/chunks/abbbbb", http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusNotFound),
+				Code:    http.StatusNotFound,
+			}),
+		)
 	})
 
 	t.Run("bad address", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/chunks/abcd1100zz", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Message: "bad address",
-			Code:    http.StatusBadRequest,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/chunks/abcd1100zz", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "bad address",
+				Code:    http.StatusBadRequest,
+			}),
+		)
 	})
 
 	t.Run("remove-chunk", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/chunks/"+key.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/chunks/"+key.String(), http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 		yes, err := mockStorer.Has(context.Background(), key)
 		if err != nil {
 			t.Fatal(err)
@@ -67,10 +75,12 @@ func TestHasChunkHandler(t *testing.T) {
 
 	t.Run("remove-not-present-chunk", func(t *testing.T) {
 		notPresentChunkAddress := "deadbeef"
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/chunks/"+notPresentChunkAddress, nil, http.StatusOK, jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/chunks/"+notPresentChunkAddress, http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: http.StatusText(http.StatusOK),
+				Code:    http.StatusOK,
+			}),
+		)
 		yes, err := mockStorer.Has(context.Background(), swarm.NewAddress([]byte(notPresentChunkAddress)))
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/debugapi/p2p_test.go
+++ b/pkg/debugapi/p2p_test.go
@@ -33,17 +33,21 @@ func TestAddresses(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/addresses", nil, http.StatusOK, debugapi.AddressesResponse{
-			Overlay:  overlay,
-			Underlay: addresses,
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/addresses", http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(debugapi.AddressesResponse{
+				Overlay:  overlay,
+				Underlay: addresses,
+			}),
+		)
 	})
 
 	t.Run("post method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/addresses", nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
-			Code:    http.StatusMethodNotAllowed,
-			Message: http.StatusText(http.StatusMethodNotAllowed),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodPost, "/addresses", http.StatusMethodNotAllowed,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusMethodNotAllowed,
+				Message: http.StatusText(http.StatusMethodNotAllowed),
+			}),
+		)
 	})
 }
 
@@ -56,8 +60,10 @@ func TestAddresses_error(t *testing.T) {
 		})),
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/addresses", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-		Code:    http.StatusInternalServerError,
-		Message: testErr.Error(),
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/addresses", http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Code:    http.StatusInternalServerError,
+			Message: testErr.Error(),
+		}),
+	)
 }

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -55,26 +55,32 @@ func TestConnect(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+underlay, nil, http.StatusOK, debugapi.PeerConnectResponse{
-			Address: overlay.String(),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodPost, "/connect"+underlay, http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(debugapi.PeerConnectResponse{
+				Address: overlay.String(),
+			}),
+		)
 		if testServer.P2PMock.ConnectNotifyCalls() != 1 {
 			t.Fatal("connect notify not called")
 		}
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+errorUnderlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Code:    http.StatusInternalServerError,
-			Message: testErr.Error(),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodPost, "/connect"+errorUnderlay, http.StatusInternalServerError,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusInternalServerError,
+				Message: testErr.Error(),
+			}),
+		)
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/connect"+underlay, nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
-			Code:    http.StatusMethodNotAllowed,
-			Message: http.StatusText(http.StatusMethodNotAllowed),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/connect"+underlay, http.StatusMethodNotAllowed,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusMethodNotAllowed,
+				Message: http.StatusText(http.StatusMethodNotAllowed),
+			}),
+		)
 	})
 
 	t.Run("error - add peer", func(t *testing.T) {
@@ -87,10 +93,12 @@ func TestConnect(t *testing.T) {
 			})),
 		})
 
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/connect"+errorUnderlay, nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Code:    http.StatusInternalServerError,
-			Message: testErr.Error(),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodPost, "/connect"+errorUnderlay, http.StatusInternalServerError,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusInternalServerError,
+				Message: testErr.Error(),
+			}),
+		)
 	})
 }
 
@@ -115,31 +123,39 @@ func TestDisconnect(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+address.String(), nil, http.StatusOK, jsonhttp.StatusResponse{
-			Code:    http.StatusOK,
-			Message: http.StatusText(http.StatusOK),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/peers/"+address.String(), http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusOK,
+				Message: http.StatusText(http.StatusOK),
+			}),
+		)
 	})
 
 	t.Run("unknown", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+unknownAdddress.String(), nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Code:    http.StatusBadRequest,
-			Message: "peer not found",
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/peers/"+unknownAdddress.String(), http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "peer not found",
+			}),
+		)
 	})
 
 	t.Run("invalid peer address", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Code:    http.StatusBadRequest,
-			Message: "invalid peer address",
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/peers/invalid-address", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "invalid peer address",
+			}),
+		)
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodDelete, "/peers/"+errorAddress.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Code:    http.StatusInternalServerError,
-			Message: testErr.Error(),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodDelete, "/peers/"+errorAddress.String(), http.StatusInternalServerError,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusInternalServerError,
+				Message: testErr.Error(),
+			}),
+		)
 	})
 }
 
@@ -152,15 +168,19 @@ func TestPeer(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/peers", nil, http.StatusOK, debugapi.PeersResponse{
-			Peers: []p2p.Peer{{Address: overlay}},
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/peers", http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(debugapi.PeersResponse{
+				Peers: []p2p.Peer{{Address: overlay}},
+			}),
+		)
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodPost, "/peers", nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
-			Code:    http.StatusMethodNotAllowed,
-			Message: http.StatusText(http.StatusMethodNotAllowed),
-		})
+		jsonhttptest.Request(t, testServer.Client, http.MethodPost, "/peers", http.StatusMethodNotAllowed,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusMethodNotAllowed,
+				Message: http.StatusText(http.StatusMethodNotAllowed),
+			}),
+		)
 	})
 }

--- a/pkg/debugapi/pingpong_test.go
+++ b/pkg/debugapi/pingpong_test.go
@@ -41,36 +41,46 @@ func TestPingpong(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+peerID.String(), nil, http.StatusOK, debugapi.PingpongResponse{
-			RTT: rtt.String(),
-		})
+		jsonhttptest.Request(t, ts.Client, http.MethodPost, "/pingpong/"+peerID.String(), http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(debugapi.PingpongResponse{
+				RTT: rtt.String(),
+			}),
+		)
 	})
 
 	t.Run("peer not found", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+unknownPeerID.String(), nil, http.StatusNotFound, jsonhttp.StatusResponse{
-			Code:    http.StatusNotFound,
-			Message: "peer not found",
-		})
+		jsonhttptest.Request(t, ts.Client, http.MethodPost, "/pingpong/"+unknownPeerID.String(), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusNotFound,
+				Message: "peer not found",
+			}),
+		)
 	})
 
 	t.Run("invalid peer address", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/invalid-address", nil, http.StatusBadRequest, jsonhttp.StatusResponse{
-			Code:    http.StatusBadRequest,
-			Message: "invalid peer address",
-		})
+		jsonhttptest.Request(t, ts.Client, http.MethodPost, "/pingpong/invalid-address", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "invalid peer address",
+			}),
+		)
 	})
 
 	t.Run("error", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodPost, "/pingpong/"+errorPeerID.String(), nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-			Code:    http.StatusInternalServerError,
-			Message: http.StatusText(http.StatusInternalServerError), // do not leak internal error
-		})
+		jsonhttptest.Request(t, ts.Client, http.MethodPost, "/pingpong/"+errorPeerID.String(), http.StatusInternalServerError,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusInternalServerError,
+				Message: http.StatusText(http.StatusInternalServerError), // do not leak internal error
+			}),
+		)
 	})
 
 	t.Run("get method not allowed", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, ts.Client, http.MethodGet, "/pingpong/"+peerID.String(), nil, http.StatusMethodNotAllowed, jsonhttp.StatusResponse{
-			Code:    http.StatusMethodNotAllowed,
-			Message: http.StatusText(http.StatusMethodNotAllowed),
-		})
+		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/pingpong/"+peerID.String(), http.StatusMethodNotAllowed,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Code:    http.StatusMethodNotAllowed,
+				Message: http.StatusText(http.StatusMethodNotAllowed),
+			}),
+		)
 	})
 }

--- a/pkg/debugapi/status_test.go
+++ b/pkg/debugapi/status_test.go
@@ -15,15 +15,19 @@ import (
 func TestHealth(t *testing.T) {
 	testServer := newTestServer(t, testServerOptions{})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/health", nil, http.StatusOK, debugapi.StatusResponse{
-		Status: "ok",
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/health", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
+			Status: "ok",
+		}),
+	)
 }
 
 func TestReadiness(t *testing.T) {
 	testServer := newTestServer(t, testServerOptions{})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/readiness", nil, http.StatusOK, debugapi.StatusResponse{
-		Status: "ok",
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/readiness", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
+			Status: "ok",
+		}),
+	)
 }

--- a/pkg/debugapi/topology_test.go
+++ b/pkg/debugapi/topology_test.go
@@ -27,9 +27,11 @@ func TestTopologyOK(t *testing.T) {
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusOK, topologyResponse{
-		Topology: "abcd",
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/topology", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(topologyResponse{
+			Topology: "abcd",
+		}),
+	)
 }
 
 func TestTopologyError(t *testing.T) {
@@ -40,8 +42,10 @@ func TestTopologyError(t *testing.T) {
 		TopologyOpts: []topmock.Option{topmock.WithMarshalJSONFunc(marshalFunc)},
 	})
 
-	jsonhttptest.ResponseDirect(t, testServer.Client, http.MethodGet, "/topology", nil, http.StatusInternalServerError, jsonhttp.StatusResponse{
-		Message: "error",
-		Code:    http.StatusInternalServerError,
-	})
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/topology", http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: "error",
+			Code:    http.StatusInternalServerError,
+		}),
+	)
 }

--- a/pkg/debugapi/welcome_message_test.go
+++ b/pkg/debugapi/welcome_message_test.go
@@ -25,9 +25,11 @@ func TestGetWelcomeMessage(t *testing.T) {
 			return DefaultTestWelcomeMessage
 		}))})
 
-	jsonhttptest.ResponseDirect(t, srv.Client, http.MethodGet, "/welcome-message", nil, http.StatusOK, debugapi.WelcomeMessageResponse{
-		WelcomeMesssage: DefaultTestWelcomeMessage,
-	})
+	jsonhttptest.Request(t, srv.Client, http.MethodGet, "/welcome-message", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.WelcomeMessageResponse{
+			WelcomeMesssage: DefaultTestWelcomeMessage,
+		}),
+	)
 }
 
 func TestSetWelcomeMessage(t *testing.T) {
@@ -81,7 +83,10 @@ func TestSetWelcomeMessage(t *testing.T) {
 				Message: tC.wantMessage,
 				Code:    tC.wantStatus,
 			}
-			jsonhttptest.ResponseDirect(t, srv.Client, http.MethodPost, testURL, body, tC.wantStatus, wantResponse)
+			jsonhttptest.Request(t, srv.Client, http.MethodPost, testURL, tC.wantStatus,
+				jsonhttptest.WithRequestBody(body),
+				jsonhttptest.WithExpectedJSONResponse(wantResponse),
+			)
 			if !tC.wantFail {
 				got := srv.P2PMock.GetWelcomeMessage()
 				if got != tC.message {
@@ -113,7 +118,10 @@ func TestSetWelcomeMessageInternalServerError(t *testing.T) {
 			Message: testError.Error(),
 			Code:    wantCode,
 		}
-		jsonhttptest.ResponseDirect(t, srv.Client, http.MethodPost, testURL, body, wantCode, wantResp)
+		jsonhttptest.Request(t, srv.Client, http.MethodPost, testURL, wantCode,
+			jsonhttptest.WithRequestBody(body),
+			jsonhttptest.WithExpectedJSONResponse(wantResp),
+		)
 	})
 
 }

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
@@ -6,6 +6,7 @@ package jsonhttptest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,172 +16,213 @@ import (
 	"net/textproto"
 	"strconv"
 	"testing"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
-func ResponseDirect(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, response interface{}) {
+func Request(t *testing.T, client *http.Client, method, url string, responseCode int, opts ...Option) http.Header {
 	t.Helper()
 
-	resp := request(t, client, method, url, body, responseCode, nil)
-	defer resp.Body.Close()
+	o := new(options)
+	for _, opt := range opts {
+		if err := opt.apply(o); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	got, err := ioutil.ReadAll(resp.Body)
+	req, err := http.NewRequest(method, url, o.requestBody)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got = bytes.TrimSpace(got)
-	if response == nil && len(got) == 0 {
-		return
+	req.Header = o.requestHeaders
+	if o.ctx != nil {
+		req = req.WithContext(o.ctx)
 	}
-	want, err := json.Marshal(response)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !bytes.Equal(got, want) {
-		t.Errorf("got response %s, want %s", string(got), string(want))
-	}
-}
-
-func ResponseDirectWithMultiPart(t *testing.T, client *http.Client, method, url, fileName string, data []byte,
-	responseCode int, contentType string, response interface{}) http.Header {
-	body := bytes.NewBuffer(nil)
-	mw := multipart.NewWriter(body)
-	hdr := make(textproto.MIMEHeader)
-	hdr.Set("Content-Disposition", fmt.Sprintf("form-data; name=%q", fileName))
-	hdr.Set("Content-Type", contentType)
-	hdr.Set("Content-Length", strconv.FormatInt(int64(len(data)), 10))
-	part, err := mw.CreatePart(hdr)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = io.Copy(part, bytes.NewReader(data))
-	if err != nil {
-		t.Error(err)
-	}
-	err = mw.Close()
-	if err != nil {
-		t.Error(err)
-	}
-
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		t.Error(err)
-	}
-	req.Header.Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%q", mw.Boundary()))
-
-	res, err := client.Do(req)
-	if err != nil {
-		t.Error(err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != responseCode {
-		t.Errorf("got response status %s, want %v %s", res.Status, responseCode, http.StatusText(responseCode))
-	}
-
-	got, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got = bytes.TrimSpace(got)
-
-	want, err := json.Marshal(response)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !bytes.Equal(got, want) {
-		t.Errorf("got response %s, want %s", string(got), string(want))
-	}
-
-	return res.Header
-}
-func ResponseDirectCheckBinaryResponse(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int,
-	response []byte, headers http.Header) http.Header {
-	t.Helper()
-
-	resp := request(t, client, method, url, body, responseCode, headers)
-	defer resp.Body.Close()
-
-	got, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got = bytes.TrimSpace(got)
-
-	if !bytes.Equal(got, response) {
-		t.Errorf("got response %s, want %s", string(got), string(response))
-	}
-	return resp.Header
-}
-
-func ResponseDirectSendHeadersAndReceiveHeaders(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int,
-	response interface{}, headers http.Header) http.Header {
-	t.Helper()
-
-	resp := request(t, client, method, url, body, responseCode, headers)
-	defer resp.Body.Close()
-
-	got, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got = bytes.TrimSpace(got)
-
-	want, err := json.Marshal(response)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !bytes.Equal(got, want) {
-		t.Errorf("got response %s, want %s", string(got), string(want))
-	}
-
-	return resp.Header
-}
-
-// ResponseDirectSendHeadersAndDontCheckResponse sends a request with the given headers and does not check for the returned reference.
-// this is useful in tests which does not know the return reference, for ex: when encryption flag is set
-func ResponseDirectSendHeadersAndDontCheckResponse(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, headers http.Header) (http.Header, []byte) {
-	t.Helper()
-
-	resp := request(t, client, method, url, body, responseCode, headers)
-	defer resp.Body.Close()
-
-	got, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got = bytes.TrimSpace(got)
-
-	return resp.Header, got
-}
-
-func ResponseUnmarshal(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, response interface{}) {
-	t.Helper()
-
-	resp := request(t, client, method, url, body, responseCode, nil)
-	defer resp.Body.Close()
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func request(t *testing.T, client *http.Client, method, url string, body io.Reader, responseCode int, headers http.Header) *http.Response {
-	t.Helper()
-
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header = headers
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != responseCode {
 		t.Errorf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
 	}
-	return resp
+
+	if o.expectedResponse != nil {
+		got, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, o.expectedResponse) {
+			t.Errorf("got response %s, want %s", string(got), string(o.expectedResponse))
+		}
+		return resp.Header
+	}
+
+	if o.expectedJSONResponse != nil {
+		if v := resp.Header.Get("Content-Type"); v != jsonhttp.DefaultContentTypeHeader {
+			t.Errorf("got content type %q, want %q", v, jsonhttp.DefaultContentTypeHeader)
+		}
+		got, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = bytes.TrimSpace(got)
+
+		want, err := json.Marshal(o.expectedJSONResponse)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Errorf("got json response %s, want %s", string(got), string(want))
+		}
+		return resp.Header
+	}
+
+	if o.unmarshalResponse != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&o.unmarshalResponse); err != nil {
+			t.Fatal(err)
+		}
+		return resp.Header
+	}
+	if o.responseBody != nil {
+		got, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		*o.responseBody = got
+	}
+	if o.noResponseBody {
+		got, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) > 0 {
+			t.Errorf("got response body %s, want none", string(got))
+		}
+	}
+	return resp.Header
 }
+
+func WithContext(ctx context.Context) Option {
+	return optionFunc(func(o *options) error {
+		o.ctx = ctx
+		return nil
+	})
+}
+
+func WithRequestBody(body io.Reader) Option {
+	return optionFunc(func(o *options) error {
+		o.requestBody = body
+		return nil
+	})
+}
+
+func WithJSONRequestBody(r interface{}) Option {
+	return optionFunc(func(o *options) error {
+		b, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("json encode request body: %w", err)
+		}
+		o.requestBody = bytes.NewReader(b)
+		return nil
+	})
+}
+
+func WithMultipartRequest(body io.Reader, length int, filename, contentType string) Option {
+	return optionFunc(func(o *options) error {
+		buf := bytes.NewBuffer(nil)
+		mw := multipart.NewWriter(buf)
+		hdr := make(textproto.MIMEHeader)
+		if filename != "" {
+			hdr.Set("Content-Disposition", fmt.Sprintf("form-data; name=%q", filename))
+		}
+		if contentType != "" {
+			hdr.Set("Content-Type", contentType)
+		}
+		if length > 0 {
+			hdr.Set("Content-Length", strconv.Itoa(length))
+		}
+		part, err := mw.CreatePart(hdr)
+		if err != nil {
+			return err
+		}
+		if _, err = io.Copy(part, body); err != nil {
+			return err
+		}
+		if err := mw.Close(); err != nil {
+			return err
+		}
+		o.requestBody = buf
+		if o.requestHeaders == nil {
+			o.requestHeaders = make(http.Header)
+		}
+		o.requestHeaders.Set("Content-Type", fmt.Sprintf("multipart/form-data; boundary=%q", mw.Boundary()))
+		return nil
+	})
+}
+
+func WithRequestHeader(key, value string) Option {
+	return optionFunc(func(o *options) error {
+		if o.requestHeaders == nil {
+			o.requestHeaders = make(http.Header)
+		}
+		o.requestHeaders.Add(key, value)
+		return nil
+	})
+}
+
+func WithExpectedResponse(response []byte) Option {
+	return optionFunc(func(o *options) error {
+		o.expectedResponse = response
+		return nil
+	})
+}
+
+func WithExpectedJSONResponse(response interface{}) Option {
+	return optionFunc(func(o *options) error {
+		o.expectedJSONResponse = response
+		return nil
+	})
+}
+
+func WithUnmarshalResponse(response interface{}) Option {
+	return optionFunc(func(o *options) error {
+		o.unmarshalResponse = response
+		return nil
+	})
+}
+
+func WithPutResponseBody(b *[]byte) Option {
+	return optionFunc(func(o *options) error {
+		o.responseBody = b
+		return nil
+	})
+}
+
+func WithNoResponseBody() Option {
+	return optionFunc(func(o *options) error {
+		o.noResponseBody = true
+		return nil
+	})
+}
+
+type options struct {
+	ctx                  context.Context
+	requestBody          io.Reader
+	requestHeaders       http.Header
+	expectedResponse     []byte
+	expectedJSONResponse interface{}
+	unmarshalResponse    interface{}
+	responseBody         *[]byte
+	noResponseBody       bool
+}
+
+type Option interface {
+	apply(*options) error
+}
+type optionFunc func(*options) error
+
+func (f optionFunc) apply(r *options) error { return f(r) }

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 )
 
-func TestResponse(t *testing.T) {
+func TestRequest(t *testing.T) {
 	type response struct {
 		Message string `json:"message"`
 	}
@@ -40,10 +40,13 @@ func TestResponse(t *testing.T) {
 
 	c := s.Client()
 
-	t.Run("direct", func(t *testing.T) {
-		jsonhttptest.ResponseDirect(t, c, wantMethod, s.URL+wantPath, strings.NewReader(wantBody), http.StatusCreated, response{
-			Message: message,
-		})
+	t.Run("WithExpectedJSONResponse", func(t *testing.T) {
+		jsonhttptest.Request(t, c, wantMethod, s.URL+wantPath, http.StatusCreated,
+			jsonhttptest.WithRequestBody(strings.NewReader(wantBody)),
+			jsonhttptest.WithExpectedJSONResponse(response{
+				Message: message,
+			}),
+		)
 
 		if gotMethod != wantMethod {
 			t.Errorf("got method %s, want %s", gotMethod, wantMethod)
@@ -56,9 +59,12 @@ func TestResponse(t *testing.T) {
 		}
 	})
 
-	t.Run("unmarshal", func(t *testing.T) {
+	t.Run("WithUnmarshalResponse", func(t *testing.T) {
 		var r response
-		jsonhttptest.ResponseUnmarshal(t, c, wantMethod, s.URL+wantPath, strings.NewReader(wantBody), http.StatusCreated, &r)
+		jsonhttptest.Request(t, c, wantMethod, s.URL+wantPath, http.StatusCreated,
+			jsonhttptest.WithRequestBody(strings.NewReader(wantBody)),
+			jsonhttptest.WithUnmarshalResponse(&r),
+		)
 
 		if gotMethod != wantMethod {
 			t.Errorf("got method %s, want %s", gotMethod, wantMethod)
@@ -70,7 +76,7 @@ func TestResponse(t *testing.T) {
 			t.Errorf("got body %s, want %s", gotBody, wantBody)
 		}
 		if r.Message != message {
-			t.Errorf("got messag %s, want %s", r.Message, message)
+			t.Errorf("got message %s, want %s", r.Message, message)
 		}
 	})
 }

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
@@ -5,7 +5,14 @@
 package jsonhttptest_test
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,68 +22,316 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 )
 
-func TestRequest(t *testing.T) {
+func TestRequest_statusCode(t *testing.T) {
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusBadRequest)
+	})
+
+	assert(t, `got response status 400 Bad Request, want 200 OK`, "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK)
+	})
+}
+
+func TestRequest_method(t *testing.T) {
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK)
+	})
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint, http.StatusMethodNotAllowed)
+	})
+}
+
+func TestRequest_url(t *testing.T) {
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK)
+	})
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint+"/bzz", http.StatusNotFound)
+	})
+}
+
+func TestRequest_responseHeader(t *testing.T) {
+	headerName := "Swarm-Header"
+	headerValue := "somevalue"
+	var gotValue string
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headerName, headerValue)
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		gotValue = jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK).Get(headerName)
+	})
+	if gotValue != headerValue {
+		t.Errorf("got header %q, want %q", gotValue, headerValue)
+	}
+}
+
+func TestWithContext(t *testing.T) {
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel the context to detect the fatal error
+
+	assert(t, "", fmt.Sprintf("Get %q: context canceled", endpoint), func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithContext(ctx),
+		)
+	})
+}
+
+func TestWithRequestBody(t *testing.T) {
+	wantBody := []byte("somebody")
+	var gotBody []byte
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint, http.StatusOK,
+			jsonhttptest.WithRequestBody(bytes.NewReader(wantBody)),
+		)
+	})
+	if !bytes.Equal(gotBody, wantBody) {
+		t.Errorf("got body %q, want %q", string(gotBody), string(wantBody))
+	}
+}
+
+func TestWithJSONRequestBody(t *testing.T) {
 	type response struct {
 		Message string `json:"message"`
 	}
 	message := "text"
 
-	wantMethod, wantPath, wantBody := http.MethodPatch, "/testing", "request body"
-	var gotMethod, gotPath, gotBody string
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		b, err := ioutil.ReadAll(r.Body)
+	wantBody := response{
+		Message: message,
+	}
+	var gotBody response
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			jsonhttp.InternalServerError(w, err)
 			return
 		}
-		gotBody = string(b)
-		jsonhttp.Created(w, response{
-			Message: message,
-		})
+		if err := json.Unmarshal(v, &gotBody); err != nil {
+			jsonhttp.BadRequest(w, err)
+			return
+		}
 	}))
-	defer s.Close()
 
-	c := s.Client()
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint, http.StatusOK,
+			jsonhttptest.WithJSONRequestBody(wantBody),
+		)
+	})
+	if gotBody.Message != message {
+		t.Errorf("got message %q, want %q", gotBody.Message, message)
+	}
+}
 
-	t.Run("WithExpectedJSONResponse", func(t *testing.T) {
-		jsonhttptest.Request(t, c, wantMethod, s.URL+wantPath, http.StatusCreated,
-			jsonhttptest.WithRequestBody(strings.NewReader(wantBody)),
+func TestWithMultipartRequest(t *testing.T) {
+	wantBody := []byte("somebody")
+	filename := "swarm.jpg"
+	contentType := "image/jpeg"
+	var gotBody []byte
+	var gotContentDisposition, gotContentType string
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			jsonhttp.BadRequest(w, err)
+			return
+		}
+		if strings.HasPrefix(mediaType, "multipart/") {
+			mr := multipart.NewReader(r.Body, params["boundary"])
+
+			p, err := mr.NextPart()
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				jsonhttp.BadRequest(w, err)
+				return
+			}
+			gotContentDisposition = p.Header.Get("Content-Disposition")
+			gotContentType = p.Header.Get("Content-Type")
+			gotBody, err = ioutil.ReadAll(p)
+			if err != nil {
+				jsonhttp.BadRequest(w, err)
+				return
+			}
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint, http.StatusOK,
+			jsonhttptest.WithMultipartRequest(bytes.NewReader(wantBody), len(wantBody), filename, contentType),
+		)
+	})
+	if !bytes.Equal(gotBody, wantBody) {
+		t.Errorf("got body %q, want %q", string(gotBody), string(wantBody))
+	}
+	if gotContentType != contentType {
+		t.Errorf("got content type %q, want %q", gotContentType, contentType)
+	}
+	if contentDisposition := fmt.Sprintf("form-data; name=%q", filename); gotContentDisposition != contentDisposition {
+		t.Errorf("got content disposition %q, want %q", gotContentDisposition, contentDisposition)
+	}
+}
+
+func TestWithRequestHeader(t *testing.T) {
+	headerName := "Swarm-Header"
+	headerValue := "somevalue"
+	var gotValue string
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotValue = r.Header.Get(headerName)
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodPost, endpoint, http.StatusOK,
+			jsonhttptest.WithRequestHeader(headerName, headerValue),
+		)
+	})
+	if gotValue != headerValue {
+		t.Errorf("got header %q, want %q", gotValue, headerValue)
+	}
+}
+
+func TestWithExpectedResponse(t *testing.T) {
+	body := []byte("something to want")
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(body)
+		if err != nil {
+			jsonhttp.InternalServerError(w, err)
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithExpectedResponse(body),
+		)
+	})
+
+	assert(t, `got response "something to want", want "invalid"`, "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithExpectedResponse([]byte("invalid")),
+		)
+	})
+}
+
+func TestWithExpectedJSONResponse(t *testing.T) {
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	want := response{
+		Message: "text",
+	}
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonhttp.OK(w, want)
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(want),
+		)
+	})
+
+	assert(t, `got json response "{\"message\":\"text\"}", want "{\"message\":\"invalid\"}"`, "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(response{
-				Message: message,
+				Message: "invalid",
 			}),
 		)
-
-		if gotMethod != wantMethod {
-			t.Errorf("got method %s, want %s", gotMethod, wantMethod)
-		}
-		if gotPath != wantPath {
-			t.Errorf("got path %s, want %s", gotPath, wantPath)
-		}
-		if gotBody != wantBody {
-			t.Errorf("got body %s, want %s", gotBody, wantBody)
-		}
 	})
+}
 
-	t.Run("WithUnmarshalResponse", func(t *testing.T) {
-		var r response
-		jsonhttptest.Request(t, c, wantMethod, s.URL+wantPath, http.StatusCreated,
-			jsonhttptest.WithRequestBody(strings.NewReader(wantBody)),
-			jsonhttptest.WithUnmarshalResponse(&r),
+func TestWithUnmarhalJSONResponse(t *testing.T) {
+	message := "text"
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonhttp.OK(w, message)
+	}))
+
+	var r jsonhttp.StatusResponse
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithUnmarshalJSONResponse(&r),
 		)
-
-		if gotMethod != wantMethod {
-			t.Errorf("got method %s, want %s", gotMethod, wantMethod)
-		}
-		if gotPath != wantPath {
-			t.Errorf("got path %s, want %s", gotPath, wantPath)
-		}
-		if gotBody != wantBody {
-			t.Errorf("got body %s, want %s", gotBody, wantBody)
-		}
-		if r.Message != message {
-			t.Errorf("got message %s, want %s", r.Message, message)
-		}
 	})
+	if r.Message != message {
+		t.Errorf("got message %q, want %q", r.Message, message)
+	}
+}
+
+func TestWithPutResponseBody(t *testing.T) {
+	wantBody := []byte("somebody")
+
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(wantBody)
+		if err != nil {
+			jsonhttp.InternalServerError(w, err)
+		}
+	}))
+
+	var gotBody []byte
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithPutResponseBody(&gotBody),
+		)
+	})
+	if !bytes.Equal(gotBody, wantBody) {
+		t.Errorf("got body %q, want %q", string(gotBody), string(wantBody))
+	}
+}
+
+func TestWithNoResponseBody(t *testing.T) {
+	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			fmt.Fprint(w, "not found")
+		}
+	}))
+
+	assert(t, "", "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint, http.StatusOK,
+			jsonhttptest.WithNoResponseBody(),
+		)
+	})
+
+	assert(t, `got response body "not found", want none`, "", func(m *mock) {
+		jsonhttptest.Request(m, c, http.MethodGet, endpoint+"/bzz", http.StatusOK,
+			jsonhttptest.WithNoResponseBody(),
+		)
+	})
+}
+
+func newClient(t *testing.T, handler http.Handler) (c *http.Client, endpoint string) {
+	s := httptest.NewServer(handler)
+	t.Cleanup(s.Close)
+	return s.Client(), s.URL
 }

--- a/pkg/jsonhttp/jsonhttptest/testing_mock_test.go
+++ b/pkg/jsonhttp/jsonhttptest/testing_mock_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package jsonhttptest_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// assert is a test helper that validates a functionality of another helper
+// function by mocking Errorf, Fatal and Helper methods on testing.TB.
+func assert(t *testing.T, wantError, wantFatal string, f func(m *mock)) {
+	t.Helper()
+
+	defer func() {
+		if v := recover(); v != nil {
+			if err, ok := v.(error); ok && errors.Is(err, errFailed) {
+				return // execution of the goroutine is stopped by a mock Fatal function
+			}
+			t.Fatalf("panic: %v", v)
+		}
+	}()
+
+	m := &mock{
+		wantError: wantError,
+		wantFatal: wantFatal,
+	}
+
+	f(m)
+
+	if !m.isHelper { // Request function is tested and it must be always a helper
+		t.Error("not a helper function")
+	}
+
+	if m.gotError != m.wantError {
+		t.Errorf("got error %q, want %q", m.gotError, m.wantError)
+	}
+
+	if m.gotFatal != m.wantFatal {
+		t.Errorf("got error %v, want %v", m.gotFatal, m.wantFatal)
+	}
+}
+
+// mock provides the same interface as testing.TB with overridden Errorf, Fatal
+// and Heleper methods.
+type mock struct {
+	testing.TB
+	isHelper  bool
+	gotError  string
+	wantError string
+	gotFatal  string
+	wantFatal string
+}
+
+func (m *mock) Helper() {
+	m.isHelper = true
+}
+
+func (m *mock) Errorf(format string, args ...interface{}) {
+	m.gotError = fmt.Sprintf(format, args...)
+}
+
+func (m *mock) Fatal(args ...interface{}) {
+	m.gotFatal = fmt.Sprint(args...)
+	panic(errFailed) // terminate the goroutine to detect it in the assert function
+}
+
+var errFailed = errors.New("failed")


### PR DESCRIPTION
This PR consolidates all functions in jsonhttptest package that piled up over time bloating its api. Unfortunately, only the initial two functions were tested, non of the followup were, so new tests are added and existing one improved. Also the package is better documented.

Tests in api and debugapi packages are adjusted.

fixes: #477 