### PR TITLE
Redirect '/debug/pprof' to endpoint with slash

### DIFF
--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -32,7 +32,11 @@ func (s *server) setupRouting() {
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 
-	router.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
+	router.Handle("/debug/pprof", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := r.URL
+		u.Path += "/"
+		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect)
+	}))
 	router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 	router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))


### PR DESCRIPTION
The pprof HTML contains relative links.