### PR TITLE
check available balance when issuing cheques

### DIFF
--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -16,7 +16,8 @@ var (
 )
 
 type chequebookBalanceResponse struct {
-	Balance *big.Int `json:"balance"`
+	TotalBalance     *big.Int `json:"totalBalance"`
+	AvailableBalance *big.Int `json:"availableBalance"`
 }
 
 type chequebookAddressResponse struct {
@@ -32,7 +33,15 @@ func (s *server) chequebookBalanceHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	jsonhttp.OK(w, chequebookBalanceResponse{Balance: balance})
+	availableBalance, err := s.Chequebook.AvailableBalance(r.Context())
+	if err != nil {
+		jsonhttp.InternalServerError(w, errChequebookBalance)
+		s.Logger.Debugf("debug api: chequebook availableBalance: %v", err)
+		s.Logger.Error("debug api: cannot get chequebook availableBalance")
+		return
+	}
+
+	jsonhttp.OK(w, chequebookBalanceResponse{TotalBalance: balance, AvailableBalance: availableBalance})
 }
 
 func (s *server) chequebookAddressHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -17,6 +17,7 @@ import (
 type SimpleSwapBinding interface {
 	Balance(*bind.CallOpts) (*big.Int, error)
 	Issuer(*bind.CallOpts) (common.Address, error)
+	TotalPaidOut(*bind.CallOpts) (*big.Int, error)
 }
 
 type SimpleSwapBindingFunc = func(common.Address, bind.ContractBackend) (SimpleSwapBinding, error)

--- a/pkg/settlement/swap/chequebook/chequebook.go
+++ b/pkg/settlement/swap/chequebook/chequebook.go
@@ -40,7 +40,7 @@ type Service interface {
 	WaitForDeposit(ctx context.Context, txHash common.Hash) error
 	// Balance returns the token balance of the chequebook.
 	Balance(ctx context.Context) (*big.Int, error)
-	// AvailableBalance returns the token balance of the chequebook not yet used for uncashed cheques.
+	// AvailableBalance returns the token balance of the chequebook which is not yet used for uncashed cheques.
 	AvailableBalance(ctx context.Context) (*big.Int, error)
 	// Address returns the address of the used chequebook contract.
 	Address() common.Address
@@ -154,7 +154,7 @@ func (s *service) Balance(ctx context.Context) (*big.Int, error) {
 	})
 }
 
-// AvailableBalance returns the token balance of the chequebook not yet used for uncashed cheques.
+// AvailableBalance returns the token balance of the chequebook which is not yet used for uncashed cheques.
 func (s *service) AvailableBalance(ctx context.Context) (*big.Int, error) {
 	totalIssued, err := s.totalIssued()
 	if err != nil {
@@ -265,6 +265,7 @@ func (s *service) Issue(ctx context.Context, beneficiary common.Address, amount 
 	return s.store.Put(totalIssuedKey, totalIssued)
 }
 
+// returns the total amount in cheques issued so far
 func (s *service) totalIssued() (totalIssued *big.Int, err error) {
 	err = s.store.Get(totalIssuedKey, &totalIssued)
 	if err != nil {

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -98,8 +98,9 @@ func (m *simpleSwapFactoryBindingMock) ERC20Address(o *bind.CallOpts) (common.Ad
 }
 
 type simpleSwapBindingMock struct {
-	balance func(*bind.CallOpts) (*big.Int, error)
-	issuer  func(*bind.CallOpts) (common.Address, error)
+	balance      func(*bind.CallOpts) (*big.Int, error)
+	issuer       func(*bind.CallOpts) (common.Address, error)
+	totalPaidOut func(o *bind.CallOpts) (*big.Int, error)
 }
 
 func (m *simpleSwapBindingMock) Balance(o *bind.CallOpts) (*big.Int, error) {
@@ -108,6 +109,10 @@ func (m *simpleSwapBindingMock) Balance(o *bind.CallOpts) (*big.Int, error) {
 
 func (m *simpleSwapBindingMock) Issuer(o *bind.CallOpts) (common.Address, error) {
 	return m.issuer(o)
+}
+
+func (m *simpleSwapBindingMock) TotalPaidOut(o *bind.CallOpts) (*big.Int, error) {
+	return m.totalPaidOut(o)
 }
 
 type erc20BindingMock struct {

--- a/pkg/settlement/swap/chequebook/mock/chequebook.go
+++ b/pkg/settlement/swap/chequebook/mock/chequebook.go
@@ -28,6 +28,12 @@ func WithChequebookBalanceFunc(f func(ctx context.Context) (*big.Int, error)) Op
 	})
 }
 
+func WithChequebookAvailableBalanceFunc(f func(ctx context.Context) (*big.Int, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.chequebookAvailableBalanceFunc = f
+	})
+}
+
 func WithChequebookAddressFunc(f func() common.Address) Option {
 	return optionFunc(func(s *Service) {
 		s.chequebookAddressFunc = f

--- a/pkg/settlement/swap/chequebook/mock/chequebook.go
+++ b/pkg/settlement/swap/chequebook/mock/chequebook.go
@@ -15,9 +15,10 @@ import (
 
 // Service is the mock chequebook service.
 type Service struct {
-	chequebookBalanceFunc func(context.Context) (*big.Int, error)
-	chequebookAddressFunc func() common.Address
-	chequebookIssueFunc   func(beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error
+	chequebookBalanceFunc          func(context.Context) (*big.Int, error)
+	chequebookAvailableBalanceFunc func(context.Context) (*big.Int, error)
+	chequebookAddressFunc          func() common.Address
+	chequebookIssueFunc            func(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error
 }
 
 // WithChequebook*Functions set the mock chequebook functions
@@ -33,7 +34,7 @@ func WithChequebookAddressFunc(f func() common.Address) Option {
 	})
 }
 
-func WithChequebookIssueFunc(f func(beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error) Option {
+func WithChequebookIssueFunc(f func(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error) Option {
 	return optionFunc(func(s *Service) {
 		s.chequebookIssueFunc = f
 	})
@@ -56,6 +57,13 @@ func (s *Service) Balance(ctx context.Context) (bal *big.Int, err error) {
 	return big.NewInt(0), errors.New("Error")
 }
 
+func (s *Service) AvailableBalance(ctx context.Context) (bal *big.Int, err error) {
+	if s.chequebookAvailableBalanceFunc != nil {
+		return s.chequebookAvailableBalanceFunc(ctx)
+	}
+	return big.NewInt(0), errors.New("Error")
+}
+
 // Deposit mocks the chequebook .Deposit function
 func (s *Service) Deposit(ctx context.Context, amount *big.Int) (hash common.Hash, err error) {
 	return common.Hash{}, errors.New("Error")
@@ -74,9 +82,9 @@ func (s *Service) Address() common.Address {
 	return common.Address{}
 }
 
-func (s *Service) Issue(beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
+func (s *Service) Issue(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
 	if s.chequebookIssueFunc != nil {
-		return s.chequebookIssueFunc(beneficiary, amount, sendChequeFunc)
+		return s.chequebookIssueFunc(ctx, beneficiary, amount, sendChequeFunc)
 	}
 	return nil
 }

--- a/pkg/settlement/swap/swap.go
+++ b/pkg/settlement/swap/swap.go
@@ -92,7 +92,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount uint64) er
 	if !known {
 		return ErrUnknownBeneficary
 	}
-	err = s.chequebook.Issue(beneficiary, big.NewInt(int64(amount)), func(signedCheque *chequebook.SignedCheque) error {
+	err = s.chequebook.Issue(ctx, beneficiary, big.NewInt(int64(amount)), func(signedCheque *chequebook.SignedCheque) error {
 		return s.proto.EmitCheque(ctx, peer, signedCheque)
 	})
 	if err != nil {

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -266,7 +266,7 @@ func TestPay(t *testing.T) {
 	peer := swarm.MustParseHexAddress("abcd")
 	var chequebookCalled bool
 	chequebookService := mockchequebook.NewChequebook(
-		mockchequebook.WithChequebookIssueFunc(func(b common.Address, a *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
+		mockchequebook.WithChequebookIssueFunc(func(ctx context.Context, b common.Address, a *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
 			if b != beneficiary {
 				t.Fatalf("issuing cheque for wrong beneficiary. wanted %v, got %v", beneficiary, b)
 			}
@@ -334,7 +334,7 @@ func TestPayIssueError(t *testing.T) {
 	peer := swarm.MustParseHexAddress("abcd")
 	errReject := errors.New("reject")
 	chequebookService := mockchequebook.NewChequebook(
-		mockchequebook.WithChequebookIssueFunc(func(b common.Address, a *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
+		mockchequebook.WithChequebookIssueFunc(func(ctx context.Context, b common.Address, a *big.Int, sendChequeFunc chequebook.SendChequeFunc) error {
 			return errReject
 		}),
 	)


### PR DESCRIPTION
ensure that we are solvent when issuing a cheque.

also changes the `/chequebook/balance` endpoint to return both the total and the available balance.

closes #738 