### PR TITLE
expose nat underlay address by p2p service

### DIFF
--- a/pkg/p2p/libp2p/static_resolver.go
+++ b/pkg/p2p/libp2p/static_resolver.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -20,7 +19,7 @@ type staticAddressResolver struct {
 	port    string
 }
 
-func newStaticAddressResolver(addr string) (handshake.AdvertisableAddressResolver, error) {
+func newStaticAddressResolver(addr string) (*staticAddressResolver, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Expose underlay address with NAT address parameters just as it would be communicated in the handshake in order to be discoverable in debugapi addresses response.

expected behaviour:

```
bee start \
    --api-addr=:8082 \
    --debug-api-enable \
    --debug-api-addr=:6062 \
    --data-dir=/tmp/bee2 \
    --bootnode="" \
    --p2p-addr=:7072 \
    --swap-enable=false \
    --nat-addr=83.95.91.7:7072
```

```
curl -s localhost:6062/addresses | jq
```

```json
{
  "overlay": "473662ffe198262e95f74491b8cebe65c2de79b8376f2356cbf6ec7cf923eaac",
  "underlay": [
    "/ip4/127.0.0.1/tcp/7072/p2p/16Uiu2HAm2a5wd2Bo45haSDUKa5gYKdGJaQWrCVRcMqTSq2s9ossz",
    "/ip4/192.168.0.100/tcp/7072/p2p/16Uiu2HAm2a5wd2Bo45haSDUKa5gYKdGJaQWrCVRcMqTSq2s9ossz",
    "/ip6/::1/tcp/7072/p2p/16Uiu2HAm2a5wd2Bo45haSDUKa5gYKdGJaQWrCVRcMqTSq2s9ossz",
    "/ip4/83.95.91.7/tcp/7072/p2p/16Uiu2HAm2a5wd2Bo45haSDUKa5gYKdGJaQWrCVRcMqTSq2s9ossz"
  ],
  "ethereum": "0x0000000000000000000000000000000000000000",
  "public_key": "02b1ba590f9a3f5ce190bd13cbaeb9c320adf67e612020cff19f466415ab0a3b4c"
}
```

fixes #792