### PR TITLE
allow first retrieval request to be upstream

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -133,7 +133,7 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 
 	peer, err = s.closestPeer(addr, skipPeers, allowUpstream)
 	if err != nil {
-		return nil, peer, fmt.Errorf("get closest for address %s: %w", addr.String(), err)
+		return nil, peer, fmt.Errorf("get closest for address %s, allow upstream %v: %w", addr.String(), allowUpstream, err)
 	}
 
 	// compute the price we pay for this chunk and reserve it for the rest of this function


### PR DESCRIPTION
This PR changes slightly the logic of retrieval. It allows the upstream chunk request by the requester node. All forwarded requests are still only downstream. This change improves the situation where the requester node is the closest to he chunk of all its peers. By allowing the first request to be upstream, retrieval is more efficient and forwarding loops are still not possible.