### PR TITLE
Update openapi definitions for debugapi /settlements/ and /chequebook/ endpoints

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -89,33 +89,19 @@ components:
               connectedPeers:
                 type: object
 
-    Cheque:
+    ChequebookBalance:
       type: object
       properties:
-        beneficiary:
-          $ref: '#/components/schemas/EthereumAddress'
-        chequebook:
-          $ref: '#/components/schemas/EthereumAddress'
-        payout:
+        totalBalance:
+          type: integer
+        availableBalance:
           type: integer
 
-    ChequeAllPeersResponse:
+    ChequebookAddress:
       type: object
       properties:
-        lastcheques:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChequePeerResponse'
-
-    ChequePeerResponse:
-      type: object
-      properties:
-        peer:
-          $ref: '#/components/schemas/SwarmAddress'
-        lastreceived:
-          $ref: '#/components/schemas/Cheque'
-        lastsent:
-          $ref: '#/components/schemas/Cheque'
+        address:
+          type: string
 
     DateTime:
       type: string

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -220,6 +220,28 @@ components:
         status:
           type: string
 
+    Settlement:
+      type: object
+      properties:
+        peer:
+          $ref: "#/components/schemas/SwarmAddress"
+        received:
+          type: integer
+        sent:
+          type: integer
+
+    Settlements:
+      type: object
+      properties:
+        totalreceived:
+          type: integer
+        totalsent:
+          type: integer
+        settlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/Settlement'
+
     SwarmAddress:
       type: string
       pattern: '^[A-Fa-f0-9]{64}$'

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -101,7 +101,7 @@ components:
       type: object
       properties:
         address:
-          type: string
+          $ref: '#/components/schemas/EthereumAddress'
 
     DateTime:
       type: string

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -89,6 +89,34 @@ components:
               connectedPeers:
                 type: object
 
+    Cheque:
+      type: object
+      properties:
+        beneficiary:
+          $ref: '#/components/schemas/EthereumAddress'
+        chequebook:
+          $ref: '#/components/schemas/EthereumAddress'
+        payout:
+          type: integer
+
+    ChequeAllPeersResponse:
+      type: object
+      properties:
+        lastcheques:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChequePeerResponse'
+
+    ChequePeerResponse:
+      type: object
+      properties:
+        peer:
+          $ref: '#/components/schemas/SwarmAddress'
+        lastreceived:
+          $ref: '#/components/schemas/Cheque'
+        lastsent:
+          $ref: '#/components/schemas/Cheque'
+
     ChequebookBalance:
       type: object
       properties:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -108,7 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookAddress'
+                $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookBalance'
         '500':
           $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -84,6 +84,36 @@ paths:
         default:
           description: Default response
 
+  '/chequebook/address':
+    get:
+      summary: Get the address of the chequebook contract used
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Ethereum address of chequebook contract
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookAddress'
+
+  '/chequebook/balance':
+    get:
+      summary: Get the balance of the chequebook
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Balance of the chequebook
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookAddress'
+        '500':
+          $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
   '/chunks/{address}':
     get:
       summary: Check if chunk at address exists locally

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -290,6 +290,42 @@ paths:
         default:
           description: Default response
 
+  '/settlements/':
+    get:
+      summary: Get settlements with all known peers and total amount sent/received
+      tags:
+        - Settlements
+      responses:
+        '200':
+          description: 'Settlements with all known peers and total amount sent/received'
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Settlements'
+        '500':
+          $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/settlements/{peer}'
+    get:
+      summary: Get amount of sent/received from settlements with a peer
+      tags:
+        - Settlements
+      responses:
+      '200':
+        description: Amount of sent/received from settlements with a peer
+        content:
+          application/json:
+            schema:
+              $ref: 'SwarmCommon.yaml#/components/schemas/Settlement'
+          '404':
+            $ref: 'SwarmCommon.yaml#/components/responses/404'
+          '500':
+            $ref: 'SwarmCommon.yaml#/components/responses/500'
+      default:
+        description: Default response
+
   '/topology':
     get:
       description: Get topology of known network

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -2,9 +2,7 @@ openapi: 3.0.0
 info:
   version: 0.1.0
   title: Bee Debug API
-  description: >-
-    A list of the currently provided debug interfaces to interact with the bee
-    node
+  description: 'A list of the currently provided debug interfaces to interact with the bee node'
 
 security:
   - {}
@@ -14,6 +12,7 @@ externalDocs:
   url: 'https://docs.swarm.eth'
 
 servers:
+
   - url: 'http://{apiRoot}:{port}'
     variables:
       apiRoot:
@@ -290,14 +289,40 @@ paths:
         default:
           description: Default response
 
-  '/settlements/':
+  '/settlements/{address}':
     get:
-      summary: Get settlements with all known peers and total amount sent/received
+      summary: Get amount of sent and received from settlements with a peer
+      tags:
+        - Settlements
+      parameters:
+        - in: path
+          name: address
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      responses:
+        '200':
+          description: Amount of sent or received from settlements with a peer
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Settlement'
+        '404':
+          $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+          $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/settlements':
+    get:
+      summary: Get settlements with all known peers and total amount sent or received
       tags:
         - Settlements
       responses:
         '200':
-          description: 'Settlements with all known peers and total amount sent/received'
+          description: Settlements with all known peers and total amount sent or received
           content:
             application/json:
               schema:
@@ -306,25 +331,6 @@ paths:
           $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
           description: Default response
-
-  '/settlements/{peer}'
-    get:
-      summary: Get amount of sent/received from settlements with a peer
-      tags:
-        - Settlements
-      responses:
-      '200':
-        description: Amount of sent/received from settlements with a peer
-        content:
-          application/json:
-            schema:
-              $ref: 'SwarmCommon.yaml#/components/schemas/Settlement'
-          '404':
-            $ref: 'SwarmCommon.yaml#/components/responses/404'
-          '500':
-            $ref: 'SwarmCommon.yaml#/components/responses/500'
-      default:
-        description: Default response
 
   '/topology':
     get:


### PR DESCRIPTION
Update the relevant schemas and openapi definitions for debugapi `/settlements/` and `/chequebook/` endpoints.