### PR TITLE
Reverse the order of the queue for push sync index

### DIFF
--- a/pkg/localstore/subscription_push.go
+++ b/pkg/localstore/subscription_push.go
@@ -92,7 +92,6 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, stop fun
 					select {
 					case chunks <- swarm.NewChunk(swarm.NewAddress(dataItem.Address), dataItem.Data).WithTagID(item.Tag):
 						count++
-						// when the chunk is successfully sent to channel
 						// we set first one sent, which is "oldest" at that point
 						if lastItem == nil {
 							lastItem = &item
@@ -121,17 +120,14 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, stop fun
 					return
 				}
 
-				// save last Item from this iteration in order to know were
+				// save last Item from this iteration in order to know where
 				// to stop on next iteration
 				if lastItem != nil && toItemKey == nil {
-					var lastItemKey []byte
 					// move 'toItemKey' to point to last item in previous iteration
-					lastItemKey, err = db.pushIndex.ItemKey(*lastItem)
+					toItemKey, err = db.pushIndex.ItemKey(*lastItem)
 					if err != nil {
 						return
 					}
-
-					toItemKey = append(lastItemKey[:0:0], lastItemKey...)
 				}
 
 				// 'lastItem' should be populated on next iteration again

--- a/pkg/localstore/subscription_push_test.go
+++ b/pkg/localstore/subscription_push_test.go
@@ -57,7 +57,7 @@ func TestDB_SubscribePush(t *testing.T) {
 		}
 	}
 
-	// REQUIRED_LOCK - chunksMu
+	// caller expected to hold lock on chunksMu
 	findChunkIndex := func(chunk swarm.Chunk) int {
 		for i, c := range chunks {
 			if chunk.Address().Equal(c.Address()) {
@@ -178,7 +178,7 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 		}
 	}
 
-	// REQUIRED_LOCK - addrsMu
+	// caller expected to hold lock on addrsMu
 	findAddressIndex := func(address swarm.Address) int {
 		for i, a := range addrs {
 			if a.Equal(address) {

--- a/pkg/localstore/subscription_push_test.go
+++ b/pkg/localstore/subscription_push_test.go
@@ -37,6 +37,8 @@ func TestDB_SubscribePush(t *testing.T) {
 	chunks := make([]swarm.Chunk, 0)
 	var chunksMu sync.Mutex
 
+	chunkProcessedTimes := make([]int, 0)
+
 	uploadRandomChunks := func(count int) {
 		chunksMu.Lock()
 		defer chunksMu.Unlock()
@@ -50,7 +52,20 @@ func TestDB_SubscribePush(t *testing.T) {
 			}
 
 			chunks = append(chunks, ch)
+
+			chunkProcessedTimes = append(chunkProcessedTimes, 0)
 		}
+	}
+
+	// REQUIRED_LOCK - chunksMu
+	findChunkIndex := func(chunk swarm.Chunk) int {
+		for i, c := range chunks {
+			if chunk.Address().Equal(c.Address()) {
+				return i
+			}
+		}
+
+		return -1
 	}
 
 	// prepopulate database with some chunks
@@ -68,8 +83,11 @@ func TestDB_SubscribePush(t *testing.T) {
 	ch, stop := db.SubscribePush(ctx)
 	defer stop()
 
+	var lastStartIndex int = -1
+
 	// receive and validate addresses from the subscription
 	go func() {
+		var err error
 		var i int // address index
 		for {
 			select {
@@ -78,9 +96,19 @@ func TestDB_SubscribePush(t *testing.T) {
 					return
 				}
 				chunksMu.Lock()
-				want := chunks[i]
+				if i > lastStartIndex {
+					// no way to know which chunk will come first here
+					gotIndex := findChunkIndex(got)
+					if gotIndex <= lastStartIndex {
+						err = fmt.Errorf("got index %v, expected index above %v", gotIndex, lastStartIndex)
+					}
+					lastStartIndex = gotIndex
+					i = 0
+				}
+				cIndex := lastStartIndex - i
+				want := chunks[cIndex]
+				chunkProcessedTimes[cIndex]++
 				chunksMu.Unlock()
-				var err error
 				if !bytes.Equal(got.Data(), want.Data()) {
 					err = fmt.Errorf("got chunk %v data %x, want %x", i, got.Data(), want.Data())
 				}
@@ -111,6 +139,18 @@ func TestDB_SubscribePush(t *testing.T) {
 	uploadRandomChunks(3)
 
 	checkErrChan(ctx, t, errChan, len(chunks))
+
+	chunksMu.Lock()
+	if lastStartIndex != len(chunks)-1 {
+		t.Fatalf("got %d chunks, expected %d", lastStartIndex, len(chunks))
+	}
+
+	for i, pc := range chunkProcessedTimes {
+		if pc != 1 {
+			t.Fatalf("chunk on address %s processed %d times, should be only once", chunks[i].Address(), pc)
+		}
+	}
+	chunksMu.Unlock()
 }
 
 // TestDB_SubscribePush_multiple uploads chunks before and after
@@ -138,6 +178,17 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 		}
 	}
 
+	// REQUIRED_LOCK - addrsMu
+	findAddressIndex := func(address swarm.Address) int {
+		for i, a := range addrs {
+			if a.Equal(address) {
+				return i
+			}
+		}
+
+		return -1
+	}
+
 	// prepopulate database with some chunks
 	// before the subscription
 	uploadRandomChunks(10)
@@ -152,6 +203,8 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 
 	subsCount := 10
 
+	lastStartIndexSlice := make([]int, subsCount)
+
 	// start a number of subscriptions
 	// that all of them will write every addresses error to errChan
 	for j := 0; j < subsCount; j++ {
@@ -160,7 +213,9 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 
 		// receive and validate addresses from the subscription
 		go func(j int) {
+			var err error
 			var i int // address index
+			lastStartIndexSlice[j] = -1
 			for {
 				select {
 				case got, ok := <-ch:
@@ -168,9 +223,18 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 						return
 					}
 					addrsMu.Lock()
-					want := addrs[i]
+					if i > lastStartIndexSlice[j] {
+						// no way to know which chunk will come first here
+						gotIndex := findAddressIndex(got.Address())
+						if gotIndex <= lastStartIndexSlice[j] {
+							err = fmt.Errorf("got index %v, expected index above %v", gotIndex, lastStartIndexSlice[j])
+						}
+						lastStartIndexSlice[j] = gotIndex
+						i = 0
+					}
+					aIndex := lastStartIndexSlice[j] - i
+					want := addrs[aIndex]
 					addrsMu.Unlock()
-					var err error
 					if !got.Address().Equal(want) {
 						err = fmt.Errorf("got chunk %v address on subscription %v %s, want %s", i, j, got, want)
 					}
@@ -202,4 +266,12 @@ func TestDB_SubscribePush_multiple(t *testing.T) {
 	wantedChunksCount := len(addrs) * subsCount
 
 	checkErrChan(ctx, t, errChan, wantedChunksCount)
+
+	for j := 0; j < subsCount; j++ {
+		addrsMu.Lock()
+		if lastStartIndexSlice[j] != len(addrs)-1 {
+			t.Fatalf("got %d chunks, expected %d", lastStartIndexSlice[j], len(addrs))
+		}
+		addrsMu.Unlock()
+	}
 }

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -358,7 +358,6 @@ func (f Index) Iterate(fn IndexIterFunc, options *IterateOptions) (err error) {
 					return it.Error()
 				}
 			}
-
 		}
 	}
 
@@ -390,8 +389,8 @@ func (f Index) Iterate(fn IndexIterFunc, options *IterateOptions) (err error) {
 	return it.Error()
 }
 
-// Increment the last byte that is not 0xFF, and returned a new byte array
-// truncated after the position that was incremented.
+// bytesIncrement increments the last byte that is not 0xFF, and returns
+// a new byte array truncated after the position that was incremented.
 func bytesIncrement(bytes []byte) []byte {
 	b := append(bytes[:0:0], bytes...)
 
@@ -401,7 +400,7 @@ func bytesIncrement(bytes []byte) []byte {
 			continue
 		}
 
-		// Found byte smaller than 0xFF: increment and truncate
+		// found byte smaller than 0xFF: increment and truncate
 		b[i]++
 		return b[:i+1]
 	}

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -134,6 +134,11 @@ func (db *DB) NewIndex(name string, funcs IndexFuncs) (f Index, err error) {
 	}, nil
 }
 
+// ItemKey accepts an Item and returns generated key for it.
+func (f Index) ItemKey(item Item) (key []byte, err error) {
+	return f.encodeKeyFunc(item)
+}
+
 // Get accepts key fields represented as Item to retrieve a
 // value from the index and return maximum available information
 // from the index represented as another Item.

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -284,6 +284,8 @@ type IterateOptions struct {
 	SkipStartFromItem bool
 	// Iterate over items which keys have a common prefix.
 	Prefix []byte
+	// Iterate over items in reverse order.
+	Reverse bool
 }
 
 // Iterate function iterates over keys of the Index.
@@ -303,21 +305,68 @@ func (f Index) Iterate(fn IndexIterFunc, options *IterateOptions) (err error) {
 			return fmt.Errorf("encode key: %w", err)
 		}
 	}
+
 	it := f.db.NewIterator()
 	defer it.Release()
 
+	var ok bool
+
 	// move the cursor to the start key
-	ok := it.Seek(startKey)
-	if !ok {
-		// stop iterator if seek has failed
-		return it.Error()
+	ok = it.Seek(startKey)
+
+	if !options.Reverse {
+		if !ok {
+			// stop iterator if seek has failed
+			return it.Error()
+		}
+	} else {
+		// reverse seeker
+		if options.StartFrom != nil {
+			if !ok {
+				return it.Error()
+			}
+		} else {
+			// find last key for this index (and prefix)
+
+			// move cursor to last key
+			ok = it.Last()
+			if !ok {
+				return it.Error()
+			}
+
+			if lastKeyHasPrefix := bytes.HasPrefix(it.Key(), prefix); !lastKeyHasPrefix {
+				// increment last prefix byte (that is not 0xFF) to try to find last key
+				incrementedPrefix := bytesIncrement(prefix)
+				if incrementedPrefix == nil {
+					return fmt.Errorf("index iterator invalid prefix: %v -> %v", prefix, string(prefix))
+				}
+
+				// should find first key after prefix (same or different index)
+				ok = it.Seek(incrementedPrefix)
+				if !ok {
+					return it.Error()
+				}
+
+				// previous key should have proper prefix
+				ok = it.Prev()
+				if !ok {
+					return it.Error()
+				}
+			}
+
+		}
+	}
+
+	itSeekerFn := it.Next
+	if options.Reverse {
+		itSeekerFn = it.Prev
 	}
 	if options.SkipStartFromItem && bytes.Equal(startKey, it.Key()) {
 		// skip the start from Item if it is the first key
 		// and it is explicitly configured to skip it
-		ok = it.Next()
+		ok = itSeekerFn()
 	}
-	for ; ok; ok = it.Next() {
+	for ; ok; ok = itSeekerFn() {
 		item, err := f.itemFromIterator(it, prefix)
 		if err != nil {
 			if errors.Is(err, leveldb.ErrNotFound) {
@@ -334,6 +383,26 @@ func (f Index) Iterate(fn IndexIterFunc, options *IterateOptions) (err error) {
 		}
 	}
 	return it.Error()
+}
+
+// Increment the last byte that is not 0xFF, and returned a new byte array
+// truncated after the position that was incremented.
+func bytesIncrement(bytes []byte) []byte {
+	b := append(bytes[:0:0], bytes...)
+
+	for i := len(bytes) - 1; i >= 0; {
+		if b[i] == 0xFF {
+			i--
+			continue
+		}
+
+		// Found byte smaller than 0xFF: increment and truncate
+		b[i]++
+		return b[:i+1]
+	}
+
+	// input contained only 0xFF bytes
+	return nil
 }
 
 // First returns the first item in the Index which encoded key starts with a prefix.


### PR DESCRIPTION
This change adds support for reverse iteration over index items, and uses that for processing push index.

Since the order is reversed, last successful processed item is no longer tracked (to be used to start on next iteration). First item from iteration is saved, and each item from iteration is compared to that one, and if reached iteration stopped.
That backward processing results in FIFO processing of added chunks into push index.

relates to: #532 