### PR TITLE
accounting: settle in reserve

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -29,7 +29,7 @@ var (
 // Interface is the Accounting interface.
 type Interface interface {
 	// Reserve reserves a portion of the balance for peer and attempts settlements if necessary.
-	// Returns an error if the operation risks exceeding the disconnect threshold.
+	// Returns an error if the operation risks exceeding the disconnect threshold or an attempted settlement failed.
 	//
 	// This has to be called (always in combination with Release) before a
 	// Credit action to prevent overspending in case of concurrent requests.

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -66,7 +66,7 @@ func TestAccountingAddBalance(t *testing.T) {
 
 	for i, booking := range bookings {
 		if booking.price < 0 {
-			err = acc.Reserve(booking.peer, uint64(-booking.price))
+			err = acc.Reserve(context.Background(), booking.peer, uint64(-booking.price))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -177,7 +177,7 @@ func TestAccountingReserve(t *testing.T) {
 	}
 
 	// it should allow to cross the threshold one time
-	err = acc.Reserve(peer1Addr, testPaymentThreshold+1)
+	err = acc.Reserve(context.Background(), peer1Addr, testPaymentThreshold+1)
 	if err == nil {
 		t.Fatal("expected error from reserve")
 	}
@@ -206,12 +206,12 @@ func TestAccountingOverflowReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = acc.Reserve(peer1Addr, testPaymentThresholdLarge)
+	err = acc.Reserve(context.Background(), peer1Addr, testPaymentThresholdLarge)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = acc.Reserve(peer1Addr, math.MaxInt64)
+	err = acc.Reserve(context.Background(), peer1Addr, math.MaxInt64)
 	if !errors.Is(err, accounting.ErrOverflow) {
 		t.Fatalf("expected overflow error from Reserve, got %v", err)
 	}
@@ -225,7 +225,7 @@ func TestAccountingOverflowReserve(t *testing.T) {
 	}
 
 	// Try reserving further value, should overflow
-	err = acc.Reserve(peer1Addr, 1)
+	err = acc.Reserve(context.Background(), peer1Addr, 1)
 	// If we had other error, assert fail
 	if !errors.Is(err, accounting.ErrOverflow) {
 		t.Fatalf("expected overflow error from Reserve, got %v", err)
@@ -435,7 +435,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = acc.Reserve(peer1Addr, testPaymentThreshold)
+	err = acc.Reserve(context.Background(), peer1Addr, testPaymentThreshold)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +449,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 	acc.Release(peer1Addr, testPaymentThreshold)
 
 	// try another request
-	err = acc.Reserve(peer1Addr, 1)
+	err = acc.Reserve(context.Background(), peer1Addr, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,14 +473,14 @@ func TestAccountingCallSettlement(t *testing.T) {
 	}
 
 	// Assume 100 is reserved by some other request
-	err = acc.Reserve(peer1Addr, 100)
+	err = acc.Reserve(context.Background(), peer1Addr, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Credit until the expected debt exceeeds payment threshold
 	expectedAmount := uint64(testPaymentThreshold - 100)
-	err = acc.Reserve(peer1Addr, expectedAmount)
+	err = acc.Reserve(context.Background(), peer1Addr, expectedAmount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,7 +493,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 	acc.Release(peer1Addr, expectedAmount)
 
 	// try another request
-	err = acc.Reserve(peer1Addr, 1)
+	err = acc.Reserve(context.Background(), peer1Addr, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +538,7 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 	}
 
 	payment := testPaymentThreshold - earlyPayment
-	err = acc.Reserve(peer1Addr, payment)
+	err = acc.Reserve(context.Background(), peer1Addr, payment)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +698,7 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = acc.Reserve(peer1Addr, lowerThreshold)
+	err = acc.Reserve(context.Background(), peer1Addr, lowerThreshold)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -15,7 +16,7 @@ import (
 type Service struct {
 	lock         sync.Mutex
 	balances     map[string]int64
-	reserveFunc  func(peer swarm.Address, price uint64) error
+	reserveFunc  func(ctx context.Context, peer swarm.Address, price uint64) error
 	releaseFunc  func(peer swarm.Address, price uint64)
 	creditFunc   func(peer swarm.Address, price uint64) error
 	debitFunc    func(peer swarm.Address, price uint64) error
@@ -24,7 +25,7 @@ type Service struct {
 }
 
 // WithReserveFunc sets the mock Reserve function
-func WithReserveFunc(f func(peer swarm.Address, price uint64) error) Option {
+func WithReserveFunc(f func(ctx context.Context, peer swarm.Address, price uint64) error) Option {
 	return optionFunc(func(s *Service) {
 		s.reserveFunc = f
 	})

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -77,9 +77,9 @@ func NewAccounting(opts ...Option) accounting.Interface {
 }
 
 // Reserve is the mock function wrapper that calls the set implementation
-func (s *Service) Reserve(peer swarm.Address, price uint64) error {
+func (s *Service) Reserve(ctx context.Context, peer swarm.Address, price uint64) error {
 	if s.reserveFunc != nil {
-		return s.reserveFunc(peer, price)
+		return s.reserveFunc(ctx, peer, price)
 	}
 	return nil
 }

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -122,7 +122,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 	// compute the price we pay for this receipt and reserve it for the rest of this function
 	receiptPrice := ps.pricer.PeerPrice(peer, chunk.Address())
-	err = ps.accounting.Reserve(peer, receiptPrice)
+	err = ps.accounting.Reserve(ctx, peer, receiptPrice)
 	if err != nil {
 		return fmt.Errorf("reserve balance for peer %s: %w", peer.String(), err)
 	}
@@ -235,7 +235,7 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 
 	// compute the price we pay for this receipt and reserve it for the rest of this function
 	receiptPrice := ps.pricer.PeerPrice(peer, ch.Address())
-	err = ps.accounting.Reserve(peer, receiptPrice)
+	err = ps.accounting.Reserve(ctx, peer, receiptPrice)
 	if err != nil {
 		return nil, fmt.Errorf("reserve balance for peer %s: %w", peer.String(), err)
 	}

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -138,7 +138,7 @@ func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skipPee
 
 	// compute the price we pay for this chunk and reserve it for the rest of this function
 	chunkPrice := s.pricer.PeerPrice(peer, addr)
-	err = s.accounting.Reserve(peer, chunkPrice)
+	err = s.accounting.Reserve(ctx, peer, chunkPrice)
 	if err != nil {
 		return nil, peer, err
 	}

--- a/pkg/settlement/pseudosettle/mock/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/mock/pseudosettle.go
@@ -24,7 +24,7 @@ type Service struct {
 	settlementsSentFunc func() (map[string]uint64, error)
 	settlementsRecvFunc func() (map[string]uint64, error)
 
-	pay func(context.Context, swarm.Address, uint64) error
+	payFunc func(context.Context, swarm.Address, uint64) error
 }
 
 // WithsettlementFunc sets the mock settlement function
@@ -55,7 +55,7 @@ func WithSettlementsRecvFunc(f func() (map[string]uint64, error)) Option {
 
 func WithPayFunc(f func(context.Context, swarm.Address, uint64) error) Option {
 	return optionFunc(func(s *Service) {
-		s.pay = f
+		s.payFunc = f
 	})
 }
 
@@ -71,8 +71,8 @@ func NewSettlement(opts ...Option) settlement.Interface {
 }
 
 func (s *Service) Pay(c context.Context, peer swarm.Address, amount uint64) error {
-	if s.pay != nil {
-		return s.Pay(c, peer, amount)
+	if s.payFunc != nil {
+		return s.payFunc(c, peer, amount)
 	}
 	s.settlementsSent[peer.String()] += amount
 	return nil

--- a/pkg/settlement/pseudosettle/mock/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/mock/pseudosettle.go
@@ -23,6 +23,8 @@ type Service struct {
 
 	settlementsSentFunc func() (map[string]uint64, error)
 	settlementsRecvFunc func() (map[string]uint64, error)
+
+	pay func(context.Context, swarm.Address, uint64) error
 }
 
 // WithsettlementFunc sets the mock settlement function
@@ -51,6 +53,12 @@ func WithSettlementsRecvFunc(f func() (map[string]uint64, error)) Option {
 	})
 }
 
+func WithPayFunc(f func(context.Context, swarm.Address, uint64) error) Option {
+	return optionFunc(func(s *Service) {
+		s.pay = f
+	})
+}
+
 // Newsettlement creates the mock settlement implementation
 func NewSettlement(opts ...Option) settlement.Interface {
 	mock := new(Service)
@@ -62,7 +70,10 @@ func NewSettlement(opts ...Option) settlement.Interface {
 	return mock
 }
 
-func (s *Service) Pay(_ context.Context, peer swarm.Address, amount uint64) error {
+func (s *Service) Pay(c context.Context, peer swarm.Address, amount uint64) error {
+	if s.pay != nil {
+		return s.Pay(c, peer, amount)
+	}
 	s.settlementsSent[peer.String()] += amount
 	return nil
 }


### PR DESCRIPTION
This PR changes the accounting flow so that settlement of actual debt is already triggered in the `Reserve` stage.

The new accounting flow is as follows:
* `Credit` like `Debit` now only updates balances and no longer attempts to settle.
* Settlement now uses the right context
* If in `Reserve` we detect we are close enough to payment threshold we trigger settlement right there and fail if settlement fails.
* We still block if the expected debt would exceed the threshold. this is possible even if settlement occurred (e.g. if all outstanding requests actually exceed the payment threshold and we had positive balance with the peer before).

Motivation:
* Currently it is possible to get in a state where we are above the payment threshold but we still will never attempt to settle again. The only way to always have a chance retry without intentionally going arbitrarily high over the payment threshold is to do this in reserve stage already.
* This PR should also reduce the frequency of overdraft errors in case of many concurrent requests.