### PR TITLE
Simplify chunk pusher worker loop

### DIFF
--- a/pkg/pusher/metrics.go
+++ b/pkg/pusher/metrics.go
@@ -17,7 +17,6 @@ type metrics struct {
 	TotalChunksToBeSentCounter prometheus.Counter
 	TotalChunksSynced          prometheus.Counter
 	ErrorSettingChunkToSynced  prometheus.Counter
-	MarkAndSweepTimer          prometheus.Histogram
 }
 
 func newMetrics() metrics {
@@ -40,14 +39,7 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "cannot_set_chunk_sync_in_db",
-			Help:      "Total no of times the chunk cannot be synced in DB.",
-		}),
-		MarkAndSweepTimer: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "mark_and_sweep_time_histogram",
-			Help:      "Histogram of time spent in mark and sweep.",
-			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60},
+			Help:      "Total number of times the chunk cannot be synced in DB.",
 		}),
 	}
 }

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -55,15 +55,14 @@ func New(storer storage.Storer, peerSuggester topology.ClosestPeerer, pushSyncer
 // and pushes them to the closest peer and get a receipt.
 func (s *Service) chunksWorker() {
 	var (
-		chunks        <-chan swarm.Chunk
-		unsubscribe   func()
-		chunksInBatch = -1
-		cctx, cancel  = context.WithCancel(context.Background())
-		ctx           = cctx
-		sem           = make(chan struct{}, concurrentJobs)
-		inflight      = make(map[string]struct{})
-		mtx           sync.Mutex
-		span          opentracing.Span
+		chunks       <-chan swarm.Chunk
+		unsubscribe  func()
+		cctx, cancel = context.WithCancel(context.Background())
+		ctx          = cctx
+		sem          = make(chan struct{}, concurrentJobs)
+		inflight     = make(map[string]struct{})
+		mtx          sync.Mutex
+		span         opentracing.Span
 	)
 	defer close(s.chunksWorkerQuitC)
 	go func() {
@@ -107,7 +106,6 @@ LOOP:
 				span, _, ctx = s.tracer.StartSpanFromContext(cctx, "pusher-sync-batch", s.logger)
 			}
 
-			chunksInBatch++
 			s.metrics.TotalChunksToBeSentCounter.Inc()
 			select {
 			case sem <- struct{}{}:

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -150,6 +150,9 @@ LOOP:
 					}
 					return
 				}
+
+				s.metrics.TotalChunksSynced.Inc()
+
 				err = s.setChunkAsSynced(ctx, ch)
 				if err != nil {
 					s.logger.Debugf("pusher: error setting chunk as synced: %v", err)

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -57,7 +57,6 @@ func (s *Service) chunksWorker() {
 	var (
 		chunks        <-chan swarm.Chunk
 		unsubscribe   func()
-		timer         = time.NewTimer(0) // timer, initially set to 0 to fall through select case on timer.C for initialisation
 		chunksInBatch = -1
 		cctx, cancel  = context.WithCancel(context.Background())
 		ctx           = cctx
@@ -66,26 +65,36 @@ func (s *Service) chunksWorker() {
 		mtx           sync.Mutex
 		span          opentracing.Span
 	)
-	defer timer.Stop()
 	defer close(s.chunksWorkerQuitC)
 	go func() {
 		<-s.quit
 		cancel()
 	}()
 
+	chunks, unsubscribe = s.storer.SubscribePush(ctx)
+
 LOOP:
 	for {
 		select {
 		// handle incoming chunks
 		case ch, more := <-chunks:
-			// if no more, set to nil, reset timer to finalise batch
+			// if no more, wait and re-subscribe
 			if !more {
-				chunks = nil
-				var dur time.Duration
-				if chunksInBatch == 0 {
-					dur = 500 * time.Millisecond
+				select {
+				case <-time.After(retryInterval):
+				case <-s.quit:
+					if unsubscribe != nil {
+						unsubscribe()
+					}
+					break LOOP
 				}
-				timer.Reset(dur)
+				// if subscribe was running, stop it
+				if unsubscribe != nil {
+					unsubscribe()
+				}
+
+				// and start iterating on Push index from the beginning
+				chunks, unsubscribe = s.storer.SubscribePush(ctx)
 				break
 			}
 
@@ -93,8 +102,6 @@ LOOP:
 				span, _, ctx = s.tracer.StartSpanFromContext(cctx, "pusher-sync-batch", s.logger)
 			}
 
-			// postpone a retry only after we've finished processing everything in index
-			timer.Reset(retryInterval)
 			chunksInBatch++
 			s.metrics.TotalChunksToBeSentCounter.Inc()
 			select {
@@ -147,28 +154,6 @@ LOOP:
 				}
 
 			}(ctx, ch)
-		case <-timer.C:
-			// initially timer is set to go off as well as every time we hit the end of push index
-			startTime := time.Now()
-
-			// if subscribe was running, stop it
-			if unsubscribe != nil {
-				unsubscribe()
-			}
-
-			chunksInBatch = 0
-
-			// and start iterating on Push index from the beginning
-			chunks, unsubscribe = s.storer.SubscribePush(ctx)
-
-			// reset timer to go off after retryInterval
-			timer.Reset(retryInterval)
-			s.metrics.MarkAndSweepTimer.Observe(time.Since(startTime).Seconds())
-
-			if span != nil {
-				span.Finish()
-				span = nil
-			}
 
 		case <-s.quit:
 			if unsubscribe != nil {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -80,6 +80,11 @@ LOOP:
 		case ch, more := <-chunks:
 			// if no more, wait and re-subscribe
 			if !more {
+				if span != nil {
+					span.Finish()
+					span = nil
+				}
+
 				select {
 				case <-time.After(retryInterval):
 				case <-s.quit:


### PR DESCRIPTION
Remove main timer case for chunk pusher worker.
If the `chunk` channel is closed, just wait for retry interval and re-subscribe. The channel will usually be only closed on some internal error.

P.S.
Basically change from [branch/pusher-new](https://github.com/ethersphere/bee/compare/pusher-new).

related to #532 