### PR TITLE
fix comments in soc package

### DIFF
--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package soc
 
 var (

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package swarm contains most basic and general Swarm concepts.
 package soc
 
 import (

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package swarm contains most basic and general Swarm concepts.
 package soc_test
 
 import (

--- a/pkg/soc/validator.go
+++ b/pkg/soc/validator.go
@@ -1,6 +1,7 @@
 // Copyright 2020 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package soc
 
 import (
@@ -9,7 +10,7 @@ import (
 
 var _ swarm.Validator = (*Validator)(nil)
 
-// SocVaildator validates that the address of a given chunk
+// Validator validates that the address of a given chunk
 // is a single-owner chunk.
 type Validator struct {
 }

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package swarm contains most basic and general Swarm concepts.
 package soc_test
 
 import (


### PR DESCRIPTION
This PR fixes formal documentation strings in `soc` package. Some comments copied from the swarm packages are removed, copyright statement correctly separated from the package declaration not to be rendered as the package documentation, and a small variable name correction in comment.