### PR TITLE
Wait until pusher active jobs are done on Close

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -214,6 +214,7 @@ func (s *Service) setChunkAsSynced(ctx context.Context, ch swarm.Chunk) error {
 }
 
 func (s *Service) Close() error {
+	s.logger.Info("pusher shutting down")
 	close(s.quit)
 
 	// Wait for chunks worker to finish

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -193,7 +193,7 @@ LOOP:
 
 	select {
 	case <-closeC:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		s.logger.Warning("pusher shutting down with pending operations")
 	}
 }
@@ -219,7 +219,7 @@ func (s *Service) Close() error {
 	// Wait for chunks worker to finish
 	select {
 	case <-s.chunksWorkerQuitC:
-	case <-time.After(3 * time.Second):
+	case <-time.After(6 * time.Second):
 	}
 	return nil
 }


### PR DESCRIPTION
Change increases timeout for waiting for pending push operations to terminate. When the `Close()` function is invoked on push service, it closes the `quit` channel which triggers closing of the worker, which has logic that waits for some time to terminate all active goroutines through semaphore.