### PR TITLE
trigger settlement before expected debt hits payment threshold

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -40,6 +40,7 @@ const (
 	optionNameGlobalPinningEnabled = "global-pinning-enable"
 	optionNamePaymentThreshold     = "payment-threshold"
 	optionNamePaymentTolerance     = "payment-tolerance"
+	optionNamePaymentEarly         = "payment-early"
 	optionNameResolverEndpoints    = "resolver-options"
 	optionNameGatewayMode          = "gateway-mode"
 	optionNameClefSignerEnable     = "clef-signer-enable"
@@ -190,6 +191,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameGlobalPinningEnabled, false, "enable global pinning")
 	cmd.Flags().Uint64(optionNamePaymentThreshold, 100000, "threshold in BZZ where you expect to get paid from your peers")
 	cmd.Flags().Uint64(optionNamePaymentTolerance, 10000, "excess debt above payment threshold in BZZ where you disconnect from your peer")
+	cmd.Flags().Uint64(optionNamePaymentEarly, 10000, "amount in BZZ below the peers payment threshold when we initiate settlement")
 	cmd.Flags().StringSlice(optionNameResolverEndpoints, []string{}, "resolver connection string, see help for format")
 	cmd.Flags().Bool(optionNameGatewayMode, false, "disable a set of sensitive features in the api")
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -536,6 +536,64 @@ func TestAccountingCallSettlement(t *testing.T) {
 	}
 }
 
+// TestAccountingCallSettlementEarly tests that settlement is called correctly if the payment threshold minus early payment is hit
+func TestAccountingCallSettlementEarly(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+
+	store := mock.NewStateStore()
+	defer store.Close()
+
+	settlement := &settlementMock{}
+	earlyPayment := uint64(1000)
+
+	acc, err := accounting.NewAccounting(accounting.Options{
+		PaymentThreshold: testPaymentThreshold,
+		PaymentTolerance: testPaymentTolerance,
+		EarlyPayment:     earlyPayment,
+		Logger:           logger,
+		Store:            store,
+		Settlement:       settlement,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peer1Addr, err := swarm.ParseHexAddress("00112233")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payment := testPaymentThreshold - earlyPayment
+	err = acc.Reserve(peer1Addr, payment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Credit until payment treshold
+	err = acc.Credit(peer1Addr, payment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acc.Release(peer1Addr, payment)
+
+	if !settlement.paidPeer.Equal(peer1Addr) {
+		t.Fatalf("paid to wrong peer. got %v wanted %v", settlement.paidPeer, peer1Addr)
+	}
+
+	if settlement.paidAmount != payment {
+		t.Fatalf("paid wrong amount. got %d wanted %d", settlement.paidAmount, payment)
+	}
+
+	balance, err := acc.Balance(peer1Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if balance != 0 {
+		t.Fatalf("expected balance to be reset. got %d", balance)
+	}
+}
+
 // TestAccountingNotifyPayment tests that payments adjust the balance and payment which put us into debt are rejected
 func TestAccountingNotifyPayment(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -96,6 +96,7 @@ type Options struct {
 	GlobalPinningEnabled   bool
 	PaymentThreshold       uint64
 	PaymentTolerance       uint64
+	PaymentEarly           uint64
 	ResolverConnectionCfgs []multiresolver.ConnectionConfig
 	GatewayMode            bool
 	SwapEndpoint           string
@@ -296,6 +297,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 		Store:            stateStore,
 		PaymentThreshold: o.PaymentThreshold,
 		PaymentTolerance: o.PaymentTolerance,
+		EarlyPayment:     o.PaymentEarly,
 		Settlement:       settlement,
 	})
 	if err != nil {


### PR DESCRIPTION
This changes accounting to trigger payment a bit earlier than the peers payment threshold. This is to avoid needlessly blocking reserve request if already near the payment threshold when several concurrent request occur.