### PR TITLE
Connect to max 3 bootnodes at startup

### DIFF
--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -721,7 +721,7 @@ func TestStart(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		waitCounter(t, &conns, 5)
+		waitCounter(t, &conns, 3)
 		waitCounter(t, &failedConns, 0)
 	})
 }


### PR DESCRIPTION
When connecting to bootnodes, put a max bootnode count to 3. There is no theoretical limit to a number of bootnodes, but this is limiting a number of bootnodes the kademlia will try to connect to at once.
In order to keep the limit strict, I have made connecting to bootnodes sequential. I don't think there is a way to be strict when there are concurrent parallel connection  attempts without doing disconnects etc...

fixes #635 