### PR TITLE
Always load balance from store

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -262,10 +262,10 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 // Balance returns the current balance for the given peer
 func (a *Accounting) Balance(peer swarm.Address) (balance int64, err error) {
 	err = a.store.Get(peerBalanceKey(peer), &balance)
-	if err == storage.ErrNotFound {
-		return 0, nil
-	}
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return 0, nil
+		}
 		return 0, err
 	}
 	return balance, nil

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -277,7 +277,7 @@ func peerBalanceKey(peer swarm.Address) string {
 }
 
 // getAccountingPeer gets the accountingPeer for a given swarm address
-// If not in memory it will initalize it
+// If not in memory it will initialize it
 func (a *Accounting) getAccountingPeer(peer swarm.Address) (*accountingPeer, error) {
 	a.accountingPeersMu.Lock()
 	defer a.accountingPeersMu.Unlock()


### PR DESCRIPTION
This PR removes the in-memory copy of accounting balances (as suggested by @janos). Balances are always loaded from disk when needed. The `balances` struct has been renamed to `accountingPeer` as it no longer holds the balance. Instead it is only for in-memory data (such as the reserved balance and the payment threshold). The accounting logic itself remains unchanged.