### PR TITLE
support api version path for tags api endpoints

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -66,14 +66,13 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.bzzDownloadHandler),
 	})
 
-	router.Handle("/tags", jsonhttp.MethodHandler{
+	handle(router, "/tags", jsonhttp.MethodHandler{
 		"POST": web.ChainHandlers(
 			jsonhttp.NewMaxBodyBytesHandler(1024),
 			web.FinalHandlerFunc(s.createTag),
 		),
 	})
-
-	router.Handle("/tags/{id}", jsonhttp.MethodHandler{
+	handle(router, "/tags/{id}", jsonhttp.MethodHandler{
 		"GET":    http.HandlerFunc(s.getTag),
 		"DELETE": http.HandlerFunc(s.deleteTag),
 		"PATCH": web.ChainHandlers(


### PR DESCRIPTION
A minor change to use the versioned `handle` function in api package router for recently put back tags endpoints.