### PR TITLE
Add support for manifest metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.2
-	github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb
+	github.com/ethersphere/manifest v0.3.0
 	github.com/ethersphere/sw3-bindings/v2 v2.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.2
-	github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576
+	github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9
 	github.com/ethersphere/sw3-bindings/v2 v2.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.2
-	github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9
+	github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb
 	github.com/ethersphere/sw3-bindings/v2 v2.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.2
-	github.com/ethersphere/manifest v0.2.0
+	github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576
 	github.com/ethersphere/sw3-bindings/v2 v2.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/ethereum/go-ethereum v1.9.20 h1:kk/J5OIoaoz3DRrCXznz3RGi212mHHXwzXlY/
 github.com/ethereum/go-ethereum v1.9.20/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh3nUTuDpH+hNrg=
 github.com/ethersphere/bmt v0.1.2 h1:FEuvQY9xuK+rDp3VwDVyde8T396Matv/u9PdtKa2r9Q=
 github.com/ethersphere/bmt v0.1.2/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
-github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb h1:4lV1g+Gss/vc7tpicid4mDidrYGI7IbxR1jZ6pirut0=
-github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
+github.com/ethersphere/manifest v0.3.0 h1:+QRXY/AQ17mg0x3e20gvn4aAOHsZpm3rzi930bsOlro=
+github.com/ethersphere/manifest v0.3.0/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0 h1:uc+wBqEMMq7c4NWj+MSkKkkpObgrUYxfAxz6FYJWkI4=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0/go.mod h1:OA34yk7ludjNag+yBDY9Gp3czWoFUVMsiK7gUXnZ26U=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -165,10 +165,10 @@ github.com/ethereum/go-ethereum v1.9.20 h1:kk/J5OIoaoz3DRrCXznz3RGi212mHHXwzXlY/
 github.com/ethereum/go-ethereum v1.9.20/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh3nUTuDpH+hNrg=
 github.com/ethersphere/bmt v0.1.2 h1:FEuvQY9xuK+rDp3VwDVyde8T396Matv/u9PdtKa2r9Q=
 github.com/ethersphere/bmt v0.1.2/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
+github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb h1:4lV1g+Gss/vc7tpicid4mDidrYGI7IbxR1jZ6pirut0=
+github.com/ethersphere/manifest v0.2.1-0.20200921213500-adad68cd28eb/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0 h1:uc+wBqEMMq7c4NWj+MSkKkkpObgrUYxfAxz6FYJWkI4=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0/go.mod h1:OA34yk7ludjNag+yBDY9Gp3czWoFUVMsiK7gUXnZ26U=
-github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9 h1:Vqh4OYH/Tg06SiiCHobsnOZizef+l/AH/ikYp9P9Hu4=
-github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/go.sum
+++ b/go.sum
@@ -165,10 +165,10 @@ github.com/ethereum/go-ethereum v1.9.20 h1:kk/J5OIoaoz3DRrCXznz3RGi212mHHXwzXlY/
 github.com/ethereum/go-ethereum v1.9.20/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh3nUTuDpH+hNrg=
 github.com/ethersphere/bmt v0.1.2 h1:FEuvQY9xuK+rDp3VwDVyde8T396Matv/u9PdtKa2r9Q=
 github.com/ethersphere/bmt v0.1.2/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
-github.com/ethersphere/manifest v0.2.0 h1:HD2ufiIaw/5Vgrl4XyeGduDJ5tn50wIhqMQoWdT2GME=
-github.com/ethersphere/manifest v0.2.0/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0 h1:uc+wBqEMMq7c4NWj+MSkKkkpObgrUYxfAxz6FYJWkI4=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0/go.mod h1:OA34yk7ludjNag+yBDY9Gp3czWoFUVMsiK7gUXnZ26U=
+github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576 h1:hObPyvFUbw7MbLQPTJkL07BuKtxWbxSPZlxVQa+Imf8=
+github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/ethersphere/bmt v0.1.2 h1:FEuvQY9xuK+rDp3VwDVyde8T396Matv/u9PdtKa2r9Q
 github.com/ethersphere/bmt v0.1.2/go.mod h1:fqRBDmYwn3lX2MH4lkImXQgFWeNP8ikLkS/hgi/HRws=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0 h1:uc+wBqEMMq7c4NWj+MSkKkkpObgrUYxfAxz6FYJWkI4=
 github.com/ethersphere/sw3-bindings/v2 v2.0.0/go.mod h1:OA34yk7ludjNag+yBDY9Gp3czWoFUVMsiK7gUXnZ26U=
-github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576 h1:hObPyvFUbw7MbLQPTJkL07BuKtxWbxSPZlxVQa+Imf8=
-github.com/ethersphere/manifest v0.2.1-0.20200918134140-74dd9468c576/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
+github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9 h1:Vqh4OYH/Tg06SiiCHobsnOZizef+l/AH/ikYp9P9Hu4=
+github.com/ethersphere/manifest v0.2.1-0.20200921204743-ce59ed7b54e9/go.mod h1:ygAx0KLhXYmKqsjUab95RCbXf8UcO7yMDjyfP0lY76Y=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	SwarmPinHeader     = "Swarm-Pin"
-	SwarmTagUidHeader  = "Swarm-Tag-Uid"
-	SwarmEncryptHeader = "Swarm-Encrypt"
-	SwarmIndextHeader  = "Swarm-Index"
+	SwarmPinHeader           = "Swarm-Pin"
+	SwarmTagUidHeader        = "Swarm-Tag-Uid"
+	SwarmEncryptHeader       = "Swarm-Encrypt"
+	SwarmIndexDocumentHeader = "Swarm-Index-Document"
+	SwarmErrorDocumentHeader = "Swarm-Error-Document"
 )
 
 var (

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -26,14 +26,15 @@ import (
 )
 
 type testServerOptions struct {
-	Storer       storage.Storer
-	Resolver     resolver.Interface
-	Pss          pss.Interface
-	WsPath       string
-	Tags         *tags.Tags
-	GatewayMode  bool
-	WsPingPeriod time.Duration
-	Logger       logging.Logger
+	Storer          storage.Storer
+	Resolver        resolver.Interface
+	Pss             pss.Interface
+	WsPath          string
+	Tags            *tags.Tags
+	GatewayMode     bool
+	WsPingPeriod    time.Duration
+	Logger          logging.Logger
+	PreventRedirect bool
 }
 
 func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.Conn, string) {
@@ -74,8 +75,14 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		if err != nil {
 			t.Fatalf("dial: %v. url %v", err, u.String())
 		}
-
 	}
+
+	if o.PreventRedirect {
+		httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
 	return httpClient, conn, ts.Listener.Addr().String()
 }
 

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -113,7 +112,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 				// index document exists
 				logger.Debugf("bzz download: serving path: %s", pathWithIndex)
 
-				s.serveManifestEntry(w, r, ctx, j, address, indexDocumentManifestEntry.Reference())
+				s.serveManifestEntry(w, r, j, address, indexDocumentManifestEntry.Reference())
 				return
 			}
 		}
@@ -153,7 +152,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 						// index document exists
 						logger.Debugf("bzz download: serving path: %s", pathWithIndex)
 
-						s.serveManifestEntry(w, r, ctx, j, address, indexDocumentManifestEntry.Reference())
+						s.serveManifestEntry(w, r, j, address, indexDocumentManifestEntry.Reference())
 						return
 					}
 				}
@@ -167,7 +166,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 						// error document exists
 						logger.Debugf("bzz download: serving path: %s", errorDocumentPath)
 
-						s.serveManifestEntry(w, r, ctx, j, address, errorDocumentManifestEntry.Reference())
+						s.serveManifestEntry(w, r, j, address, errorDocumentManifestEntry.Reference())
 						return
 					}
 				}
@@ -181,18 +180,12 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// serve requested path
-	s.serveManifestEntry(w, r, ctx, j, address, me.Reference())
+	s.serveManifestEntry(w, r, j, address, me.Reference())
 }
 
-func (s *server) serveManifestEntry(
-	w http.ResponseWriter,
-	r *http.Request,
-	ctx context.Context,
-	j file.JoinSeeker,
-	address swarm.Address,
-	manifestEntryAddress swarm.Address,
-) {
+func (s *server) serveManifestEntry(w http.ResponseWriter, r *http.Request, j file.JoinSeeker, address, manifestEntryAddress swarm.Address) {
 	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
+	ctx := r.Context()
 
 	// read file entry
 	buf := bytes.NewBuffer(nil)

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -16,14 +16,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-
 	"github.com/ethersphere/bee/pkg/collection/entry"
+	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/manifest"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	smock "github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -104,7 +103,7 @@ func TestBzz(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		e := manifest.NewEntry(fileReference)
+		e := manifest.NewEntry(fileReference, nil)
 
 		err = m.Add(filePath, e)
 		if err != nil {

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -22,6 +22,12 @@ var (
 )
 
 var (
+	ManifestRootPath                      = manifestRootPath
+	ManifestWebsiteIndexDocumentSuffixKey = manifestWebsiteIndexDocumentSuffixKey
+	ManifestWebsiteErrorDocumentPathKey   = manifestWebsiteErrorDocumentPathKey
+)
+
+var (
 	ErrNoResolver           = errNoResolver
 	ErrInvalidNameOrAddress = errInvalidNameOrAddress
 )

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -41,6 +41,8 @@ type Interface interface {
 type Entry interface {
 	// Reference returns the address of the file.
 	Reference() swarm.Address
+	// Metadata returns the metadata of the file.
+	Metadata() map[string]string
 }
 
 // NewDefaultManifest creates a new manifest with default type.
@@ -87,15 +89,21 @@ func NewManifestReference(
 
 type manifestEntry struct {
 	reference swarm.Address
+	metadata  map[string]string
 }
 
 // NewEntry creates a new manifest entry.
-func NewEntry(reference swarm.Address) Entry {
+func NewEntry(reference swarm.Address, metadata map[string]string) Entry {
 	return &manifestEntry{
 		reference: reference,
+		metadata:  metadata,
 	}
 }
 
 func (e *manifestEntry) Reference() swarm.Address {
 	return e.reference
+}
+
+func (e *manifestEntry) Metadata() map[string]string {
+	return e.metadata
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -33,6 +33,8 @@ type Interface interface {
 	Remove(string) error
 	// Lookup returns a manifest entry if one is found in the specified path.
 	Lookup(string) (Entry, error)
+	// HasPrefix tests whether the specified prefix path exists.
+	HasPrefix(string) (bool, error)
 	// Store stores the manifest, returning the resulting address.
 	Store(context.Context, storage.ModePut) (swarm.Address, error)
 }

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -68,7 +68,7 @@ func (m *mantarayManifest) Add(path string, entry Entry) error {
 	p := []byte(path)
 	e := entry.Reference().Bytes()
 
-	return m.trie.Add(p, e, m.loader)
+	return m.trie.Add(p, e, entry.Metadata(), m.loader)
 }
 
 func (m *mantarayManifest) Remove(path string) error {
@@ -88,14 +88,14 @@ func (m *mantarayManifest) Remove(path string) error {
 func (m *mantarayManifest) Lookup(path string) (Entry, error) {
 	p := []byte(path)
 
-	ref, err := m.trie.Lookup(p, m.loader)
+	node, err := m.trie.LookupNode(p, m.loader)
 	if err != nil {
 		return nil, ErrNotFound
 	}
 
-	address := swarm.NewAddress(ref)
+	address := swarm.NewAddress(node.Entry())
 
-	entry := NewEntry(address)
+	entry := NewEntry(address, node.Metadata())
 
 	return entry, nil
 }

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -100,6 +100,12 @@ func (m *mantarayManifest) Lookup(path string) (Entry, error) {
 	return entry, nil
 }
 
+func (m *mantarayManifest) HasPrefix(prefix string) (bool, error) {
+	p := []byte(prefix)
+
+	return m.trie.HasPrefix(p, m.loader)
+}
+
 func (m *mantarayManifest) Store(ctx context.Context, mode storage.ModePut) (swarm.Address, error) {
 
 	saver := newMantaraySaver(ctx, m.encrypted, m.storer, mode)

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -93,6 +93,10 @@ func (m *mantarayManifest) Lookup(path string) (Entry, error) {
 		return nil, ErrNotFound
 	}
 
+	if !node.IsValueType() {
+		return nil, ErrNotFound
+	}
+
 	address := swarm.NewAddress(node.Entry())
 
 	entry := NewEntry(address, node.Metadata())

--- a/pkg/manifest/simple.go
+++ b/pkg/manifest/simple.go
@@ -66,7 +66,7 @@ func (m *simpleManifest) Type() string {
 func (m *simpleManifest) Add(path string, entry Entry) error {
 	e := entry.Reference().String()
 
-	return m.manifest.Add(path, e)
+	return m.manifest.Add(path, e, entry.Metadata())
 }
 
 func (m *simpleManifest) Remove(path string) error {
@@ -94,7 +94,7 @@ func (m *simpleManifest) Lookup(path string) (Entry, error) {
 		return nil, fmt.Errorf("parse swarm address: %w", err)
 	}
 
-	entry := NewEntry(address)
+	entry := NewEntry(address, n.Metadata())
 
 	return entry, nil
 }

--- a/pkg/manifest/simple.go
+++ b/pkg/manifest/simple.go
@@ -99,6 +99,10 @@ func (m *simpleManifest) Lookup(path string) (Entry, error) {
 	return entry, nil
 }
 
+func (m *simpleManifest) HasPrefix(prefix string) (bool, error) {
+	return m.manifest.HasPrefix(prefix), nil
+}
+
 func (m *simpleManifest) Store(ctx context.Context, mode storage.ModePut) (swarm.Address, error) {
 
 	data, err := m.manifest.MarshalBinary()


### PR DESCRIPTION
Includes support for metadata that can be stored in manifest.

Initially it i used to store `index-document` and `error-document` in the manifest.
These two are stored in root path (`/`) entry metadata.
During serving files from paths, on the `bzz` endpoint, if some of these documents are configured, attempt will be made to redirect to some of them (based on the actual state of the request).

Some naming changes are done by this PR (headers), which should be open for discussion.

One additional change was made to `api_test.go`, where additional option was added, that allows caller to disable client redirect. This was done to support some additional tests related to redirection to these mentioned (optional) documents.