### PR TITLE
block peers on disconnect threshold

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -253,7 +254,7 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 	if nextBalance >= int64(a.paymentThreshold+a.paymentTolerance) {
 		// peer too much in debt
 		a.metrics.AccountingDisconnectsCount.Inc()
-		return p2p.NewDisconnectError(ErrDisconnectThresholdExceeded)
+		return p2p.NewBlockPeerError(10000*time.Hour, ErrDisconnectThresholdExceeded)
 	}
 
 	return nil

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -197,7 +197,7 @@ func TestAccountingReserve(t *testing.T) {
 	}
 }
 
-// TestAccountingDisconnect tests that exceeding the disconnect threshold with Debit returns a p2p.DisconnectError
+// TestAccountingDisconnect tests that exceeding the disconnect threshold with Debit returns a p2p.BlockPeerError
 func TestAccountingDisconnect(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
@@ -231,9 +231,9 @@ func TestAccountingDisconnect(t *testing.T) {
 		t.Fatal("expected Add to return error")
 	}
 
-	var e *p2p.DisconnectError
+	var e *p2p.BlockPeerError
 	if !errors.As(err, &e) {
-		t.Fatalf("expected DisconnectError, got %v", err)
+		t.Fatalf("expected BlockPeerError, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR blocks peers instead of just disconnecting if the threshold is reached to prevent them from reconnecting.
The time period for the block has been chosen arbitrarily. Better suggestions are welcome.