### PR TITLE
set http server timeouts

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -423,8 +423,10 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		}
 
 		apiServer := &http.Server{
-			Handler:  apiService,
-			ErrorLog: log.New(b.errorLogWriter, "", 0),
+			IdleTimeout:       30 * time.Second,
+			ReadHeaderTimeout: 3 * time.Second,
+			Handler:           apiService,
+			ErrorLog:          log.New(b.errorLogWriter, "", 0),
 		}
 
 		go func() {
@@ -475,8 +477,10 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		}
 
 		debugAPIServer := &http.Server{
-			Handler:  debugAPIService,
-			ErrorLog: log.New(b.errorLogWriter, "", 0),
+			IdleTimeout:       30 * time.Second,
+			ReadHeaderTimeout: 3 * time.Second,
+			Handler:           debugAPIService,
+			ErrorLog:          log.New(b.errorLogWriter, "", 0),
 		}
 
 		go func() {


### PR DESCRIPTION
Set connection idle and read header timeouts for API and DebugAPI HTTP servers in order to cleanup connections and avoid potential large number of open files. This is something that may improve situation described in https://github.com/ethersphere/bee/issues/867.