### PR TITLE
cashout cheques

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -99,6 +99,14 @@ components:
         payout:
           type: integer
 
+    ChequeAllPeersResponse:
+      type: object
+      properties:
+        lastcheques:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChequePeerResponse'
+
     ChequePeerResponse:
       type: object
       properties:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -89,6 +89,26 @@ components:
               connectedPeers:
                 type: object
 
+    Cheque:
+      type: object
+      properties:
+        beneficiary:
+          type: '#/components/schemas/EthereumAddress'
+        chequebook:
+          type: '#/components/schemas/EthereumAddress'
+        payout:
+          type: integer
+
+    ChequePeerResponse:
+      type: object
+      properties:
+        peer:
+          type: '#/components/schemas/SwarmAddress'
+        lastreceived:
+          type: '#/components/schemas/Cheque'
+        lastsent:
+          type: '#/components/schemas/Cheque'
+
     DateTime:
       type: string
       format: date-time

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -100,6 +100,11 @@ components:
       type: string
       example: "5.0018ms"
 
+    EthereumAddress:
+      type: string
+      pattern: '^[A-Fa-f0-9]{40}$'
+      example: "36b7efd913ca4cf880b8eeac5093fa27b0825906"
+
     FileName:
       type: string
 
@@ -213,8 +218,45 @@ components:
         - $ref: '#/components/schemas/SwarmEncryptedReference'
         - $ref: '#/components/schemas/DomainName'
 
+    SwapCashoutResult:
+      type: object
+      properties:
+        recipient:
+          type: '#/components/schemas/EthereumAddress'
+        lastPayout:
+          type: integer
+        bounced:
+          type: boolean
+
+    SwapCashoutStatus:
+      type: object
+      properties:
+        peer:
+          type: '#/components/schemas/SwarmAddress'
+        chequebook:
+          type: '#/components/schemas/EthereumAddress'
+        cumulativePayout:
+          type: integer
+        beneficiary:
+          type: '#/components/schemas/EthereumAddress'
+        transactionHash:
+          type: '#/components/schemas/TransactionHash'
+        result:
+          type: '#/components/schemas/SwapCashoutResult'
+
     TagName:
       type: string
+
+    TransactionHash:
+      type: string
+      pattern: '^[A-Fa-f0-9]{64}$'
+      example: "e28a34ffe7b1710c1baf97ca6d71d81b7f159a9920910876856c8d94dd7be4ae"
+
+    TransactionResponse:
+      type: object
+      properties:
+        transactionHash:
+          type: '#/components/schemas/TransactionHash'
 
     Uid:
       type: integer

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -93,9 +93,9 @@ components:
       type: object
       properties:
         beneficiary:
-          type: '#/components/schemas/EthereumAddress'
+          $ref: '#/components/schemas/EthereumAddress'
         chequebook:
-          type: '#/components/schemas/EthereumAddress'
+          $ref: '#/components/schemas/EthereumAddress'
         payout:
           type: integer
 
@@ -103,11 +103,11 @@ components:
       type: object
       properties:
         peer:
-          type: '#/components/schemas/SwarmAddress'
+          $ref: '#/components/schemas/SwarmAddress'
         lastreceived:
-          type: '#/components/schemas/Cheque'
+          $ref: '#/components/schemas/Cheque'
         lastsent:
-          type: '#/components/schemas/Cheque'
+          $ref: '#/components/schemas/Cheque'
 
     DateTime:
       type: string
@@ -242,7 +242,7 @@ components:
       type: object
       properties:
         recipient:
-          type: '#/components/schemas/EthereumAddress'
+          $ref: '#/components/schemas/EthereumAddress'
         lastPayout:
           type: integer
         bounced:
@@ -252,17 +252,17 @@ components:
       type: object
       properties:
         peer:
-          type: '#/components/schemas/SwarmAddress'
+          $ref: '#/components/schemas/SwarmAddress'
         chequebook:
-          type: '#/components/schemas/EthereumAddress'
+          $ref: '#/components/schemas/EthereumAddress'
         cumulativePayout:
           type: integer
         beneficiary:
-          type: '#/components/schemas/EthereumAddress'
+          $ref: '#/components/schemas/EthereumAddress'
         transactionHash:
-          type: '#/components/schemas/TransactionHash'
+          $ref: '#/components/schemas/TransactionHash'
         result:
-          type: '#/components/schemas/SwapCashoutResult'
+          $ref: '#/components/schemas/SwapCashoutResult'
 
     TagName:
       type: string
@@ -276,7 +276,7 @@ components:
       type: object
       properties:
         transactionHash:
-          type: '#/components/schemas/TransactionHash'
+          $ref: '#/components/schemas/TransactionHash'
 
     Uid:
       type: integer

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -273,7 +273,7 @@ paths:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/BzzTopology'
 
-  '/welcome-message':
+   '/welcome-message':
     get:
       summary: Get configured P2P welcome message
       tags:
@@ -307,6 +307,56 @@ paths:
                 $ref: 'SwarmCommon.yaml#/components/schemas/Status'
         '400':
           $ref: 'SwarmCommon.yaml#/components/responses/400'
+        '500':
+          $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/chequebook/cashout/{peer-id}':
+    get:
+      summary: Get last cashout action for the peer
+      parameters:
+        - in: path
+          name: peer-id
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Cashout status
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/SwapCashoutStatus'
+        '404':
+           $ref: 'SwarmCommon.yaml#/components/responses/404'                
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+    post:
+      summary: Cashout the last cheque for the peer
+      parameters:
+        - in: path
+          name: peer-id
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      tags:
+        - Chequebook      
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/TransactionResponse'
+        '404':
+          $ref: 'SwarmCommon.yaml#/components/responses/404'
         '500':
           $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -387,3 +387,22 @@ paths:
            $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
           description: Default response
+
+  '/chequebook/cheque':
+    get:
+      summary: Get last cheques for all peers
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Last cheques
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/ChequeAllPeersResponse'
+        '404':
+           $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -361,3 +361,29 @@ paths:
           $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
           description: Default response
+
+  '/chequebook/cheque/{peer-id}':
+    get:
+      summary: Get last cheques for the peer
+      parameters:
+        - in: path
+          name: peer-id
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Last cheques
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/ChequePeerResponse'
+        '404':
+           $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -273,7 +273,7 @@ paths:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/BzzTopology'
 
-   '/welcome-message':
+  '/welcome-message':
     get:
       summary: Get configured P2P welcome message
       tags:

--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -208,15 +208,19 @@ func (s *server) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, swapCashoutResponse{TransactionHash: txHash.String()})
 }
 
+type swapCashoutStatusResult struct {
+	Recipient  common.Address `json:"recipient"`
+	LastPayout *big.Int       `json:"lastPayout"`
+	Bounced    bool           `json:"bounced"`
+}
+
 type swapCashoutStatusResponse struct {
-	Peer             swarm.Address  `json:"peer"`
-	Chequebook       common.Address `json:"chequebook"`
-	CumulativePayout *big.Int       `json:"cumulativePayout"`
-	Beneficiary      common.Address `json:"beneficiary"`
-	TransactionHash  common.Hash    `json:"transactionHash"`
-	Recipient        common.Address `json:"recipient"`
-	LastPayout       *big.Int       `json:"lastPayout"`
-	Bounced          bool           `json:"bounced"`
+	Peer             swarm.Address            `json:"peer"`
+	Chequebook       common.Address           `json:"chequebook"`
+	CumulativePayout *big.Int                 `json:"cumulativePayout"`
+	Beneficiary      common.Address           `json:"beneficiary"`
+	TransactionHash  common.Hash              `json:"transactionHash"`
+	Result           *swapCashoutStatusResult `json:"result"`
 }
 
 func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -237,14 +241,21 @@ func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	var result *swapCashoutStatusResult
+	if status.Result != nil {
+		result = &swapCashoutStatusResult{
+			Recipient:  status.Result.Recipient,
+			LastPayout: status.Result.TotalPayout,
+			Bounced:    status.Result.Bounced,
+		}
+	}
+
 	jsonhttp.OK(w, swapCashoutStatusResponse{
 		Peer:             peer,
 		TransactionHash:  status.TxHash,
 		Chequebook:       status.Cheque.Chequebook,
 		CumulativePayout: status.Cheque.CumulativePayout,
 		Beneficiary:      status.Cheque.Beneficiary,
-		Recipient:        status.Result.Recipient,
-		LastPayout:       status.Result.TotalPayout,
-		Bounced:          status.Result.Bounced,
+		Result:           result,
 	})
 }

--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -204,7 +204,7 @@ func (s *server) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.Logger.Debugf("debug api: cashout peer: cannot cash %s: %v", addr, err)
 		s.Logger.Error("debug api: cashout peer: cannot cash %s", addr)
-		jsonhttp.NotFound(w, errCannotCash)
+		jsonhttp.InternalServerError(w, errCannotCash)
 		return
 	}
 
@@ -252,7 +252,7 @@ func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request
 		}
 		s.Logger.Debugf("debug api: cashout status peer: cannot get status %s: %v", addr, err)
 		s.Logger.Error("debug api: cashout status peer: cannot get status %s", addr)
-		jsonhttp.NotFound(w, errCannotCashStatus)
+		jsonhttp.InternalServerError(w, errCannotCashStatus)
 		return
 	}
 

--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net/http"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 
@@ -19,6 +20,8 @@ var (
 	errChequebookBalance  = "cannot get chequebook balance"
 	errCantLastChequePeer = "cannot get last cheque for peer"
 	errCantLastCheque     = "cannot get last cheque for all peers"
+	errCannotCash         = "cannot cash cheque"
+	errCannotCashStatus   = "cannot get cashout status"
 )
 
 type chequebookBalanceResponse struct {
@@ -178,4 +181,70 @@ func (s *server) chequebookAllLastHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	jsonhttp.OK(w, chequebookLastChequesResponse{LastCheques: lcresponses})
+}
+
+type swapCashoutResponse struct {
+	TransactionHash string `json:"transactionHash"`
+}
+
+func (s *server) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: cashout peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Error("debug api: cashout peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+
+	txHash, err := s.Swap.CashCheque(r.Context(), peer)
+	if err != nil {
+		s.Logger.Debugf("debug api: cashout peer: cannot cash %s: %v", addr, err)
+		s.Logger.Error("debug api: cashout peer: cannot cash %s", addr)
+		jsonhttp.NotFound(w, errCannotCash)
+		return
+	}
+
+	jsonhttp.OK(w, swapCashoutResponse{TransactionHash: txHash.String()})
+}
+
+type swapCashoutStatusResponse struct {
+	Peer             swarm.Address  `json:"peer"`
+	Chequebook       common.Address `json:"chequebook"`
+	CumulativePayout *big.Int       `json:"cumulativePayout"`
+	Beneficiary      common.Address `json:"beneficiary"`
+	TransactionHash  common.Hash    `json:"transactionHash"`
+	Recipient        common.Address `json:"recipient"`
+	LastPayout       *big.Int       `json:"lastPayout"`
+	Bounced          bool           `json:"bounced"`
+}
+
+func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: cashout status peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Error("debug api: cashout status peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+
+	status, err := s.Swap.CashoutStatus(r.Context(), peer)
+	if err != nil {
+		s.Logger.Debugf("debug api: cashout status peer: cannot get status %s: %v", addr, err)
+		s.Logger.Error("debug api: cashout status peer: cannot get status %s", addr)
+		jsonhttp.NotFound(w, errCannotCashStatus)
+		return
+	}
+
+	jsonhttp.OK(w, swapCashoutStatusResponse{
+		Peer:             peer,
+		TransactionHash:  status.TxHash,
+		Chequebook:       status.Cheque.Chequebook,
+		CumulativePayout: status.Cheque.CumulativePayout,
+		Beneficiary:      status.Cheque.Beneficiary,
+		Recipient:        status.Result.Recipient,
+		LastPayout:       status.Result.TotalPayout,
+		Bounced:          status.Result.Bounced,
+	})
 }

--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -239,10 +239,14 @@ func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request
 	status, err := s.Swap.CashoutStatus(r.Context(), peer)
 	if err != nil {
 		if errors.Is(err, chequebook.ErrNoCheque) {
+			s.Logger.Debugf("debug api: cashout status peer: %v", addr, err)
+			s.Logger.Error("debug api: cashout status peer: %s", addr)
 			jsonhttp.NotFound(w, errNoCheque)
 			return
 		}
 		if errors.Is(err, chequebook.ErrNoCashout) {
+			s.Logger.Debugf("debug api: cashout status peer: %v", addr, err)
+			s.Logger.Error("debug api: cashout status peer: %s", addr)
 			jsonhttp.NotFound(w, errNoCashout)
 			return
 		}

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -21,6 +21,9 @@ type (
 	ChequebookLastChequePeerResponse  = chequebookLastChequePeerResponse
 	ChequebookLastChequesResponse     = chequebookLastChequesResponse
 	ChequebookLastChequesPeerResponse = chequebookLastChequesPeerResponse
+	SwapCashoutResponse               = swapCashoutResponse
+	SwapCashoutStatusResponse         = swapCashoutStatusResponse
+	SwapCashoutStatusResult           = swapCashoutStatusResult
 )
 
 var (

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -110,6 +110,11 @@ func (s *server) setupRouting() {
 		router.Handle("/chequebook/cheque", jsonhttp.MethodHandler{
 			"GET": http.HandlerFunc(s.chequebookAllLastHandler),
 		})
+
+		router.Handle("/chequebook/cashout/{peer}", jsonhttp.MethodHandler{
+			"GET":  http.HandlerFunc(s.swapCashoutStatusHandler),
+			"POST": http.HandlerFunc(s.swapCashoutHandler),
+		})
 	}
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),

--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -19,6 +19,8 @@ type SimpleSwapBinding interface {
 	Issuer(*bind.CallOpts) (common.Address, error)
 	TotalPaidOut(*bind.CallOpts) (*big.Int, error)
 	PaidOut(*bind.CallOpts, common.Address) (*big.Int, error)
+	ParseChequeCashed(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error)
+	ParseChequeBounced(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error)
 }
 
 type SimpleSwapBindingFunc = func(common.Address, bind.ContractBackend) (SimpleSwapBinding, error)

--- a/pkg/settlement/swap/chequebook/cashout.go
+++ b/pkg/settlement/swap/chequebook/cashout.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package chequebook
 
 import (

--- a/pkg/settlement/swap/chequebook/cashout.go
+++ b/pkg/settlement/swap/chequebook/cashout.go
@@ -1,0 +1,225 @@
+package chequebook
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
+)
+
+// CashoutService is the service responsible for managing cashout actions
+type CashoutService interface {
+	// CashCheque sends a cashing transaction for the last cheque of the chequebook
+	CashCheque(ctx context.Context, chequebook common.Address, recipient common.Address) (common.Hash, error)
+	// CashoutStatus gets the status of the latest cashout transaction for the chequebook
+	CashoutStatus(ctx context.Context, chequebookAddress common.Address) (*CashoutStatus, error)
+}
+
+type cashoutService struct {
+	store                 storage.StateStorer
+	simpleSwapBindingFunc SimpleSwapBindingFunc
+	backend               Backend
+	transactionService    TransactionService
+	chequebookABI         abi.ABI
+	chequeStore           ChequeStore
+}
+
+// CashoutStatus is the action plus its result
+type CashoutStatus struct {
+	TxHash   common.Hash
+	Cheque   SignedCheque // the cheque that was used to cashout which may be different from the latest cheque
+	Result   *CashChequeResult
+	Reverted bool
+}
+
+// CashChequeResult summarizes the result of a CashCheque or CashChequeBeneficiary call
+type CashChequeResult struct {
+	Beneficiary      common.Address // beneficiary of the cheque
+	Recipient        common.Address // address which received the funds
+	Caller           common.Address // caller of cashCheque
+	TotalPayout      *big.Int       // total amount that was paid out in this call
+	CumulativePayout *big.Int       // cumulative payout of the cheque that was cashed
+	CallerPayout     *big.Int       // payout for the caller of cashCheque
+	Bounced          bool           // indicates wether parts of the cheque bounced
+}
+
+// cashoutAction is the data we store for a cashout
+type cashoutAction struct {
+	TxHash common.Hash
+	Cheque SignedCheque // the cheque that was used to cashout which may be different from the latest cheque
+}
+
+// NewCashoutService creates a new CashoutService
+func NewCashoutService(
+	store storage.StateStorer,
+	simpleSwapBindingFunc SimpleSwapBindingFunc,
+	backend Backend,
+	transactionService TransactionService,
+	chequeStore ChequeStore,
+) (CashoutService, error) {
+	chequebookABI, err := abi.JSON(strings.NewReader(simpleswapfactory.ERC20SimpleSwapABI))
+	if err != nil {
+		return nil, err
+	}
+
+	return &cashoutService{
+		store:                 store,
+		simpleSwapBindingFunc: simpleSwapBindingFunc,
+		backend:               backend,
+		transactionService:    transactionService,
+		chequebookABI:         chequebookABI,
+		chequeStore:           chequeStore,
+	}, nil
+}
+
+// cashoutActionKey computes the store key for the last cashout action for the chequebook
+func cashoutActionKey(chequebook common.Address) string {
+	return fmt.Sprintf("cashout_%x", chequebook)
+}
+
+// CashCheque sends a cashout transaction for the last cheque of the chequebook
+func (s *cashoutService) CashCheque(ctx context.Context, chequebook common.Address, recipient common.Address) (common.Hash, error) {
+	cheque, err := s.chequeStore.LastCheque(chequebook)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	callData, err := s.chequebookABI.Pack("cashChequeBeneficiary", recipient, cheque.CumulativePayout, cheque.Signature)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	request := &TxRequest{
+		To:       chequebook,
+		Data:     callData,
+		GasPrice: nil,
+		GasLimit: 0,
+		Value:    big.NewInt(0),
+	}
+
+	txHash, err := s.transactionService.Send(ctx, request)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	err = s.store.Put(cashoutActionKey(chequebook), &cashoutAction{
+		TxHash: txHash,
+		Cheque: *cheque,
+	})
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return txHash, nil
+}
+
+// CashoutStatus gets the status of the latest cashout transaction for the chequebook
+func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress common.Address) (*CashoutStatus, error) {
+	var action *cashoutAction
+	err := s.store.Get(cashoutActionKey(chequebookAddress), &action)
+	if err != nil {
+		return nil, err
+	}
+
+	_, pending, err := s.backend.TransactionByHash(ctx, action.TxHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if pending {
+		return &CashoutStatus{
+			TxHash:   action.TxHash,
+			Cheque:   action.Cheque,
+			Result:   nil,
+			Reverted: false,
+		}, nil
+	}
+
+	receipt, err := s.backend.TransactionReceipt(ctx, action.TxHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if receipt.Status == types.ReceiptStatusFailed {
+		return &CashoutStatus{
+			TxHash:   action.TxHash,
+			Cheque:   action.Cheque,
+			Result:   nil,
+			Reverted: true,
+		}, nil
+	}
+
+	result, err := s.parseCashChequeBeneficiaryReceipt(chequebookAddress, receipt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CashoutStatus{
+		TxHash:   action.TxHash,
+		Cheque:   action.Cheque,
+		Result:   result,
+		Reverted: false,
+	}, nil
+}
+
+// parseCashChequeBeneficiaryReceipt processes the receipt from a CashChequeBeneficiary transaction
+func (s *cashoutService) parseCashChequeBeneficiaryReceipt(chequebookAddress common.Address, receipt *types.Receipt) (*CashChequeResult, error) {
+	result := &CashChequeResult{
+		Bounced: false,
+	}
+
+	binding, err := s.simpleSwapBindingFunc(chequebookAddress, s.backend)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, log := range receipt.Logs {
+		if log.Address != chequebookAddress {
+			continue
+		}
+		if event, err := binding.ParseChequeCashed(*log); err == nil {
+			result.Beneficiary = event.Beneficiary
+			result.Caller = event.Caller
+			result.CallerPayout = event.CallerPayout
+			result.TotalPayout = event.TotalPayout
+			result.CumulativePayout = event.CumulativePayout
+			result.Recipient = event.Recipient
+		} else if _, err := binding.ParseChequeBounced(*log); err == nil {
+			result.Bounced = true
+		}
+	}
+
+	return result, nil
+}
+
+// Equal compares to CashChequeResults
+func (r *CashChequeResult) Equal(o *CashChequeResult) bool {
+	if r.Beneficiary != o.Beneficiary {
+		return false
+	}
+	if r.Bounced != o.Bounced {
+		return false
+	}
+	if r.Caller != o.Caller {
+		return false
+	}
+	if r.CallerPayout.Cmp(o.CallerPayout) != 0 {
+		return false
+	}
+	if r.CumulativePayout.Cmp(o.CumulativePayout) != 0 {
+		return false
+	}
+	if r.Recipient != o.Recipient {
+		return false
+	}
+	if r.TotalPayout.Cmp(o.TotalPayout) != 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/settlement/swap/chequebook/cashout.go
+++ b/pkg/settlement/swap/chequebook/cashout.go
@@ -2,6 +2,7 @@ package chequebook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -11,6 +12,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
+)
+
+var (
+	// ErrNoCashout is the error if there has not been any cashout action for the chequebook
+	ErrNoCashout = errors.New("no prior cashout")
 )
 
 // CashoutService is the service responsible for managing cashout actions
@@ -124,6 +130,9 @@ func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress co
 	var action *cashoutAction
 	err := s.store.Get(cashoutActionKey(chequebookAddress), &action)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, ErrNoCashout
+		}
 		return nil, err
 	}
 

--- a/pkg/settlement/swap/chequebook/cashout_test.go
+++ b/pkg/settlement/swap/chequebook/cashout_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package chequebook_test
 
 import (

--- a/pkg/settlement/swap/chequebook/cashout_test.go
+++ b/pkg/settlement/swap/chequebook/cashout_test.go
@@ -1,0 +1,443 @@
+package chequebook_test
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+	chequestoremock "github.com/ethersphere/bee/pkg/settlement/swap/chequestore/mock"
+	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
+)
+
+func TestCashout(t *testing.T) {
+	chequebookAddress := common.HexToAddress("abcd")
+	recipientAddress := common.HexToAddress("efff")
+	txHash := common.HexToHash("dddd")
+	log1Topic := common.HexToHash("eeee")
+	totalPayout := big.NewInt(100)
+	cumulativePayout := big.NewInt(500)
+
+	cheque := &chequebook.SignedCheque{
+		Cheque: chequebook.Cheque{
+			Beneficiary:      common.HexToAddress("aaaa"),
+			CumulativePayout: cumulativePayout,
+			Chequebook:       chequebookAddress,
+		},
+		Signature: []byte{},
+	}
+
+	store := storemock.NewStateStore()
+	cashoutService, err := chequebook.NewCashoutService(
+		store,
+		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
+			return &simpleSwapBindingMock{
+				parseChequeCashed: func(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error) {
+					if l.Topics[0] != log1Topic {
+						t.Fatalf("parsing wrong log. wanted %v, got %v", log1Topic, l.Topics[0])
+					}
+					return &simpleswapfactory.ERC20SimpleSwapChequeCashed{
+						Beneficiary:      cheque.Beneficiary,
+						Recipient:        recipientAddress,
+						Caller:           cheque.Beneficiary,
+						TotalPayout:      totalPayout,
+						CumulativePayout: cumulativePayout,
+						CallerPayout:     big.NewInt(0),
+					}, nil
+				},
+			}, nil
+		},
+		&backendMock{
+			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+				if hash != txHash {
+					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
+				}
+				return nil, false, nil
+			},
+			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+				if hash != txHash {
+					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
+				}
+				return &types.Receipt{
+					Status: types.ReceiptStatusSuccessful,
+					Logs: []*types.Log{
+						&types.Log{
+							Address: chequebookAddress,
+							Topics:  []common.Hash{log1Topic},
+						},
+					},
+				}, nil
+			},
+		},
+		&transactionServiceMock{
+			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
+				if request.To != chequebookAddress {
+					t.Fatalf("sending to wrong contract. wanted %x, got %x", chequebookAddress, request.To)
+				}
+				if request.Value.Cmp(big.NewInt(0)) != 0 {
+					t.Fatal("sending ether to chequebook contract")
+				}
+				return txHash, nil
+			},
+		},
+		chequestoremock.NewChequeStore(
+			chequestoremock.WithLastChequeFunc(func(c common.Address) (*chequebook.SignedCheque, error) {
+				if c != chequebookAddress {
+					t.Fatalf("using wrong chequebook. wanted %v, got %v", chequebookAddress, c)
+				}
+				return cheque, nil
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	returnedTxHash, err := cashoutService.CashCheque(context.Background(), chequebookAddress, recipientAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if returnedTxHash != txHash {
+		t.Fatalf("returned wrong transaction hash. wanted %v, got %v", txHash, returnedTxHash)
+	}
+
+	status, err := cashoutService.CashoutStatus(context.Background(), chequebookAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.Reverted {
+		t.Fatal("reported reverted transaction")
+	}
+
+	if status.TxHash != txHash {
+		t.Fatalf("wrong transaction hash. wanted %v, got %v", txHash, status.TxHash)
+	}
+
+	if !status.Cheque.Equal(cheque) {
+		t.Fatalf("wrong cheque in status. wanted %v, got %v", cheque, status.Cheque)
+	}
+
+	if status.Result == nil {
+		t.Fatal("missing result")
+	}
+
+	expectedResult := &chequebook.CashChequeResult{
+		Beneficiary:      cheque.Beneficiary,
+		Recipient:        recipientAddress,
+		Caller:           cheque.Beneficiary,
+		TotalPayout:      totalPayout,
+		CumulativePayout: cumulativePayout,
+		CallerPayout:     big.NewInt(0),
+		Bounced:          false,
+	}
+
+	if !status.Result.Equal(expectedResult) {
+		t.Fatalf("wrong result. wanted %v, got %v", expectedResult, status.Result)
+	}
+}
+
+func TestCashoutBounced(t *testing.T) {
+	chequebookAddress := common.HexToAddress("abcd")
+	recipientAddress := common.HexToAddress("efff")
+	txHash := common.HexToHash("dddd")
+	log1Topic := common.HexToHash("eeee")
+	logBouncedTopic := common.HexToHash("bbbb")
+	totalPayout := big.NewInt(100)
+	cumulativePayout := big.NewInt(500)
+
+	cheque := &chequebook.SignedCheque{
+		Cheque: chequebook.Cheque{
+			Beneficiary:      common.HexToAddress("aaaa"),
+			CumulativePayout: cumulativePayout,
+			Chequebook:       chequebookAddress,
+		},
+		Signature: []byte{},
+	}
+
+	store := storemock.NewStateStore()
+	cashoutService, err := chequebook.NewCashoutService(
+		store,
+		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
+			return &simpleSwapBindingMock{
+				parseChequeCashed: func(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error) {
+					if l.Topics[0] != log1Topic {
+						return nil, errors.New("")
+					}
+					return &simpleswapfactory.ERC20SimpleSwapChequeCashed{
+						Beneficiary:      cheque.Beneficiary,
+						Recipient:        recipientAddress,
+						Caller:           cheque.Beneficiary,
+						TotalPayout:      totalPayout,
+						CumulativePayout: cumulativePayout,
+						CallerPayout:     big.NewInt(0),
+					}, nil
+				},
+				parseChequeBounced: func(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error) {
+					if l.Topics[0] != logBouncedTopic {
+						t.Fatalf("parsing wrong bounced log. wanted %v, got %v", logBouncedTopic, l.Topics[0])
+					}
+					return &simpleswapfactory.ERC20SimpleSwapChequeBounced{}, nil
+				},
+			}, nil
+		},
+		&backendMock{
+			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+				if hash != txHash {
+					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
+				}
+				return nil, false, nil
+			},
+			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+				if hash != txHash {
+					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
+				}
+				return &types.Receipt{
+					Status: types.ReceiptStatusSuccessful,
+					Logs: []*types.Log{
+						&types.Log{
+							Address: chequebookAddress,
+							Topics:  []common.Hash{log1Topic},
+						},
+						&types.Log{
+							Address: chequebookAddress,
+							Topics:  []common.Hash{logBouncedTopic},
+						},
+					},
+				}, nil
+			},
+		},
+		&transactionServiceMock{
+			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
+				if request.To != chequebookAddress {
+					t.Fatalf("sending to wrong contract. wanted %x, got %x", chequebookAddress, request.To)
+				}
+				if request.Value.Cmp(big.NewInt(0)) != 0 {
+					t.Fatal("sending ether to chequebook contract")
+				}
+				return txHash, nil
+			},
+		},
+		chequestoremock.NewChequeStore(
+			chequestoremock.WithLastChequeFunc(func(c common.Address) (*chequebook.SignedCheque, error) {
+				if c != chequebookAddress {
+					t.Fatalf("using wrong chequebook. wanted %v, got %v", chequebookAddress, c)
+				}
+				return cheque, nil
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	returnedTxHash, err := cashoutService.CashCheque(context.Background(), chequebookAddress, recipientAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if returnedTxHash != txHash {
+		t.Fatalf("returned wrong transaction hash. wanted %v, got %v", txHash, returnedTxHash)
+	}
+
+	status, err := cashoutService.CashoutStatus(context.Background(), chequebookAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.Reverted {
+		t.Fatal("reported reverted transaction")
+	}
+
+	if status.TxHash != txHash {
+		t.Fatalf("wrong transaction hash. wanted %v, got %v", txHash, status.TxHash)
+	}
+
+	if !status.Cheque.Equal(cheque) {
+		t.Fatalf("wrong cheque in status. wanted %v, got %v", cheque, status.Cheque)
+	}
+
+	if status.Result == nil {
+		t.Fatal("missing result")
+	}
+
+	expectedResult := &chequebook.CashChequeResult{
+		Beneficiary:      cheque.Beneficiary,
+		Recipient:        recipientAddress,
+		Caller:           cheque.Beneficiary,
+		TotalPayout:      totalPayout,
+		CumulativePayout: cumulativePayout,
+		CallerPayout:     big.NewInt(0),
+		Bounced:          true,
+	}
+
+	if !status.Result.Equal(expectedResult) {
+		t.Fatalf("wrong result. wanted %v, got %v", expectedResult, status.Result)
+	}
+}
+
+func TestCashoutStatusReverted(t *testing.T) {
+	chequebookAddress := common.HexToAddress("abcd")
+	recipientAddress := common.HexToAddress("efff")
+	txHash := common.HexToHash("dddd")
+	cumulativePayout := big.NewInt(500)
+
+	cheque := &chequebook.SignedCheque{
+		Cheque: chequebook.Cheque{
+			Beneficiary:      common.HexToAddress("aaaa"),
+			CumulativePayout: cumulativePayout,
+			Chequebook:       chequebookAddress,
+		},
+		Signature: []byte{},
+	}
+
+	store := storemock.NewStateStore()
+	cashoutService, err := chequebook.NewCashoutService(
+		store,
+		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
+			return &simpleSwapBindingMock{}, nil
+		},
+		&backendMock{
+			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+				if hash != txHash {
+					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
+				}
+				return nil, false, nil
+			},
+			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+				if hash != txHash {
+					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
+				}
+				return &types.Receipt{
+					Status: types.ReceiptStatusFailed,
+				}, nil
+			},
+		},
+		&transactionServiceMock{
+			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
+				return txHash, nil
+			},
+		},
+		chequestoremock.NewChequeStore(
+			chequestoremock.WithLastChequeFunc(func(c common.Address) (*chequebook.SignedCheque, error) {
+				if c != chequebookAddress {
+					t.Fatalf("using wrong chequebook. wanted %v, got %v", chequebookAddress, c)
+				}
+				return cheque, nil
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	returnedTxHash, err := cashoutService.CashCheque(context.Background(), chequebookAddress, recipientAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if returnedTxHash != txHash {
+		t.Fatalf("returned wrong transaction hash. wanted %v, got %v", txHash, returnedTxHash)
+	}
+
+	status, err := cashoutService.CashoutStatus(context.Background(), chequebookAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !status.Reverted {
+		t.Fatal("did not report failed transaction as reverted")
+	}
+
+	if status.TxHash != txHash {
+		t.Fatalf("wrong transaction hash. wanted %v, got %v", txHash, status.TxHash)
+	}
+
+	if !status.Cheque.Equal(cheque) {
+		t.Fatalf("wrong cheque in status. wanted %v, got %v", cheque, status.Cheque)
+	}
+}
+
+func TestCashoutStatusPending(t *testing.T) {
+	chequebookAddress := common.HexToAddress("abcd")
+	recipientAddress := common.HexToAddress("efff")
+	txHash := common.HexToHash("dddd")
+	cumulativePayout := big.NewInt(500)
+
+	cheque := &chequebook.SignedCheque{
+		Cheque: chequebook.Cheque{
+			Beneficiary:      common.HexToAddress("aaaa"),
+			CumulativePayout: cumulativePayout,
+			Chequebook:       chequebookAddress,
+		},
+		Signature: []byte{},
+	}
+
+	store := storemock.NewStateStore()
+	cashoutService, err := chequebook.NewCashoutService(
+		store,
+		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
+			return &simpleSwapBindingMock{}, nil
+		},
+		&backendMock{
+			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+				if hash != txHash {
+					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
+				}
+				return nil, true, nil
+			},
+		},
+		&transactionServiceMock{
+			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
+				return txHash, nil
+			},
+		},
+		chequestoremock.NewChequeStore(
+			chequestoremock.WithLastChequeFunc(func(c common.Address) (*chequebook.SignedCheque, error) {
+				if c != chequebookAddress {
+					t.Fatalf("using wrong chequebook. wanted %v, got %v", chequebookAddress, c)
+				}
+				return cheque, nil
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	returnedTxHash, err := cashoutService.CashCheque(context.Background(), chequebookAddress, recipientAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if returnedTxHash != txHash {
+		t.Fatalf("returned wrong transaction hash. wanted %v, got %v", txHash, returnedTxHash)
+	}
+
+	status, err := cashoutService.CashoutStatus(context.Background(), chequebookAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.Reverted {
+		t.Fatal("did report pending transaction as reverted")
+	}
+
+	if status.TxHash != txHash {
+		t.Fatalf("wrong transaction hash. wanted %v, got %v", txHash, status.TxHash)
+	}
+
+	if !status.Cheque.Equal(cheque) {
+		t.Fatalf("wrong cheque in status. wanted %v, got %v", cheque, status.Cheque)
+	}
+
+	if status.Result != nil {
+		t.Fatalf("got result for pending cashout: %v", status.Result)
+	}
+}

--- a/pkg/settlement/swap/chequebook/cashout_test.go
+++ b/pkg/settlement/swap/chequebook/cashout_test.go
@@ -66,7 +66,7 @@ func TestCashout(t *testing.T) {
 				return &types.Receipt{
 					Status: types.ReceiptStatusSuccessful,
 					Logs: []*types.Log{
-						&types.Log{
+						{
 							Address: chequebookAddress,
 							Topics:  []common.Hash{log1Topic},
 						},
@@ -201,11 +201,11 @@ func TestCashoutBounced(t *testing.T) {
 				return &types.Receipt{
 					Status: types.ReceiptStatusSuccessful,
 					Logs: []*types.Log{
-						&types.Log{
+						{
 							Address: chequebookAddress,
 							Topics:  []common.Hash{log1Topic},
 						},
-						&types.Log{
+						{
 							Address: chequebookAddress,
 							Topics:  []common.Hash{logBouncedTopic},
 						},

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -25,6 +25,7 @@ type backendMock struct {
 	estimateGas        func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)
 	transactionReceipt func(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	pendingNonceAt     func(ctx context.Context, account common.Address) (uint64, error)
+	transactionByHash  func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 func (m *backendMock) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
@@ -67,6 +68,10 @@ func (m *backendMock) TransactionReceipt(ctx context.Context, txHash common.Hash
 	return m.transactionReceipt(ctx, txHash)
 }
 
+func (m *backendMock) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	return m.transactionByHash(ctx, hash)
+}
+
 type transactionServiceMock struct {
 	send           func(ctx context.Context, request *chequebook.TxRequest) (txHash common.Hash, err error)
 	waitForReceipt func(ctx context.Context, txHash common.Hash) (receipt *types.Receipt, err error)
@@ -98,10 +103,12 @@ func (m *simpleSwapFactoryBindingMock) ERC20Address(o *bind.CallOpts) (common.Ad
 }
 
 type simpleSwapBindingMock struct {
-	balance      func(*bind.CallOpts) (*big.Int, error)
-	issuer       func(*bind.CallOpts) (common.Address, error)
-	totalPaidOut func(o *bind.CallOpts) (*big.Int, error)
-	paidOut      func(*bind.CallOpts, common.Address) (*big.Int, error)
+	balance            func(*bind.CallOpts) (*big.Int, error)
+	issuer             func(*bind.CallOpts) (common.Address, error)
+	totalPaidOut       func(o *bind.CallOpts) (*big.Int, error)
+	paidOut            func(*bind.CallOpts, common.Address) (*big.Int, error)
+	parseChequeCashed  func(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error)
+	parseChequeBounced func(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error)
 }
 
 func (m *simpleSwapBindingMock) Balance(o *bind.CallOpts) (*big.Int, error) {
@@ -114,6 +121,14 @@ func (m *simpleSwapBindingMock) Issuer(o *bind.CallOpts) (common.Address, error)
 
 func (m *simpleSwapBindingMock) TotalPaidOut(o *bind.CallOpts) (*big.Int, error) {
 	return m.totalPaidOut(o)
+}
+
+func (m *simpleSwapBindingMock) ParseChequeCashed(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error) {
+	return m.parseChequeCashed(l)
+}
+
+func (m *simpleSwapBindingMock) ParseChequeBounced(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error) {
+	return m.parseChequeBounced(l)
 }
 
 func (m *simpleSwapBindingMock) PaidOut(o *bind.CallOpts, c common.Address) (*big.Int, error) {

--- a/pkg/settlement/swap/chequebook/transaction.go
+++ b/pkg/settlement/swap/chequebook/transaction.go
@@ -26,6 +26,7 @@ var (
 type Backend interface {
 	bind.ContractBackend
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 }
 
 // TxRequest describes a request for a transaction that can be executed.

--- a/pkg/settlement/swap/mock/swap.go
+++ b/pkg/settlement/swap/mock/swap.go
@@ -111,6 +111,18 @@ func WithLastReceivedChequesFunc(f func() (map[string]*chequebook.SignedCheque, 
 	})
 }
 
+func WithCashChequeFunc(f func(ctx context.Context, peer swarm.Address) (common.Hash, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.cashChequeFunc = f
+	})
+}
+
+func WithCashoutStatusFunc(f func(ctx context.Context, peer swarm.Address) (*chequebook.CashoutStatus, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.cashoutStatusFunc = f
+	})
+}
+
 // New creates the mock swap implementation
 func New(opts ...Option) settlement.Interface {
 	mock := new(Service)

--- a/pkg/settlement/swap/mock/swap.go
+++ b/pkg/settlement/swap/mock/swap.go
@@ -31,6 +31,9 @@ type Service struct {
 
 	lastReceivedChequeFunc  func(swarm.Address) (*chequebook.SignedCheque, error)
 	lastReceivedChequesFunc func() (map[string]*chequebook.SignedCheque, error)
+
+	cashChequeFunc    func(ctx context.Context, peer swarm.Address) (common.Hash, error)
+	cashoutStatusFunc func(ctx context.Context, peer swarm.Address) (*chequebook.CashoutStatus, error)
 }
 
 // WithsettlementFunc sets the mock settlement function
@@ -214,6 +217,20 @@ func (s *Service) LastReceivedCheque(address swarm.Address) (*chequebook.SignedC
 func (s *Service) LastReceivedCheques() (map[string]*chequebook.SignedCheque, error) {
 	if s.lastReceivedChequesFunc != nil {
 		return s.lastReceivedChequesFunc()
+	}
+	return nil, nil
+}
+
+func (s *Service) CashCheque(ctx context.Context, peer swarm.Address) (common.Hash, error) {
+	if s.cashChequeFunc != nil {
+		return s.cashChequeFunc(ctx, peer)
+	}
+	return common.Hash{}, nil
+}
+
+func (s *Service) CashoutStatus(ctx context.Context, peer swarm.Address) (*chequebook.CashoutStatus, error) {
+	if s.cashoutStatusFunc != nil {
+		return s.cashoutStatusFunc(ctx, peer)
 	}
 	return nil, nil
 }

--- a/pkg/settlement/swap/swap.go
+++ b/pkg/settlement/swap/swap.go
@@ -37,6 +37,10 @@ type ApiInterface interface {
 	LastReceivedCheque(peer swarm.Address) (*chequebook.SignedCheque, error)
 	// LastReceivedCheques returns the list of last received cheques for all peers
 	LastReceivedCheques() (map[string]*chequebook.SignedCheque, error)
+	// CashCheque sends a cashing transaction for the last cheque of the peer
+	CashCheque(ctx context.Context, peer swarm.Address) (common.Hash, error)
+	// CashoutStatus gets the status of the latest cashout transaction for the peers chequebook
+	CashoutStatus(ctx context.Context, peer swarm.Address) (*chequebook.CashoutStatus, error)
 }
 
 // Service is the implementation of the swap settlement layer.
@@ -48,12 +52,13 @@ type Service struct {
 	metrics     metrics
 	chequebook  chequebook.Service
 	chequeStore chequebook.ChequeStore
+	cashout     chequebook.CashoutService
 	addressbook Addressbook
 	networkID   uint64
 }
 
 // New creates a new swap Service.
-func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64) *Service {
+func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64, cashout chequebook.CashoutService) *Service {
 	return &Service{
 		proto:       proto,
 		logger:      logger,
@@ -63,6 +68,7 @@ func New(proto swapprotocol.Interface, logger logging.Logger, store storage.Stat
 		chequeStore: chequeStore,
 		addressbook: addressbook,
 		networkID:   networkID,
+		cashout:     cashout,
 	}
 }
 
@@ -292,4 +298,28 @@ func (s *Service) LastReceivedCheques() (map[string]*chequebook.SignedCheque, er
 	}
 
 	return resultmap, nil
+}
+
+// CashCheque sends a cashing transaction for the last cheque of the peer
+func (s *Service) CashCheque(ctx context.Context, peer swarm.Address) (common.Hash, error) {
+	chequebookAddress, known, err := s.addressbook.Chequebook(peer)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if !known {
+		return common.Hash{}, chequebook.ErrNoCheque
+	}
+	return s.cashout.CashCheque(ctx, chequebookAddress, s.chequebook.Address())
+}
+
+// CashoutStatus gets the status of the latest cashout transaction for the peers chequebook
+func (s *Service) CashoutStatus(ctx context.Context, peer swarm.Address) (*chequebook.CashoutStatus, error) {
+	chequebookAddress, known, err := s.addressbook.Chequebook(peer)
+	if err != nil {
+		return nil, err
+	}
+	if !known {
+		return nil, chequebook.ErrNoCheque
+	}
+	return s.cashout.CashoutStatus(ctx, chequebookAddress)
 }

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -74,6 +74,16 @@ func (m *addressbookMock) PutChequebook(peer swarm.Address, chequebook common.Ad
 	return m.putChequebook(peer, chequebook)
 }
 
+type cashoutMock struct {
+}
+
+func (*cashoutMock) CashCheque(ctx context.Context, chequebook common.Address) (common.Hash, error) {
+	return common.Hash{}, nil
+}
+func (*cashoutMock) CashoutStatus(ctx context.Context, chequebookAddress common.Address) (*chequebook.CashoutStatus, error) {
+	return nil, nil
+}
+
 func TestReceiveCheque(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 	store := mockstore.NewStateStore()
@@ -126,6 +136,7 @@ func TestReceiveCheque(t *testing.T) {
 		chequeStore,
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	observer := &testObserver{}
@@ -187,6 +198,7 @@ func TestReceiveChequeReject(t *testing.T) {
 		chequeStore,
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	observer := &testObserver{}
@@ -237,6 +249,7 @@ func TestReceiveChequeWrongChequebook(t *testing.T) {
 		chequeStore,
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	observer := &testObserver{}
@@ -308,6 +321,7 @@ func TestPay(t *testing.T) {
 		mockchequestore.NewChequeStore(),
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swap.Pay(context.Background(), peer, amount)
@@ -357,6 +371,7 @@ func TestPayIssueError(t *testing.T) {
 		mockchequestore.NewChequeStore(),
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swap.Pay(context.Background(), peer, amount)
@@ -389,6 +404,7 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 		mockchequestore.NewChequeStore(),
 		addressbook,
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swapService.Pay(context.Background(), peer, amount)
@@ -422,6 +438,7 @@ func TestHandshake(t *testing.T) {
 			},
 		},
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)
@@ -459,6 +476,7 @@ func TestHandshakeNewPeer(t *testing.T) {
 			},
 		},
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)
@@ -487,6 +505,7 @@ func TestHandshakeWrongBeneficiary(t *testing.T) {
 		mockchequestore.NewChequeStore(),
 		&addressbookMock{},
 		networkID,
+		&cashoutMock{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)


### PR DESCRIPTION
adds endpoints:
* `POST /chequebook/cashout/<peer>` to initiate a cashout for the latest cheque for this peer.
* `GET /chequebook/cashout/<peer>` to view the status or result for the latest cashout for this peer.

Info about the latest cashout per peer is stored in statestore. Builds on top of `lastcheque-endpoint` as it uses some of the interfaces / mocks from there.

This is a very minimal implementation. It does not actively monitor the transaction for success, only when queried by the user.