### PR TITLE
api: increase pss test read timeout before mining

### DIFF
--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -30,11 +30,12 @@ import (
 )
 
 var (
-	target  = pss.Target([]byte{1})
-	targets = pss.Targets([]pss.Target{target})
-	payload = []byte("testdata")
-	topic   = pss.NewTopic("testtopic")
-	timeout = 10 * time.Second
+	target      = pss.Target([]byte{1})
+	targets     = pss.Targets([]pss.Target{target})
+	payload     = []byte("testdata")
+	topic       = pss.NewTopic("testtopic")
+	timeout     = 10 * time.Second
+	longTimeout = 30 * time.Second
 )
 
 // creates a single websocket handler for an arbitrary topic, and receives a message
@@ -48,7 +49,9 @@ func TestPssWebsocketSingleHandler(t *testing.T) {
 		done       = make(chan struct{})
 	)
 
-	err := cl.SetReadDeadline(time.Now().Add(timeout))
+	// the long timeout is needed so that we dont time out while still mining the message with Wrap()
+	// otherwise the test (and other tests below) flakes
+	err := cl.SetReadDeadline(time.Now().Add(longTimeout))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +83,7 @@ func TestPssWebsocketSingleHandlerDeregister(t *testing.T) {
 		done       = make(chan struct{})
 	)
 
-	err := cl.SetReadDeadline(time.Now().Add(timeout))
+	err := cl.SetReadDeadline(time.Now().Add(longTimeout))
 
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +125,7 @@ func TestPssWebsocketMultiHandler(t *testing.T) {
 		t.Fatalf("dial: %v. url %v", err, u.String())
 	}
 
-	err = cl.SetReadDeadline(time.Now().Add(timeout))
+	err = cl.SetReadDeadline(time.Now().Add(longTimeout))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Tests in `api/pss_test.go` are flaking. This is apparently since the read timeout for the websocket is set before mining the chunk using the real pss type. We should improve this by mocking pss in this test in a way that we don't need to mine the chunk every time and run through the actual pss code. This PR is meant to serve as a quick fix so everyone can continue working with the CI without needing the restart the builds constantly.