### PR TITLE
add git commit to version and expose version in debugapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,8 @@ GOLANGCI_LINT_VERSION ?= v1.30.0
 GOGOPROTOBUF ?= protoc-gen-gogofaster
 GOGOPROTOBUF_VERSION ?= v1.3.1
 
-LDFLAGS ?= -s -w
-ifdef COMMIT
-LDFLAGS += -X github.com/ethersphere/bee.commit="$(COMMIT)"
-endif
+COMMIT ?= "$(shell git describe --long --dirty --always --match "" || true)"
+LDFLAGS ?= -s -w -X github.com/ethersphere/bee.commit="$(COMMIT)"
 
 .PHONY: all
 all: build lint vet test-race binary

--- a/pkg/debugapi/status.go
+++ b/pkg/debugapi/status.go
@@ -7,15 +7,18 @@ package debugapi
 import (
 	"net/http"
 
+	"github.com/ethersphere/bee"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
 type statusResponse struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
+	Version string `json:"version"`
 }
 
 func (s *server) statusHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, statusResponse{
-		Status: "ok",
+		Status:  "ok",
+		Version: bee.Version,
 	})
 }

--- a/pkg/debugapi/status_test.go
+++ b/pkg/debugapi/status_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethersphere/bee"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 )
@@ -17,7 +18,8 @@ func TestHealth(t *testing.T) {
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/health", http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
-			Status: "ok",
+			Status:  "ok",
+			Version: bee.Version,
 		}),
 	)
 }
@@ -27,7 +29,8 @@ func TestReadiness(t *testing.T) {
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/readiness", http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
-			Status: "ok",
+			Status:  "ok",
+			Version: bee.Version,
 		}),
 	)
 }


### PR DESCRIPTION
This is a simple change to include the git commit when building with Makefile and .git directory is available very similar to what we had before https://github.com/ethersphere/bee/commit/dc1951843baeebbe7dc417216e86cc5ab6cd9fc4#diff-b67911656ef5d18c4ae36cb6741b7965L4, but if the COMMIT environment variable is provided, the git command will not be executed. When building a docker image COMMIT environment must be provided as .git directory is in .dockerignore, this is not changed.

fixes: #683 