### PR TITLE
Surplus balances for peers

### DIFF
--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -42,7 +42,7 @@ paths:
 
   '/balances':
     get:
-      summary: Get the balances with all known peers
+      summary: Get the balances with all known peers including prepaid services
       tags:
         - Balance
       responses:
@@ -59,7 +59,7 @@ paths:
 
   '/balances/{address}':
     get:
-      summary: Get the balances with a specific peer
+      summary: Get the balances with a specific peer including prepaid services
       tags:
         - Balance
       parameters:
@@ -71,7 +71,50 @@ paths:
           description: Swarm address of peer
       responses:
         '200':
-          description: Peer is known
+          description: Balance with the specific peer
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balance'
+        '404':
+          $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+ 
+  '/consumed':
+    get:
+      summary: Get the past due consumption balances with all known peers
+      tags:
+        - Balance
+      responses:
+        '200':
+          description: Own past due consumption balances with all known peers
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/consumed/{address}':
+    get:
+      summary: Get the past due consumption balance with a specific peer
+      tags:
+        - Balance
+      parameters:
+        - in: path
+          name: address
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      responses:
+        '200':
+          description: Past-due consumption balance with the specific peer
           content:
             application/json:
               schema:

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -306,7 +306,7 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 	cost := price
 
 	// see if peer has surplus balance to deduct this transaction of
-	if accountingPeer.surplus == true {
+	if accountingPeer.surplus {
 		surplusBalance, err := a.SurplusBalance(peer)
 		if err != nil {
 			if !errors.Is(err, ErrPeerNoBalance) {
@@ -343,6 +343,9 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 
 		// if surplus balance didn't cover full transaction, let's continue with leftover part as cost
 		debitIncrease, err := subtractU64mI64(price, surplusBalance)
+		if err != nil {
+			return err
+		}
 		// conversion to uint64 is safe because we know the relationship between the values by now, but let's make a sanity check
 		if debitIncrease <= 0 {
 			return fmt.Errorf("sanity check failed for partial debit after surplus balance drawn")

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -547,10 +547,6 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 			return ErrOverflow
 		}
 
-		if increasedSurplus > math.MaxInt64 {
-			return ErrOverflow
-		}
-
 		err = a.store.Put(peerSurplusBalanceKey(peer), increasedSurplus)
 		if err != nil {
 			return fmt.Errorf("failed to persist surplus balance: %w", err)

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -435,6 +435,8 @@ func (a *Accounting) getAccountingPeer(peer swarm.Address) (*accountingPeer, err
 			reservedBalance: 0,
 			// initially assume the peer has the same threshold as us
 			paymentThreshold: a.paymentThreshold,
+			// set surplus to true, so first debit will try using surplus, and will set this to false if there's none
+			surplus: true,
 		}
 		a.accountingPeers[peer.String()] = peerData
 	}
@@ -505,8 +507,8 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 		if !errors.Is(err, ErrPeerNoBalance) {
 			return err
 		}
-	}
 
+	}
 	newBalance, err := subtractI64mU64(currentBalance, amount)
 	if err != nil {
 		return err

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -90,8 +90,8 @@ var (
 	ErrPeerNoBalance = errors.New("no balance for peer")
 	// ErrOverflow denotes an arithmetic operation overflowed.
 	ErrOverflow = errors.New("overflow error")
-	// ErrInValue denotes an invalid value read from store
-	ErrInValue = errors.New("invalid value")
+	// ErrInvalidValue denotes an invalid value read from store
+	ErrInvalidValue = errors.New("invalid value")
 )
 
 // NewAccounting creates a new Accounting instance with the provided options.
@@ -176,7 +176,7 @@ func (a *Accounting) Reserve(ctx context.Context, peer swarm.Address, price uint
 
 	// uint64 conversion of surplusbalance is safe because surplusbalance is always positive
 	if additionalDebt < 0 {
-		return ErrInValue
+		return ErrInvalidValue
 	}
 
 	increasedExpectedDebt, err := addI64pU64(expectedDebt, uint64(additionalDebt))
@@ -449,7 +449,7 @@ func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, 
 		return 0, err
 	}
 	if surplus < 0 {
-		return 0, ErrInValue
+		return 0, ErrInvalidValue
 	}
 	// Compensated balance is balance decreased by surplus balance
 	compensated, err = subtractI64mU64(balance, uint64(surplus))

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -47,6 +47,10 @@ type Interface interface {
 	SurplusBalance(peer swarm.Address) (int64, error)
 	// Balances returns balances for all known peers.
 	Balances() (map[string]int64, error)
+	// CompensatedBalance returns the current balance deducted by current surplus balance for the given peer.
+	CompensatedBalance(peer swarm.Address) (int64, error)
+	// CompensatedBalances returns the compensated balances for all known peers.
+	CompensatedBalances() (map[string]int64, error)
 }
 
 // accountingPeer holds all in-memory accounting information for one peer.
@@ -86,6 +90,8 @@ var (
 	ErrPeerNoBalance = errors.New("no balance for peer")
 	// ErrOverflow denotes an arithmetic operation overflowed.
 	ErrOverflow = errors.New("overflow error")
+	// ErrInValue denotes an invalid value read from store
+	ErrInValue = errors.New("invalid value")
 )
 
 // NewAccounting creates a new Accounting instance with the provided options.
@@ -163,10 +169,25 @@ func (a *Accounting) Reserve(ctx context.Context, peer swarm.Address, price uint
 		threshold = 0
 	}
 
+	additionalDebt, err := a.SurplusBalance(peer)
+	if err != nil {
+		return fmt.Errorf("failed to load surplus balance: %w", err)
+	}
+
+	// uint64 conversion of surplusbalance is safe because surplusbalance is always positive
+	if additionalDebt < 0 {
+		return ErrInValue
+	}
+
+	increasedExpectedDebt, err := addI64pU64(expectedDebt, uint64(additionalDebt))
+	if err != nil {
+		return err
+	}
+
 	// If our expected debt is less than earlyPayment away from our payment threshold
 	// and we are actually in debt, trigger settlement.
 	// we pay early to avoid needlessly blocking request later when concurrent requests occur and we are already close to the payment threshold.
-	if expectedDebt >= int64(threshold) && currentBalance < 0 {
+	if increasedExpectedDebt >= int64(threshold) && currentBalance < 0 {
 		err = a.settle(ctx, peer, accountingPeer)
 		if err != nil {
 			return fmt.Errorf("failed to settle with peer %v: %v", peer, err)
@@ -174,11 +195,15 @@ func (a *Accounting) Reserve(ctx context.Context, peer swarm.Address, price uint
 		// if we settled successfully our balance is back at 0
 		// and the expected debt therefore equals next reserved amount
 		expectedDebt = int64(nextReserved)
+		increasedExpectedDebt, err = addI64pU64(expectedDebt, uint64(additionalDebt))
+		if err != nil {
+			return err
+		}
 	}
 
 	// if expectedDebt would still exceed the paymentThreshold at this point block this request
 	// this can happen if there is a large number of concurrent requests to the same peer
-	if expectedDebt > int64(a.paymentThreshold) {
+	if increasedExpectedDebt > int64(a.paymentThreshold) {
 		a.metrics.AccountingBlocksCount.Inc()
 		return ErrOverdraft
 	}
@@ -413,6 +438,28 @@ func (a *Accounting) SurplusBalance(peer swarm.Address) (balance int64, err erro
 	return balance, nil
 }
 
+// CompensatedBalance returns balance decreased by surplus balance
+func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, err error) {
+	balance, err := a.Balance(peer)
+	if err != nil {
+		return 0, err
+	}
+	surplus, err := a.SurplusBalance(peer)
+	if err != nil {
+		return 0, err
+	}
+	if surplus < 0 {
+		return 0, ErrInValue
+	}
+	// Compensated balance is balance decreased by surplus balance
+	compensated, err = subtractI64mU64(balance, uint64(surplus))
+	if err != nil {
+		return 0, err
+	}
+
+	return compensated, nil
+}
+
 // peerBalanceKey returns the balance storage key for the given peer.
 func peerBalanceKey(peer swarm.Address) string {
 	return fmt.Sprintf("%s%s", balancesPrefix, peer.String())
@@ -472,11 +519,76 @@ func (a *Accounting) Balances() (map[string]int64, error) {
 	return s, nil
 }
 
+// Balances gets balances for all peers from store.
+func (a *Accounting) CompensatedBalances() (map[string]int64, error) {
+	s := make(map[string]int64)
+
+	err := a.store.Iterate(balancesPrefix, func(key, val []byte) (stop bool, err error) {
+		addr, err := balanceKeyPeer(key)
+		if err != nil {
+			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+		}
+		if _, ok := s[addr.String()]; !ok {
+			value, err := a.CompensatedBalance(addr)
+			if err != nil {
+				return false, fmt.Errorf("get peer %s balance: %v", addr.String(), err)
+			}
+
+			s[addr.String()] = value
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = a.store.Iterate(balancesSurplusPrefix, func(key, val []byte) (stop bool, err error) {
+		addr, err := surplusBalanceKeyPeer(key)
+		if err != nil {
+			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+		}
+		if _, ok := s[addr.String()]; !ok {
+			value, err := a.CompensatedBalance(addr)
+			if err != nil {
+				return false, fmt.Errorf("get peer %s balance: %v", addr.String(), err)
+			}
+
+			s[addr.String()] = value
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
 // balanceKeyPeer returns the embedded peer from the balance storage key.
 func balanceKeyPeer(key []byte) (swarm.Address, error) {
 	k := string(key)
 
 	split := strings.SplitAfter(k, balancesPrefix)
+	if len(split) != 2 {
+		return swarm.ZeroAddress, errors.New("no peer in key")
+	}
+
+	addr, err := swarm.ParseHexAddress(split[1])
+	if err != nil {
+		return swarm.ZeroAddress, err
+	}
+
+	return addr, nil
+}
+
+func surplusBalanceKeyPeer(key []byte) (swarm.Address, error) {
+	k := string(key)
+
+	split := strings.SplitAfter(k, balancesSurplusPrefix)
 	if len(split) != 2 {
 		return swarm.ZeroAddress, errors.New("no peer in key")
 	}
@@ -507,6 +619,28 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 		}
 
 	}
+	// if balance is already negative or zero, we credit full amount received to surplus balance and terminate early
+	if currentBalance <= 0 {
+		surplus, err := a.SurplusBalance(peer)
+		if err != nil {
+			return fmt.Errorf("failed to get surplus balance: %w", err)
+		}
+		increasedSurplus, err := addI64pU64(surplus, amount)
+		if err != nil {
+			return err
+		}
+
+		a.logger.Tracef("surplus crediting peer %v with amount %d due to payment, new surplus balance is %d", peer, amount, increasedSurplus)
+
+		err = a.store.Put(peerSurplusBalanceKey(peer), increasedSurplus)
+		if err != nil {
+			return fmt.Errorf("failed to persist surplus balance: %w", err)
+		}
+
+		return nil
+	}
+
+	// if current balance is positive, let's make a partial credit to
 	newBalance, err := subtractI64mU64(currentBalance, amount)
 	if err != nil {
 		return err

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -328,7 +328,7 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 		}
 
 		// if we still have something to debit, than have run out of surplus balance,
-		// let's set surplus flag to false and store 0 as surplus balance
+		// let's store 0 as surplus balance
 		err = a.store.Put(peerSurplusBalanceKey(peer), 0)
 		if err != nil {
 			return fmt.Errorf("failed to persist surplus balance: %w", err)

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -43,7 +43,7 @@ type Interface interface {
 	Debit(peer swarm.Address, price uint64) error
 	// Balance returns the current balance for the given peer.
 	Balance(peer swarm.Address) (int64, error)
-	//
+	// SurplusBalance returns the current surplus balance for the given peer.
 	SurplusBalance(peer swarm.Address) (int64, error)
 	// Balances returns balances for all known peers.
 	Balances() (map[string]int64, error)
@@ -303,9 +303,7 @@ func (a *Accounting) Debit(peer swarm.Address, price uint64) error {
 	defer accountingPeer.lock.Unlock()
 
 	cost := price
-
 	// see if peer has surplus balance to deduct this transaction of
-
 	surplusBalance, err := a.SurplusBalance(peer)
 	if err != nil {
 		if !errors.Is(err, ErrPeerNoBalance) {

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -562,8 +562,8 @@ func TestAccountingNotifyPayment(t *testing.T) {
 	}
 
 	err = acc.NotifyPayment(peer1Addr, debtAmount+testPaymentTolerance+1)
-	if err == nil {
-		t.Fatal("expected payment to be rejected")
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -299,16 +299,18 @@ func TestAccountingOverflowNotifyPayment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Notify of incoming payment from same peer, further decreasing balance, this should overflow
+
+	// NotifyPayment for peer should now fill the surplus balance
 	err = acc.NotifyPayment(peer1Addr, math.MaxInt64)
-	if err == nil {
-		t.Fatal("Expected overflow from NotifyPayment")
+	if err != nil {
+		t.Fatalf("Expected no error but got one: %v", err)
 	}
-	// If we had other error, assert fail
+
+	// Notify of incoming payment from same peer, further increasing the surplus balance into an overflow
+	err = acc.NotifyPayment(peer1Addr, 1)
 	if !errors.Is(err, accounting.ErrOverflow) {
 		t.Fatalf("expected overflow error from Debit, got %v", err)
 	}
-
 }
 
 func TestAccountingOverflowDebit(t *testing.T) {

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -14,14 +14,15 @@ import (
 
 // Service is the mock Accounting service.
 type Service struct {
-	lock         sync.Mutex
-	balances     map[string]int64
-	reserveFunc  func(ctx context.Context, peer swarm.Address, price uint64) error
-	releaseFunc  func(peer swarm.Address, price uint64)
-	creditFunc   func(peer swarm.Address, price uint64) error
-	debitFunc    func(peer swarm.Address, price uint64) error
-	balanceFunc  func(swarm.Address) (int64, error)
-	balancesFunc func() (map[string]int64, error)
+	lock               sync.Mutex
+	balances           map[string]int64
+	reserveFunc        func(ctx context.Context, peer swarm.Address, price uint64) error
+	releaseFunc        func(peer swarm.Address, price uint64)
+	creditFunc         func(peer swarm.Address, price uint64) error
+	debitFunc          func(peer swarm.Address, price uint64) error
+	balanceFunc        func(swarm.Address) (int64, error)
+	balancesFunc       func() (map[string]int64, error)
+	balanceSurplusFunc func(swarm.Address) (int64, error)
 }
 
 // WithReserveFunc sets the mock Reserve function
@@ -63,6 +64,13 @@ func WithBalanceFunc(f func(swarm.Address) (int64, error)) Option {
 func WithBalancesFunc(f func() (map[string]int64, error)) Option {
 	return optionFunc(func(s *Service) {
 		s.balancesFunc = f
+	})
+}
+
+// WithBalanceSurplusFunc sets the mock SurplusBalance function
+func WithBalanceSurplusFunc(f func(swarm.Address) (int64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.balanceSurplusFunc = f
 	})
 }
 
@@ -129,6 +137,16 @@ func (s *Service) Balances() (map[string]int64, error) {
 		return s.balancesFunc()
 	}
 	return s.balances, nil
+}
+
+//
+func (s *Service) SurplusBalance(peer swarm.Address) (int64, error) {
+	if s.balanceFunc != nil {
+		return s.balanceSurplusFunc(peer)
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return 0, nil
 }
 
 // Option is the option passed to the mock accounting service

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -14,14 +14,17 @@ import (
 
 // Service is the mock Accounting service.
 type Service struct {
-	lock               sync.Mutex
-	balances           map[string]int64
-	reserveFunc        func(ctx context.Context, peer swarm.Address, price uint64) error
-	releaseFunc        func(peer swarm.Address, price uint64)
-	creditFunc         func(peer swarm.Address, price uint64) error
-	debitFunc          func(peer swarm.Address, price uint64) error
-	balanceFunc        func(swarm.Address) (int64, error)
-	balancesFunc       func() (map[string]int64, error)
+	lock                    sync.Mutex
+	balances                map[string]int64
+	reserveFunc             func(ctx context.Context, peer swarm.Address, price uint64) error
+	releaseFunc             func(peer swarm.Address, price uint64)
+	creditFunc              func(peer swarm.Address, price uint64) error
+	debitFunc               func(peer swarm.Address, price uint64) error
+	balanceFunc             func(swarm.Address) (int64, error)
+	balancesFunc            func() (map[string]int64, error)
+	compensatedBalanceFunc  func(swarm.Address) (int64, error)
+	compensatedBalancesFunc func() (map[string]int64, error)
+
 	balanceSurplusFunc func(swarm.Address) (int64, error)
 }
 
@@ -64,6 +67,20 @@ func WithBalanceFunc(f func(swarm.Address) (int64, error)) Option {
 func WithBalancesFunc(f func() (map[string]int64, error)) Option {
 	return optionFunc(func(s *Service) {
 		s.balancesFunc = f
+	})
+}
+
+// WithCompensatedBalanceFunc sets the mock Balance function
+func WithCompensatedBalanceFunc(f func(swarm.Address) (int64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.compensatedBalanceFunc = f
+	})
+}
+
+// WithCompensatedBalancesFunc sets the mock Balances function
+func WithCompensatedBalancesFunc(f func() (map[string]int64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.compensatedBalancesFunc = f
 	})
 }
 
@@ -135,6 +152,24 @@ func (s *Service) Balance(peer swarm.Address) (int64, error) {
 func (s *Service) Balances() (map[string]int64, error) {
 	if s.balancesFunc != nil {
 		return s.balancesFunc()
+	}
+	return s.balances, nil
+}
+
+// CompensatedBalance is the mock function wrapper that calls the set implementation
+func (s *Service) CompensatedBalance(peer swarm.Address) (int64, error) {
+	if s.compensatedBalanceFunc != nil {
+		return s.compensatedBalanceFunc(peer)
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.balances[peer.String()], nil
+}
+
+// CompensatedBalances is the mock function wrapper that calls the set implementation
+func (s *Service) CompensatedBalances() (map[string]int64, error) {
+	if s.compensatedBalancesFunc != nil {
+		return s.compensatedBalancesFunc()
 	}
 	return s.balances, nil
 }

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -79,3 +79,53 @@ func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 		Balance: balance,
 	})
 }
+
+func (s *server) compensatedBalancesHandler(w http.ResponseWriter, r *http.Request) {
+	balances, err := s.Accounting.CompensatedBalances()
+	if err != nil {
+		jsonhttp.InternalServerError(w, errCantBalances)
+		s.Logger.Debugf("debug api: compensated balances: %v", err)
+		s.Logger.Error("debug api: can not get compensated balances")
+		return
+	}
+
+	balResponses := make([]balanceResponse, len(balances))
+	i := 0
+	for k := range balances {
+		balResponses[i] = balanceResponse{
+			Peer:    k,
+			Balance: balances[k],
+		}
+		i++
+	}
+
+	jsonhttp.OK(w, balancesResponse{Balances: balResponses})
+}
+
+func (s *server) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: compensated balances peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Errorf("debug api: compensated balances peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+
+	balance, err := s.Accounting.CompensatedBalance(peer)
+	if err != nil {
+		if errors.Is(err, accounting.ErrPeerNoBalance) {
+			jsonhttp.NotFound(w, errNoBalance)
+			return
+		}
+		s.Logger.Debugf("debug api: compensated balances peer: get peer %s balance: %v", peer.String(), err)
+		s.Logger.Errorf("debug api: compensated balances peer: can't get peer %s balance", peer.String())
+		jsonhttp.InternalServerError(w, errCantBalance)
+		return
+	}
+
+	jsonhttp.OK(w, balanceResponse{
+		Peer:    peer.String(),
+		Balance: balance,
+	})
+}

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -84,16 +84,27 @@ func (s *server) setupRouting() {
 			web.FinalHandlerFunc(s.setWelcomeMessageHandler),
 		),
 	})
+
 	router.Handle("/balances", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.compensatedBalancesHandler),
+	})
+
+	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.compensatedPeerBalanceHandler),
+	})
+
+	router.Handle("/consumed", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.balancesHandler),
 	})
-	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
+
+	router.Handle("/consumed/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.peerBalanceHandler),
 	})
 
 	router.Handle("/settlements", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.settlementsHandler),
 	})
+
 	router.Handle("/settlements/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.peerSettlementsHandler),
 	})


### PR DESCRIPTION
The aim of this PR is to add safety for settlements that have an amount over current balance.
If a peer sends us an oversettlement, we want the extra amount to be stored as a reserve for future forwarding services towards the peer, but we do not want it to be part of regular balance, so that it can not form the base for triggering a settlement back.