### PR TITLE
Swap ux improvements

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -182,11 +182,11 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 			var found bool
 			factoryAddress, found = chequebook.DiscoverFactoryAddress(chainID.Int64())
 			if !found {
-				return nil, errors.New("no known factory address")
+				return nil, errors.New("no known factory address for this network")
 			}
 			logger.Infof("using default factory address for chain id %d: %x", chainID, factoryAddress)
 		} else if !common.IsHexAddress(o.SwapFactoryAddress) {
-			return nil, errors.New("invalid factory address")
+			return nil, errors.New("malformed factory address")
 		} else {
 			factoryAddress = common.HexToAddress(o.SwapFactoryAddress)
 			logger.Infof("using custom factory address: %x", factoryAddress)

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -163,7 +163,8 @@ func (m *chequeSignerMock) Sign(cheque *chequebook.Cheque) ([]byte, error) {
 
 type factoryMock struct {
 	erc20Address     func(ctx context.Context) (common.Address, error)
-	deploy           func(ctx context.Context, issuer common.Address, defaultHardDepositTimeoutDuration *big.Int) (common.Address, error)
+	deploy           func(ctx context.Context, issuer common.Address, defaultHardDepositTimeoutDuration *big.Int) (common.Hash, error)
+	waitDeployed     func(ctx context.Context, txHash common.Hash) (common.Address, error)
 	verifyBytecode   func(ctx context.Context) error
 	verifyChequebook func(ctx context.Context, chequebook common.Address) error
 }
@@ -173,9 +174,12 @@ func (m *factoryMock) ERC20Address(ctx context.Context) (common.Address, error) 
 	return m.erc20Address(ctx)
 }
 
-// Deploy deploys a new chequebook and returns once confirmed.
-func (m *factoryMock) Deploy(ctx context.Context, issuer common.Address, defaultHardDepositTimeoutDuration *big.Int) (common.Address, error) {
+func (m *factoryMock) Deploy(ctx context.Context, issuer common.Address, defaultHardDepositTimeoutDuration *big.Int) (common.Hash, error) {
 	return m.deploy(ctx, issuer, defaultHardDepositTimeoutDuration)
+}
+
+func (m *factoryMock) WaitDeployed(ctx context.Context, txHash common.Hash) (common.Address, error) {
+	return m.waitDeployed(ctx, txHash)
 }
 
 // VerifyBytecode checks that the factory is valid.

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -6,7 +6,7 @@ package chequebook
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -41,6 +41,8 @@ func Init(
 		return nil, err
 	}
 
+	logger.Info("no chequebook found, deploying new one.")
+
 	var chequebookAddress common.Address
 	err = stateStore.Get(chequebookKey, &chequebookAddress)
 	if err != nil {
@@ -62,17 +64,17 @@ func Init(
 			}
 
 			if balance.Cmp(big.NewInt(int64(swapInitialDeposit))) < 0 {
-				return nil, errors.New("insufficient token for initial deposit")
+				return nil, fmt.Errorf("insufficient token for initial deposit. Please make sure there is sufficient eth and bzz available on %x", overlayEthAddress)
 			}
 		}
 
 		// if we don't yet have a chequebook, deploy a new one
-		logger.Info("deploying new chequebook")
-
 		txHash, err := chequebookFactory.Deploy(ctx, overlayEthAddress, big.NewInt(0))
 		if err != nil {
 			return nil, err
 		}
+
+		logger.Infof("deploying new chequebook in transaction %x", txHash)
 
 		chequebookAddress, err = chequebookFactory.WaitDeployed(ctx, txHash)
 		if err != nil {
@@ -93,19 +95,19 @@ func Init(
 		}
 
 		if swapInitialDeposit != 0 {
-			logger.Info("depositing into new chequebook")
-
+			logger.Infof("depositing %d token into new chequebook", swapInitialDeposit)
 			depositHash, err := chequebookService.Deposit(ctx, big.NewInt(int64(swapInitialDeposit)))
 			if err != nil {
 				return nil, err
 			}
 
+			logger.Infof("sent deposit transaction %x", depositHash)
 			err = chequebookService.WaitForDeposit(ctx, depositHash)
 			if err != nil {
 				return nil, err
 			}
 
-			logger.Infof("deposited to chequebook %x in transaction %x", chequebookAddress, depositHash)
+			logger.Info("successfully deposited to chequebook")
 		}
 	} else {
 		chequebookService, err = New(swapBackend, transactionService, chequebookAddress, erc20Address, overlayEthAddress, stateStore, chequeSigner, simpleSwapBindingFunc, erc20BindingFunc)

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -69,7 +69,12 @@ func Init(
 		// if we don't yet have a chequebook, deploy a new one
 		logger.Info("deploying new chequebook")
 
-		chequebookAddress, err = chequebookFactory.Deploy(ctx, overlayEthAddress, big.NewInt(0))
+		txHash, err := chequebookFactory.Deploy(ctx, overlayEthAddress, big.NewInt(0))
+		if err != nil {
+			return nil, err
+		}
+
+		chequebookAddress, err = chequebookFactory.WaitDeployed(ctx, txHash)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Splits chequebook deployment into two parts so we can tell the user the tx hash in init.
* Some error messages changed
* insufficient token error contains info which address to fund
* more logs during init