### PR TITLE
disable port reuse in libp2p

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/libp2p/go-libp2p-discovery v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-peerstore v0.2.6
 	github.com/libp2p/go-libp2p-quic-transport v0.8.0
+	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-openssl v0.0.6 // indirect
 	github.com/libp2p/go-tcp-transport v0.2.0
 	github.com/libp2p/go-ws-transport v0.3.1

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -34,6 +34,7 @@ import (
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	libp2pquic "github.com/libp2p/go-libp2p-quic-transport"
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	"github.com/libp2p/go-tcp-transport"
 	ws "github.com/libp2p/go-ws-transport"
@@ -146,7 +147,11 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	}
 
 	transports := []libp2p.Option{
-		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(func(u *tptu.Upgrader) *tcp.TcpTransport {
+			t := tcp.NewTCPTransport(u)
+			t.DisableReuseport = true
+			return t
+		}),
 	}
 
 	if o.EnableWS {


### PR DESCRIPTION
LibP2P TCP transport default behaviour is to use port reuse which allows to open multiple listeners on the same local port. This is confusing as to or more bee nodes can run on the same system with the same p2p port but makes non of them usable as packets are distributed among them.

With this change, bee node will exit with an error if another process is already listening on the same port, just as it is the case with api and debugapi listeners.