### PR TITLE
account for totalPaidOut in liquidity check

### DIFF
--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -18,6 +18,7 @@ type SimpleSwapBinding interface {
 	Balance(*bind.CallOpts) (*big.Int, error)
 	Issuer(*bind.CallOpts) (common.Address, error)
 	TotalPaidOut(*bind.CallOpts) (*big.Int, error)
+	PaidOut(*bind.CallOpts, common.Address) (*big.Int, error)
 }
 
 type SimpleSwapBindingFunc = func(common.Address, bind.ContractBackend) (SimpleSwapBinding, error)

--- a/pkg/settlement/swap/chequebook/chequestore.go
+++ b/pkg/settlement/swap/chequebook/chequestore.go
@@ -167,7 +167,14 @@ func (s *chequeStore) ReceiveCheque(ctx context.Context, cheque *SignedCheque) (
 		return nil, err
 	}
 
-	if balance.Cmp(cheque.CumulativePayout) < 0 {
+	alreadyPaidOut, err := binding.PaidOut(&bind.CallOpts{
+		Context: ctx,
+	}, s.beneficiary)
+	if err != nil {
+		return nil, err
+	}
+
+	if balance.Cmp(big.NewInt(0).Sub(cheque.CumulativePayout, alreadyPaidOut)) < 0 {
 		return nil, ErrBouncingCheque
 	}
 

--- a/pkg/settlement/swap/chequebook/chequestore_test.go
+++ b/pkg/settlement/swap/chequebook/chequestore_test.go
@@ -63,6 +63,12 @@ func TestReceiveCheque(t *testing.T) {
 				balance: func(*bind.CallOpts) (*big.Int, error) {
 					return cumulativePayout2, nil
 				},
+				paidOut: func(o *bind.CallOpts, b common.Address) (*big.Int, error) {
+					if b != beneficiary {
+						t.Fatalf("checking for wrong beneficiary. wanted %x, got %x", beneficiary, b)
+					}
+					return big.NewInt(0), nil
+				},
 			}, nil
 		},
 		func(c *chequebook.SignedCheque, cid int64) (common.Address, error) {
@@ -186,6 +192,9 @@ func TestReceiveChequeInvalidAmount(t *testing.T) {
 				balance: func(*bind.CallOpts) (*big.Int, error) {
 					return cumulativePayout, nil
 				},
+				paidOut: func(o *bind.CallOpts, b common.Address) (*big.Int, error) {
+					return big.NewInt(0), nil
+				},
 			}, nil
 		},
 		func(c *chequebook.SignedCheque, cid int64) (common.Address, error) {
@@ -246,6 +255,9 @@ func TestReceiveChequeInvalidChequebook(t *testing.T) {
 				},
 				balance: func(*bind.CallOpts) (*big.Int, error) {
 					return cumulativePayout, nil
+				},
+				paidOut: func(o *bind.CallOpts, b common.Address) (*big.Int, error) {
+					return big.NewInt(0), nil
 				},
 			}, nil
 		},
@@ -339,6 +351,9 @@ func TestReceiveChequeInsufficientBalance(t *testing.T) {
 				balance: func(*bind.CallOpts) (*big.Int, error) {
 					return big.NewInt(0).Sub(cumulativePayout, big.NewInt(1)), nil
 				},
+				paidOut: func(o *bind.CallOpts, b common.Address) (*big.Int, error) {
+					return big.NewInt(0), nil
+				},
 			}, nil
 		},
 		func(c *chequebook.SignedCheque, cid int64) (common.Address, error) {
@@ -355,5 +370,54 @@ func TestReceiveChequeInsufficientBalance(t *testing.T) {
 	})
 	if !errors.Is(err, chequebook.ErrBouncingCheque) {
 		t.Fatalf("wrong error. wanted %v, got %v", chequebook.ErrBouncingCheque, err)
+	}
+}
+
+func TestReceiveChequeSufficientBalancePaidOut(t *testing.T) {
+	store := storemock.NewStateStore()
+	beneficiary := common.HexToAddress("0xffff")
+	issuer := common.HexToAddress("0xbeee")
+	cumulativePayout := big.NewInt(10)
+	chequebookAddress := common.HexToAddress("0xeeee")
+	sig := make([]byte, 65)
+	chainID := int64(1)
+
+	chequestore := chequebook.NewChequeStore(
+		store,
+		&backendMock{},
+		&factoryMock{
+			verifyChequebook: func(ctx context.Context, address common.Address) error {
+				return nil
+			},
+		},
+		chainID,
+		beneficiary,
+		func(address common.Address, b bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
+			return &simpleSwapBindingMock{
+				issuer: func(*bind.CallOpts) (common.Address, error) {
+					return issuer, nil
+				},
+				balance: func(*bind.CallOpts) (*big.Int, error) {
+					return big.NewInt(0).Sub(cumulativePayout, big.NewInt(100)), nil
+				},
+				paidOut: func(o *bind.CallOpts, b common.Address) (*big.Int, error) {
+					return big.NewInt(100), nil
+				},
+			}, nil
+		},
+		func(c *chequebook.SignedCheque, cid int64) (common.Address, error) {
+			return issuer, nil
+		})
+
+	_, err := chequestore.ReceiveCheque(context.Background(), &chequebook.SignedCheque{
+		Cheque: chequebook.Cheque{
+			Beneficiary:      beneficiary,
+			CumulativePayout: cumulativePayout,
+			Chequebook:       chequebookAddress,
+		},
+		Signature: sig,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -101,6 +101,7 @@ type simpleSwapBindingMock struct {
 	balance      func(*bind.CallOpts) (*big.Int, error)
 	issuer       func(*bind.CallOpts) (common.Address, error)
 	totalPaidOut func(o *bind.CallOpts) (*big.Int, error)
+	paidOut      func(*bind.CallOpts, common.Address) (*big.Int, error)
 }
 
 func (m *simpleSwapBindingMock) Balance(o *bind.CallOpts) (*big.Int, error) {
@@ -113,6 +114,10 @@ func (m *simpleSwapBindingMock) Issuer(o *bind.CallOpts) (common.Address, error)
 
 func (m *simpleSwapBindingMock) TotalPaidOut(o *bind.CallOpts) (*big.Int, error) {
 	return m.totalPaidOut(o)
+}
+
+func (m *simpleSwapBindingMock) PaidOut(o *bind.CallOpts, c common.Address) (*big.Int, error) {
+	return m.paidOut(o, c)
 }
 
 type erc20BindingMock struct {


### PR DESCRIPTION
instead of requiring the counterparty chequebook balance to be more than the cheque amount, just check it is more than the uncashed amount.