### PR TITLE
fix warning log message format it hive

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -131,13 +131,13 @@ func (s *Service) peersHandler(ctx context.Context, peer p2p.Peer, stream p2p.St
 	for _, newPeer := range peersReq.Peers {
 		bzzAddress, err := bzz.ParseAddress(newPeer.Underlay, newPeer.Overlay, newPeer.Signature, s.networkID)
 		if err != nil {
-			s.logger.Warningf("skipping peer in response %s: %w", newPeer, err)
+			s.logger.Warningf("skipping peer in response %s: %v", newPeer.String(), err)
 			continue
 		}
 
 		err = s.addressBook.Put(bzzAddress.Overlay, *bzzAddress)
 		if err != nil {
-			s.logger.Warningf("skipping peer in response %s: %w", newPeer, err)
+			s.logger.Warningf("skipping peer in response %s: %v", newPeer.String(), err)
 			continue
 		}
 


### PR DESCRIPTION
This is a small change to address invalid format in log messages such as this:

```
time="2020-09-28T15:08:56Z" level=warning msg="skipping peer in response Underlay:\"\\004\\262\\375\\361\\346\\006\\033\\236\\245\\003'\\000%\\010\\002\\022!\\003N\\254\\227\\r\\302\\276\\323O\\020\\004\\216\\036\\301\\246\\301\\230\\200\\265j\\342|\\215@\\276\\212\\\"<J\\340\\037\\245|\" Signature:\" \\211\\205\\037;K\\306O\\\\\\202\\221\\231\\271\\354\\005nh\\217\\030\\2624\\313\\352\\363\\341\\311\\024$\\251\\006\\264r_$\\035\\032i\\347\\217\\325\\204\\327\\324k\\240\\nE\\024\\202\\275\\244\\332\\372\\303f~\\341\\302\\005\\267%\\345Ra\\344\" Overlay:\"\\246\\251\\373\\342\\334\\214K\\304\\013\\360b\\311\\336iQ\\013iI\\200?e\\370,\\207\\334\\022\\230\\246\\030\\006\\037\\241\" : %!w(*errors.errorString=&{invalid address})"

```