### PR TITLE
expose swarm public key in logs and debugapi

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -28,6 +28,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/P2PUnderlay'
+        public_key:
+          $ref: '#/components/schemas/PublicKey'
 
     Balance:
       type: object
@@ -189,6 +191,11 @@ components:
       type: string
       pattern: '^[A-Fa-f0-9]{64}$'
       example: "36b7efd913ca4cf880b8eeac5093fa27b0825906c600685b6abdd6566e6cfe8f"
+
+    PublicKey:
+      type: string
+      pattern: '^[A-Fa-f0-9]{66}$'
+      example: "02ab7473879005929d10ce7d4f626412dad9fe56b0a6622038931d26bd79abf0a4"
 
     SwarmEncryptedReference:
       type: string

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -52,6 +52,11 @@ func EncodeSecp256k1PrivateKey(k *ecdsa.PrivateKey) []byte {
 	return (*btcec.PrivateKey)(k).Serialize()
 }
 
+// EncodeSecp256k1PublicKey encodes raw ECDSA public key in a 33-byte compressed format.
+func EncodeSecp256k1PublicKey(k *ecdsa.PublicKey) []byte {
+	return (*btcec.PublicKey)(k).SerializeCompressed()
+}
+
 // DecodeSecp256k1PrivateKey decodes raw ECDSA private key.
 func DecodeSecp256k1PrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 	if l := len(data); l != btcec.PrivKeyBytesLen {

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -5,6 +5,7 @@
 package debugapi
 
 import (
+	"crypto/ecdsa"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -28,6 +29,7 @@ type Service interface {
 
 type server struct {
 	Overlay           swarm.Address
+	PublicKey         ecdsa.PublicKey
 	P2P               p2p.DebugService
 	Pingpong          pingpong.Interface
 	TopologyDriver    topology.Driver
@@ -43,9 +45,10 @@ type server struct {
 	metricsRegistry *prometheus.Registry
 }
 
-func New(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, chequebook chequebook.Service) Service {
+func New(overlay swarm.Address, publicKey ecdsa.PublicKey, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, chequebook chequebook.Service) Service {
 	s := &server{
 		Overlay:           overlay,
+		PublicKey:         publicKey,
 		P2P:               p2p,
 		Pingpong:          pingpong,
 		TopologyDriver:    topologyDriver,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -5,6 +5,7 @@
 package debugapi_test
 
 import (
+	"crypto/ecdsa"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +30,7 @@ import (
 
 type testServerOptions struct {
 	Overlay        swarm.Address
+	PublicKey      ecdsa.PublicKey
 	P2P            *p2pmock.Service
 	Pingpong       pingpong.Interface
 	Storer         storage.Storer
@@ -50,7 +52,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	acc := accountingmock.NewAccounting(o.AccountingOpts...)
 	settlement := settlementmock.NewSettlement(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
-	s := debugapi.New(o.Overlay, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, chequebook)
+	s := debugapi.New(o.Overlay, o.PublicKey, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, chequebook)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -5,16 +5,19 @@
 package debugapi
 
 import (
+	"encoding/hex"
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/multiformats/go-multiaddr"
 )
 
 type addressesResponse struct {
-	Overlay  swarm.Address         `json:"overlay"`
-	Underlay []multiaddr.Multiaddr `json:"underlay"`
+	Overlay   swarm.Address         `json:"overlay"`
+	Underlay  []multiaddr.Multiaddr `json:"underlay"`
+	PublicKey string                `json:"public_key"`
 }
 
 func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +28,8 @@ func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonhttp.OK(w, addressesResponse{
-		Overlay:  s.Overlay,
-		Underlay: underlay,
+		Overlay:   s.Overlay,
+		Underlay:  underlay,
+		PublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PublicKey)),
 	})
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -6,6 +6,7 @@ package node
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"io"
@@ -108,7 +109,7 @@ type Options struct {
 	SwapEnable             bool
 }
 
-func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, signer crypto.Signer, networkID uint64, logger logging.Logger, o Options) (*Bee, error) {
+func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, keystore keystore.Service, signer crypto.Signer, networkID uint64, logger logging.Logger, o Options) (*Bee, error) {
 	tracer, tracerCloser, err := tracing.NewTracer(&tracing.Options{
 		Enabled:     o.TracingEnabled,
 		Endpoint:    o.TracingEndpoint,
@@ -437,7 +438,7 @@ func NewBee(addr string, swarmAddress swarm.Address, keystore keystore.Service, 
 
 	if o.DebugAPIAddr != "" {
 		// Debug API server
-		debugAPIService := debugapi.New(swarmAddress, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc, settlement, o.SwapEnable, chequebookService)
+		debugAPIService := debugapi.New(swarmAddress, publicKey, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc, settlement, o.SwapEnable, chequebookService)
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)


### PR DESCRIPTION
This PR add a log message on start with a public key and also extends debugapi addresses endpoint with the same information. Required information for encrypted PSS.