### PR TITLE
add scheduled run for infra-test

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,31 @@
+name: Scheduled Infra Test
+
+on:
+ schedule:
+ - cron: 0 1 * * *
+
+jobs:
+  infra-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name:  Activity check
+        run: |
+          COMMIT=$(curl -s https://api.github.com/repos/ethersphere/bee/commits | jq -r '.[0]')
+          AUTHOR=$(jq -r '.commit.author.name' <<<$COMMIT)
+          URL=$(jq -r '.html_url' <<<$COMMIT)
+          DAYS=$(( ( $(date --utc +%s) - $(date --utc -d $(jq -r '.commit.author.date' <<<$COMMIT) +%s)) / 86400 ))
+          if [ $DAYS -eq 0 ]; then
+            echo "There are new commits..."
+            echo "Last commit from $AUTHOR, URL => $URL"
+            echo ::set-env name=GHA_REPO_RUN::true
+          else
+            echo "No new commits, exiting..."
+            echo ::set-env name=GHA_REPO_RUN::false
+          fi
+      - name: Trigger ArgoCD
+        if: env.GHA_REPO_ALIVE == 'true'
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+          repository: ethersphere/bee-argo
+          event-type: trigger-install

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -23,7 +23,7 @@ jobs:
             echo ::set-env name=GHA_REPO_RUN::false
           fi
       - name: Trigger ArgoCD
-        if: env.GHA_REPO_ALIVE == 'true'
+        if: env.GHA_REPO_RUN == 'true'
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}


### PR DESCRIPTION
This action will be executed every night at 1am, check if there were any commits in the past 24h, if yes it will trigger (dispatch) `trigger-install` event to bee-argo repo and infra-tests will be executed