### PR TITLE
enable swap by default

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -199,5 +199,5 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNameSwapEndpoint, "http://localhost:8545", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory address")
 	cmd.Flags().Uint64(optionNameSwapInitialDeposit, 0, "initial deposit if deploying a new chequebook")
-	cmd.Flags().Bool(optionNameSwapEnable, false, "enable swap")
+	cmd.Flags().Bool(optionNameSwapEnable, true, "enable swap")
 }


### PR DESCRIPTION
Enables swap by default. To run without swap use `--swap-enable=false`, in which case it will use `pseudosettle`. This flag is necessary even in standalone mode.