### PR TITLE
add tunshell installation if workflow failed

### DIFF
--- a/.github/workflows/beekeeper.yaml
+++ b/.github/workflows/beekeeper.yaml
@@ -95,3 +95,7 @@ jobs:
           repository: ethersphere/bee-argo
           event-type: trigger-argo
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "digest": "${{ env.IMAGE_DIGEST }}"}'
+      - name: Debug workflow if failed
+        if: failure()
+        run: |
+          curl -sSf https://lets.tunshell.com/init.sh | sh /dev/stdin T ${{ secrets.TUNSHELL_KEY }} eu.relay.tunshell.com


### PR DESCRIPTION
Too often beekeeper tests are failing, mostly retrieval related, this should start [Tunshell](https://github.com/TimeToogo/tunshell) debug session that should last for max timeout for github actions (6 hours I think)
If pipeline hangs with executed Tunshell action ping @svetomir or me for access.