### PR TITLE
swapprotocol: don't wait for full close in emitcheque

### DIFF
--- a/pkg/settlement/swap/swapprotocol/swapprotocol.go
+++ b/pkg/settlement/swap/swapprotocol/swapprotocol.go
@@ -186,7 +186,7 @@ func (s *Service) EmitCheque(ctx context.Context, peer swarm.Address, cheque *ch
 		if err != nil {
 			_ = stream.Reset()
 		} else {
-			// don't wait for full close to avoid deadlocks if cheques are sent simultaniously in both directions
+			// don't wait for full close to avoid deadlocks if cheques are sent simultaneously in both directions
 			go stream.FullClose()
 		}
 	}()

--- a/pkg/settlement/swap/swapprotocol/swapprotocol.go
+++ b/pkg/settlement/swap/swapprotocol/swapprotocol.go
@@ -186,9 +186,8 @@ func (s *Service) EmitCheque(ctx context.Context, peer swarm.Address, cheque *ch
 		if err != nil {
 			_ = stream.Reset()
 		} else {
-			// wait for full close
-			// this ensure the accounting lock for this peer will be held long for the other peer to process the cheque
-			_ = stream.FullClose()
+			// don't wait for full close to avoid deadlocks if cheques are sent simultaniously in both directions
+			go stream.FullClose()
 		}
 	}()
 


### PR DESCRIPTION
avoids a deadlock when two nodes send each other cheques at the same time and end up holding their accounting locks of their counterparty preventing both from processing.