### PR TITLE
Remove connect notify

### DIFF
--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -28,7 +28,7 @@ type server struct {
 	Overlay        swarm.Address
 	P2P            p2p.DebugService
 	Pingpong       pingpong.Interface
-	TopologyDriver topology.PeerAdder
+	TopologyDriver topology.Driver
 	Storer         storage.Storer
 	Logger         logging.Logger
 	Tracer         *tracing.Tracer
@@ -39,7 +39,7 @@ type server struct {
 	metricsRegistry *prometheus.Registry
 }
 
-func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.PeerAdder, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface) Service {
+func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface) Service {
 	s := &server{
 		Overlay:         overlay,
 		P2P:             p2p,

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -27,13 +27,15 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bzzAddr, err := s.P2P.ConnectNotify(r.Context(), addr)
+	bzzAddr, err := s.P2P.Connect(r.Context(), addr)
 	if err != nil {
 		s.Logger.Debugf("debug api: peer connect %s: %v", addr, err)
 		s.Logger.Errorf("unable to connect to peer %s", addr)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
+
+	s.TopologyDriver.Connected(r.Context(), bzzAddr.Overlay)
 
 	jsonhttp.OK(w, peerConnectResponse{
 		Address: bzzAddr.Overlay.String(),

--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -35,7 +35,13 @@ func (s *server) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.TopologyDriver.Connected(r.Context(), bzzAddr.Overlay)
+	if err := s.TopologyDriver.Connected(r.Context(), bzzAddr.Overlay); err != nil {
+		_ = s.P2P.Disconnect(bzzAddr.Overlay)
+		s.Logger.Debugf("debug api: peer connect handler %s: %v", addr, err)
+		s.Logger.Errorf("unable to connect to peer %s", addr)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
 
 	jsonhttp.OK(w, peerConnectResponse{
 		Address: bzzAddr.Overlay.String(),

--- a/pkg/debugapi/peer_test.go
+++ b/pkg/debugapi/peer_test.go
@@ -60,9 +60,6 @@ func TestConnect(t *testing.T) {
 				Address: overlay.String(),
 			}),
 		)
-		if testServer.P2PMock.ConnectNotifyCalls() != 1 {
-			t.Fatal("connect notify not called")
-		}
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -431,8 +431,6 @@ func (k *Kad) AddPeers(ctx context.Context, addrs ...swarm.Address) error {
 		k.knownPeers.Add(addr, po)
 	}
 
-	fmt.Println("triggering manage C from addPeers")
-
 	select {
 	case k.manageC <- struct{}{}:
 	default:
@@ -447,7 +445,6 @@ func (k *Kad) Connected(ctx context.Context, addr swarm.Address) error {
 		return err
 	}
 
-	fmt.Println("triggering manage C from connected")
 	select {
 	case k.manageC <- struct{}{}:
 	default:
@@ -490,7 +487,6 @@ func (k *Kad) Disconnected(addr swarm.Address) {
 	k.depthMu.Lock()
 	k.depth = recalcDepth(k.connectedPeers)
 	k.depthMu.Unlock()
-	fmt.Println("triggering manage C from disconnected")
 
 	select {
 	case k.manageC <- struct{}{}:

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -720,7 +720,7 @@ func TestStart(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		waitCounter(t, &conns, 5)
+		waitCounter(t, &conns, 3)
 		waitCounter(t, &failedConns, 0)
 	})
 }

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -479,7 +479,7 @@ func TestClosestPeer(t *testing.T) {
 	ab := addressbook.New(mockstate.NewStateStore())
 	var conns int32
 
-	kad := kademlia.New(base, ab, disc, p2pMock(ab, &conns, nil), logger, kademlia.Options{})
+	kad := kademlia.New(base, ab, disc, p2pMock(ab, nil, &conns, nil), logger, kademlia.Options{})
 	if err := kad.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -674,8 +674,7 @@ func TestMarshal(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	var bootnodes []ma.Multiaddr
-
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		multiaddr, err := ma.NewMultiaddr(underlayBase + test.RandomAddress().String())
 		if err != nil {
 			t.Fatal(err)
@@ -721,26 +720,28 @@ func TestStart(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		waitCounter(t, &conns, 3)
+		waitCounter(t, &conns, 5)
 		waitCounter(t, &failedConns, 0)
 	})
 }
 
 func newTestKademlia(connCounter, failedConnCounter *int32, f func(bin uint8, peers, connected *pslice.PSlice) bool, bootnodes []ma.Multiaddr) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+	pk, _ := crypto.GenerateSecp256k1Key()
+
 	var (
+		signer = beeCrypto.NewDefaultSigner(pk)
 		base   = test.RandomAddress()                       // base address
 		ab     = addressbook.New(mockstate.NewStateStore()) // address book
-		p2p    = p2pMock(ab, connCounter, failedConnCounter)
+		p2p    = p2pMock(ab, signer, connCounter, failedConnCounter)
 		logger = logging.New(ioutil.Discard, 0) // logger
 		disc   = mock.NewDiscovery()
 		kad    = kademlia.New(base, ab, disc, p2p, logger, kademlia.Options{SaturationFunc: f, Bootnodes: bootnodes}) // kademlia instance
 	)
 
-	pk, _ := crypto.GenerateSecp256k1Key()
-	return base, kad, ab, disc, beeCrypto.NewDefaultSigner(pk)
+	return base, kad, ab, disc, signer
 }
 
-func p2pMock(ab addressbook.Interface, counter, failedCounter *int32) p2p.Service {
+func p2pMock(ab addressbook.Interface, signer beeCrypto.Signer, counter, failedCounter *int32) p2p.Service {
 	p2ps := p2pmock.New(p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (*bzz.Address, error) {
 		if addr.Equal(nonConnectableAddress) {
 			_ = atomic.AddInt32(failedCounter, 1)
@@ -761,7 +762,17 @@ func p2pMock(ab addressbook.Interface, counter, failedCounter *int32) p2p.Servic
 			}
 		}
 
-		return nil, nil
+		address := test.RandomAddress()
+		bzzAddr, err := bzz.NewAddress(signer, addr, address, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := ab.Put(address, *bzzAddr); err != nil {
+			return nil, err
+		}
+
+		return bzzAddr, nil
 	}))
 
 	return p2ps

--- a/pkg/p2p/discover.go
+++ b/pkg/p2p/discover.go
@@ -14,7 +14,7 @@ import (
 	madns "github.com/multiformats/go-multiaddr-dns"
 )
 
-func Discover(ctx context.Context, addr ma.Multiaddr, f func(ma.Multiaddr) (stop bool, err error)) (stopped bool, err error) {
+func Discover(ctx context.Context, addr ma.Multiaddr, f func(ma.Multiaddr) (bool, error)) (bool, error) {
 	if comp, _ := ma.SplitFirst(addr); comp.Protocol().Name != "dnsaddr" {
 		return f(addr)
 	}
@@ -32,12 +32,13 @@ func Discover(ctx context.Context, addr ma.Multiaddr, f func(ma.Multiaddr) (stop
 		addrs[i], addrs[j] = addrs[j], addrs[i]
 	})
 	for _, addr := range addrs {
-		stopped, err = Discover(ctx, addr, f)
+		stopped, err := Discover(ctx, addr, f)
 		if err != nil {
 			return false, fmt.Errorf("discover %s: %w", addr, err)
 		}
+
 		if stopped {
-			break
+			return true, nil
 		}
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -351,29 +351,6 @@ func buildUnderlayAddress(addr ma.Multiaddr, peerID libp2ppeer.ID) (ma.Multiaddr
 	return addr.Encapsulate(hostAddr), nil
 }
 
-func (s *Service) ConnectNotify(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error) {
-	info, err := libp2ppeer.AddrInfoFromP2pAddr(addr)
-	if err != nil {
-		return nil, fmt.Errorf("addr from p2p: %w", err)
-	}
-
-	address, err = s.Connect(ctx, addr)
-	if err != nil {
-		return nil, fmt.Errorf("connect notify: %w", err)
-	}
-
-	if len(s.topologyNotifiers) > 0 {
-		for _, tn := range s.topologyNotifiers {
-			if err := tn.Connected(ctx, address.Overlay); err != nil {
-				_ = s.disconnect(info.ID)
-				return nil, fmt.Errorf("notify topology: %w", err)
-			}
-		}
-	}
-
-	return address, nil
-}
-
 func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error) {
 	// Extract the peer ID from the multiaddr.
 	info, err := libp2ppeer.AddrInfoFromP2pAddr(addr)

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -7,7 +7,6 @@ package mock
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 
 	"github.com/ethersphere/bee/pkg/bzz"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -27,7 +26,6 @@ type Service struct {
 	setWelcomeMessageFunc func(string) error
 	getWelcomeMessageFunc func() string
 	welcomeMessage        string
-	notifyCalled          int32
 }
 
 // WithAddProtocolFunc sets the mock implementation of the AddProtocol function
@@ -102,14 +100,6 @@ func (s *Service) AddProtocol(spec p2p.ProtocolSpec) error {
 	return s.addProtocolFunc(spec)
 }
 
-func (s *Service) ConnectNotify(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error) {
-	if s.connectFunc == nil {
-		return nil, errors.New("function Connect not configured")
-	}
-	atomic.AddInt32(&s.notifyCalled, 1)
-	return s.connectFunc(ctx, addr)
-}
-
 func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error) {
 	if s.connectFunc == nil {
 		return nil, errors.New("function Connect not configured")
@@ -144,11 +134,6 @@ func (s *Service) Peers() []p2p.Peer {
 		return nil
 	}
 	return s.peersFunc()
-}
-
-func (s *Service) ConnectNotifyCalls() int32 {
-	c := atomic.LoadInt32(&s.notifyCalled)
-	return c
 }
 
 func (s *Service) SetWelcomeMessage(val string) error {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -17,9 +17,6 @@ import (
 // Service provides methods to handle p2p Peers and Protocols.
 type Service interface {
 	AddProtocol(ProtocolSpec) error
-	// ConnectNotify connects to the given multiaddress and notifies the topology once the
-	// peer has been successfully connected.
-	ConnectNotify(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
 	// Connect to a peer but do not notify topology about the established connection.
 	Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
 	Disconnect(overlay swarm.Address) error


### PR DESCRIPTION
Potentially remove connect notify from toplogy driver as a cleanup, as it is used only in debugapi.

TODO:
Polish up the p2pMock a little bit and check toplogy notifier in `peer_tests` in debugapi.