### PR TITLE
Distinguish no balance for peer

### DIFF
--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -17,7 +17,7 @@ import (
 var (
 	errCantBalances  = "Cannot get balances"
 	errCantBalance   = "Cannot get balance"
-	errPeerNoBalance = "No balance for peer"
+	errNoBalance     = "No balance for peer"
 	errInvaliAddress = "Invalid address"
 )
 
@@ -65,7 +65,7 @@ func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 	balance, err := s.Accounting.Balance(peer)
 	if err != nil {
 		if errors.Is(err, accounting.ErrPeerNoBalance) {
-			jsonhttp.NotFound(w, errPeerNoBalance)
+			jsonhttp.NotFound(w, errNoBalance)
 			return
 		}
 		s.Logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -5,8 +5,10 @@
 package debugapi
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
@@ -15,6 +17,7 @@ import (
 var (
 	errCantBalances  = "Cannot get balances"
 	errCantBalance   = "Cannot get balance"
+	errPeerNoBalance = "No balance for peer"
 	errInvaliAddress = "Invalid address"
 )
 
@@ -61,6 +64,10 @@ func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 
 	balance, err := s.Accounting.Balance(peer)
 	if err != nil {
+		if errors.Is(err, accounting.ErrPeerNoBalance) {
+			jsonhttp.NotFound(w, errPeerNoBalance)
+			return
+		}
 		s.Logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)
 		s.Logger.Errorf("debug api: balances peer: can't get peer %s balance", peer.String())
 		jsonhttp.InternalServerError(w, errCantBalance)

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -106,6 +107,23 @@ func TestBalancesPeersError(t *testing.T) {
 		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
 			Message: debugapi.ErrCantBalance,
 			Code:    http.StatusInternalServerError,
+		}),
+	)
+}
+
+func TestBalancesPeersNoBalance(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	balanceFunc := func(swarm.Address) (int64, error) {
+		return 0, accounting.ErrPeerNoBalance
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrNoBalance,
+			Code:    http.StatusNotFound,
 		}),
 	)
 }

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -21,6 +21,7 @@ type (
 var (
 	ErrCantBalance         = errCantBalance
 	ErrCantBalances        = errCantBalances
+	ErrNoBalance           = errNoBalance
 	ErrCantSettlementsPeer = errCantSettlementsPeer
 	ErrCantSettlements     = errCantSettlements
 	ErrInvaliAddress       = errInvaliAddress


### PR DESCRIPTION
The aim of this change is to return "No balance for peer" instead of 0 in case there is no balance associated with the peer key in storage.