### PR TITLE
set chunk as synced only by push sync

### DIFF
--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -81,7 +81,7 @@ func testDBCollectGarbageWorker(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -173,7 +173,7 @@ func TestPinGC(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,14 +270,14 @@ func TestGCAfterPin(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Pin before adding to GC in ModeSetSyncPull
+		// Pin before adding to GC in ModeSetSync
 		err = db.Set(context.Background(), storage.ModeSetPin, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
 		pinAddrs = append(pinAddrs, ch.Address())
 
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -321,7 +321,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -363,7 +363,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+	err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,7 +454,7 @@ func TestDB_gcSize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -549,7 +549,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -565,7 +565,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -576,7 +576,7 @@ func TestPinAfterMultiGC(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -612,7 +612,7 @@ func generateAndPinAChunk(t *testing.T, db *DB) swarm.Chunk {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.Set(context.Background(), storage.ModeSetSyncPull, pinnedChunk.Address())
+	err = db.Set(context.Background(), storage.ModeSetSync, pinnedChunk.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +698,7 @@ func addRandomChunks(t *testing.T, count int, db *DB, pin bool) []swarm.Chunk {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+			err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -713,7 +713,7 @@ func addRandomChunks(t *testing.T, count int, db *DB, pin bool) []swarm.Chunk {
 		} else {
 			// Non pinned chunks could be GC'd by the time they reach here.
 			// so it is okay to ignore the error
-			_ = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+			_ = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 			_ = db.Set(context.Background(), storage.ModeSetAccess, ch.Address())
 			_, _ = db.Get(context.Background(), storage.ModeGetRequest, ch.Address())
 		}

--- a/pkg/localstore/index_test.go
+++ b/pkg/localstore/index_test.go
@@ -133,7 +133,7 @@ func TestDB_gcIndex(t *testing.T) {
 	t.Run("sync one chunk", func(t *testing.T) {
 		ch := chunks[0]
 
-		err := db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+		err := db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -146,7 +146,7 @@ func TestDB_gcIndex(t *testing.T) {
 
 	t.Run("sync all chunks", func(t *testing.T) {
 		for i := range chunks {
-			err := db.Set(context.Background(), storage.ModeSetSyncPull, chunks[i].Address())
+			err := db.Set(context.Background(), storage.ModeSetSync, chunks[i].Address())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/localstore/mode_get_test.go
+++ b/pkg/localstore/mode_get_test.go
@@ -75,7 +75,7 @@ func TestModeGetRequest(t *testing.T) {
 	})
 
 	// set chunk to synced state
-	err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+	err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -19,11 +19,12 @@ package localstore
 import (
 	"context"
 	"errors"
-	"github.com/ethersphere/bee/pkg/logging"
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -72,7 +73,7 @@ func TestModeSetAccess(t *testing.T) {
 // here we try to set a normal tag (that should be handled by pushsync)
 // as a result we should expect the tag value to remain in the pull index
 // and we expect that the tag should not be incremented by pull sync set
-func TestModeSetSyncPullNormalTag(t *testing.T) {
+func TestModeSetSyncNormalTag(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
 	logger := logging.New(ioutil.Discard, 0)
 	db := newTestDB(t, &Options{Tags: tags.NewTags(mockStatestore, logger)})
@@ -105,7 +106,7 @@ func TestModeSetSyncPullNormalTag(t *testing.T) {
 		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
 	}
 
-	err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
+	err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,85 +125,8 @@ func TestModeSetSyncPullNormalTag(t *testing.T) {
 		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
 	}
 
-	// 1 stored (because incremented manually in test), 1 sent, 1 total
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 1, 0, 1)
-}
-
-// TestModeSetSyncPushNormalTag makes sure that push sync increments tags
-// correctly on a normal tag (that is, a tag that is expected to show progress bars
-// according to push sync progress)
-func TestModeSetSyncPushNormalTag(t *testing.T) {
-	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
-	db := newTestDB(t, &Options{Tags: tags.NewTags(mockStatestore, logger)})
-
-	tag, err := db.tags.Create("test", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ch := generateTestRandomChunk().WithTagID(tag.Uid)
-	_, err = db.Put(context.Background(), storage.ModePutUpload, ch)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = tag.Inc(tags.StateStored) // so we don't get an error on tag.Status later on
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	item, err := db.pullIndex.Get(shed.Item{
-		Address: ch.Address().Bytes(),
-		BinID:   1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if item.Tag != tag.Uid {
-		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
-	}
-
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 0, 0, 1)
-
-	err = db.Set(context.Background(), storage.ModeSetSyncPush, ch.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	item, err = db.pullIndex.Get(shed.Item{
-		Address: ch.Address().Bytes(),
-		BinID:   1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if item.Tag != tag.Uid {
-		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
-	}
-
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 0, 1, 1)
-
-	// call pull sync set, expect no changes
-	err = db.Set(context.Background(), storage.ModeSetSyncPull, ch.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	item, err = db.pullIndex.Get(shed.Item{
-		Address: ch.Address().Bytes(),
-		BinID:   1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 0, 1, 1)
-
-	if item.Tag != tag.Uid {
-		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
-	}
+	// 1 stored (because incremented manually in test), 1 sent, 1 synced, 1 total
+	tagtesting.CheckTag(t, tag, 0, 1, 0, 1, 1, 1)
 }
 
 // TestModeSetRemove validates ModeSetRemove index values on the provided DB.

--- a/pkg/localstore/retrieval_index_test.go
+++ b/pkg/localstore/retrieval_index_test.go
@@ -83,7 +83,7 @@ func benchmarkRetrievalIndexes(b *testing.B, o *Options, count int) {
 	b.StartTimer()
 
 	for i := 0; i < count; i++ {
-		err := db.Set(context.Background(), storage.ModeSetSyncPull, addrs[i])
+		err := db.Set(context.Background(), storage.ModeSetSync, addrs[i])
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -199,7 +199,7 @@ LOOP:
 }
 
 func (s *Service) setChunkAsSynced(ctx context.Context, ch swarm.Chunk) error {
-	if err := s.storer.Set(ctx, storage.ModeSetSyncPush, ch.Address()); err != nil {
+	if err := s.storer.Set(ctx, storage.ModeSetSync, ch.Address()); err != nil {
 		s.logger.Errorf("pusher: error setting chunk as synced: %v", err)
 		s.metrics.ErrorSettingChunkToSynced.Inc()
 	}

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -40,7 +40,7 @@ type Store struct {
 	setAfterCloseCount  int
 }
 
-// Override the Set function to capture the ModeSetSyncPush
+// Override the Set function to capture the ModeSetSync
 func (s *Store) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Address) error {
 	s.modeSetMu.Lock()
 	defer s.modeSetMu.Unlock()
@@ -67,8 +67,8 @@ func (s *Store) Close() error {
 
 // TestSendChunkToPushSync sends a chunk to pushsync to be sent ot its closest peer and get a receipt.
 // once the receipt is got this check to see if the localstore is updated to see if the chunk is set
-// as ModeSetSyncPush status.
-func TestSendChunkToPushSyncWithTag(t *testing.T) {
+// as ModeSetSync status.
+func TestSendChunkToSyncWithTag(t *testing.T) {
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
@@ -99,7 +99,7 @@ func TestSendChunkToPushSyncWithTag(t *testing.T) {
 		// Give some time for chunk to be pushed and receipt to be received
 		time.Sleep(10 * time.Millisecond)
 
-		err = checkIfModeSet(chunk.Address(), storage.ModeSetSyncPush, storer)
+		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err == nil {
 			break
 		}
@@ -144,7 +144,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 		// Give some time for chunk to be pushed and receipt to be received
 		time.Sleep(10 * time.Millisecond)
 
-		err = checkIfModeSet(chunk.Address(), storage.ModeSetSyncPush, storer)
+		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err == nil {
 			break
 		}
@@ -157,7 +157,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 
 // TestSendChunkAndReceiveInvalidReceipt sends a chunk to pushsync to be sent ot its closest peer and
 // get a invalid receipt (not with the address of the chunk sent). The test makes sure that this error
-// is received and the ModeSetSyncPush is not set for the chunk.
+// is received and the ModeSetSync is not set for the chunk.
 func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 	chunk := createChunk()
 
@@ -182,7 +182,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 		// Give some time for chunk to be pushed and receipt to be received
 		time.Sleep(10 * time.Millisecond)
 
-		err = checkIfModeSet(chunk.Address(), storage.ModeSetSyncPush, storer)
+		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err != nil {
 			continue
 		}
@@ -195,7 +195,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 
 // TestSendChunkAndTimeoutinReceivingReceipt sends a chunk to pushsync to be sent ot its closest peer and
 // expects a timeout to get instead of getting a receipt. The test makes sure that timeout error
-// is received and the ModeSetSyncPush is not set for the chunk.
+// is received and the ModeSetSync is not set for the chunk.
 func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 	chunk := createChunk()
 
@@ -224,7 +224,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 		// Give some time for chunk to be pushed and receipt to be received
 		time.Sleep(10 * time.Millisecond)
 
-		err = checkIfModeSet(chunk.Address(), storage.ModeSetSyncPush, storer)
+		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err != nil {
 			continue
 		}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -86,10 +86,8 @@ func (m ModeSet) String() string {
 	switch m {
 	case ModeSetAccess:
 		return "Access"
-	case ModeSetSyncPush:
-		return "SyncPush"
-	case ModeSetSyncPull:
-		return "SyncPull"
+	case ModeSetSync:
+		return "Sync"
 	case ModeSetRemove:
 		return "Remove"
 	case ModeSetPin:
@@ -105,10 +103,8 @@ func (m ModeSet) String() string {
 const (
 	// ModeSetAccess: when an update request is received for a chunk or chunk is retrieved for delivery
 	ModeSetAccess ModeSet = iota
-	// ModeSetSyncPush: when a push sync receipt is received for a chunk
-	ModeSetSyncPush
-	// ModeSetSyncPull: when a chunk is added to a pull sync batch
-	ModeSetSyncPull
+	// ModeSetSync: when a push sync receipt is received for a chunk
+	ModeSetSync
 	// ModeSetRemove: when a chunk is removed
 	ModeSetRemove
 	// ModeSetPin: when a chunk is pinned during upload or separately


### PR DESCRIPTION
This PR addresses the problem of data integrity with relation to setting chunk as synced by both pull and push syncing while garbage collection can remove a chunk from retrieval index (as synced by push sync) and leave its address in push index.

As discussed with @zelig and @acud, the chunk should be set as synced only by push sync.