### PR TITLE
Export additional metrics

### DIFF
--- a/pkg/localstore/metrics.go
+++ b/pkg/localstore/metrics.go
@@ -216,7 +216,7 @@ func newMetrics() metrics {
 		ModeGetMultiFailure: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "mode_get_failure_count",
+			Name:      "mode_get_multi_failure_count",
 			Help:      "Number of times MODE_GET invocation failed.",
 		}),
 		ModePut: prometheus.NewCounter(prometheus.CounterOpts{
@@ -252,7 +252,7 @@ func newMetrics() metrics {
 		ModeHasFailure: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "mode_has_count",
+			Name:      "mode_has_failure_count",
 			Help:      "Number of times MODE_HAS invocation failed.",
 		}),
 		ModeHasMulti: prometheus.NewCounter(prometheus.CounterOpts{
@@ -264,7 +264,7 @@ func newMetrics() metrics {
 		ModeHasMultiFailure: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "mode_has_multi_fail_count",
+			Name:      "mode_has_multi_failure_count",
 			Help:      "Number of times MODE_HAS_MULTI invocation failed.",
 		}),
 		SubscribePull: prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -446,6 +446,15 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)
 		debugAPIService.MustRegisterMetrics(acc.Metrics()...)
+		debugAPIService.MustRegisterMetrics(storer.Metrics()...)
+		debugAPIService.MustRegisterMetrics(puller.Metrics()...)
+		debugAPIService.MustRegisterMetrics(pushSyncProtocol.Metrics()...)
+		debugAPIService.MustRegisterMetrics(pushSyncPusher.Metrics()...)
+		debugAPIService.MustRegisterMetrics(pullSync.Metrics()...)
+
+		if pssService, ok := psss.(metrics.Collector); ok {
+			debugAPIService.MustRegisterMetrics(pssService.Metrics()...)
+		}
 
 		if apiService != nil {
 			debugAPIService.MustRegisterMetrics(apiService.Metrics()...)


### PR DESCRIPTION
While debugging "pushsync" package, I noticed that metrics are not exported. After including those to debug API, I also noticed some other seem to be missing from there. 

This change includes those missing metrics from other packages, and fixes names of metrics from `localstore` (discovered after metrics were added).

One remaining metric group that was not included here is from `shed` package. Since that is only internally used in `localstore`, different change would be needed to include it.
Since I am not totally sure about that package anyway, I have left it out. If someone thinks that it should be added, I can update this PR.