### PR TITLE
Add multiresolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.0
 	github.com/libp2p/go-ws-transport v0.3.1
 	github.com/libp2p/go-yamux v1.3.8 // indirect
-	github.com/marten-seemann/qtls v0.10.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.2.2
@@ -37,7 +36,6 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
-	github.com/sclevine/agouti v3.0.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/smartystreets/assertions v1.1.1 // indirect
 	github.com/spf13/afero v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethersphere/bmt v0.1.1 h1:vwHSJwnDyzJ0fqP3YQBDk+/vqdAfulfRGJesQ5kL2ps=
-github.com/ethersphere/bmt v0.1.1/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
 github.com/ethersphere/bmt v0.1.2 h1:FEuvQY9xuK+rDp3VwDVyde8T396Matv/u9PdtKa2r9Q=
 github.com/ethersphere/bmt v0.1.2/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -127,6 +125,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,7 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
-github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
@@ -437,8 +436,6 @@ github.com/libp2p/go-libp2p-peerstore v0.2.6/go.mod h1:ss/TWTgHZTMpsU/oKVVPQCGuD
 github.com/libp2p/go-libp2p-pnet v0.2.0 h1:J6htxttBipJujEjz1y0a5+eYoiPcFHhSYHH6na5f0/k=
 github.com/libp2p/go-libp2p-pnet v0.2.0/go.mod h1:Qqvq6JH/oMZGwqs3N1Fqhv8NVhrdYcO0BW4wssv21LA=
 github.com/libp2p/go-libp2p-quic-transport v0.5.0/go.mod h1:IEcuC5MLxvZ5KuHKjRu+dr3LjCT1Be3rcD/4d8JrX8M=
-github.com/libp2p/go-libp2p-quic-transport v0.6.0 h1:d5bcq7y+t6IiumD9Ib0S4oHgWu66rRjQ1Y8ligii6G8=
-github.com/libp2p/go-libp2p-quic-transport v0.6.0/go.mod h1:HR435saAZhTrFabI+adf3tVBY7ZJg5rKNoJ+CrIIg8c=
 github.com/libp2p/go-libp2p-quic-transport v0.8.0 h1:mHA94K2+TD0e9XtjWx/P5jGGZn0GdQ4OFYwNllagv4E=
 github.com/libp2p/go-libp2p-quic-transport v0.8.0/go.mod h1:F2FG/6Bzz0U6essUVxDzE0s9CrY4XGLbl7QEmDNvU7A=
 github.com/libp2p/go-libp2p-secio v0.1.0/go.mod h1:tMJo2w7h3+wN4pgU2LSYeiKPrfqBgkOsdiKK77hE7c8=
@@ -533,9 +530,6 @@ github.com/libp2p/go-yamux v1.3.8 h1:aw0ZXyawL//qvrshGT9v/Mc82sKiD6hBYZ6OBHWXe5s
 github.com/libp2p/go-yamux v1.3.8/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/lucas-clemente/quic-go v0.15.2/go.mod h1:qxmO5Y4ZMhdNkunGfxuZnZXnJwYpW9vjQkyrZ7BsgUI=
 github.com/lucas-clemente/quic-go v0.16.0/go.mod h1:I0+fcNTdb9eS1ZcjQZbDVPGchJ86chcIxPALn9lEJqE=
-github.com/lucas-clemente/quic-go v0.16.2/go.mod h1:I0+fcNTdb9eS1ZcjQZbDVPGchJ86chcIxPALn9lEJqE=
-github.com/lucas-clemente/quic-go v0.17.1 h1:ezsH76xpn6hKugfsXUy6voIJBFmAOwnM/Oy9F4b/n+M=
-github.com/lucas-clemente/quic-go v0.17.1/go.mod h1:I0+fcNTdb9eS1ZcjQZbDVPGchJ86chcIxPALn9lEJqE=
 github.com/lucas-clemente/quic-go v0.18.0 h1:JhQDdqxdwdmGdKsKgXi1+coHRoGhvU6z0rNzOJqZ/4o=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
@@ -660,8 +654,7 @@ github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
-github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
+github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -724,7 +717,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
@@ -947,8 +939,6 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200320220750-118fecf932d8/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/resolver/doc.go
+++ b/pkg/resolver/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package resolver handles name resolution for the Swarm bee. It implements
+// the Resolver interface as well as clients to connect to external name
+// resolution services.
+package resolver

--- a/pkg/resolver/mock/resolver.go
+++ b/pkg/resolver/mock/resolver.go
@@ -8,18 +8,14 @@ import (
 	"fmt"
 
 	"github.com/ethersphere/bee/pkg/resolver"
-	"github.com/ethersphere/bee/pkg/swarm"
 )
-
-// Address is the swarm bzz address.
-type Address = swarm.Address
 
 // Assure mock Resolver implements the Resolver interface.
 var _ resolver.Interface = (*Resolver)(nil)
 
 // Resolver is the mock Resolver implementation.
 type Resolver struct {
-	resolveFunc func(string) (Address, error)
+	resolveFunc func(string) (resolver.Address, error)
 }
 
 // Option function sets the option on the mock Resolver.
@@ -38,16 +34,16 @@ func NewResolver(opts ...Option) resolver.Interface {
 }
 
 // WithResolveFunc will override the Resolve function implementation.
-func WithResolveFunc(f func(string) (Address, error)) Option {
+func WithResolveFunc(f func(string) (resolver.Address, error)) Option {
 	return func(r *Resolver) {
 		r.resolveFunc = f
 	}
 }
 
 // Resolve implements the Resolver interface.
-func (r *Resolver) Resolve(name string) (Address, error) {
+func (r *Resolver) Resolve(name string) (resolver.Address, error) {
 	if r.resolveFunc != nil {
 		return r.resolveFunc(name)
 	}
-	return Address{}, fmt.Errorf("not implemented")
+	return resolver.Address{}, fmt.Errorf("not implemented")
 }

--- a/pkg/resolver/mock/resolver.go
+++ b/pkg/resolver/mock/resolver.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"fmt"
+
+	"github.com/ethersphere/bee/pkg/resolver"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// Address is the swarm bzz address.
+type Address = swarm.Address
+
+// Assure mock Resolver implements the Resolver interface.
+var _ resolver.Interface = (*Resolver)(nil)
+
+// Resolver is the mock Resolver implementation.
+type Resolver struct {
+	resolveFunc func(string) (Address, error)
+}
+
+// Option function sets the option on the mock Resolver.
+type Option func(*Resolver)
+
+// NewResolver will create a new mock Resolver.
+func NewResolver(opts ...Option) resolver.Interface {
+	r := &Resolver{}
+
+	// Apply all options.
+	for _, o := range opts {
+		o(r)
+	}
+
+	return r
+}
+
+// WithResolveFunc will override the Resolve function implementation.
+func WithResolveFunc(f func(string) (Address, error)) Option {
+	return func(r *Resolver) {
+		r.resolveFunc = f
+	}
+}
+
+// Resolve implements the Resolver interface.
+func (r *Resolver) Resolve(name string) (Address, error) {
+	if r.resolveFunc != nil {
+		return r.resolveFunc(name)
+	}
+	return Address{}, fmt.Errorf("not implemented")
+}

--- a/pkg/resolver/multi.go
+++ b/pkg/resolver/multi.go
@@ -1,0 +1,133 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// MultiResolver errors.
+var (
+	ErrInvalidTLD         = errors.New("invalid TLD")
+	ErrResolverChainEmpty = errors.New("resolver chain empty")
+)
+
+type resolverMap map[string][]Interface
+
+// MultiResolver performs name resolutions based on the TLD of the URL.
+type MultiResolver struct {
+	resolvers resolverMap
+	// ForceDefault will force all names to be resolved by the default
+	// resolution chain, regadless of their TLD.
+	ForceDefault bool
+}
+
+// Option is a function that applies an option to a MultiResolver.
+type Option func(*MultiResolver)
+
+// NewMultiResolver will return a new MultiResolver instance.
+func NewMultiResolver(opts ...Option) *MultiResolver {
+	mr := &MultiResolver{
+		resolvers: make(resolverMap),
+	}
+
+	// Apply all options.
+	for _, o := range opts {
+		o(mr)
+	}
+
+	return mr
+}
+
+// WithForceDefault will force resolution using the default resolver
+// chain.
+func WithForceDefault() Option {
+	return func(mr *MultiResolver) {
+		mr.ForceDefault = true
+	}
+}
+
+// PushResolver will push a new Resolver to the name resolution chain for the
+// given TLD.
+// TLD names should be prepended with a dot (eg ".tld"). An empty TLD will push
+// to the default resolver chain.
+func (mr *MultiResolver) PushResolver(tld string, r Interface) error {
+	if tld != "" && !isTLD(tld) {
+		return ErrInvalidTLD
+	}
+
+	mr.resolvers[tld] = append(mr.resolvers[tld], r)
+	return nil
+}
+
+// PopResolver will pop the last reslover from the name resolution chain for the
+// given TLD.
+// TLD names should be prepended with a dot (eg ".tld"). An empty TLD will pop
+// from the default resolver chain.
+func (mr *MultiResolver) PopResolver(tld string) error {
+	if tld != "" && !isTLD(tld) {
+		return ErrInvalidTLD
+	}
+
+	l := len(mr.resolvers[tld])
+	if l == 0 {
+		return ErrResolverChainEmpty
+	}
+	mr.resolvers[tld] = mr.resolvers[tld][:l-1]
+	return nil
+}
+
+// ChainCount retruns the number of resolvers in a resolver chain for the given
+// tld.
+// TLD names should be prepended with a dot (eg ".tld"). An empty TLD will
+// return the number of resolvers in the default resolver chain.
+func (mr *MultiResolver) ChainCount(tld string) int {
+	return len(mr.resolvers[tld])
+}
+
+// GetChain will return the resolution chain for a given TLD.
+// TLD names should be prepended with a dot (eg ".tld"). An empty TLD will
+// return all resolvers in the default resolver chain.
+func (mr *MultiResolver) GetChain(tld string) []Interface {
+	return mr.resolvers[tld]
+}
+
+// Resolve will attempt to resolve a name to an address.
+// The resolution chain is selected based on the TLD of the name. If the name
+// does not end in a TLD, the default resolution chain is selected.
+// The resolution will be performed iteratively on the resolution chain,
+// returning the result of the first Resolver that succeeds. If all resolvers
+// in the chain return an error, the function will return an ErrResolveFailed.
+func (mr *MultiResolver) Resolve(name string) (Address, error) {
+	tld := ""
+	if !mr.ForceDefault {
+		tld = getTLD(name)
+	}
+	chain := mr.resolvers[tld]
+
+	if len(chain) == 0 {
+		return Address{}, ErrResolverChainEmpty
+	}
+
+	for _, res := range chain {
+		adr, err := res.Resolve(name)
+		if err == nil {
+			return adr, nil
+		}
+	}
+
+	return Address{}, fmt.Errorf("name resolution failed for %q", name)
+}
+
+func isTLD(tld string) bool {
+	return len(tld) > 1 && tld[0] == '.'
+}
+
+func getTLD(name string) string {
+	return path.Ext(strings.ToLower(name))
+}

--- a/pkg/resolver/multi.go
+++ b/pkg/resolver/multi.go
@@ -6,7 +6,6 @@ package resolver
 
 import (
 	"errors"
-	"fmt"
 	"path"
 	"strings"
 )
@@ -114,6 +113,7 @@ func (mr *MultiResolver) Resolve(name string) (Address, error) {
 		return Address{}, ErrResolverChainEmpty
 	}
 
+	var err error
 	for _, res := range chain {
 		adr, err := res.Resolve(name)
 		if err == nil {
@@ -121,7 +121,8 @@ func (mr *MultiResolver) Resolve(name string) (Address, error) {
 		}
 	}
 
-	return Address{}, fmt.Errorf("name resolution failed for %q", name)
+	// TODO: consider wrapping errors from the resolver chain.
+	return Address{}, err
 }
 
 func isTLD(tld string) bool {

--- a/pkg/resolver/multi_test.go
+++ b/pkg/resolver/multi_test.go
@@ -1,0 +1,221 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package resolver_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/resolver"
+	"github.com/ethersphere/bee/pkg/resolver/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type Address = swarm.Address
+
+func newAddr(s string) Address {
+	return swarm.NewAddress([]byte(s))
+}
+
+func TestWithForceDefault(t *testing.T) {
+	mr := resolver.NewMultiResolver(
+		resolver.WithForceDefault(),
+	)
+
+	if !mr.ForceDefault {
+		t.Error("did not set ForceDefault")
+	}
+}
+
+func TestPushResolver(t *testing.T) {
+	tld := ".tld"
+	mr := resolver.NewMultiResolver()
+
+	t.Run("error on bad tld", func(t *testing.T) {
+		err := mr.PushResolver("invalid", &mock.Resolver{})
+		want := resolver.ErrInvalidTLD
+		if err != want {
+			t.Errorf("bad error: got %v, want %v", err, want)
+		}
+	})
+
+	t.Run("start empty", func(t *testing.T) {
+		if mr.ChainCount(tld) > 0 {
+			t.Fatal("not empty")
+		}
+	})
+
+	t.Run("ok on tld", func(t *testing.T) {
+		want := mock.NewResolver()
+		err := mr.PushResolver(tld, want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := mr.GetChain(tld)[0]
+		if !reflect.DeepEqual(got, want) {
+			t.Error("failed to push")
+		}
+	})
+}
+
+func TestPopResolver(t *testing.T) {
+	tld := ".tld"
+	mr := resolver.NewMultiResolver()
+
+	t.Run("error on bad tld", func(t *testing.T) {
+		err := mr.PopResolver("invalid")
+		want := resolver.ErrInvalidTLD
+		if err != want {
+			t.Fatalf("bad error: got %v, want %v", err, want)
+		}
+	})
+
+	t.Run("error on empty", func(t *testing.T) {
+		err := mr.PopResolver(tld)
+		want := resolver.ErrResolverChainEmpty
+		if err != want {
+			t.Fatalf("bad error: got %v, want %v", err, want)
+		}
+	})
+
+	t.Run("ok on regular tld", func(t *testing.T) {
+		if err := mr.PushResolver(tld, mock.NewResolver()); err != nil {
+			t.Fatal(err)
+		}
+		err := mr.PopResolver(tld)
+		if err != nil {
+			t.Error(err)
+		}
+		if mr.ChainCount(tld) > 0 {
+			t.Error("failed to pop")
+		}
+	})
+}
+
+func TestResolve(t *testing.T) {
+	testAdr := newAddr("aaaabbbbccccdddd")
+	testAdrAlt := newAddr("ddddccccbbbbaaaa")
+
+	newOKResolver := func(adr Address) resolver.Interface {
+		return mock.NewResolver(
+			mock.WithResolveFunc(func(_ string) (Address, error) {
+				return adr, nil
+			}),
+		)
+	}
+	newErrResolver := func() resolver.Interface {
+		return mock.NewResolver(
+			mock.WithResolveFunc(func(name string) (Address, error) {
+				err := fmt.Errorf("name resolution failed for %q", name)
+				return Address{}, err
+			}),
+		)
+	}
+
+	testFixture := []struct {
+		tld       string
+		res       []resolver.Interface
+		expectAdr Address
+	}{
+		{
+			// Default chain:
+			tld: "",
+			res: []resolver.Interface{
+				newOKResolver(testAdr),
+			},
+			expectAdr: testAdr,
+		},
+		{
+			tld: ".tld",
+			res: []resolver.Interface{
+				newErrResolver(),
+				newErrResolver(),
+				newOKResolver(testAdr),
+			},
+			expectAdr: testAdr,
+		},
+		{
+			tld: ".good",
+			res: []resolver.Interface{
+				newOKResolver(testAdr),
+				newOKResolver(testAdrAlt),
+			},
+			expectAdr: testAdr,
+		},
+		{
+			tld: ".empty",
+		},
+		{
+			tld: ".fails",
+			res: []resolver.Interface{
+				newErrResolver(),
+				newErrResolver(),
+			},
+		},
+	}
+
+	testCases := []struct {
+		name    string
+		wantAdr Address
+		wantErr error
+	}{
+		{
+			name:    "",
+			wantAdr: testAdr,
+		},
+		{
+			name:    "hello",
+			wantAdr: testAdr,
+		},
+		{
+			name:    "example.tld",
+			wantAdr: testAdr,
+		},
+		{
+			name:    ".tld",
+			wantAdr: testAdr,
+		},
+		{
+			name:    "get.good",
+			wantAdr: testAdr,
+		},
+		{
+			name:    "this.empty",
+			wantErr: resolver.ErrResolverChainEmpty,
+		},
+		{
+			name:    "this.fails",
+			wantErr: fmt.Errorf("name resolution failed for %q", "this.fails"),
+		},
+	}
+
+	// Load the test fixture.
+	mr := resolver.NewMultiResolver()
+	for _, tE := range testFixture {
+		for _, r := range tE.res {
+			if err := mr.PushResolver(tE.tld, r); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			adr, err := mr.Resolve(tC.name)
+			if err != nil {
+				if tC.wantErr == nil {
+					t.Fatalf("unexpected error: got %v", err)
+				}
+				if err.Error() != tC.wantErr.Error() {
+					t.Fatalf("got %v, want %v", err, tC.wantErr)
+				}
+			}
+			if !adr.Equal(tC.wantAdr) {
+				t.Errorf("got %q, want %q", adr, tC.wantAdr)
+			}
+		})
+	}
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package resolver
+
+import (
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// Address is the swarm bzz address.
+type Address = swarm.Address
+
+// Interface can resolve an URL into an associated Ethereum address.
+type Interface interface {
+	Resolve(url string) (Address, error)
+}


### PR DESCRIPTION
# Mutliresolver and resolver chains

Multiresolver allows a registered resolver chain to be selected based on a TLD in a name (eg. "name.eth" -> ENS resolver chain).
A resolver chain attempts to resolve a name using all resolvers in a chain, returning an error if all resolvers fail.