### PR TITLE
joiner: add breaking test to joiner test

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -130,6 +130,7 @@ func TestEncryptionAndDecryption(t *testing.T) {
 		{4096},
 		{4097},
 		{15000},
+		{20000000},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
test to demonstrate failing case on `master`. everything above 16 megs fails