### PR TITLE
remove meaningless code from encryption transform method

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -130,6 +130,9 @@ func TestEncryptionAndDecryption(t *testing.T) {
 		{4096},
 		{4097},
 		{15000},
+		{256 * 1024},
+		// {256 * 1024 * 2}, // TODO: fix - incorrect join
+		// {256 * 1024 * 3}, // TODO: fix - deadlock
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR removes code which does not make much sense. The core problem is the calculation of wait group size which makes TestEncryptionAndDecryption block on 256*1024 bytes. With this change it passes, but there are more problems left.