### PR TITLE
Config command

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -61,7 +61,9 @@ func newCommand(opts ...option) (c *command, err error) {
 
 	c.initVersionCmd()
 
-	c.initConfigurateOptionsCmd()
+	if err := c.initConfigurateOptionsCmd(); err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }

--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -60,6 +60,9 @@ func newCommand(opts ...option) (c *command, err error) {
 	}
 
 	c.initVersionCmd()
+
+	c.initConfigurateOptionsCmd()
+
 	return c, nil
 }
 

--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -6,12 +6,39 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+)
+
+const (
+	optionNameDataDir              = "data-dir"
+	optionNameDBCapacity           = "db-capacity"
+	optionNamePassword             = "password"
+	optionNamePasswordFile         = "password-file"
+	optionNameAPIAddr              = "api-addr"
+	optionNameP2PAddr              = "p2p-addr"
+	optionNameNATAddr              = "nat-addr"
+	optionNameP2PWSEnable          = "p2p-ws-enable"
+	optionNameP2PQUICEnable        = "p2p-quic-enable"
+	optionNameDebugAPIEnable       = "debug-api-enable"
+	optionNameDebugAPIAddr         = "debug-api-addr"
+	optionNameBootnodes            = "bootnode"
+	optionNameNetworkID            = "network-id"
+	optionWelcomeMessage           = "welcome-message"
+	optionCORSAllowedOrigins       = "cors-allowed-origins"
+	optionNameTracingEnabled       = "tracing-enable"
+	optionNameTracingEndpoint      = "tracing-endpoint"
+	optionNameTracingServiceName   = "tracing-service-name"
+	optionNameVerbosity            = "verbosity"
+	optionNameGlobalPinningEnabled = "global-pinning-enable"
+	optionNamePaymentThreshold     = "payment-threshold"
+	optionNamePaymentTolerance     = "payment-tolerance"
 )
 
 func init() {
@@ -128,4 +155,28 @@ func (c *command) setHomeDir() (err error) {
 	}
 	c.homeDir = dir
 	return nil
+}
+
+func (c *command) setAllFlags(cmd *cobra.Command) {
+	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
+	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, fmt.Sprintf("db capacity in chunks, multiply by %d to get approximate capacity in bytes", swarm.ChunkSize))
+	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
+	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
+	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")
+	cmd.Flags().String(optionNameP2PAddr, ":7070", "P2P listen address")
+	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
+	cmd.Flags().Bool(optionNameP2PWSEnable, false, "enable P2P WebSocket transport")
+	cmd.Flags().Bool(optionNameP2PQUICEnable, false, "enable P2P QUIC transport")
+	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/bootnode.ethswarm.org"}, "initial nodes to connect to")
+	cmd.Flags().Bool(optionNameDebugAPIEnable, false, "enable debug HTTP API")
+	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")
+	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
+	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
+	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
+	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
+	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
+	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
+	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
+	cmd.Flags().Uint64(optionNamePaymentThreshold, 100000, "threshold in BZZ where you expect to get paid from your peers")
+	cmd.Flags().Uint64(optionNamePaymentTolerance, 10000, "excess debt above payment threshold in BZZ where you disconnect from your peer")
 }

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -5,40 +5,12 @@
 package cmd
 
 import (
-	"fmt"
-	"github.com/ethersphere/bee/pkg/swarm"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 func (c *command) initConfigurateOptionsCmd() (err error) {
-
-	const (
-		optionNameDataDir              = "data-dir"
-		optionNameDBCapacity           = "db-capacity"
-		optionNamePassword             = "password"
-		optionNamePasswordFile         = "password-file"
-		optionNameAPIAddr              = "api-addr"
-		optionNameP2PAddr              = "p2p-addr"
-		optionNameNATAddr              = "nat-addr"
-		optionNameP2PWSEnable          = "p2p-ws-enable"
-		optionNameP2PQUICEnable        = "p2p-quic-enable"
-		optionNameDebugAPIEnable       = "debug-api-enable"
-		optionNameDebugAPIAddr         = "debug-api-addr"
-		optionNameBootnodes            = "bootnode"
-		optionNameNetworkID            = "network-id"
-		optionWelcomeMessage           = "welcome-message"
-		optionCORSAllowedOrigins       = "cors-allowed-origins"
-		optionNameTracingEnabled       = "tracing-enable"
-		optionNameTracingEndpoint      = "tracing-endpoint"
-		optionNameTracingServiceName   = "tracing-service-name"
-		optionNameVerbosity            = "verbosity"
-		optionNameGlobalPinningEnabled = "global-pinning-enable"
-		optionNamePaymentThreshold     = "payment-threshold"
-		optionNamePaymentTolerance     = "payment-tolerance"
-	)
 
 	cmd := &cobra.Command{
 		Use:   "config",
@@ -63,27 +35,7 @@ func (c *command) initConfigurateOptionsCmd() (err error) {
 		},
 	}
 
-	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
-	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, fmt.Sprintf("db capacity in chunks, multiply by %d to get approximate capacity in bytes", swarm.ChunkSize))
-	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
-	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
-	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")
-	cmd.Flags().String(optionNameP2PAddr, ":7070", "P2P listen address")
-	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
-	cmd.Flags().Bool(optionNameP2PWSEnable, false, "enable P2P WebSocket transport")
-	cmd.Flags().Bool(optionNameP2PQUICEnable, false, "enable P2P QUIC transport")
-	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/bootnode.ethswarm.org"}, "initial nodes to connect to")
-	cmd.Flags().Bool(optionNameDebugAPIEnable, false, "enable debug HTTP API")
-	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")
-	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
-	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
-	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
-	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
-	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
-	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
-	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
-	cmd.Flags().Uint64(optionNamePaymentThreshold, 100000, "threshold in BZZ where you expect to get paid from your peers")
-	cmd.Flags().Uint64(optionNamePaymentTolerance, 10000, "excess debt above payment threshold in BZZ where you disconnect from your peer")
+	c.setAllFlags(cmd)
 
 	c.root.AddCommand(cmd)
 

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -22,11 +22,11 @@ func (c *command) initConfigurateOptionsCmd() (err error) {
 			}
 
 			d := c.config.AllSettings()
-			bs, err := yaml.Marshal(d)
+			ym, err := yaml.Marshal(d)
 			if err != nil {
 				cmd.Printf("unable to marshal config to yaml: %v", err)
 			}
-			cmd.Printf("%+v\n", string(bs))
+			cmd.Println(string(ym))
 			return nil
 
 		},

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -5,16 +5,81 @@
 package cmd
 
 import (
+	"fmt"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
-func (c *command) initConfigurateOptionsCmd() {
-	c.root.AddCommand(&cobra.Command{
+func (c *command) initConfigurateOptionsCmd() (err error) {
+
+	const (
+		optionNameDataDir              = "data-dir"
+		optionNameDBCapacity           = "db-capacity"
+		optionNamePassword             = "password"
+		optionNamePasswordFile         = "password-file"
+		optionNameAPIAddr              = "api-addr"
+		optionNameP2PAddr              = "p2p-addr"
+		optionNameNATAddr              = "nat-addr"
+		optionNameP2PWSEnable          = "p2p-ws-enable"
+		optionNameP2PQUICEnable        = "p2p-quic-enable"
+		optionNameDebugAPIEnable       = "debug-api-enable"
+		optionNameDebugAPIAddr         = "debug-api-addr"
+		optionNameBootnodes            = "bootnode"
+		optionNameNetworkID            = "network-id"
+		optionWelcomeMessage           = "welcome-message"
+		optionCORSAllowedOrigins       = "cors-allowed-origins"
+		optionNameTracingEnabled       = "tracing-enable"
+		optionNameTracingEndpoint      = "tracing-endpoint"
+		optionNameTracingServiceName   = "tracing-service-name"
+		optionNameVerbosity            = "verbosity"
+		optionNameGlobalPinningEnabled = "global-pinning-enable"
+		optionNamePaymentThreshold     = "payment-threshold"
+		optionNamePaymentTolerance     = "payment-tolerance"
+	)
+
+	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Print configuration options",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			if len(args) > 0 {
+				return cmd.Help()
+			}
+
 			d := c.config.AllSettings()
-			cmd.Printf("%v\n", d)
+			cmd.Printf("%+v\n", d)
+			return nil
 		},
-	})
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.config.BindPFlags(cmd.Flags())
+		},
+	}
+
+	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
+	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, fmt.Sprintf("db capacity in chunks, multiply by %d to get approximate capacity in bytes", swarm.ChunkSize))
+	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
+	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
+	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")
+	cmd.Flags().String(optionNameP2PAddr, ":7070", "P2P listen address")
+	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
+	cmd.Flags().Bool(optionNameP2PWSEnable, false, "enable P2P WebSocket transport")
+	cmd.Flags().Bool(optionNameP2PQUICEnable, false, "enable P2P QUIC transport")
+	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/bootnode.ethswarm.org"}, "initial nodes to connect to")
+	cmd.Flags().Bool(optionNameDebugAPIEnable, false, "enable debug HTTP API")
+	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")
+	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
+	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
+	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
+	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
+	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
+	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
+	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
+	cmd.Flags().Uint64(optionNamePaymentThreshold, 100000, "threshold in BZZ where you expect to get paid from your peers")
+	cmd.Flags().Uint64(optionNamePaymentTolerance, 10000, "excess debt above payment threshold in BZZ where you disconnect from your peer")
+
+	c.root.AddCommand(cmd)
+
+	return nil
+
 }

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -24,7 +24,7 @@ func (c *command) initConfigurateOptionsCmd() (err error) {
 			d := c.config.AllSettings()
 			ym, err := yaml.Marshal(d)
 			if err != nil {
-				cmd.Printf("unable to marshal config to yaml: %v", err)
+				return err
 			}
 			cmd.Println(string(ym))
 			return nil

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (c *command) initConfigurateOptionsCmd() {
+	c.root.AddCommand(&cobra.Command{
+		Use:   "config",
+		Short: "Print configuration options",
+		Run: func(cmd *cobra.Command, args []string) {
+			d := c.config.AllSettings()
+			cmd.Printf("%v\n", d)
+		},
+	})
+}

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -7,6 +7,8 @@ package cmd
 import (
 	"fmt"
 	"github.com/ethersphere/bee/pkg/swarm"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/spf13/cobra"
 	"path/filepath"
 )
@@ -48,8 +50,13 @@ func (c *command) initConfigurateOptionsCmd() (err error) {
 			}
 
 			d := c.config.AllSettings()
-			cmd.Printf("%+v\n", d)
+			bs, err := yaml.Marshal(d)
+			if err != nil {
+				cmd.Printf("unable to marshal config to yaml: %v", err)
+			}
+			cmd.Printf("%+v\n", string(bs))
 			return nil
+
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.config.BindPFlags(cmd.Flags())

--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -13,8 +13,8 @@ import (
 func (c *command) initConfigurateOptionsCmd() (err error) {
 
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Print configuration options",
+		Use:   "printconfig",
+		Short: "Print default or provided configuration in yaml format",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 
 			if len(args) > 0 {

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -11,44 +11,19 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"path/filepath"
+
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/node"
-	"github.com/ethersphere/bee/pkg/swarm"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func (c *command) initStartCmd() (err error) {
-
-	const (
-		optionNameDataDir              = "data-dir"
-		optionNameDBCapacity           = "db-capacity"
-		optionNamePassword             = "password"
-		optionNamePasswordFile         = "password-file"
-		optionNameAPIAddr              = "api-addr"
-		optionNameP2PAddr              = "p2p-addr"
-		optionNameNATAddr              = "nat-addr"
-		optionNameP2PWSEnable          = "p2p-ws-enable"
-		optionNameP2PQUICEnable        = "p2p-quic-enable"
-		optionNameDebugAPIEnable       = "debug-api-enable"
-		optionNameDebugAPIAddr         = "debug-api-addr"
-		optionNameBootnodes            = "bootnode"
-		optionNameNetworkID            = "network-id"
-		optionWelcomeMessage           = "welcome-message"
-		optionCORSAllowedOrigins       = "cors-allowed-origins"
-		optionNameTracingEnabled       = "tracing-enable"
-		optionNameTracingEndpoint      = "tracing-endpoint"
-		optionNameTracingServiceName   = "tracing-service-name"
-		optionNameVerbosity            = "verbosity"
-		optionNameGlobalPinningEnabled = "global-pinning-enable"
-		optionNamePaymentThreshold     = "payment-threshold"
-		optionNamePaymentTolerance     = "payment-tolerance"
-	)
 
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -179,27 +154,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 		},
 	}
 
-	cmd.Flags().String(optionNameDataDir, filepath.Join(c.homeDir, ".bee"), "data directory")
-	cmd.Flags().Uint64(optionNameDBCapacity, 5000000, fmt.Sprintf("db capacity in chunks, multiply by %d to get approximate capacity in bytes", swarm.ChunkSize))
-	cmd.Flags().String(optionNamePassword, "", "password for decrypting keys")
-	cmd.Flags().String(optionNamePasswordFile, "", "path to a file that contains password for decrypting keys")
-	cmd.Flags().String(optionNameAPIAddr, ":8080", "HTTP API listen address")
-	cmd.Flags().String(optionNameP2PAddr, ":7070", "P2P listen address")
-	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
-	cmd.Flags().Bool(optionNameP2PWSEnable, false, "enable P2P WebSocket transport")
-	cmd.Flags().Bool(optionNameP2PQUICEnable, false, "enable P2P QUIC transport")
-	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/bootnode.ethswarm.org"}, "initial nodes to connect to")
-	cmd.Flags().Bool(optionNameDebugAPIEnable, false, "enable debug HTTP API")
-	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")
-	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
-	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
-	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
-	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
-	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
-	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
-	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")
-	cmd.Flags().Uint64(optionNamePaymentThreshold, 100000, "threshold in BZZ where you expect to get paid from your peers")
-	cmd.Flags().Uint64(optionNamePaymentTolerance, 10000, "excess debt above payment threshold in BZZ where you disconnect from your peer")
+	c.setAllFlags(cmd)
 
 	c.root.AddCommand(cmd)
 	return nil

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -11,14 +11,12 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/node"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 	resenje.org/web v0.4.3


### PR DESCRIPTION
#522 

To achieve a greater degree of configuration overviewability, we are introducing the bee config command.

Behavior of the command is to show all options and default values of configuration used without a provided configuration file, 
Or - in presence of a configuration file provided to bee - to show all of the options and the actual values used with that configuration file loaded.

The aim is to display the output formatted as valid yaml