### PR TITLE
fix goerli factory address

### DIFF
--- a/pkg/settlement/swap/chequebook/factory.go
+++ b/pkg/settlement/swap/chequebook/factory.go
@@ -161,7 +161,7 @@ func (c *factory) ERC20Address(ctx context.Context) (common.Address, error) {
 func DiscoverFactoryAddress(chainID int64) (common.Address, bool) {
 	if chainID == 5 {
 		// goerli
-		return common.HexToAddress("0x334394E8c891E77b1449084aaDD659920BB25247"), true
+		return common.HexToAddress("0xA6B88705036F2a56807af157c116b7dfCDabf968"), true
 	}
 	return common.Address{}, false
 }

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -6,8 +6,10 @@ package chequebook
 
 import (
 	"context"
+	"errors"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -45,6 +47,25 @@ func Init(
 		if err != storage.ErrNotFound {
 			return nil, err
 		}
+
+		if swapInitialDeposit != 0 {
+			erc20Token, err := erc20BindingFunc(erc20Address, swapBackend)
+			if err != nil {
+				return nil, err
+			}
+
+			balance, err := erc20Token.BalanceOf(&bind.CallOpts{
+				Context: ctx,
+			}, overlayEthAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			if balance.Cmp(big.NewInt(int64(swapInitialDeposit))) < 0 {
+				return nil, errors.New("insufficient token for initial deposit")
+			}
+		}
+
 		// if we don't yet have a chequebook, deploy a new one
 		logger.Info("deploying new chequebook")
 


### PR DESCRIPTION
changes goerli factory address to the correct one. the other address is a valid factory but it does not use the token we want to use. (it was the test factory used before deploying the final gbbz token)

also checks we can afford initial deposit before deploying.