### PR TITLE
add trigger for argocd deploy

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -84,3 +84,14 @@ jobs:
           docker tag registry.localhost:5000/ethersphere/bee:latest ethersphere/bee:latest
           printf ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push ethersphere/bee:latest
+      - name: Set IMAGE_DIGEST variable
+        if: success()
+        run: echo "::set-env name=IMAGE_DIGEST::$(docker inspect --format='{{index .RepoDigests 0}}' ethersphere/bee:latest | cut -d'@' -f 2 | tr -d '\n')"
+      - name: Trigger ArgoCD
+        if: success()
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+          repository: ethersphere/bee-argo
+          event-type: trigger-argo
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "digest": "${{ env.IMAGE_DIGEST }}"}'


### PR DESCRIPTION
Here is the workflow that will be trigger after build and all tests passed -> [bee-argo](https://github.com/ethersphere/bee-argo/blob/master/.github/workflows/update.yaml)
That workflow will generate k8s yamls for deployment and self-commit to edge folder, argocd running on staging cluster will detect repo folder's change and update the cluster.