### PR TITLE
throw error when target string is empty

### DIFF
--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -42,14 +42,17 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			// request from network
-			ch, err = s.retrieval.RetrieveChunk(ctx, addr)
-			if err != nil {
+			ch, err1 := s.retrieval.RetrieveChunk(ctx, addr)
+			if err1 != nil {
 				if s.recoveryCallback == nil {
-					return nil, err
+					return nil, err1
 				}
-				targets, err := sctx.GetTargets(ctx)
-				if err != nil {
-					return nil, err
+				targets, err2 := sctx.GetTargets(ctx)
+				if err2 != nil {
+					if errors.Is(err2, sctx.ErrEmptyPrefix) {
+						return nil, err1
+					}
+					return nil, err2
 				}
 				go func() {
 					err := s.recoveryCallback(addr, targets)

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -97,6 +97,7 @@ func TestNetstoreNoRetrieval(t *testing.T) {
 	}
 }
 
+// TestRecovery verifies if recovery is called if it is not empty
 func TestRecovery(t *testing.T) {
 	hookWasCalled := make(chan bool, 1)
 	rec := &mockRecovery{
@@ -122,6 +123,7 @@ func TestRecovery(t *testing.T) {
 	}
 }
 
+// TestRecovery verifies that recovery function is not called if it is not set
 func TestInvalidRecoveryFunction(t *testing.T) {
 	retrieve, _, nstore := newRetrievingNetstore(nil)
 	addr := swarm.MustParseHexAddress("deadbeef")
@@ -135,6 +137,7 @@ func TestInvalidRecoveryFunction(t *testing.T) {
 	}
 }
 
+// TestInvalidTargets verifies that the recovery is not triggered if the target is invalid
 func TestInvalidTargets(t *testing.T) {
 	hookWasCalled := make(chan bool, 1)
 	rec := &mockRecovery{
@@ -153,6 +156,7 @@ func TestInvalidTargets(t *testing.T) {
 	}
 }
 
+// TestEmptyTarget verifies that the recovery is not triggered if the target is empty string
 func TestEmptyTarget(t *testing.T) {
 	hookWasCalled := make(chan bool, 1)
 	rec := &mockRecovery{

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -132,7 +132,7 @@ func TestInvalidRecoveryFunction(t *testing.T) {
 	ctx = sctx.SetTargets(ctx, "be, cd")
 
 	_, err := nstore.Get(ctx, storage.ModeGetRequest, addr)
-	if err != nil && err.Error() != "chunk not found" {
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		t.Fatal(err)
 	}
 }
@@ -170,7 +170,7 @@ func TestEmptyTarget(t *testing.T) {
 	ctx = sctx.SetTargets(ctx, "")
 
 	_, err := nstore.Get(ctx, storage.ModeGetRequest, addr)
-	if err != nil && !errors.Is(err, sctx.ErrTargetPrefix) {
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		t.Fatal(err)
 	}
 }
@@ -200,7 +200,7 @@ type retrievalMock struct {
 
 func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk swarm.Chunk, err error) {
 	if r.failure {
-		return nil, fmt.Errorf("chunk not found")
+		return nil, storage.ErrNotFound
 	}
 	r.called = true
 	atomic.AddInt32(&r.callCount, 1)

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -153,6 +153,24 @@ func TestInvalidTargets(t *testing.T) {
 	}
 }
 
+func TestEmptyTarget(t *testing.T) {
+	hookWasCalled := make(chan bool, 1)
+	rec := &mockRecovery{
+		hookC: hookWasCalled,
+	}
+
+	retrieve, _, nstore := newRetrievingNetstore(rec)
+	addr := swarm.MustParseHexAddress("deadbeef")
+	retrieve.failure = true
+	ctx := context.Background()
+	ctx = sctx.SetTargets(ctx, "")
+
+	_, err := nstore.Get(ctx, storage.ModeGetRequest, addr)
+	if err != nil && !errors.Is(err, sctx.ErrTargetPrefix) {
+		t.Fatal(err)
+	}
+}
+
 // returns a mock retrieval protocol, a mock local storage and a netstore
 func newRetrievingNetstore(rec *mockRecovery) (ret *retrievalMock, mockStore, ns storage.Storer) {
 	retrieve := &retrievalMock{}

--- a/pkg/sctx/sctx.go
+++ b/pkg/sctx/sctx.go
@@ -68,6 +68,9 @@ func GetTargets(ctx context.Context) (trojan.Targets, error) {
 	if !ok {
 		return nil, ErrTargetPrefix
 	}
+	if targetString == "" {
+		return nil, ErrTargetPrefix
+	}
 
 	prefixes := strings.Split(targetString, ",")
 	var targets trojan.Targets

--- a/pkg/sctx/sctx.go
+++ b/pkg/sctx/sctx.go
@@ -19,6 +19,7 @@ import (
 var (
 	// ErrTargetPrefix is returned when target prefix decoding fails.
 	ErrTargetPrefix = errors.New("error decoding prefix string")
+	ErrEmptyPrefix  = errors.New("empty value in targets")
 )
 
 type (
@@ -69,7 +70,7 @@ func GetTargets(ctx context.Context) (trojan.Targets, error) {
 		return nil, ErrTargetPrefix
 	}
 	if targetString == "" {
-		return nil, ErrTargetPrefix
+		return nil, ErrEmptyPrefix
 	}
 
 	prefixes := strings.Split(targetString, ",")


### PR DESCRIPTION
When target is set in context and is empty, do not trigger recovery, instead throw target decode error and return.
this was reported in [mattermost](https://beehive.ethswarm.org/swarm/pl/ht1phqu9ffn7bdcbmk6w36b75a) 