### PR TITLE
kademlia: TestClosestPeer wait for peers to be added to the backing data structure

### DIFF
--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -477,9 +477,8 @@ func TestClosestPeer(t *testing.T) {
 
 	disc := mock.NewDiscovery()
 	ab := addressbook.New(mockstate.NewStateStore())
-	var conns int32
 
-	kad := kademlia.New(base, ab, disc, p2pMock(ab, nil, &conns, nil), logger, kademlia.Options{})
+	kad := kademlia.New(base, ab, disc, p2pMock(ab, nil, nil, nil), logger, kademlia.Options{})
 	if err := kad.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -489,7 +489,8 @@ func TestClosestPeer(t *testing.T) {
 	for _, v := range connectedPeers {
 		addOne(t, beeCrypto.NewDefaultSigner(pk), kad, ab, v.Address)
 	}
-	waitCounter(t, &conns, 3)
+
+	waitPeers(t, kad, 3)
 
 	for _, tc := range []struct {
 		chunkAddress swarm.Address // chunk address to test
@@ -861,6 +862,26 @@ func waitCounter(t *testing.T, conns *int32, exp int32) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for counter to reach expected value. got %d want %d", got, exp)
+}
+
+func waitPeers(t *testing.T, k *kademlia.Kad, peers int) {
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for peers")
+		default:
+		}
+		i := 0
+		k.EachPeer(func(_ swarm.Address, _ uint8) (bool, bool, error) {
+			i++
+			return false, false, nil
+		})
+		if i == peers {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // wait for discovery BroadcastPeers to happen

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -872,7 +872,7 @@ func waitPeers(t *testing.T, k *kademlia.Kad, peers int) {
 		default:
 		}
 		i := 0
-		k.EachPeer(func(_ swarm.Address, _ uint8) (bool, bool, error) {
+		_ = k.EachPeer(func(_ swarm.Address, _ uint8) (bool, bool, error) {
 			i++
 			return false, false, nil
 		})


### PR DESCRIPTION
In `TestClosestPeer`, there was a possibility for a race condition where the `conns` counter that was used has been incremented, but the peer was not yet added to the backing `pslice` data structure.
This is possible since the `conns` counter was incremented in the mock p2p connect function, meaning that kademlia initiated a dial, but the actual addition to `connectedPeers` is done some lines of code after the connection is done on the p2p level, resulting in a data race where indeed 3 connections were initiated, but not all 3 peers are in `connectedPeers`.

This is also evident, since the test was flaking on the first test case:
```
=== RUN   TestClosestPeer
##[error]    kademlia_test.go:509: peers not equal. got 4000000000000000000000000000000000000000000000000000000000000000 expected 6000000000000000000000000000000000000000000000000000000000000000
--- FAIL: TestClosestPeer (0.26s)
```
So it is reasonable to assume that this is happening due to the aforementioned race condition.

fixes #512 