### PR TITLE
add proper backend mock

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,7 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/influxdata/influxdb v1.7.7 h1:UvNzAPfBrKMENVbQ4mr4ccA9sW+W1Ihl0Yh1s0BiVAg=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/pkg/settlement/swap/chequebook/cashout_test.go
+++ b/pkg/settlement/swap/chequebook/cashout_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 	chequestoremock "github.com/ethersphere/bee/pkg/settlement/swap/chequestore/mock"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
 	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
 )
@@ -56,14 +57,14 @@ func TestCashout(t *testing.T) {
 				},
 			}, nil
 		},
-		&backendMock{
-			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+		backendmock.New(
+			backendmock.WithTransactionByHashFunc(func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
 				if hash != txHash {
 					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
 				}
 				return nil, false, nil
-			},
-			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+			}),
+			backendmock.WithTransactionReceiptFunc(func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
 				if hash != txHash {
 					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
 				}
@@ -76,8 +77,8 @@ func TestCashout(t *testing.T) {
 						},
 					},
 				}, nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				if request.To != chequebookAddress {
@@ -191,14 +192,14 @@ func TestCashoutBounced(t *testing.T) {
 				},
 			}, nil
 		},
-		&backendMock{
-			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+		backendmock.New(
+			backendmock.WithTransactionByHashFunc(func(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
 				if hash != txHash {
 					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
 				}
 				return nil, false, nil
-			},
-			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+			}),
+			backendmock.WithTransactionReceiptFunc(func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
 				if hash != txHash {
 					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
 				}
@@ -215,8 +216,8 @@ func TestCashoutBounced(t *testing.T) {
 						},
 					},
 				}, nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				if request.To != chequebookAddress {
@@ -307,22 +308,22 @@ func TestCashoutStatusReverted(t *testing.T) {
 		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
 			return &simpleSwapBindingMock{}, nil
 		},
-		&backendMock{
-			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+		backendmock.New(
+			backendmock.WithTransactionByHashFunc(func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
 				if hash != txHash {
 					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
 				}
 				return nil, false, nil
-			},
-			transactionReceipt: func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
+			}),
+			backendmock.WithTransactionReceiptFunc(func(ctx context.Context, hash common.Hash) (*types.Receipt, error) {
 				if hash != txHash {
 					t.Fatalf("fetching receipt for transaction. wanted %v, got %v", txHash, hash)
 				}
 				return &types.Receipt{
 					Status: types.ReceiptStatusFailed,
 				}, nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				return txHash, nil
@@ -389,14 +390,14 @@ func TestCashoutStatusPending(t *testing.T) {
 		func(common.Address, bind.ContractBackend) (chequebook.SimpleSwapBinding, error) {
 			return &simpleSwapBindingMock{}, nil
 		},
-		&backendMock{
-			transactionByHash: func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+		backendmock.New(
+			backendmock.WithTransactionByHashFunc(func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
 				if hash != txHash {
 					t.Fatalf("fetching wrong transaction. wanted %v, got %v", txHash, hash)
 				}
 				return nil, true, nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				return txHash, nil

--- a/pkg/settlement/swap/chequebook/chequebook_test.go
+++ b/pkg/settlement/swap/chequebook/chequebook_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
 	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 )
@@ -64,7 +65,7 @@ func TestChequebookAddress(t *testing.T) {
 	ownerAdress := common.HexToAddress("0xfff")
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		address,
 		erc20address,
@@ -89,7 +90,7 @@ func TestChequebookBalance(t *testing.T) {
 	balance := big.NewInt(10)
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		address,
 		erc20address,
@@ -125,7 +126,7 @@ func TestChequebookDeposit(t *testing.T) {
 	txHash := common.HexToHash("0xdddd")
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				if request.To != erc20address {
@@ -172,7 +173,7 @@ func TestChequebookWaitForDeposit(t *testing.T) {
 	txHash := common.HexToHash("0xdddd")
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			waitForReceipt: func(ctx context.Context, tx common.Hash) (*types.Receipt, error) {
 				if tx != txHash {
@@ -207,7 +208,7 @@ func TestChequebookWaitForDepositReverted(t *testing.T) {
 	txHash := common.HexToHash("0xdddd")
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			waitForReceipt: func(ctx context.Context, tx common.Hash) (*types.Receipt, error) {
 				if tx != txHash {
@@ -252,7 +253,7 @@ func TestChequebookIssue(t *testing.T) {
 
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		address,
 		erc20address,
@@ -403,7 +404,7 @@ func TestChequebookIssueErrorSend(t *testing.T) {
 
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		address,
 		erc20address,
@@ -451,7 +452,7 @@ func TestChequebookIssueOutOfFunds(t *testing.T) {
 
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		address,
 		erc20address,
@@ -496,7 +497,7 @@ func TestChequebookWithdraw(t *testing.T) {
 	store := storemock.NewStateStore()
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				if request.To != address {
@@ -553,7 +554,7 @@ func TestChequebookWithdrawInsufficientFunds(t *testing.T) {
 	store := storemock.NewStateStore()
 	chequebookService, err := newTestChequebook(
 		t,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			send: func(c context.Context, request *chequebook.TxRequest) (common.Hash, error) {
 				if request.To != address {

--- a/pkg/settlement/swap/chequebook/chequestore_test.go
+++ b/pkg/settlement/swap/chequebook/chequestore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
 	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
 )
 
@@ -48,7 +49,7 @@ func TestReceiveCheque(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		factory,
 		chainID,
 		beneficiary,
@@ -148,7 +149,7 @@ func TestReceiveChequeInvalidBeneficiary(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{},
 		chainID,
 		beneficiary,
@@ -176,7 +177,7 @@ func TestReceiveChequeInvalidAmount(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{
 			verifyChequebook: func(ctx context.Context, address common.Address) error {
 				return nil
@@ -240,7 +241,7 @@ func TestReceiveChequeInvalidChequebook(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{
 			verifyChequebook: func(ctx context.Context, address common.Address) error {
 				return chequebook.ErrNotDeployedByFactory
@@ -289,7 +290,7 @@ func TestReceiveChequeInvalidSignature(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{
 			verifyChequebook: func(ctx context.Context, address common.Address) error {
 				return nil
@@ -335,7 +336,7 @@ func TestReceiveChequeInsufficientBalance(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{
 			verifyChequebook: func(ctx context.Context, address common.Address) error {
 				return nil
@@ -384,7 +385,7 @@ func TestReceiveChequeSufficientBalancePaidOut(t *testing.T) {
 
 	chequestore := chequebook.NewChequeStore(
 		store,
-		&backendMock{},
+		backendmock.New(),
 		&factoryMock{
 			verifyChequebook: func(ctx context.Context, address common.Address) error {
 				return nil

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,60 +16,6 @@ import (
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
 )
-
-type backendMock struct {
-	codeAt             func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error)
-	sendTransaction    func(ctx context.Context, tx *types.Transaction) error
-	suggestGasPrice    func(ctx context.Context) (*big.Int, error)
-	estimateGas        func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)
-	transactionReceipt func(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
-	pendingNonceAt     func(ctx context.Context, account common.Address) (uint64, error)
-	transactionByHash  func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
-}
-
-func (m *backendMock) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
-	return m.codeAt(ctx, contract, blockNumber)
-}
-
-func (*backendMock) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (*backendMock) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
-	panic("not implemented")
-}
-
-func (m *backendMock) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-	return m.pendingNonceAt(ctx, account)
-}
-
-func (m *backendMock) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
-	return m.suggestGasPrice(ctx)
-}
-
-func (m *backendMock) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-	return m.estimateGas(ctx, call)
-}
-
-func (m *backendMock) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	return m.sendTransaction(ctx, tx)
-}
-
-func (*backendMock) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
-	panic("not implemented")
-}
-
-func (*backendMock) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-	panic("not implemented")
-}
-
-func (m *backendMock) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-	return m.transactionReceipt(ctx, txHash)
-}
-
-func (m *backendMock) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
-	return m.transactionByHash(ctx, hash)
-}
 
 type transactionServiceMock struct {
 	send           func(ctx context.Context, request *chequebook.TxRequest) (txHash common.Hash, err error)

--- a/pkg/settlement/swap/chequebook/factory_test.go
+++ b/pkg/settlement/swap/chequebook/factory_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
 	"github.com/ethersphere/sw3-bindings/v2/simpleswapfactory"
 )
 
@@ -37,7 +38,7 @@ func TestFactoryERC20Address(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		&simpleSwapFactoryBindingMock{
 			erc20Address: func(*bind.CallOpts) (common.Address, error) {
@@ -63,8 +64,8 @@ func TestFactoryVerifySelf(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{
-			codeAt: func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+		backendmock.New(
+			backendmock.WithCodeAtFunc(func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
 				if contract != factoryAddress {
 					t.Fatalf("called with wrong address. wanted %x, got %x", factoryAddress, contract)
 				}
@@ -72,8 +73,8 @@ func TestFactoryVerifySelf(t *testing.T) {
 					t.Fatal("not called for latest block")
 				}
 				return common.FromHex(simpleswapfactory.SimpleSwapFactoryDeployedCode), nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{},
 		&simpleSwapFactoryBindingMock{})
 	if err != nil {
@@ -91,8 +92,8 @@ func TestFactoryVerifySelfInvalidCode(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{
-			codeAt: func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+		backendmock.New(
+			backendmock.WithCodeAtFunc(func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
 				if contract != factoryAddress {
 					t.Fatalf("called with wrong address. wanted %x, got %x", factoryAddress, contract)
 				}
@@ -100,8 +101,8 @@ func TestFactoryVerifySelfInvalidCode(t *testing.T) {
 					t.Fatal("not called for latest block")
 				}
 				return common.FromHex(simpleswapfactory.AddressBin), nil
-			},
-		},
+			}),
+		),
 		&transactionServiceMock{},
 		&simpleSwapFactoryBindingMock{})
 	if err != nil {
@@ -123,7 +124,7 @@ func TestFactoryVerifyChequebook(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		&simpleSwapFactoryBindingMock{
 			deployedContracts: func(o *bind.CallOpts, address common.Address) (bool, error) {
@@ -149,7 +150,7 @@ func TestFactoryVerifyChequebookInvalid(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{},
 		&simpleSwapFactoryBindingMock{
 			deployedContracts: func(o *bind.CallOpts, address common.Address) (bool, error) {
@@ -182,7 +183,7 @@ func TestFactoryDeploy(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			send: func(ctx context.Context, request *chequebook.TxRequest) (txHash common.Hash, err error) {
 				if request.To != factoryAddress {
@@ -250,7 +251,7 @@ func TestFactoryDeployReverted(t *testing.T) {
 	factory, err := newTestFactory(
 		t,
 		factoryAddress,
-		&backendMock{},
+		backendmock.New(),
 		&transactionServiceMock{
 			waitForReceipt: func(ctx context.Context, txHash common.Hash) (receipt *types.Receipt, err error) {
 				if txHash != deployTransactionHash {

--- a/pkg/settlement/swap/chequebook/transaction_test.go
+++ b/pkg/settlement/swap/chequebook/transaction_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
 )
 
 func TestTransactionSend(t *testing.T) {
@@ -35,14 +36,14 @@ func TestTransactionSend(t *testing.T) {
 	}
 
 	transactionService, err := chequebook.NewTransactionService(logger,
-		&backendMock{
-			sendTransaction: func(ctx context.Context, tx *types.Transaction) error {
+		backendmock.New(
+			backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 				if tx != signedTx {
 					t.Fatal("not sending signed transaction")
 				}
 				return nil
-			},
-			estimateGas: func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+			}),
+			backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
 				if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
 					t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
 				}
@@ -50,14 +51,14 @@ func TestTransactionSend(t *testing.T) {
 					t.Fatal("estimating with wrong data")
 				}
 				return estimatedGasLimit, nil
-			},
-			suggestGasPrice: func(ctx context.Context) (*big.Int, error) {
+			}),
+			backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
 				return suggestedGasPrice, nil
-			},
-			pendingNonceAt: func(ctx context.Context, account common.Address) (uint64, error) {
+			}),
+			backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
 				return nonce, nil
-			},
-		},
+			}),
+		),
 		&signerMock{
 			signTx: func(transaction *types.Transaction) (*types.Transaction, error) {
 				if !bytes.Equal(transaction.To().Bytes(), recipient.Bytes()) {
@@ -102,13 +103,13 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 	txHash := common.HexToHash("0xabcdee")
 
 	transactionService, err := chequebook.NewTransactionService(logger,
-		&backendMock{
-			transactionReceipt: func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+		backendmock.New(
+			backendmock.WithTransactionReceiptFunc(func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 				return &types.Receipt{
 					TxHash: txHash,
 				}, nil
-			},
-		},
+			}),
+		),
 		&signerMock{})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/settlement/swap/transaction/backendmock/backend.go
+++ b/pkg/settlement/swap/transaction/backendmock/backend.go
@@ -1,0 +1,150 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package backendmock
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
+)
+
+type backendMock struct {
+	codeAt             func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error)
+	sendTransaction    func(ctx context.Context, tx *types.Transaction) error
+	suggestGasPrice    func(ctx context.Context) (*big.Int, error)
+	estimateGas        func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)
+	transactionReceipt func(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	pendingNonceAt     func(ctx context.Context, account common.Address) (uint64, error)
+	transactionByHash  func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
+}
+
+func (m *backendMock) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	if m.codeAt != nil {
+		return m.codeAt(ctx, contract, blockNumber)
+	}
+	return nil, errors.New("Error")
+}
+
+func (*backendMock) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return nil, errors.New("Error")
+}
+
+func (*backendMock) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+	return nil, errors.New("Error")
+}
+
+func (m *backendMock) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	if m.pendingNonceAt != nil {
+		return m.pendingNonceAt(ctx, account)
+	}
+	return 0, errors.New("Error")
+}
+
+func (m *backendMock) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	if m.suggestGasPrice != nil {
+		return m.suggestGasPrice(ctx)
+	}
+	return nil, errors.New("Error")
+}
+
+func (m *backendMock) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+	if m.estimateGas != nil {
+		return m.estimateGas(ctx, call)
+	}
+	return 0, errors.New("Error")
+}
+
+func (m *backendMock) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	if m.sendTransaction != nil {
+		return m.sendTransaction(ctx, tx)
+	}
+	return errors.New("Error")
+}
+
+func (*backendMock) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	return nil, errors.New("Error")
+}
+
+func (*backendMock) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, errors.New("Error")
+}
+
+func (m *backendMock) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	if m.transactionReceipt != nil {
+		return m.transactionReceipt(ctx, txHash)
+	}
+	return nil, errors.New("Error")
+}
+
+func (m *backendMock) TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	if m.transactionByHash != nil {
+		return m.transactionByHash(ctx, hash)
+	}
+	return nil, false, errors.New("Error")
+}
+
+func New(opts ...Option) chequebook.Backend {
+	mock := new(backendMock)
+	for _, o := range opts {
+		o.apply(mock)
+	}
+	return mock
+}
+
+// Option is the option passed to the mock Chequebook service
+type Option interface {
+	apply(*backendMock)
+}
+
+type optionFunc func(*backendMock)
+
+func (f optionFunc) apply(r *backendMock) { f(r) }
+
+func WithCodeAtFunc(f func(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.codeAt = f
+	})
+}
+
+func WithPendingNonceAtFunc(f func(ctx context.Context, account common.Address) (uint64, error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.pendingNonceAt = f
+	})
+}
+
+func WithSuggestGasPriceFunc(f func(ctx context.Context) (*big.Int, error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.suggestGasPrice = f
+	})
+}
+
+func WithEstimateGasFunc(f func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.estimateGas = f
+	})
+}
+
+func WithTransactionReceiptFunc(f func(ctx context.Context, txHash common.Hash) (*types.Receipt, error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.transactionReceipt = f
+	})
+}
+
+func WithTransactionByHashFunc(f func(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)) Option {
+	return optionFunc(func(s *backendMock) {
+		s.transactionByHash = f
+	})
+}
+
+func WithSendTransactionFunc(f func(ctx context.Context, tx *types.Transaction) error) Option {
+	return optionFunc(func(s *backendMock) {
+		s.sendTransaction = f
+	})
+}


### PR DESCRIPTION
Creates a proper mock for the Ethereum backend which can be used from different packages. This mock is used in all tests instead of the old ones. There are no other changes.

The mock is in the `transaction/backendmock` package because the next PR will move the transaction service to its own package.