### PR TITLE
settlement persistence and debug api

### DIFF
--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -248,6 +248,14 @@ func (s *settlementMock) Pay(ctx context.Context, peer swarm.Address, amount uin
 	return nil
 }
 
+func (s *settlementMock) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
+	return 0, nil
+}
+
+func (s *settlementMock) TotalReceived(peer swarm.Address) (totalReceived uint64, err error) {
+	return 0, nil
+}
+
 // TestAccountingCallSettlement tests that settlement is called correctly if the payment threshold is hit
 func TestAccountingCallSettlement(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -256,6 +256,14 @@ func (s *settlementMock) TotalReceived(peer swarm.Address) (totalReceived uint64
 	return 0, nil
 }
 
+func (s *settlementMock) SettlementsSent() (SettlementSent map[string]uint64, err error) {
+	return nil, nil
+}
+
+func (s *settlementMock) SettlementsReceived() (SettlementReceived map[string]uint64, err error) {
+	return nil, nil
+}
+
 // TestAccountingCallSettlement tests that settlement is called correctly if the payment threshold is hit
 func TestAccountingCallSettlement(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/pingpong"
+	"github.com/ethersphere/bee/pkg/settlement"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -34,12 +35,12 @@ type server struct {
 	Tracer         *tracing.Tracer
 	Tags           *tags.Tags
 	Accounting     accounting.Interface
+	Settlement     settlement.Interface
 	http.Handler
-
 	metricsRegistry *prometheus.Registry
 }
 
-func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface) Service {
+func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface) Service {
 	s := &server{
 		Overlay:         overlay,
 		P2P:             p2p,
@@ -50,6 +51,7 @@ func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interfac
 		Tracer:          tracer,
 		Tags:            tags,
 		Accounting:      accounting,
+		Settlement:      settlement,
 		metricsRegistry: newMetricsRegistry(),
 	}
 

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -17,7 +17,6 @@ import (
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/resolver"
-	resolverMock "github.com/ethersphere/bee/pkg/resolver/mock"
 	settlementmock "github.com/ethersphere/bee/pkg/settlement/pseudosettle/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -17,6 +17,8 @@ import (
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/resolver"
+	resolverMock "github.com/ethersphere/bee/pkg/resolver/mock"
+	settlementmock "github.com/ethersphere/bee/pkg/settlement/pseudosettle/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -34,6 +36,7 @@ type testServerOptions struct {
 	TopologyOpts   []topologymock.Option
 	Tags           *tags.Tags
 	AccountingOpts []accountingmock.Option
+	SettlementOpts []settlementmock.Option
 }
 
 type testServer struct {
@@ -44,8 +47,9 @@ type testServer struct {
 func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	topologyDriver := topologymock.NewTopologyDriver(o.TopologyOpts...)
 	acc := accountingmock.NewAccounting(o.AccountingOpts...)
+	settlement := settlementmock.NewSettlement(o.SettlementOpts...)
 
-	s := debugapi.New(o.Overlay, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc)
+	s := debugapi.New(o.Overlay, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -19,9 +19,9 @@ type (
 )
 
 var (
-	ErrCantBalance     = errCantBalance
-	ErrCantBalances    = errCantBalances
-	ErrCantSettlement  = errCantSettlementsPeer
-	ErrCantSettlements = errCantSettlements
-	ErrInvaliAddress   = errInvaliAddress
+	ErrCantBalance         = errCantBalance
+	ErrCantBalances        = errCantBalances
+	ErrCantSettlementsPeer = errCantSettlementsPeer
+	ErrCantSettlements     = errCantSettlements
+	ErrInvaliAddress       = errInvaliAddress
 )

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -21,7 +21,7 @@ type (
 var (
 	ErrCantBalance     = errCantBalance
 	ErrCantBalances    = errCantBalances
-	ErrCantSettlement  = errCantSettlements
+	ErrCantSettlement  = errCantSettlementsPeer
 	ErrCantSettlements = errCantSettlements
 	ErrInvaliAddress   = errInvaliAddress
 )

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -14,10 +14,14 @@ type (
 	WelcomeMessageResponse = welcomeMessageResponse
 	BalancesResponse       = balancesResponse
 	BalanceResponse        = balanceResponse
+	SettlementResponse     = settlementResponse
+	SettlementsResponse    = settlementsResponse
 )
 
 var (
-	ErrCantBalance   = errCantBalance
-	ErrCantBalances  = errCantBalances
-	ErrInvaliAddress = errInvaliAddress
+	ErrCantBalance     = errCantBalance
+	ErrCantBalances    = errCantBalances
+	ErrCantSettlement  = errCantSettlements
+	ErrCantSettlements = errCantSettlements
+	ErrInvaliAddress   = errInvaliAddress
 )

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -87,6 +87,16 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.peerBalanceHandler),
 	})
 
+	router.Handle("/settlements", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.settlementsHandler),
+	})
+	router.Handle("/settlements/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.peerSettlementsHandler),
+	})
+	router.Handle("/settlements/pay/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.payPeerHandler),
+	})
+
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),
 		handlers.CompressHandler,

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -93,9 +93,6 @@ func (s *server) setupRouting() {
 	router.Handle("/settlements/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.peerSettlementsHandler),
 	})
-	router.Handle("/settlements/pay/{peer}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.payPeerHandler),
-	})
 
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -1,0 +1,136 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/gorilla/mux"
+)
+
+var (
+	errCantSettlements = "Cannot get settlements"
+)
+
+type settlementResponse struct {
+	Peer               string `json:"peer"`
+	SettlementReceived uint64 `json:"received"`
+	SettlementSent     uint64 `json:"sent"`
+}
+
+type settlementsResponse struct {
+	TotalSettlementReceived *big.Int             `json:"totalreceived"`
+	TotalSettlementSent     *big.Int             `json:"totalsent""`
+	Settlements             []settlementResponse `json:"settlements"`
+}
+
+func (s *server) payPeerHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	amount := uint64(1000)
+
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: settlements peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Error("debug api: settlements peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+	s.Settlement.Pay(context.Background(), peer, amount)
+	jsonhttp.OK(w, statusResponse{
+		Status: "ok",
+	})
+}
+
+func (s *server) settlementsHandler(w http.ResponseWriter, r *http.Request) {
+
+	settlementsSent, err := s.Settlement.SettlementsSent()
+	if err != nil {
+		jsonhttp.InternalServerError(w, errCantSettlements)
+		s.Logger.Debugf("debug api: sent settlements: %v", err)
+		s.Logger.Error("debug api: can not get sent settlements")
+		return
+	}
+	settlementsReceived, err := s.Settlement.SettlementsReceived()
+	if err != nil {
+		jsonhttp.InternalServerError(w, errCantSettlements)
+		s.Logger.Debugf("debug api: received settlements: %v", err)
+		s.Logger.Error("debug api: can not get received settlements")
+		return
+	}
+
+	totalReceived := big.NewInt(0)
+	totalSent := big.NewInt(0)
+
+	settlementResponses := make(map[string]settlementResponse)
+
+	for a, b := range settlementsSent {
+		settlementResponses[a] = settlementResponse{
+			Peer:               a,
+			SettlementSent:     b,
+			SettlementReceived: 0,
+		}
+		totalSent.Add(big.NewInt(int64(b)), totalSent)
+	}
+
+	for a, b := range settlementsReceived {
+		if _, ok := settlementResponses[a]; ok {
+			t := settlementResponses[a]
+			t.SettlementReceived = b
+			settlementResponses[a] = t
+		} else {
+			settlementResponses[a] = settlementResponse{
+				Peer:               a,
+				SettlementSent:     0,
+				SettlementReceived: b,
+			}
+		}
+		totalReceived.Add(big.NewInt(int64(b)), totalReceived)
+	}
+
+	settlementResponsesArray := make([]settlementResponse, len(settlementResponses))
+	i := 0
+	for k := range settlementResponses {
+		settlementResponsesArray[i] = settlementResponses[k]
+		i++
+	}
+
+	jsonhttp.OK(w, settlementsResponse{TotalSettlementReceived: totalReceived, TotalSettlementSent: totalSent, Settlements: settlementResponsesArray})
+}
+
+func (s *server) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: settlements peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Error("debug api: settlements peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+
+	received, err := s.Settlement.TotalReceived(peer)
+	if err != nil {
+		s.Logger.Debugf("debug api: settlements peer: get peer %s received settlement: %v", peer.String(), err)
+		s.Logger.Errorf("debug api: settlements peer: can't get peer %s received settlement", peer.String())
+		jsonhttp.InternalServerError(w, errCantSettlements)
+		return
+	}
+	sent, err := s.Settlement.TotalSent(peer)
+	if err != nil {
+		s.Logger.Debugf("debug api: settlements peer: get peer %s sent settlement: %v", peer.String(), err)
+		s.Logger.Errorf("debug api: settlements peer: can't get peer %s sent settlement", peer.String())
+		jsonhttp.InternalServerError(w, errCantSettlements)
+		return
+	}
+
+	jsonhttp.OK(w, settlementResponse{
+		Peer:               peer.String(),
+		SettlementReceived: received,
+		SettlementSent:     sent,
+	})
+}

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -5,7 +5,6 @@
 package debugapi
 
 import (
-	"context"
 	"math/big"
 	"net/http"
 

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	errCantSettlements     = "Cannot get settlements"
-	errCantSettlementsPeer = "Cannot get settlements for peer"
+	errCantSettlements     = "can not get settlements"
+	errCantSettlementsPeer = "can not get settlements for peer"
 )
 
 type settlementResponse struct {

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -32,7 +32,7 @@ type settlementsResponse struct {
 
 func (s *server) payPeerHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
-	amount := uint64(1000)
+	amount := uint64(100)
 
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
@@ -41,10 +41,15 @@ func (s *server) payPeerHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
-	s.Settlement.Pay(context.Background(), peer, amount)
+	err = s.Settlement.Pay(context.Background(), peer, amount)
+	if err != nil {
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
 	jsonhttp.OK(w, statusResponse{
 		Status: "ok",
 	})
+
 }
 
 func (s *server) settlementsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -26,30 +26,8 @@ type settlementResponse struct {
 
 type settlementsResponse struct {
 	TotalSettlementReceived *big.Int             `json:"totalreceived"`
-	TotalSettlementSent     *big.Int             `json:"totalsent""`
+	TotalSettlementSent     *big.Int             `json:"totalsent"`
 	Settlements             []settlementResponse `json:"settlements"`
-}
-
-func (s *server) payPeerHandler(w http.ResponseWriter, r *http.Request) {
-	addr := mux.Vars(r)["peer"]
-	amount := uint64(100)
-
-	peer, err := swarm.ParseHexAddress(addr)
-	if err != nil {
-		s.Logger.Debugf("debug api: settlements peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Error("debug api: settlements peer: invalid peer address %s", addr)
-		jsonhttp.NotFound(w, errInvaliAddress)
-		return
-	}
-	err = s.Settlement.Pay(context.Background(), peer, amount)
-	if err != nil {
-		jsonhttp.InternalServerError(w, err)
-		return
-	}
-	jsonhttp.OK(w, statusResponse{
-		Status: "ok",
-	})
-
 }
 
 func (s *server) settlementsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	errCantSettlements = "Cannot get settlements"
+	errCantSettlements     = "Cannot get settlements"
+	errCantSettlementsPeer = "Cannot get settlements for peer"
 )
 
 type settlementResponse struct {
@@ -104,7 +105,7 @@ func (s *server) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) 
 		if !errors.Is(err, pseudosettle.ErrPeerNoSettlements) {
 			s.Logger.Debugf("debug api: settlements peer: get peer %s received settlement: %v", peer.String(), err)
 			s.Logger.Errorf("debug api: settlements peer: can't get peer %s received settlement", peer.String())
-			jsonhttp.InternalServerError(w, errCantSettlements)
+			jsonhttp.InternalServerError(w, errCantSettlementsPeer)
 			return
 		}
 	}
@@ -118,7 +119,7 @@ func (s *server) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) 
 		if !errors.Is(err, pseudosettle.ErrPeerNoSettlements) {
 			s.Logger.Debugf("debug api: settlements peer: get peer %s sent settlement: %v", peer.String(), err)
 			s.Logger.Errorf("debug api: settlements peer: can't get peer %s sent settlement", peer.String())
-			jsonhttp.InternalServerError(w, errCantSettlements)
+			jsonhttp.InternalServerError(w, errCantSettlementsPeer)
 			return
 		}
 	}

--- a/pkg/debugapi/settlements_test.go
+++ b/pkg/debugapi/settlements_test.go
@@ -1,0 +1,182 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"errors"
+	"math/big"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/settlement/pseudosettle/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func TestSettlements(t *testing.T) {
+	settlementsSentFunc := func() (ret map[string]uint64, err error) {
+		ret = make(map[string]uint64)
+		ret["DEAD"] = 10000
+		ret["BEEF"] = 20000
+		ret["FFFF"] = 50000
+		return ret, err
+	}
+
+	settlementsRecvFunc := func() (ret map[string]uint64, err error) {
+		ret = make(map[string]uint64)
+		ret["BEEF"] = 10000
+		ret["EEEE"] = 5000
+		return ret, err
+	}
+
+	testServer := newTestServer(t, testServerOptions{
+		SettlementOpts: []mock.Option{mock.WithSettlementsSentFunc(settlementsSentFunc), mock.WithSettlementsRecvFunc(settlementsRecvFunc)},
+	})
+
+	expected := &debugapi.SettlementsResponse{
+		TotalSettlementReceived: big.NewInt(15000),
+		TotalSettlementSent:     big.NewInt(80000),
+		Settlements: []debugapi.SettlementResponse{
+			{
+				Peer:               "DEAD",
+				SettlementReceived: 0,
+				SettlementSent:     10000,
+			},
+			{
+				Peer:               "BEEF",
+				SettlementReceived: 10000,
+				SettlementSent:     20000,
+			},
+			{
+				Peer:               "FFFF",
+				SettlementReceived: 0,
+				SettlementSent:     50000,
+			},
+			{
+				Peer:               "EEEE",
+				SettlementReceived: 5000,
+				SettlementSent:     0,
+			},
+		},
+	}
+
+	// We expect a list of items unordered by peer:
+	var got *debugapi.SettlementsResponse
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements", http.StatusOK,
+		jsonhttptest.WithUnmarshalJSONResponse(&got),
+	)
+
+	if !equalSettlements(got, expected) {
+		t.Errorf("got settlements: %+v, expected: %+v", got, expected)
+	}
+
+}
+
+func TestSettlementsError(t *testing.T) {
+	wantErr := errors.New("New errors")
+	settlementsSentFunc := func() (map[string]uint64, error) {
+		return nil, wantErr
+	}
+	testServer := newTestServer(t, testServerOptions{
+		SettlementOpts: []mock.Option{mock.WithSettlementsSentFunc(settlementsSentFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements", http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantSettlements,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
+}
+
+func TestSettlementsPeers(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	settlementSentFunc := func(swarm.Address) (uint64, error) {
+		return 1000000000000000000, nil
+	}
+	testServer := newTestServer(t, testServerOptions{
+		SettlementOpts: []mock.Option{mock.WithSettlementSentFunc(settlementSentFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.SettlementResponse{
+			Peer:               peer,
+			SettlementSent:     1000000000000000000,
+			SettlementReceived: 0,
+		}),
+	)
+}
+
+func TestSettlementsPeersError(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	wantErr := errors.New("Error")
+	settlementSentFunc := func(swarm.Address) (uint64, error) {
+		return 0, wantErr
+	}
+	testServer := newTestServer(t, testServerOptions{
+		SettlementOpts: []mock.Option{mock.WithSettlementSentFunc(settlementSentFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantSettlement,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
+}
+
+func TestSettlementsInvalidAddress(t *testing.T) {
+	peer := "bad peer address"
+
+	testServer := newTestServer(t, testServerOptions{})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrInvaliAddress,
+			Code:    http.StatusNotFound,
+		}),
+	)
+}
+
+func equalSettlements(a, b *debugapi.SettlementsResponse) bool {
+	var state bool
+
+	for akeys := range a.Settlements {
+		state = false
+		for bkeys := range b.Settlements {
+			if reflect.DeepEqual(a.Settlements[akeys], b.Settlements[bkeys]) {
+				state = true
+			}
+		}
+		if !state {
+			return false
+		}
+	}
+
+	for bkeys := range b.Settlements {
+		state = false
+		for akeys := range a.Settlements {
+			if reflect.DeepEqual(a.Settlements[akeys], b.Settlements[bkeys]) {
+				state = true
+			}
+		}
+		if !state {
+			return false
+		}
+	}
+
+	if a.TotalSettlementReceived.Cmp(b.TotalSettlementReceived) != 0 {
+		return false
+	}
+
+	if a.TotalSettlementSent.Cmp(b.TotalSettlementSent) != 0 {
+		return false
+	}
+
+	return true
+}

--- a/pkg/debugapi/settlements_test.go
+++ b/pkg/debugapi/settlements_test.go
@@ -124,7 +124,7 @@ func TestSettlementsPeersError(t *testing.T) {
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusInternalServerError,
 		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-			Message: debugapi.ErrCantSettlement,
+			Message: debugapi.ErrCantSettlementsPeer,
 			Code:    http.StatusInternalServerError,
 		}),
 	)
@@ -151,6 +151,7 @@ func equalSettlements(a, b *debugapi.SettlementsResponse) bool {
 		for bkeys := range b.Settlements {
 			if reflect.DeepEqual(a.Settlements[akeys], b.Settlements[bkeys]) {
 				state = true
+				break
 			}
 		}
 		if !state {
@@ -163,6 +164,7 @@ func equalSettlements(a, b *debugapi.SettlementsResponse) bool {
 		for akeys := range a.Settlements {
 			if reflect.DeepEqual(a.Settlements[akeys], b.Settlements[bkeys]) {
 				state = true
+				break
 			}
 		}
 		if !state {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -327,7 +327,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 
 	if o.DebugAPIAddr != "" {
 		// Debug API server
-		debugAPIService := debugapi.New(swarmAddress, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc)
+		debugAPIService := debugapi.New(swarmAddress, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc, settlement)
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -220,10 +220,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 	}
 	b.localstoreCloser = storer
 
-	settlement := pseudosettle.New(pseudosettle.Options{
-		Streamer: p2ps,
-		Logger:   logger,
-	})
+	settlement := pseudosettle.New(p2ps, logger, stateStore)
 
 	if err = p2ps.AddProtocol(settlement.Protocol()); err != nil {
 		return nil, fmt.Errorf("pseudosettle service: %w", err)

--- a/pkg/settlement/interface.go
+++ b/pkg/settlement/interface.go
@@ -15,6 +15,10 @@ type Interface interface {
 	// Pay initiates a payment to the given peer
 	// It should return without error it is likely that the payment worked
 	Pay(ctx context.Context, peer swarm.Address, amount uint64) error
+	// TotalSent returns the total amount sent to a peer
+	TotalSent(peer swarm.Address) (totalSent uint64, err error)
+	// TotalReceived returns the total amount received from a peer
+	TotalReceived(peer swarm.Address) (totalSent uint64, err error)
 }
 
 // PaymentObserver is the interface Settlement uses to notify other components of an incoming payment

--- a/pkg/settlement/interface.go
+++ b/pkg/settlement/interface.go
@@ -19,6 +19,10 @@ type Interface interface {
 	TotalSent(peer swarm.Address) (totalSent uint64, err error)
 	// TotalReceived returns the total amount received from a peer
 	TotalReceived(peer swarm.Address) (totalSent uint64, err error)
+	// SettlementsSent returns sent settlements for each individual known peer
+	SettlementsSent() (map[string]uint64, error)
+	// SettlementsReceived returns received settlements for each individual known peer
+	SettlementsReceived() (map[string]uint64, error)
 }
 
 // PaymentObserver is the interface Settlement uses to notify other components of an incoming payment

--- a/pkg/settlement/pseudosettle/mock/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/mock/pseudosettle.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/settlement"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// Service is the mock settlement service.
+type Service struct {
+	lock            sync.Mutex
+	settlementsSent map[string]uint64
+	settlementsRecv map[string]uint64
+
+	settlementSentFunc func(swarm.Address) (uint64, error)
+	settlementRecvFunc func(swarm.Address) (uint64, error)
+
+	settlementsSentFunc func() (map[string]uint64, error)
+	settlementsRecvFunc func() (map[string]uint64, error)
+}
+
+// WithsettlementFunc sets the mock settlement function
+func WithSettlementSentFunc(f func(swarm.Address) (uint64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.settlementSentFunc = f
+	})
+}
+
+func WithSettlementRecvFunc(f func(swarm.Address) (uint64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.settlementRecvFunc = f
+	})
+}
+
+// WithsettlementsFunc sets the mock settlements function
+func WithSettlementsSentFunc(f func() (map[string]uint64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.settlementsSentFunc = f
+	})
+}
+
+func WithSettlementsRecvFunc(f func() (map[string]uint64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.settlementsRecvFunc = f
+	})
+}
+
+// Newsettlement creates the mock settlement implementation
+func NewSettlement(opts ...Option) settlement.Interface {
+	mock := new(Service)
+	mock.settlementsSent = make(map[string]uint64)
+	mock.settlementsRecv = make(map[string]uint64)
+	for _, o := range opts {
+		o.apply(mock)
+	}
+	return mock
+}
+
+func (s *Service) Pay(_ context.Context, peer swarm.Address, amount uint64) error {
+	s.settlementsSent[peer.String()] += amount
+	return nil
+}
+
+func (s *Service) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
+	if s.settlementSentFunc != nil {
+		return s.settlementSentFunc(peer)
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.settlementsSent[peer.String()], nil
+}
+
+func (s *Service) TotalReceived(peer swarm.Address) (totalSent uint64, err error) {
+	if s.settlementRecvFunc != nil {
+		return s.settlementRecvFunc(peer)
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.settlementsRecv[peer.String()], nil
+}
+
+// settlements is the mock function wrapper that calls the set implementation
+func (s *Service) SettlementsSent() (map[string]uint64, error) {
+	if s.settlementsSentFunc != nil {
+		return s.settlementsSentFunc()
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.settlementsSent, nil
+}
+
+func (s *Service) SettlementsReceived() (map[string]uint64, error) {
+	if s.settlementsRecvFunc != nil {
+		return s.settlementsRecvFunc()
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.settlementsRecv, nil
+}
+
+// Option is the option passed to the mock settlement service
+type Option interface {
+	apply(*Service)
+}
+
+type optionFunc func(*Service)
+
+func (f optionFunc) apply(r *Service) { f(r) }

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -95,7 +95,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 
 	totalReceived, err := s.TotalReceived(p.Address)
 	if err != nil {
-		if !error.Is(err, ErrPeerNoSettlements) {
+		if !errors.Is(err, ErrPeerNoSettlements) {
 			return err
 		}
 		totalReceived = 0
@@ -136,7 +136,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	}
 	totalSent, err := s.TotalSent(peer)
 	if err != nil {
-		if error.Is(err, ErrPeerNoSettlements) {
+		if errors.Is(err, ErrPeerNoSettlements) {
 			return err
 		}
 		totalSent = 0

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -29,7 +29,7 @@ const (
 var (
 	SettlementReceivedPrefix = "pseudosettle_total_received_"
 	SettlementSentPrefix     = "pseudosettle_total_sent_"
-	ErrPeerNoSettlements     = errors.New("No settlements for peer")
+	ErrPeerNoSettlements     = errors.New("no settlements for peer")
 )
 
 type Service struct {

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -41,8 +41,8 @@ type Service struct {
 
 func New(streamer p2p.Streamer, logger logging.Logger, store storage.StateStorer) *Service {
 	return &Service{
-		streamer: o.Streamer,
-		logger:   o.Logger,
+		streamer: streamer,
+		logger:   logger,
 		metrics:  newMetrics(),
 		store:    store,
 	}

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -155,7 +155,7 @@ func (s *Service) SetPaymentObserver(observer settlement.PaymentObserver) {
 
 // TotalSent returns the total amount sent to a peer
 func (s *Service) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
-	key := totalKey(peer, SettlementReceivedPrefix)
+	key := totalKey(peer, SettlementSentPrefix)
 	err = s.store.Get(key, &totalSent)
 	if err != nil {
 		if err == storage.ErrNotFound {
@@ -169,7 +169,7 @@ func (s *Service) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
 
 // TotalReceived returns the total amount received from a peer
 func (s *Service) TotalReceived(peer swarm.Address) (totalReceived uint64, err error) {
-	key := totalKey(peer, SettlementSentPrefix)
+	key := totalKey(peer, SettlementReceivedPrefix)
 	err = s.store.Get(key, &totalReceived)
 	if err != nil {
 		if err == storage.ErrNotFound {

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -139,7 +139,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 		if err != ErrPeerNoSettlements {
 			return err
 		}
-		totalSent = uint64(0)
+		totalSent = 0
 	}
 	err = s.store.Put(totalKey(peer, SettlementSentPrefix), totalSent+amount)
 	if err != nil {

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -72,13 +72,7 @@ func totalKeyPeer(key []byte, prefix string) (peer swarm.Address, err error) {
 	if len(split) != 2 {
 		return swarm.ZeroAddress, errors.New("no peer in key")
 	}
-
-	addr, err := swarm.ParseHexAddress(split[1])
-	if err != nil {
-		return swarm.ZeroAddress, err
-	}
-
-	return addr, nil
+	return swarm.ParseHexAddress(split[1])
 }
 
 func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
@@ -160,9 +154,8 @@ func (s *Service) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
 	if err != nil {
 		if err == storage.ErrNotFound {
 			return 0, nil
-		} else {
-			return 0, err
 		}
+		return 0, err
 	}
 	return totalSent, nil
 }
@@ -174,9 +167,8 @@ func (s *Service) TotalReceived(peer swarm.Address) (totalReceived uint64, err e
 	if err != nil {
 		if err == storage.ErrNotFound {
 			return 0, nil
-		} else {
-			return 0, err
 		}
+		return 0, err
 	}
 	return totalReceived, nil
 }
@@ -187,13 +179,13 @@ func (s *Service) SettlementsSent() (map[string]uint64, error) {
 	err := s.store.Iterate(SettlementSentPrefix, func(key, val []byte) (stop bool, err error) {
 		addr, err := totalKeyPeer(key, SettlementSentPrefix)
 		if err != nil {
-			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+			return false, fmt.Errorf("parse address from key: %s: %w", string(key), err)
 		}
 		if _, ok := sent[addr.String()]; !ok {
 			var storevalue uint64
 			err = s.store.Get(totalKey(addr, SettlementSentPrefix), &storevalue)
 			if err != nil {
-				return false, fmt.Errorf("get peer %s settlement balance: %v", addr.String(), err)
+				return false, fmt.Errorf("get peer %s settlement balance: %w", addr.String(), err)
 			}
 
 			sent[addr.String()] = storevalue
@@ -211,13 +203,13 @@ func (s *Service) SettlementsReceived() (map[string]uint64, error) {
 	err := s.store.Iterate(SettlementReceivedPrefix, func(key, val []byte) (stop bool, err error) {
 		addr, err := totalKeyPeer(key, SettlementReceivedPrefix)
 		if err != nil {
-			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+			return false, fmt.Errorf("parse address from key: %s: %w", string(key), err)
 		}
 		if _, ok := received[addr.String()]; !ok {
 			var storevalue uint64
 			err = s.store.Get(totalKey(addr, SettlementReceivedPrefix), &storevalue)
 			if err != nil {
-				return false, fmt.Errorf("get peer %s settlement balance: %v", addr.String(), err)
+				return false, fmt.Errorf("get peer %s settlement balance: %w", addr.String(), err)
 			}
 
 			received[addr.String()] = storevalue

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -136,7 +136,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	}
 	totalSent, err := s.TotalSent(peer)
 	if err != nil {
-		if errors.Is(err, ErrPeerNoSettlements) {
+		if !errors.Is(err, ErrPeerNoSettlements) {
 			return err
 		}
 		totalSent = 0

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -95,7 +95,10 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 
 	totalReceived, err := s.TotalReceived(p.Address)
 	if err != nil {
-		return err
+		if err != ErrPeerNoSettlements {
+			return err
+		}
+		totalReceived = 0
 	}
 
 	err = s.store.Put(totalKey(p.Address, SettlementReceivedPrefix), totalReceived+req.Amount)

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -95,7 +95,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 
 	totalReceived, err := s.TotalReceived(p.Address)
 	if err != nil {
-		if err != ErrPeerNoSettlements {
+		if !error.Is(err, ErrPeerNoSettlements) {
 			return err
 		}
 		totalReceived = 0
@@ -136,7 +136,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	}
 	totalSent, err := s.TotalSent(peer)
 	if err != nil {
-		if err != ErrPeerNoSettlements {
+		if error.Is(err, ErrPeerNoSettlements) {
 			return err
 		}
 		totalSent = 0
@@ -159,7 +159,7 @@ func (s *Service) TotalSent(peer swarm.Address) (totalSent uint64, err error) {
 	key := totalKey(peer, SettlementSentPrefix)
 	err = s.store.Get(key, &totalSent)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			return 0, ErrPeerNoSettlements
 		}
 		return 0, err
@@ -172,7 +172,7 @@ func (s *Service) TotalReceived(peer swarm.Address) (totalReceived uint64, err e
 	key := totalKey(peer, SettlementReceivedPrefix)
 	err = s.store.Get(key, &totalReceived)
 	if err != nil {
-		if err == storage.ErrNotFound {
+		if errors.Is(err, storage.ErrNotFound) {
 			return 0, ErrPeerNoSettlements
 		}
 		return 0, err


### PR DESCRIPTION
The aim of this pull request is to create the

`/settlements`
`/settlements/{peer}`
endpoints in the debug api that return the swap settlements associated with all peers or a specified peer in json format