### PR TITLE
log pss error instead of stream reset

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -320,5 +320,9 @@ func (ps *PushSync) handleDeliveryResponse(ctx context.Context, w protobuf.Write
 	}
 
 	// since all PSS messages comes through push sync, deliver them here if this node is the destination
-	return ps.deliverToPSS(ctx, chunk)
+	err = ps.deliverToPSS(ctx, chunk)
+	if err != nil {
+		ps.logger.Debugf("error pss delivery for chunk %v: %v", chunk.Address(), err)
+	}
+	return nil
 }


### PR DESCRIPTION
Log errors from the pss delivery handler instead of returning them to the push sync handler. This is to avoid them causing a stream reset which sometimes prevents the receiving of the receipt by the other peer.

The loglevel was chosen as `DEBUG` because this is how it would be logged before this PR (as an `error handle protocol`).