### PR TITLE
api: communicate tag uid right away

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -30,6 +30,11 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, "cannot get or create tag")
 		return
 	}
+	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	w.WriteHeader(http.StatusContinue)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
 
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
@@ -46,7 +51,6 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if created {
 		tag.DoneSplit(address)
 	}
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagUidHeader)
 	jsonhttp.OK(w, bytesPostResponse{
 		Reference: address,

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -40,6 +40,12 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	w.WriteHeader(http.StatusContinue)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
 

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -53,6 +53,12 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	w.WriteHeader(http.StatusContinue)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
 	// Add the tag to the context
 	ctx = sctx.SetTag(ctx, tag)
 
@@ -66,7 +72,6 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if created {
 		tag.DoneSplit(reference)
 	}
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
 	jsonhttp.OK(w, fileUploadResponse{
 		Reference: reference,
 	})

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -72,6 +72,12 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	w.WriteHeader(http.StatusContinue)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
 
@@ -209,7 +215,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		tag.DoneSplit(reference)
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%q", reference.String()))
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	//w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagUidHeader)
 	jsonhttp.OK(w, fileUploadResponse{
 		Reference: reference,


### PR DESCRIPTION
works with `curl`. not sure if we can/want to unit test this as a separate feature (it will also be a bit tricky to correctly unit test)

closes #492 