### PR TITLE
blocklist peer on retrieval timeout

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -244,7 +244,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 
 	chunkvalidator := swarm.NewChunkValidator(soc.NewValidator(), content.NewValidator())
 
-	retrieve := retrieval.New(p2ps, kad, logger, acc, accounting.NewFixedPricer(swarmAddress, 10), chunkvalidator)
+	retrieve := retrieval.New(p2ps, storer, kad, logger, acc, accounting.NewFixedPricer(swarmAddress, 10), chunkvalidator)
 	tagg := tags.NewTags(stateStore, logger)
 	b.tagsCloser = tagg
 
@@ -263,7 +263,6 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 	} else {
 		ns = netstore.New(storer, nil, retrieve, logger, chunkvalidator)
 	}
-	retrieve.SetStorer(ns)
 
 	pushSyncProtocol := pushsync.New(p2ps, storer, kad, tagg, psss.TryUnwrap, logger, acc, accounting.NewFixedPricer(swarmAddress, 10))
 

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -20,13 +20,17 @@ type Service interface {
 	AddProtocol(ProtocolSpec) error
 	// Connect to a peer but do not notify topology about the established connection.
 	Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.Address, err error)
+	Disconnecter
+	Peers() []Peer
+	AddNotifier(topology.Notifier)
+	Addresses() ([]ma.Multiaddr, error)
+}
+
+type Disconnecter interface {
 	Disconnect(overlay swarm.Address) error
 	// Blocklist will disconnect a peer and put it on a blocklist (blocking in & out connections) for provided duration
 	// duration 0 is treated as an infinite duration
 	Blocklist(overlay swarm.Address, duration time.Duration) error
-	Peers() []Peer
-	AddNotifier(topology.Notifier)
-	Addresses() ([]ma.Multiaddr, error)
 }
 
 // DebugService extends the Service with method used for debugging.
@@ -39,6 +43,11 @@ type DebugService interface {
 // Streamer is able to create a new Stream.
 type Streamer interface {
 	NewStream(ctx context.Context, address swarm.Address, h Headers, protocol, version, stream string) (Stream, error)
+}
+
+type StreamerDisconnecter interface {
+	Streamer
+	Disconnecter
 }
 
 // Stream represent a bidirectional data Stream.

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -319,3 +319,52 @@ type Option interface {
 type optionFunc func(*Recorder)
 
 func (f optionFunc) apply(r *Recorder) { f(r) }
+
+var _ p2p.StreamerDisconnecter = (*RecorderDisconnecter)(nil)
+
+type RecorderDisconnecter struct {
+	*Recorder
+	disconnected map[string]struct{}
+	blocklisted  map[string]time.Duration
+	mu           sync.RWMutex
+}
+
+func NewRecorderDisconnecter(r *Recorder) *RecorderDisconnecter {
+	return &RecorderDisconnecter{
+		Recorder:     r,
+		disconnected: make(map[string]struct{}),
+		blocklisted:  make(map[string]time.Duration),
+	}
+}
+
+func (r *RecorderDisconnecter) Disconnect(overlay swarm.Address) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.disconnected[overlay.String()] = struct{}{}
+	return nil
+}
+
+func (r *RecorderDisconnecter) Blocklist(overlay swarm.Address, d time.Duration) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.blocklisted[overlay.String()] = d
+	return nil
+}
+
+func (r *RecorderDisconnecter) IsDisconnected(overlay swarm.Address) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, yes := r.disconnected[overlay.String()]
+	return yes
+}
+
+func (r *RecorderDisconnecter) IsBlocklisted(overlay swarm.Address) (bool, time.Duration) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	d, yes := r.blocklisted[overlay.String()]
+	return yes, d
+}

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -269,13 +269,11 @@ func newTestNetStore(t *testing.T, recoveryFunc recovery.RecoveryHook) storage.S
 		_, _, _ = f(peerID, 0)
 		return nil
 	}}
-	server := retrieval.New(nil, nil, logger, serverMockAccounting, nil, nil)
-	server.SetStorer(mockStorer)
-	recorder := streamtest.New(
+	server := retrieval.New(nil, mockStorer, ps, logger, serverMockAccounting, nil, nil)
+	recorder := streamtest.NewRecorderDisconnecter(streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
-	)
-	retrieve := retrieval.New(recorder, ps, logger, serverMockAccounting, pricerMock, nil)
-	retrieve.SetStorer(mockStorer)
+	))
+	retrieve := retrieval.New(recorder, mockStorer, ps, logger, serverMockAccounting, pricerMock, nil)
 	ns := netstore.New(storer, recoveryFunc, retrieve, logger, nil)
 	return ns
 }

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -51,11 +51,10 @@ func TestDelivery(t *testing.T) {
 	pricerMock := accountingmock.NewPricer(price, price)
 
 	// create the server that will handle the request and will serve the response
-	server := retrieval.New(nil, nil, logger, serverMockAccounting, pricerMock, mockValidator)
-	server.SetStorer(mockStorer)
-	recorder := streamtest.New(
+	server := retrieval.New(nil, mockStorer, nil, logger, serverMockAccounting, pricerMock, mockValidator)
+	recorder := streamtest.NewRecorderDisconnecter(streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
-	)
+	))
 
 	clientMockAccounting := accountingmock.NewAccounting()
 
@@ -70,8 +69,7 @@ func TestDelivery(t *testing.T) {
 		_, _, _ = f(peerID, 0)
 		return nil
 	}}
-	client := retrieval.New(recorder, ps, logger, clientMockAccounting, pricerMock, mockValidator)
-	client.SetStorer(clientMockStorer)
+	client := retrieval.New(recorder, clientMockStorer, ps, logger, clientMockAccounting, pricerMock, mockValidator)
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 	v, err := client.RetrieveChunk(ctx, reqAddr)


### PR DESCRIPTION
This PR is an attempt to improve chunk retrieval.

- block peer for some short time if the retrieval times out (since it forwards, maybe to extend the timeout from 10s to 30s)
- decouple netstore from the retrieval protocol, avoiding circular dependency between these two services
- small improvements to logging

Changes were also tested with beekeeper retrieval check.