### PR TITLE
trojan,pss: optimise trojan mining

### DIFF
--- a/pkg/pss/pss.go
+++ b/pkg/pss/pss.go
@@ -67,7 +67,7 @@ func (p *pss) Send(ctx context.Context, targets trojan.Targets, topic trojan.Top
 		return err
 	}
 	var tc swarm.Chunk
-	tc, err = m.Wrap(targets)
+	tc, err = m.Wrap(ctx, targets)
 	if err != nil {
 
 		return err

--- a/pkg/pss/pss_test.go
+++ b/pkg/pss/pss_test.go
@@ -123,7 +123,7 @@ func TestDeliver(t *testing.T) {
 	// test chunk
 	target := trojan.Target([]byte{1}) // arbitrary test target
 	targets := trojan.Targets([]trojan.Target{target})
-	c, err := msg.Wrap(targets)
+	c, err := msg.Wrap(ctx, targets)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/trojan/error.go
+++ b/pkg/trojan/error.go
@@ -15,9 +15,6 @@ var (
 	// ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
 	ErrVarLenTargets = errors.New("target list cannot have targets of different length")
 
-	// ErrUnMarshallingTrojanMessage is returned when a trojan message could not be de-serialized
+	// ErrUnmarshal is returned when a trojan message could not be de-serialized
 	ErrUnmarshal = errors.New("trojan message unmarshall error")
-
-	// ErrMinerTimeout is returned when mining a new nonce takes more time than swarm.TrojanMinerTimeout seconds
-	ErrMinerTimeout = errors.New("miner timeout error")
 )

--- a/pkg/trojan/export_test.go
+++ b/pkg/trojan/export_test.go
@@ -1,7 +1,5 @@
 package trojan
 
 var (
-	Contains  = contains
-	HashBytes = hashBytes
-	PadBytes  = padBytesLeft
+	Contains = contains
 )

--- a/pkg/trojan/message.go
+++ b/pkg/trojan/message.go
@@ -6,14 +6,13 @@ package trojan
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/binary"
-	"math/big"
-	"time"
-
-	bmtlegacy "github.com/ethersphere/bmt/legacy"
+	random "math/rand"
 
 	"github.com/ethersphere/bee/pkg/swarm"
+	bmtlegacy "github.com/ethersphere/bmt/legacy"
 )
 
 // Topic is an alias for a 32 byte fixed-size array which contains an encoding of a message topic
@@ -39,12 +38,15 @@ const (
 	// MaxPayloadSize + Topic + Length + Nonce = Default ChunkSize
 	//    (4030)      +  (32) +   (2)  +  (32) = 4096 Bytes
 	MaxPayloadSize = swarm.ChunkSize - NonceSize - LengthSize - TopicSize
-	NonceSize      = 32
-	LengthSize     = 2
-	TopicSize      = 32
+	// NonceSize is a hash bit sequence
+	NonceSize = 32
+	// LengthSize is the byte length to represent message
+	LengthSize = 2
+	// TopicSize is a hash bit sequence
+	TopicSize = 32
 )
 
-var minerTimeout = 20 * time.Second
+// var MinerTimeout = 20 * time.Second
 
 // NewTopic creates a new Topic variable with the given input string
 // the input string is taken as a byte slice and hashed
@@ -89,14 +91,37 @@ func NewMessage(topic Topic, payload []byte) (Message, error) {
 // Wrap creates a new trojan chunk for the given targets and Message
 // a trojan chunk is a content-addressed chunk made up of span, a nonce, and a payload which contains the Message
 // the chunk address will have one of the targets as its prefix and thus will be forwarded to the neighbourhood of the recipient overlay address the target is derived from
-func (m *Message) Wrap(targets Targets) (swarm.Chunk, error) {
+// this is done by iteratively enumerating different nonces until the BMT hash of the serialization of the trojan chunk fields results in a chunk address that has one of the targets as its prefix
+func (m *Message) Wrap(ctx context.Context, targets Targets) (swarm.Chunk, error) {
 	if err := checkTargets(targets); err != nil {
 		return nil, err
 	}
+	targetsLen := len(targets[0])
 
+	// serialize message
+	b, err := m.MarshalBinary() // TODO: this should be encrypted
+	if err != nil {
+		return nil, err
+	}
 	span := make([]byte, 8)
-	binary.LittleEndian.PutUint64(span, swarm.ChunkSize)
-	return m.toChunk(targets, span)
+	binary.LittleEndian.PutUint64(span, uint64(len(b)+NonceSize))
+	h := hasher(span, b)
+	f := func(nonce []byte) (interface{}, error) {
+		hash, err := h(nonce)
+		if err != nil {
+			return nil, err
+		}
+		if !contains(targets, hash[:targetsLen]) {
+			return nil, nil
+		}
+		chunk := swarm.NewChunk(swarm.NewAddress(hash), append(span, append(nonce, b...)...))
+		return chunk, nil
+	}
+	chunk, err := mine(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	return chunk.(swarm.Chunk), nil
 }
 
 // Unwrap creates a new trojan message from the given chunk payload
@@ -141,81 +166,19 @@ func checkTargets(targets Targets) error {
 	return nil
 }
 
-// toChunk finds a nonce so that when the given trojan chunk fields are hashed, the result will fall in the neighbourhood of one of the given targets
-// this is done by iteratively enumerating different nonces until the BMT hash of the serialization of the trojan chunk fields results in a chunk address that has one of the targets as its prefix
-// the function returns a new chunk, with the found matching hash to be used as its address,
-// and its data set to the serialization of the trojan chunk fields which correctly hash into the matching address
-func (m *Message) toChunk(targets Targets, span []byte) (swarm.Chunk, error) {
-	// start out with random nonce
-	nonce := make([]byte, NonceSize)
-	if _, err := rand.Read(nonce); err != nil {
-		return nil, err
-	}
-	nonceInt := new(big.Int).SetBytes(nonce)
-	targetsLen := len(targets[0])
-
-	// serialize message
-	b, err := m.MarshalBinary() // TODO: this should be encrypted
-	if err != nil {
-		return nil, err
-	}
-
-	errC := make(chan error)
-	var hash, s []byte
-	go func() {
-		defer close(errC)
-
-		// mining operation: hash chunk fields with different nonces until an acceptable one is found
-		for {
-			s = append(append(span, nonce...), b...) // serialize chunk fields
-			hash, err = hashBytes(s)
-			if err != nil {
-				errC <- err
-				return
-			}
-
-			// take as much of the hash as the targets are long
-			if contains(targets, hash[:targetsLen]) {
-				// if nonce found, stop loop and return chunk
-				errC <- nil
-				return
-			}
-			// else, add 1 to nonce and try again
-			nonceInt.Add(nonceInt, big.NewInt(1))
-			// loop around in case of overflow after 256 bits
-			if nonceInt.BitLen() > (NonceSize * swarm.SpanSize) {
-				nonceInt = big.NewInt(0)
-			}
-			nonce = padBytesLeft(nonceInt.Bytes()) // pad in case Bytes call is not 32 bytes long
-		}
-	}()
-
-	// checks whether the mining is completed or times out
-	select {
-	case err := <-errC:
-		if err == nil {
-			return swarm.NewChunk(swarm.NewAddress(hash), s), nil
-		}
-		return nil, err
-	case <-time.After(minerTimeout):
-		return nil, ErrMinerTimeout
-	}
-}
-
-// hashBytes hashes the given serialization of chunk fields with the hashing func
-func hashBytes(s []byte) ([]byte, error) {
+func hasher(span, b []byte) func([]byte) ([]byte, error) {
 	hashPool := bmtlegacy.NewTreePool(swarm.NewHasher, swarm.Branches, bmtlegacy.PoolSize)
-	hasher := bmtlegacy.New(hashPool)
-	hasher.Reset()
-	span := binary.LittleEndian.Uint64(s[:8])
-	err := hasher.SetSpan(int64(span))
-	if err != nil {
-		return nil, err
+	return func(nonce []byte) ([]byte, error) {
+		s := append(nonce, b...) // serialize chunk fields
+		hasher := bmtlegacy.New(hashPool)
+		if err := hasher.SetSpanBytes(span); err != nil {
+			return nil, err
+		}
+		if _, err := hasher.Write(s); err != nil {
+			return nil, err
+		}
+		return hasher.Sum(nil), nil
 	}
-	if _, err := hasher.Write(s[8:]); err != nil {
-		return nil, err
-	}
-	return hasher.Sum(nil), nil
 }
 
 // contains returns whether the given collection contains the given element
@@ -226,19 +189,6 @@ func contains(col Targets, elem []byte) bool {
 		}
 	}
 	return false
-}
-
-// padBytesLeft adds 0s to the given byte slice as left padding,
-// returning this as a new byte slice with a length of exactly 32
-// given param is assumed to be at most 32 bytes long
-func padBytesLeft(b []byte) []byte {
-	l := len(b)
-	if l == 32 {
-		return b
-	}
-	bb := make([]byte, 32)
-	copy(bb[32-l:], b)
-	return bb
 }
 
 // MarshalBinary serializes a message struct
@@ -268,4 +218,51 @@ func (m *Message) UnmarshalBinary(data []byte) (err error) {
 	m.Payload = data[LengthSize+TopicSize : payloadEnd]
 	m.padding = data[payloadEnd:]
 	return nil
+}
+
+func mine(ctx context.Context, f func(nonce []byte) (interface{}, error)) (interface{}, error) {
+	seeds := make([]uint32, 8)
+	for i := range seeds {
+		seeds[i] = random.Uint32()
+	}
+	initnonce := make([]byte, 32)
+	for i := 0; i < 8; i++ {
+		binary.LittleEndian.PutUint32(initnonce[i*4:i*4+4], seeds[i])
+	}
+	quit := make(chan struct{})
+	// make both  errs  and result channels buffered so they never block
+	result := make(chan interface{}, 8)
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		go func(j int) {
+			nonce := make([]byte, 32)
+			copy(nonce, initnonce)
+			for seed := seeds[j]; ; seed++ {
+				binary.LittleEndian.PutUint32(nonce[j*4:j*4+4], seed)
+				res, err := f(nonce)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if res != nil {
+					result <- res
+					return
+				}
+				select {
+				case <-quit:
+					return
+				default:
+				}
+			}
+		}(i)
+	}
+	defer close(quit)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errs:
+		return nil, err
+	case res := <-result:
+		return res, nil
+	}
 }

--- a/pkg/trojan/mining_test.go
+++ b/pkg/trojan/mining_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package trojan_test
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/trojan"
+)
+
+func newTargets(length, depth int) trojan.Targets {
+	targets := make([]trojan.Target, length)
+	for i := 0; i < length; i++ {
+		buf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf, uint64(i))
+		targets[i] = trojan.Target(buf[:depth])
+	}
+	return trojan.Targets(targets)
+}
+
+func BenchmarkWrap(b *testing.B) {
+	payload := []byte("foopayload")
+	m, err := trojan.NewMessage(testTopic, payload)
+	if err != nil {
+		b.Fatal(err)
+	}
+	cases := []struct {
+		length int
+		depth  int
+	}{
+		{1, 1},
+		{4, 1},
+		{16, 1},
+		{16, 2},
+		{64, 2},
+		{256, 2},
+		{256, 3},
+		{4096, 3},
+		{16384, 3},
+	}
+	for _, c := range cases {
+		name := fmt.Sprintf("length:%d,depth:%d", c.length, c.depth)
+		b.Run(name, func(b *testing.B) {
+			targets := newTargets(c.length, c.depth)
+			for i := 0; i < b.N; i++ {
+				if _, err := m.Wrap(context.Background(), targets); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
closes #444 

 - introduce context to Wrap and eliminate MinerTimeout
 - simplify Wrap
 - add mine function that finds a nonce that makes a function true
 - introduce mining benchmarks
BEFORE
```
:) go test -v -run None -bench .
goos: darwin
goarch: amd64
pkg: github.com/ethersphere/bee/pkg/trojan
BenchmarkWrap
BenchmarkWrap/length:1,depth:1
BenchmarkWrap/length:1,depth:1-8         	     100	  25259359 ns/op
BenchmarkWrap/length:4,depth:1
BenchmarkWrap/length:4,depth:1-8         	     211	   5987303 ns/op
BenchmarkWrap/length:16,depth:1
BenchmarkWrap/length:16,depth:1-8        	     662	   1601796 ns/op
BenchmarkWrap/length:64,depth:2
BenchmarkWrap/length:64,depth:2-8        	      15	 118159956 ns/op
BenchmarkWrap/length:256,depth:2
BenchmarkWrap/length:256,depth:2-8       	      44	  23306940 ns/op
BenchmarkWrap/length:1024,depth:2
BenchmarkWrap/length:1024,depth:2-8      	     188	   6117949 ns/op
BenchmarkWrap/length:1024,depth:3
BenchmarkWrap/length:1024,depth:3-8      	       1	4418328590 ns/op
BenchmarkWrap/length:4096,depth:3
BenchmarkWrap/length:4096,depth:3-8      	       3	 443126126 ns/op
BenchmarkWrap/length:16384,depth:3
BenchmarkWrap/length:16384,depth:3-8     	       6	 203879796 ns/op
PASS
ok  	github.com/ethersphere/bee/pkg/trojan	21.083s
```

AFTER
```
goarch: amd64
pkg: github.com/ethersphere/bee/pkg/trojan
BenchmarkWrap
BenchmarkWrap/length:1,depth:1
BenchmarkWrap/length:1,depth:1-8         	      93	  13613038 ns/op
BenchmarkWrap/length:4,depth:1
BenchmarkWrap/length:4,depth:1-8         	     325	   4058203 ns/op
BenchmarkWrap/length:16,depth:1
BenchmarkWrap/length:16,depth:1-8        	     705	   1583214 ns/op
BenchmarkWrap/length:16,depth:2
BenchmarkWrap/length:16,depth:2-8        	       8	 137261977 ns/op
BenchmarkWrap/length:64,depth:2
BenchmarkWrap/length:64,depth:2-8        	      27	  49296687 ns/op
BenchmarkWrap/length:256,depth:2
BenchmarkWrap/length:256,depth:2-8       	      90	  13566495 ns/op
BenchmarkWrap/length:256,depth:3
BenchmarkWrap/length:256,depth:3-8       	       1	1618499838 ns/op
BenchmarkWrap/length:4096,depth:3
BenchmarkWrap/length:4096,depth:3-8      	       8	 265504439 ns/op
BenchmarkWrap/length:16384,depth:3
BenchmarkWrap/length:16384,depth:3-8     	      26	  78521115 ns/op
PASS
ok  	github.com/ethersphere/bee/pkg/trojan	16.418s

```

at https://github.com/ethersphere/bee/pull/695/commits/12b4f9779515aa7aa9789b0bb9d61ec208d905ca

```
goos: darwin
goarch: amd64
pkg: github.com/ethersphere/bee/pkg/trojan
BenchmarkWrap
BenchmarkWrap/length:1,depth:1
BenchmarkWrap/length:1,depth:1-8         	     100	  13093521 ns/op
BenchmarkWrap/length:4,depth:1
BenchmarkWrap/length:4,depth:1-8         	     330	   4050533 ns/op
BenchmarkWrap/length:16,depth:1
BenchmarkWrap/length:16,depth:1-8        	     722	   1580087 ns/op
BenchmarkWrap/length:16,depth:2
BenchmarkWrap/length:16,depth:2-8        	      40	 236741716 ns/op
BenchmarkWrap/length:64,depth:2
BenchmarkWrap/length:64,depth:2-8        	      26	  49744130 ns/op
BenchmarkWrap/length:256,depth:2
BenchmarkWrap/length:256,depth:2-8       	     100	  16560863 ns/op
BenchmarkWrap/length:256,depth:3
BenchmarkWrap/length:256,depth:3-8       	       2	1991208560 ns/op
BenchmarkWrap/length:4096,depth:3
BenchmarkWrap/length:4096,depth:3-8      	       3	 400150111 ns/op
BenchmarkWrap/length:16384,depth:3
BenchmarkWrap/length:16384,depth:3-8     	      13	  93524278 ns/op
```