### PR TITLE
retrieval: remove test that forbids upstream request

### DIFF
--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -172,29 +172,6 @@ func TestRetrieveChunk(t *testing.T) {
 			t.Fatalf("got data %x, want %x", got.Data(), chunk.Data())
 		}
 	})
-
-	// requesting a chunk from the upstream peer should not be possible to avoid request forwarding loops
-	t.Run("upstream", func(t *testing.T) {
-		serverAddress := swarm.MustParseHexAddress("01")
-		chunkAddress := swarm.MustParseHexAddress("02")
-		clientAddress := swarm.MustParseHexAddress("03")
-
-		server := retrieval.New(serverAddress, nil, nil, logger, accountingmock.NewAccounting(), pricer, mockValidator, nil)
-
-		recorder := streamtest.New(streamtest.WithProtocols(server.Protocol()))
-
-		clientSuggester := mockPeerSuggester{eachPeerRevFunc: func(f topology.EachPeerFunc) error {
-			_, _, _ = f(serverAddress, 0)
-			return nil
-		}}
-		client := retrieval.New(clientAddress, recorder, clientSuggester, logger, accountingmock.NewAccounting(), pricer, mockValidator, nil)
-
-		// do not request from the upstream peer
-		_, err := client.RetrieveChunk(context.Background(), chunkAddress)
-		if !errors.Is(err, topology.ErrNotFound) {
-			t.Fatalf("got error %v, want %v", err, topology.ErrNotFound)
-		}
-	})
 }
 
 type mockPeerSuggester struct {


### PR DESCRIPTION
Changes introduced in #742 are conflicting with tests that were introduced in #705. Namely the test that asserts that upstream peer should not be called.

The only way I managed to get this to fail locally is by running `go test -v -count 2 -race` in the retrieve protocol directory. using just one iteration did no manifest in a panic for some reason. But it was evident that the client handler was being called from stream recorder

fixes #764 
