### PR TITLE
chequebook and payment threshold logging fixes

### DIFF
--- a/pkg/pricing/pricing.go
+++ b/pkg/pricing/pricing.go
@@ -85,7 +85,6 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 }
 
 func (s *Service) init(ctx context.Context, p p2p.Peer) error {
-	s.logger.Tracef("sending payment threshold announcement to peer %v", p.Address)
 	err := s.AnnouncePaymentThreshold(ctx, p.Address, s.paymentThreshold)
 	if err != nil {
 		s.logger.Warningf("error sending payment threshold announcement to peer %v", p.Address)

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -41,8 +41,6 @@ func Init(
 		return nil, err
 	}
 
-	logger.Info("no chequebook found, deploying new one.")
-
 	var chequebookAddress common.Address
 	err = stateStore.Get(chequebookKey, &chequebookAddress)
 	if err != nil {
@@ -50,6 +48,7 @@ func Init(
 			return nil, err
 		}
 
+		logger.Info("no chequebook found, deploying new one.")
 		if swapInitialDeposit != 0 {
 			erc20Token, err := erc20BindingFunc(erc20Address, swapBackend)
 			if err != nil {


### PR DESCRIPTION
log is in the wrong position. is shown even if chequebook already exists. also removes a duplicate log from payment threshold announcement.