### PR TITLE
add ethereum address to /addresses

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -28,6 +28,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/P2PUnderlay'
+        ethereum:
+          $ref: '#/components/schemas/EthereumAddress'
         public_key:
           $ref: '#/components/schemas/PublicKey'
 

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ecdsa"
 	"net/http"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -31,6 +32,7 @@ type Service interface {
 type server struct {
 	Overlay           swarm.Address
 	PublicKey         ecdsa.PublicKey
+	EthereumAddress   common.Address
 	P2P               p2p.DebugService
 	Pingpong          pingpong.Interface
 	TopologyDriver    topology.Driver
@@ -47,10 +49,11 @@ type server struct {
 	http.Handler
 }
 
-func New(overlay swarm.Address, publicKey ecdsa.PublicKey, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) Service {
+func New(overlay swarm.Address, publicKey ecdsa.PublicKey, ethereumAddress common.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) Service {
 	s := &server{
 		Overlay:           overlay,
 		PublicKey:         publicKey,
+		EthereumAddress:   ethereumAddress,
 		P2P:               p2p,
 		Pingpong:          pingpong,
 		TopologyDriver:    topologyDriver,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/logging"
@@ -30,18 +31,19 @@ import (
 )
 
 type testServerOptions struct {
-	Overlay        swarm.Address
-	PublicKey      ecdsa.PublicKey
-	P2P            *p2pmock.Service
-	Pingpong       pingpong.Interface
-	Storer         storage.Storer
-	Resolver       resolver.Interface
-	TopologyOpts   []topologymock.Option
-	Tags           *tags.Tags
-	AccountingOpts []accountingmock.Option
-	SettlementOpts []settlementmock.Option
-	ChequebookOpts []chequebookmock.Option
-	SwapOpts       []swapmock.Option
+	Overlay         swarm.Address
+	PublicKey       ecdsa.PublicKey
+	EthereumAddress common.Address
+	P2P             *p2pmock.Service
+	Pingpong        pingpong.Interface
+	Storer          storage.Storer
+	Resolver        resolver.Interface
+	TopologyOpts    []topologymock.Option
+	Tags            *tags.Tags
+	AccountingOpts  []accountingmock.Option
+	SettlementOpts  []settlementmock.Option
+	ChequebookOpts  []chequebookmock.Option
+	SwapOpts        []swapmock.Option
 }
 
 type testServer struct {
@@ -55,7 +57,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	settlement := settlementmock.NewSettlement(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
-	s := debugapi.New(o.Overlay, o.PublicKey, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook)
+	s := debugapi.New(o.Overlay, o.PublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"net/http"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -17,6 +18,7 @@ import (
 type addressesResponse struct {
 	Overlay   swarm.Address         `json:"overlay"`
 	Underlay  []multiaddr.Multiaddr `json:"underlay"`
+	Ethereum  common.Address        `json:"ethereum"`
 	PublicKey string                `json:"public_key"`
 }
 
@@ -30,6 +32,7 @@ func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, addressesResponse{
 		Overlay:   s.Overlay,
 		Underlay:  underlay,
+		Ethereum:  s.EthereumAddress,
 		PublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PublicKey)),
 	})
 }

--- a/pkg/debugapi/p2p_test.go
+++ b/pkg/debugapi/p2p_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -31,9 +32,12 @@ func TestAddresses(t *testing.T) {
 		mustMultiaddr(t, "/ip4/127.0.0.1/udp/7071/quic/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"),
 	}
 
+	ethereumAddress := common.HexToAddress("abcd")
+
 	testServer := newTestServer(t, testServerOptions{
-		PublicKey: privateKey.PublicKey,
-		Overlay:   overlay,
+		PublicKey:       privateKey.PublicKey,
+		Overlay:         overlay,
+		EthereumAddress: ethereumAddress,
 		P2P: mock.New(mock.WithAddressesFunc(func() ([]multiaddr.Multiaddr, error) {
 			return addresses, nil
 		})),
@@ -45,6 +49,7 @@ func TestAddresses(t *testing.T) {
 				Overlay:   overlay,
 				Underlay:  addresses,
 				PublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&privateKey.PublicKey)),
+				Ethereum:  ethereumAddress,
 			}),
 		)
 	})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -439,7 +439,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	if o.DebugAPIAddr != "" {
 		// Debug API server
 
-		debugAPIService := debugapi.New(swarmAddress, publicKey, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc, settlement, o.SwapEnable, swapService, chequebookService)
+		debugAPIService := debugapi.New(swarmAddress, publicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagg, acc, settlement, o.SwapEnable, swapService, chequebookService)
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)


### PR DESCRIPTION
Enables eth address to be queried by api.

Might be useful, but not strictly necessary for release.