### PR TITLE
add withdraw and deposit endpoints

### DIFF
--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -406,3 +406,55 @@ paths:
            $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
           description: Default response
+
+  '/chequebook/deposit':
+    post:
+      summary: Deposit tokens from overlay address into chequebook
+      parameters:
+        - in: query
+          name: amount
+          schema:
+            type: integer
+          required: true
+          description: amount of tokens to deposit
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Transaction hash of the deposit transaction
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/TransactionResponse'
+        '400':
+           $ref: 'SwarmCommon.yaml#/components/responses/404'                
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/chequebook/withdraw':
+    post:
+      summary: Withdraw tokens from the chequebook to the overlay address
+      parameters:
+        - in: query
+          name: amount
+          schema:
+            type: integer
+          required: true
+          description: amount of tokens to withdraw
+      tags:
+        - Chequebook
+      responses:
+        '200':
+          description: Transaction hash of the withdraw transaction
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/TransactionResponse'
+        '400':
+           $ref: 'SwarmCommon.yaml#/components/responses/404'                
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response 

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -21,6 +21,7 @@ type (
 	ChequebookLastChequePeerResponse  = chequebookLastChequePeerResponse
 	ChequebookLastChequesResponse     = chequebookLastChequesResponse
 	ChequebookLastChequesPeerResponse = chequebookLastChequesPeerResponse
+	ChequebookTxResponse              = chequebookTxResponse
 	SwapCashoutResponse               = swapCashoutResponse
 	SwapCashoutStatusResponse         = swapCashoutStatusResponse
 	SwapCashoutStatusResult           = swapCashoutStatusResult

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -103,19 +103,28 @@ func (s *server) setupRouting() {
 			"GET": http.HandlerFunc(s.chequebookAddressHandler),
 		})
 
-		router.Handle("/chequebook/cheque/{peer}", jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.chequebookLastPeerHandler),
+		router.Handle("/chequebook/deposit", jsonhttp.MethodHandler{
+			"POST": http.HandlerFunc(s.chequebookDepositHandler),
 		})
 
-		router.Handle("/chequebook/cheque", jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.chequebookAllLastHandler),
-		})
-
-		router.Handle("/chequebook/cashout/{peer}", jsonhttp.MethodHandler{
-			"GET":  http.HandlerFunc(s.swapCashoutStatusHandler),
-			"POST": http.HandlerFunc(s.swapCashoutHandler),
+		router.Handle("/chequebook/withdraw", jsonhttp.MethodHandler{
+			"POST": http.HandlerFunc(s.chequebookWithdrawHandler),
 		})
 	}
+
+	router.Handle("/chequebook/cheque/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.chequebookLastPeerHandler),
+	})
+
+	router.Handle("/chequebook/cheque", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.chequebookAllLastHandler),
+	})
+
+	router.Handle("/chequebook/cashout/{peer}", jsonhttp.MethodHandler{
+		"GET":  http.HandlerFunc(s.swapCashoutStatusHandler),
+		"POST": http.HandlerFunc(s.swapCashoutHandler),
+	})
+
 	baseRouter.Handle("/", web.ChainHandlers(
 		logging.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, "debug api access"),
 		handlers.CompressHandler,

--- a/pkg/settlement/swap/chequebook/mock/chequebook.go
+++ b/pkg/settlement/swap/chequebook/mock/chequebook.go
@@ -20,6 +20,7 @@ type Service struct {
 	chequebookAddressFunc          func() common.Address
 	chequebookIssueFunc            func(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error
 	chequebookWithdrawFunc         func(ctx context.Context, amount *big.Int) (hash common.Hash, err error)
+	chequebookDepositFunc          func(ctx context.Context, amount *big.Int) (hash common.Hash, err error)
 }
 
 // WithChequebook*Functions set the mock chequebook functions
@@ -41,9 +42,21 @@ func WithChequebookAddressFunc(f func() common.Address) Option {
 	})
 }
 
+func WithChequebookDepositFunc(f func(ctx context.Context, amount *big.Int) (hash common.Hash, err error)) Option {
+	return optionFunc(func(s *Service) {
+		s.chequebookDepositFunc = f
+	})
+}
+
 func WithChequebookIssueFunc(f func(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error) Option {
 	return optionFunc(func(s *Service) {
 		s.chequebookIssueFunc = f
+	})
+}
+
+func WithChequebookWithdrawFunc(f func(ctx context.Context, amount *big.Int) (hash common.Hash, err error)) Option {
+	return optionFunc(func(s *Service) {
+		s.chequebookWithdrawFunc = f
 	})
 }
 
@@ -73,6 +86,9 @@ func (s *Service) AvailableBalance(ctx context.Context) (bal *big.Int, err error
 
 // Deposit mocks the chequebook .Deposit function
 func (s *Service) Deposit(ctx context.Context, amount *big.Int) (hash common.Hash, err error) {
+	if s.chequebookDepositFunc != nil {
+		return s.chequebookDepositFunc(ctx, amount)
+	}
 	return common.Hash{}, errors.New("Error")
 }
 

--- a/pkg/settlement/swap/chequebook/mock/chequebook.go
+++ b/pkg/settlement/swap/chequebook/mock/chequebook.go
@@ -19,6 +19,7 @@ type Service struct {
 	chequebookAvailableBalanceFunc func(context.Context) (*big.Int, error)
 	chequebookAddressFunc          func() common.Address
 	chequebookIssueFunc            func(ctx context.Context, beneficiary common.Address, amount *big.Int, sendChequeFunc chequebook.SendChequeFunc) error
+	chequebookWithdrawFunc         func(ctx context.Context, amount *big.Int) (hash common.Hash, err error)
 }
 
 // WithChequebook*Functions set the mock chequebook functions
@@ -101,6 +102,10 @@ func (s *Service) LastCheque(beneficiary common.Address) (*chequebook.SignedCheq
 
 func (s *Service) LastCheques() (map[common.Address]*chequebook.SignedCheque, error) {
 	return nil, errors.New("Error")
+}
+
+func (s *Service) Withdraw(ctx context.Context, amount *big.Int) (hash common.Hash, err error) {
+	return s.chequebookWithdrawFunc(ctx, amount)
 }
 
 // Option is the option passed to the mock Chequebook service


### PR DESCRIPTION
adds
* `POST /chequebook/withdraw?amount=VALUE`
* `POST /chequebook/deposit?amount=VALUE`

so users can send bzz token between chequebook and overlay.

openapi yaml use the TransactionReponse type from cashout PR which should be merged first.