### PR TITLE
Add basic metrics counters for total sent/recieved pseudosettle amounts

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -340,6 +340,7 @@ func NewBee(addr string, logger logging.Logger, o Options) (*Bee, error) {
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)
 		debugAPIService.MustRegisterMetrics(acc.Metrics()...)
+		debugAPIService.MustRegisterMetrics(settlement.Metrics()...)
 
 		if apiService != nil {
 			debugAPIService.MustRegisterMetrics(apiService.Metrics()...)

--- a/pkg/settlement/pseudosettle/metrics.go
+++ b/pkg/settlement/pseudosettle/metrics.go
@@ -25,13 +25,13 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_received_pseudosettlements",
-			Help:      "Amount of BZZ received from peers (actual income of the node)",
+			Help:      "Amount of pseudotokens received from peers (income of the node)",
 		}),
 		TotalSentPseudoSettlements: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "total_sent_pseudosettlements",
-			Help:      "Amount of BZZ sent to peers (actual cost of the node)",
+			Help:      "Amount of pseudotokens sent to peers (costs paid by the node)",
 		}),
 	}
 }

--- a/pkg/settlement/pseudosettle/metrics.go
+++ b/pkg/settlement/pseudosettle/metrics.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pseudosettle
+
+import (
+	m "github.com/ethersphere/bee/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	// all metrics fields must be exported
+	// to be able to return them by Metrics()
+	// using reflection
+	TotalReceivedPseudoSettlements prometheus.Counter
+	TotalSentPseudoSettlements     prometheus.Counter
+}
+
+func newMetrics() metrics {
+	subsystem := "pseudosettle"
+
+	return metrics{
+		TotalReceivedPseudoSettlements: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_received_pseudosettlements",
+			Help:      "Amount of BZZ received from peers (actual income of the node)",
+		}),
+		TotalSentPseudoSettlements: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_sent_pseudosettlements",
+			Help:      "Amount of BZZ sent to peers (actual cost of the node)",
+		}),
+	}
+}
+
+func (s *Service) Metrics() []prometheus.Collector {
+	return m.PrometheusCollectorsFromFields(s.metrics)
+}

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -95,12 +95,11 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 
 	s.logger.Tracef("sending payment message to peer %v of %d", peer, amount)
 
-	s.metrics.TotalSentPseudoSettlements.Add(float64(amount))
-
 	w := protobuf.NewWriter(stream)
 	err = w.WriteMsgWithContext(ctx, &pb.Payment{
 		Amount: amount,
 	})
+	s.metrics.TotalSentPseudoSettlements.Add(float64(amount))
 	return err
 }
 

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -97,8 +97,11 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	err = w.WriteMsgWithContext(ctx, &pb.Payment{
 		Amount: amount,
 	})
+	if err != nil {
+		return err
+	}
 	s.metrics.TotalSentPseudoSettlements.Add(float64(amount))
-	return err
+	return nil
 }
 
 // SetPaymentObserver sets the payment observer which will be notified of incoming payments

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -27,6 +27,7 @@ type Service struct {
 	streamer p2p.Streamer
 	logger   logging.Logger
 	observer settlement.PaymentObserver
+	metrics  metrics
 }
 
 type Options struct {
@@ -38,6 +39,7 @@ func New(o Options) *Service {
 	return &Service{
 		streamer: o.Streamer,
 		logger:   o.Logger,
+		metrics:  newMetrics(),
 	}
 }
 
@@ -68,6 +70,8 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		return fmt.Errorf("read request from peer %v: %w", p.Address, err)
 	}
 
+	s.metrics.TotalRecievedPseudoSettlements.Add(float64(req.Amount))
+
 	s.logger.Tracef("received payment message from peer %v of %d", p.Address, req.Amount)
 	return s.observer.NotifyPayment(p.Address, req.Amount)
 }
@@ -90,6 +94,9 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	}()
 
 	s.logger.Tracef("sending payment message to peer %v of %d", peer, amount)
+
+	s.metrics.TotalSentPseudoSettlements.Add(float64(amount))
+
 	w := protobuf.NewWriter(stream)
 	err = w.WriteMsgWithContext(ctx, &pb.Payment{
 		Amount: amount,

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -70,7 +70,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		return fmt.Errorf("read request from peer %v: %w", p.Address, err)
 	}
 
-	s.metrics.TotalRecievedPseudoSettlements.Add(float64(req.Amount))
+	s.metrics.TotalReceivedPseudoSettlements.Add(float64(req.Amount))
 
 	s.logger.Tracef("received payment message from peer %v of %d", p.Address, req.Amount)
 	return s.observer.NotifyPayment(p.Address, req.Amount)

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -71,7 +71,6 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	}
 
 	s.metrics.TotalReceivedPseudoSettlements.Add(float64(req.Amount))
-
 	s.logger.Tracef("received payment message from peer %v of %d", p.Address, req.Amount)
 	return s.observer.NotifyPayment(p.Address, req.Amount)
 }
@@ -94,7 +93,6 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	}()
 
 	s.logger.Tracef("sending payment message to peer %v of %d", peer, amount)
-
 	w := protobuf.NewWriter(stream)
 	err = w.WriteMsgWithContext(ctx, &pb.Payment{
 		Amount: amount,


### PR DESCRIPTION
The aim of this PR is to introduce some monitoring opportunity to sent / recieved pseudosettlements through the /metrics endpoint of the debug API