### PR TITLE
Standalone flag option for bee

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -32,6 +32,7 @@ const (
 	optionNameNetworkID            = "network-id"
 	optionWelcomeMessage           = "welcome-message"
 	optionCORSAllowedOrigins       = "cors-allowed-origins"
+	optionNameStandalone           = "standalone"
 	optionNameTracingEnabled       = "tracing-enable"
 	optionNameTracingEndpoint      = "tracing-endpoint"
 	optionNameTracingServiceName   = "tracing-service-name"
@@ -172,6 +173,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNameDebugAPIAddr, ":6060", "debug HTTP API listen address")
 	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
 	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
+	cmd.Flags().Bool(optionNameStandalone, false, "whether we want the node to start with no listen addresses for p2p")
 	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
 	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
 	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -139,6 +139,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 				WelcomeMessage:       c.config.GetString(optionWelcomeMessage),
 				Bootnodes:            c.config.GetStringSlice(optionNameBootnodes),
 				CORSAllowedOrigins:   c.config.GetStringSlice(optionCORSAllowedOrigins),
+				Standalone:           c.config.GetBool(optionNameStandalone),
 				TracingEnabled:       c.config.GetBool(optionNameTracingEnabled),
 				TracingEndpoint:      c.config.GetString(optionNameTracingEndpoint),
 				TracingServiceName:   c.config.GetString(optionNameTracingServiceName),

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -133,12 +133,10 @@ func (k *Kad) manage() {
 				return
 			default:
 			}
-
+			if k.standalone {
+				continue
+			}
 			err := k.knownPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
-
-				if k.standalone {
-					return false, true, nil
-				}
 
 				if k.connectedPeers.Exists(peer) {
 					return false, false, nil

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -41,6 +41,7 @@ type binSaturationFunc func(bin uint8, peers, connected *pslice.PSlice) bool
 type Options struct {
 	SaturationFunc binSaturationFunc
 	Bootnodes      []ma.Multiaddr
+	Standalone     bool
 }
 
 // Kad is the Swarm forwarding kademlia implementation.
@@ -61,8 +62,9 @@ type Kad struct {
 	peerSig        []chan struct{}
 	peerSigMtx     sync.Mutex
 	logger         logging.Logger // logger
-	quit           chan struct{}  // quit channel
-	done           chan struct{}  // signal that `manage` has quit
+	standalone     bool
+	quit           chan struct{} // quit channel
+	done           chan struct{} // signal that `manage` has quit
 	wg             sync.WaitGroup
 }
 
@@ -89,6 +91,7 @@ func New(base swarm.Address, addressbook addressbook.Interface, discovery discov
 		manageC:        make(chan struct{}, 1),
 		waitNext:       make(map[string]retryInfo),
 		logger:         logger,
+		standalone:     o.Standalone,
 		quit:           make(chan struct{}),
 		done:           make(chan struct{}),
 		wg:             sync.WaitGroup{},
@@ -132,6 +135,11 @@ func (k *Kad) manage() {
 			}
 
 			err := k.knownPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+
+				if k.standalone {
+					return false, true, nil
+				}
+
 				if k.connectedPeers.Exists(peer) {
 					return false, false, nil
 				}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -80,6 +80,7 @@ type Options struct {
 	Bootnodes            []string
 	CORSAllowedOrigins   []string
 	Logger               logging.Logger
+	Standalone           bool
 	TracingEnabled       bool
 	TracingEndpoint      string
 	TracingServiceName   string
@@ -136,6 +137,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 		NATAddr:        o.NATAddr,
 		EnableWS:       o.EnableWS,
 		EnableQUIC:     o.EnableQUIC,
+		Standalone:     o.Standalone,
 		WelcomeMessage: o.WelcomeMessage,
 	})
 	if err != nil {
@@ -170,15 +172,17 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 	}
 
 	var bootnodes []ma.Multiaddr
-	for _, a := range o.Bootnodes {
-		addr, err := ma.NewMultiaddr(a)
-		if err != nil {
-			logger.Debugf("multiaddress fail %s: %v", a, err)
-			logger.Warningf("invalid bootnode address %s", a)
-			continue
-		}
+	if o.Standalone != true {
+		for _, a := range o.Bootnodes {
+			addr, err := ma.NewMultiaddr(a)
+			if err != nil {
+				logger.Debugf("multiaddress fail %s: %v", a, err)
+				logger.Warningf("invalid bootnode address %s", a)
+				continue
+			}
 
-		bootnodes = append(bootnodes, addr)
+			bootnodes = append(bootnodes, addr)
+		}
 	}
 
 	kad := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger, kademlia.Options{Bootnodes: bootnodes})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -172,7 +172,9 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 	}
 
 	var bootnodes []ma.Multiaddr
-	if !o.Standalone {
+	if o.Standalone {
+		logger.Info("Starting node in standalone mode, no p2p connections will be made or accepted")
+	} else {
 		for _, a := range o.Bootnodes {
 			addr, err := ma.NewMultiaddr(a)
 			if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -185,7 +185,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 		}
 	}
 
-	kad := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger, kademlia.Options{Bootnodes: bootnodes})
+	kad := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger, kademlia.Options{Bootnodes: bootnodes, Standalone: o.Standalone})
 	b.topologyCloser = kad
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.AddNotifier(kad)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -172,7 +172,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 	}
 
 	var bootnodes []ma.Multiaddr
-	if o.Standalone != true {
+	if !o.Standalone {
 		for _, a := range o.Bootnodes {
 			addr, err := ma.NewMultiaddr(a)
 			if err != nil {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -64,6 +64,7 @@ type Options struct {
 	NATAddr        string
 	EnableWS       bool
 	EnableQUIC     bool
+	Standalone     bool
 	LightNode      bool
 	WelcomeMessage string
 }
@@ -146,6 +147,10 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 
 	if o.EnableQUIC {
 		transports = append(transports, libp2p.Transport(libp2pquic.NewTransport))
+	}
+
+	if o.Standalone == true {
+		opts = append(opts, libp2p.NoListenAddrs)
 	}
 
 	opts = append(opts, transports...)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -149,7 +149,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		transports = append(transports, libp2p.Transport(libp2pquic.NewTransport))
 	}
 
-	if o.Standalone == true {
+	if o.Standalone {
 		opts = append(opts, libp2p.NoListenAddrs)
 	}
 


### PR DESCRIPTION
fixes #536 

The --standalone flag's intended behaviour is to:
- inhibit bootstrapping connections to bootnodes
- inhibit connecting to known peers
- disable listen addresses so incoming connections are not accepted
