### PR TITLE
use absolute path for golangci-lint in Makfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-GOLANGCI_LINT ?= golangci-lint
+GOLANGCI_LINT ?= $$($(GO) env GOPATH)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.30.0
 GOGOPROTOBUF ?= protoc-gen-gogofaster
 GOGOPROTOBUF_VERSION ?= v1.3.1
@@ -31,7 +31,7 @@ lint: linter
 
 .PHONY: linter
 linter:
-	which $(GOLANGCI_LINT) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$($(GO) env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	test -f $(GOLANGCI_LINT) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$($(GO) env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
Do not rely that $GOPATH/bin is in the environment's $PATH for Makefile lint rule

fixes: #816 