### PR TITLE
 localstore: preliminary changes related to postage stamps/batches

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -29,11 +30,12 @@ import (
 )
 
 const (
-	SwarmPinHeader           = "Swarm-Pin"
-	SwarmTagUidHeader        = "Swarm-Tag-Uid"
-	SwarmEncryptHeader       = "Swarm-Encrypt"
-	SwarmIndexDocumentHeader = "Swarm-Index-Document"
-	SwarmErrorDocumentHeader = "Swarm-Error-Document"
+	SwarmPinHeader            = "Swarm-Pin"
+	SwarmTagUidHeader         = "Swarm-Tag-Uid"
+	SwarmEncryptHeader        = "Swarm-Encrypt"
+	SwarmIndexDocumentHeader  = "Swarm-Index-Document"
+	SwarmErrorDocumentHeader  = "Swarm-Error-Document"
+	SwarmPostageBatchIdHeader = "Swarm-Postage-Batch-Id"
 )
 
 // The size of buffer used for prefetching content with Langos.
@@ -51,6 +53,7 @@ const (
 var (
 	errInvalidNameOrAddress = errors.New("invalid name or bzz address")
 	errNoResolver           = errors.New("no resolver connected")
+	errInvalidPostageBatch  = errors.New("invalid postage batch id")
 )
 
 // Service is the API service interface.
@@ -186,6 +189,22 @@ func requestEncrypt(r *http.Request) bool {
 	return strings.ToLower(r.Header.Get(SwarmEncryptHeader)) == "true"
 }
 
+func requestPostageBatchId(r *http.Request) ([]byte, error) {
+	if h := strings.ToLower(r.Header.Get(SwarmPostageBatchIdHeader)); h != "" {
+		if len(h) != 64 {
+			return nil, errInvalidPostageBatch
+		}
+		b, err := hex.DecodeString(h)
+		if err != nil {
+			return nil, errInvalidPostageBatch
+		}
+		return b, nil
+	}
+
+	// fallback to a slice of 32 zeros
+	return make([]byte, 32), nil
+}
+
 func (s *server) newTracingHandler(spanName string) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -250,10 +269,10 @@ func equalASCIIFold(s, t string) bool {
 
 type pipelineFunc func(context.Context, io.Reader, int64) (swarm.Address, error)
 
-func requestPipelineFn(s storage.Storer, r *http.Request) pipelineFunc {
+func requestPipelineFn(s storage.Storer, r *http.Request, batch []byte) pipelineFunc {
 	mode, encrypt := requestModePut(r), requestEncrypt(r)
 	return func(ctx context.Context, r io.Reader, l int64) (swarm.Address, error) {
-		pipe := builder.NewPipelineBuilder(ctx, s, mode, encrypt)
+		pipe := builder.NewPipelineBuilder(ctx, s, mode, encrypt, nil)
 		return builder.FeedPipeline(ctx, pipe, r, l)
 	}
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -5,6 +5,7 @@
 package api_test
 
 import (
+	"encoding/hex"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -14,11 +15,14 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/pkg/api"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/pss"
 	"github.com/ethersphere/bee/pkg/resolver"
 	resolverMock "github.com/ethersphere/bee/pkg/resolver/mock"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/traversal"
@@ -160,6 +164,69 @@ func TestParseName(t *testing.T) {
 				t.Errorf("got %s, want %s", got, tC.wantAdr)
 			}
 
+		})
+	}
+}
+
+// TestPostageHeaderError tests that incorrect postage batch ids
+// provided to the api correct the appropriate error code.
+func TestPostageHeaderError(t *testing.T) {
+	var (
+		mockStorer     = mock.NewStorer()
+		mockStatestore = statestore.NewStateStore()
+		logger         = logging.New(ioutil.Discard, 0)
+		client, _, _   = newTestServer(t, testServerOptions{
+			Storer: mockStorer,
+			Tags:   tags.NewTags(mockStatestore, logger),
+			Logger: logger,
+		})
+	)
+
+	for _, tc := range []struct {
+		name     string
+		endpoint string
+		batchId  []byte
+		expErr   bool
+	}{
+		{
+			name:     "bytes",
+			endpoint: "/bytes",
+			batchId:  []byte{0},
+			expErr:   true,
+		},
+		{
+			name:     "bytes",
+			endpoint: "/bytes",
+			batchId:  []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, //32 bytes - ok
+		},
+		{
+			name:     "bytes",
+			endpoint: "/bytes",
+			batchId:  []byte{}, // empty batch id falls back to the default zero batch id, so expect 200 OK. This will change once we do not fall back to a default value
+		},
+		{
+			name:     "dirs",
+			endpoint: "/dirs",
+			batchId:  []byte{0},
+			expErr:   true,
+		},
+		{
+			name:     "files",
+			endpoint: "/files",
+			batchId:  []byte{0},
+			expErr:   true,
+		},
+	} {
+
+		t.Run(tc.name, func(t *testing.T) {
+			hexbatch := hex.EncodeToString(tc.batchId)
+			expCode := http.StatusOK
+			if tc.expErr {
+				expCode = http.StatusBadRequest
+			}
+			jsonhttptest.Request(t, client, http.MethodPost, tc.endpoint, expCode,
+				jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
+			)
 		})
 	}
 }

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -35,7 +35,15 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
 
-	pipe := builder.NewPipelineBuilder(ctx, s.Storer, requestModePut(r), requestEncrypt(r))
+	batch, err := requestPostageBatchId(r)
+	if err != nil {
+		logger.Debugf("bytes upload: postage batch id:%v", err)
+		logger.Error("bytes upload: postage batch id")
+		jsonhttp.BadRequest(w, nil)
+		return
+	}
+
+	pipe := builder.NewPipelineBuilder(ctx, s.Storer, requestModePut(r), requestEncrypt(r), batch)
 	address, err := builder.FeedPipeline(ctx, pipe, r.Body, r.ContentLength)
 	if err != nil {
 		logger.Debugf("bytes upload: split write all: %v", err)

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -10,12 +10,11 @@ import (
 	"net/http"
 	"testing"
 
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -14,8 +14,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/gorilla/mux"
-
 	"github.com/ethersphere/bee/pkg/collection/entry"
 	"github.com/ethersphere/bee/pkg/file"
 	"github.com/ethersphere/bee/pkg/file/joiner"
@@ -26,6 +24,7 @@ import (
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tracing"
+	"github.com/gorilla/mux"
 )
 
 func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
@@ -109,7 +108,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	m, err := manifest.NewManifestReference(
 		manifestMetadata.MimeType,
 		e.Reference(),
-		loadsave.New(s.Storer, storage.ModePutRequest, false), // mode and encryption values are fallback
+		loadsave.New(s.Storer, storage.ModePutRequest, false, nil), // mode and encryption values are fallback
 	)
 	if err != nil {
 		logger.Debugf("bzz download: not manifest %s: %v", address, err)

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -43,7 +43,7 @@ func TestBzz(t *testing.T) {
 			Logger: logging.New(ioutil.Discard, 5),
 		})
 		pipeWriteAll = func(r io.Reader, l int64) (swarm.Address, error) {
-			pipe := builder.NewPipelineBuilder(ctx, storer, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, storer, storage.ModePutUpload, false, nil)
 			return builder.FeedPipeline(ctx, pipe, r, l)
 		}
 	)
@@ -99,7 +99,7 @@ func TestBzz(t *testing.T) {
 		}
 
 		// save manifest
-		m, err := manifest.NewDefaultManifest(loadsave.New(storer, storage.ModePutRequest, false))
+		m, err := manifest.NewDefaultManifest(loadsave.New(storer, storage.ModePutRequest, false, nil))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -60,8 +60,17 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
-	p := requestPipelineFn(s.Storer, r)
-	l := loadsave.New(s.Storer, requestModePut(r), requestEncrypt(r))
+
+	batch, err := requestPostageBatchId(r)
+	if err != nil {
+		logger.Debugf("dir upload: postage batch id:%v", err)
+		logger.Error("dir upload: postage batch id")
+		jsonhttp.InternalServerError(w, nil)
+		return
+	}
+
+	p := requestPipelineFn(s.Storer, r, batch)
+	l := loadsave.New(s.Storer, requestModePut(r), requestEncrypt(r), batch)
 	reference, err := storeDir(ctx, r.Body, s.Logger, p, l, r.Header.Get(SwarmIndexDocumentHeader), r.Header.Get(SwarmErrorDocumentHeader))
 	if err != nil {
 		logger.Debugf("dir upload: store dir err: %v", err)

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -284,7 +284,7 @@ func TestDirs(t *testing.T) {
 			verifyManifest, err := manifest.NewManifestReference(
 				manifest.DefaultManifestType,
 				e.Reference(),
-				loadsave.New(storer, storage.ModePutRequest, false),
+				loadsave.New(storer, storage.ModePutRequest, false, nil),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -149,8 +149,15 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		fileSize = uint64(n)
 		reader = tmp
 	}
+	batch, err := requestPostageBatchId(r)
+	if err != nil {
+		logger.Debugf("file upload: postage batch id:%v", err)
+		logger.Error("file upload: postage batch id")
+		jsonhttp.BadRequest(w, nil)
+		return
+	}
 
-	p := requestPipelineFn(s.Storer, r)
+	p := requestPipelineFn(s.Storer, r, batch)
 
 	// first store the file and get its reference
 	fr, err := p(ctx, reader, int64(fileSize))

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -44,7 +44,7 @@ func testSplitThenJoin(t *testing.T) {
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
 		store       = mock.NewStorer()
-		p           = builder.NewPipelineBuilder(context.Background(), store, storage.ModePutUpload, false)
+		p           = builder.NewPipelineBuilder(context.Background(), store, storage.ModePutUpload, false, nil)
 		data, _     = test.GetVector(t, int(dataIdx))
 	)
 

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -184,7 +184,7 @@ func TestEncryptDecrypt(t *testing.T) {
 				t.Fatal(err)
 			}
 			ctx := context.Background()
-			pipe := builder.NewPipelineBuilder(ctx, store, storage.ModePutUpload, true)
+			pipe := builder.NewPipelineBuilder(ctx, store, storage.ModePutUpload, true, nil)
 			testDataReader := bytes.NewReader(testData)
 			resultAddress, err := builder.FeedPipeline(ctx, pipe, testDataReader, int64(len(testData)))
 			if err != nil {

--- a/pkg/file/loadsave/loadsave.go
+++ b/pkg/file/loadsave/loadsave.go
@@ -21,7 +21,7 @@ type loadSave struct {
 	encrypted bool
 }
 
-func New(storer storage.Storer, mode storage.ModePut, enc bool) file.LoadSaver {
+func New(storer storage.Storer, mode storage.ModePut, enc bool, _ []byte) file.LoadSaver {
 	return &loadSave{
 		storer:    storer,
 		mode:      mode,
@@ -45,7 +45,7 @@ func (ls *loadSave) Load(ctx context.Context, ref []byte) ([]byte, error) {
 }
 
 func (ls *loadSave) Save(ctx context.Context, data []byte) ([]byte, error) {
-	pipe := builder.NewPipelineBuilder(ctx, ls.storer, ls.mode, ls.encrypted)
+	pipe := builder.NewPipelineBuilder(ctx, ls.storer, ls.mode, ls.encrypted, nil)
 	address, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return swarm.ZeroAddress.Bytes(), err

--- a/pkg/file/pipeline/builder/builder.go
+++ b/pkg/file/pipeline/builder/builder.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewPipelineBuilder returns the appropriate pipeline according to the specified parameters
-func NewPipelineBuilder(ctx context.Context, s storage.Putter, mode storage.ModePut, encrypt bool) pipeline.Interface {
+func NewPipelineBuilder(ctx context.Context, s storage.Putter, mode storage.ModePut, encrypt bool, batch []byte) pipeline.Interface {
 	if encrypt {
 		return newEncryptionPipeline(ctx, s, mode)
 	}

--- a/pkg/file/pipeline/builder/builder_test.go
+++ b/pkg/file/pipeline/builder/builder_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestPartialWrites(t *testing.T) {
 	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false, nil)
 	_, _ = p.Write([]byte("hello "))
 	_, _ = p.Write([]byte("world"))
 
@@ -38,7 +38,7 @@ func TestPartialWrites(t *testing.T) {
 
 func TestHelloWorld(t *testing.T) {
 	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false, nil)
 
 	data := []byte("hello world")
 	_, err := p.Write(data)
@@ -61,7 +61,7 @@ func TestAllVectors(t *testing.T) {
 		data, expect := test.GetVector(t, i)
 		t.Run(fmt.Sprintf("data length %d, vector %d", len(data), i), func(t *testing.T) {
 			m := mock.NewStorer()
-			p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+			p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false, nil)
 
 			_, err := p.Write(data)
 			if err != nil {
@@ -122,7 +122,7 @@ func benchmarkPipeline(b *testing.B, count int) {
 	b.StopTimer()
 
 	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false, nil)
 	data := make([]byte, count)
 	_, err := rand.Read(data)
 	if err != nil {

--- a/pkg/localstore/export_test.go
+++ b/pkg/localstore/export_test.go
@@ -41,7 +41,11 @@ func TestExportImport(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		chunks[ch.Address().String()] = ch.Data()
+		stamp, err := ch.Stamp().MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		chunks[ch.Address().String()] = append(stamp, ch.Data()...)
 	}
 
 	var buf bytes.Buffer
@@ -71,9 +75,13 @@ func TestExportImport(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		got := ch.Data()
+		stamp, err := ch.Stamp().MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := append(stamp, ch.Data()...)
 		if !bytes.Equal(got, want) {
-			t.Fatalf("chunk %s: got data %x, want %x", addr, got, want)
+			t.Fatalf("chunk %s: got stamp+data %x, want %x", addr, got, want)
 		}
 	}
 }

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -156,8 +157,11 @@ func newTestDB(t testing.TB, o *Options) *DB {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
+
+	batchStore := mockbatchstore.New()
+
 	logger := logging.New(ioutil.Discard, 0)
-	db, err := New("", baseKey, o, logger)
+	db, err := New("", baseKey, o, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,8 +175,9 @@ func newTestDB(t testing.TB, o *Options) *DB {
 }
 
 var (
-	generateTestRandomChunk  = chunktesting.GenerateTestRandomChunk
-	generateTestRandomChunks = chunktesting.GenerateTestRandomChunks
+	generateTestRandomChunk   = chunktesting.GenerateTestRandomChunk
+	generateTestRandomChunkAt = chunktesting.GenerateTestRandomChunkAt
+	generateTestRandomChunks  = chunktesting.GenerateTestRandomChunks
 )
 
 // chunkAddresses return chunk addresses of provided chunks.

--- a/pkg/localstore/migration_test.go
+++ b/pkg/localstore/migration_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/logging"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 )
 
 func TestOneMigration(t *testing.T) {
@@ -58,10 +59,10 @@ func TestOneMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := logging.New(ioutil.Discard, 0)
+	batchStore := mockbatchstore.New()
 
-	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, logger)
+	logger := logging.New(ioutil.Discard, 0)
+	db, err := New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestOneMigration(t *testing.T) {
 	DbSchemaCurrent = dbSchemaNext
 
 	// start the existing localstore and expect the migration to run
-	db, err = New(dir, baseKey, nil, logger)
+	db, err = New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,10 +146,9 @@ func TestManyMigrations(t *testing.T) {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
+	batchStore := mockbatchstore.New()
 	logger := logging.New(ioutil.Discard, 0)
-
-	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, logger)
+	db, err := New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestManyMigrations(t *testing.T) {
 	DbSchemaCurrent = "salvation"
 
 	// start the existing localstore and expect the migration to run
-	db, err = New(dir, baseKey, nil, logger)
+	db, err = New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,10 +225,9 @@ func TestMigrationErrorFrom(t *testing.T) {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
+	batchStore := mockbatchstore.New()
 	logger := logging.New(ioutil.Discard, 0)
-
-	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, logger)
+	db, err := New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +240,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 	DbSchemaCurrent = "foo"
 
 	// start the existing localstore and expect the migration to run
-	_, err = New(dir, baseKey, nil, logger)
+	_, err = New(dir, baseKey, nil, batchStore, logger)
 	if !strings.Contains(err.Error(), errMissingCurrentSchema.Error()) {
 		t.Fatalf("expected errCannotFindSchema but got %v", err)
 	}
@@ -286,10 +285,9 @@ func TestMigrationErrorTo(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	batchStore := mockbatchstore.New()
 	logger := logging.New(ioutil.Discard, 0)
-
-	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, logger)
+	db, err := New(dir, baseKey, nil, batchStore, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +300,7 @@ func TestMigrationErrorTo(t *testing.T) {
 	DbSchemaCurrent = "foo"
 
 	// start the existing localstore and expect the migration to run
-	_, err = New(dir, baseKey, nil, logger)
+	_, err = New(dir, baseKey, nil, batchStore, logger)
 	if !strings.Contains(err.Error(), errMissingTargetSchema.Error()) {
 		t.Fatalf("expected errMissingTargetSchema but got %v", err)
 	}

--- a/pkg/localstore/mode_get.go
+++ b/pkg/localstore/mode_get.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb"
-
+	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // Get returns a chunk from the database. If the chunk is
@@ -50,7 +50,10 @@ func (db *DB) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address)
 		}
 		return nil, err
 	}
-	return swarm.NewChunk(swarm.NewAddress(out.Address), out.Data).WithPinCounter(out.PinCounter), nil
+	return swarm.NewChunk(swarm.NewAddress(out.Address), out.Data).
+		WithPinCounter(out.PinCounter).
+		// WithTag(out.Tag).
+		WithStamp(postage.NewStamp(out.BatchID, out.Sig)), nil
 }
 
 // get returns Item from the retrieval index

--- a/pkg/localstore/mode_get_multi.go
+++ b/pkg/localstore/mode_get_multi.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -50,7 +51,9 @@ func (db *DB) GetMulti(ctx context.Context, mode storage.ModeGet, addrs ...swarm
 	}
 	chunks = make([]swarm.Chunk, len(out))
 	for i, ch := range out {
-		chunks[i] = swarm.NewChunk(swarm.NewAddress(ch.Address), ch.Data).WithPinCounter(ch.PinCounter)
+		chunks[i] = swarm.NewChunk(swarm.NewAddress(ch.Address), ch.Data).
+			WithPinCounter(ch.PinCounter).
+			WithStamp(postage.NewStamp(ch.BatchID, ch.Sig))
 	}
 	return chunks, nil
 }

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -113,6 +113,8 @@ func TestModePutSync(t *testing.T) {
 				newItemsCountTest(db.gcIndex, tc.count)(t)
 				newIndexGCSizeTest(db)(t)
 			}
+			newItemsCountTest(db.gcIndex, tc.count)(t)
+			newIndexGCSizeTest(db)(t)
 		})
 	}
 }

--- a/pkg/localstore/postage.go
+++ b/pkg/localstore/postage.go
@@ -1,0 +1,180 @@
+package localstore
+
+import (
+	"errors"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/shed"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+var (
+	// ErrOverissued is returned if number of chunks found in neighbourhood extrapolates to overissued stamp
+	// count(batch, po) > 1<< (depth(batch) - po)
+	ErrBatchOverissued = errors.New("postage batch overissued")
+	ErrBatchNotFound   = errors.New("postage batch not found or expired")
+)
+
+// BatchStore interface to
+type BatchStore interface {
+	Get(id []byte) (*postage.Batch, error)
+}
+
+type postageBatches struct {
+	// postage batch to chunks index
+	chunks     shed.Index
+	counts     shed.Index
+	po         func(itemAddr []byte) (bin int)
+	batchStore BatchStore
+}
+
+func (db *DB) newPostageBatches(batchStore BatchStore) (*postageBatches, error) {
+
+	// po applied to the item address returns the proximity order (as int)
+	// of the chunk relative to the node base address
+	// return value is max swarm.MaxPO
+	pof := func(addr []byte) int {
+		po := db.po(swarm.NewAddress(addr))
+		if po > swarm.MaxPO {
+			po = swarm.MaxPO
+		}
+		return int(po)
+	}
+
+	chunksIndex, err := db.shed.NewIndex("BatchID|Hash->nil", shed.IndexFuncs{
+		EncodeKey: func(fields shed.Item) (key []byte, err error) {
+			key = make([]byte, 65)
+			copy(key[:32], fields.BatchID)
+			key[32] = uint8(pof(fields.Address))
+			copy(key[33:], fields.Address)
+			return key, nil
+		},
+		DecodeKey: func(key []byte) (e shed.Item, err error) {
+			e.BatchID = key[:32]
+			e.Address = key[33:65]
+			return e, nil
+		},
+		EncodeValue: func(fields shed.Item) (value []byte, err error) {
+			return nil, nil
+		},
+		DecodeValue: func(keyItem shed.Item, value []byte) (e shed.Item, err error) {
+			return e, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	countsIndex, err := db.shed.NewIndex("BatchID->counts", shed.IndexFuncs{
+		EncodeKey: func(fields shed.Item) (key []byte, err error) {
+			return fields.BatchID, nil
+		},
+		DecodeKey: func(key []byte) (e shed.Item, err error) {
+			e.BatchID = key[:32]
+			return e, nil
+		},
+		EncodeValue: func(fields shed.Item) (value []byte, err error) {
+			return fields.Counts.Counts, nil
+		},
+		DecodeValue: func(keyItem shed.Item, value []byte) (e shed.Item, err error) {
+			e.Counts = &shed.Counts{Counts: value}
+			return e, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &postageBatches{
+		chunks:     chunksIndex,
+		counts:     countsIndex,
+		po:         pof,
+		batchStore: batchStore,
+	}, nil
+}
+
+func (p *postageBatches) decInBatch(batch *leveldb.Batch, e shed.Item) (bool, error) {
+	item, err := p.counts.Get(e)
+	if err != nil {
+		return false, err
+	}
+	for i := 0; i < p.po(item.Address); i++ {
+		count := item.Counts.Dec(i)
+		if count == 0 { // if 0 then all subsequent counts are 0 too
+			if i == 0 { // if all counts 0 the entire batch entry can be deleted
+				return true, nil
+			}
+			break
+		}
+	}
+	return false, p.counts.PutInBatch(batch, item)
+}
+
+func (p *postageBatches) incInBatch(batch *leveldb.Batch, e shed.Item) error {
+	item, err := p.counts.Get(e)
+	if err != nil {
+		// initialise counts
+		if !errors.Is(err, leveldb.ErrNotFound) {
+			return err
+		}
+		e.Counts = &shed.Counts{Counts: make([]byte, swarm.MaxPO*4+4)}
+		item = e
+	}
+	// retrieve batch - if not found or expired -> invalid
+	b, err := p.batchStore.Get(item.BatchID)
+	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return ErrBatchNotFound
+		}
+		return err
+	}
+	depth := int(b.Depth)
+	po := p.po(item.Address)
+	// increment counts
+	for i := 0; i <= po; i++ {
+		count := item.Counts.Inc(i)
+		// counts track batch number of stamps in the batch for neighbourhoods of all depths
+		// if neighbourhood_depth > batch_depth then the batch itself is invalid
+		if order := depth - i; order >= 0 {
+			if count > 1<<order {
+				return ErrBatchOverissued
+			}
+		}
+	}
+	return p.counts.PutInBatch(batch, item)
+}
+
+func (p *postageBatches) putInBatch(batch *leveldb.Batch, item shed.Item) error {
+	err := p.chunks.PutInBatch(batch, item)
+	if err != nil {
+		return err
+	}
+	return p.incInBatch(batch, item)
+}
+
+func (p *postageBatches) deleteInBatch(batch *leveldb.Batch, item shed.Item) error {
+	err := p.chunks.DeleteInBatch(batch, item)
+	if err != nil {
+		return err
+	}
+	empty, err := p.decInBatch(batch, item)
+	if err != nil {
+		return err
+	}
+	if empty {
+		return p.counts.DeleteInBatch(batch, item)
+	}
+	return nil
+}
+
+// func (p *postageBatches) moveChunksToGC(batch *leveldb.Batch, batchID []byte, po int) error {
+// 	return p.chunks.Iterate(func(item shed.Item) (stop bool, err error) {
+// 		if p.po(item.Address) > po {
+// 			return true, nil
+// 		}
+// 		// put to gc queue
+// 		return false, nil
+// 	}, &shed.IterateOptions{StartFrom: &shed.Item{BatchID: batchID}})
+
+// }

--- a/pkg/localstore/postage_test.go
+++ b/pkg/localstore/postage_test.go
@@ -1,0 +1,131 @@
+package localstore
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/storage"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var postageTestCases = []struct {
+	mode    storage.ModePut
+	count   int
+	batches int
+	depth   uint8
+}{
+	{storage.ModePutRequest, 1, 1, 8},
+	{storage.ModePutRequest, 16, 2, 8},
+	{storage.ModePutSync, 1, 1, 8},
+	{storage.ModePutSync, 16, 2, 8},
+	{storage.ModePutUpload, 1, 1, 8},
+	{storage.ModePutUpload, 16, 2, 8},
+	{storage.ModePutUpload, 16, 1, 8},
+	{storage.ModePutUpload, 16, 1, 8},
+}
+
+func TestPutPostage(t *testing.T) {
+	for _, tc := range postageTestCases {
+		t.Run(fmt.Sprintf("mode:%v,count=%v,batches=%v,depth:%v", tc.mode, tc.count, tc.batches, tc.depth), func(t *testing.T) {
+			db := newTestDB(t, nil)
+			db.postage.batchStore.(*mockbatchstore.MockBatchStore).WithGet(func(_ []byte) (*postage.Batch, error) { return &postage.Batch{Depth: tc.depth}, nil })
+
+			chunks := generateTestRandomChunks(tc.count)
+			for i := tc.batches; i < tc.count; i++ {
+				chunks[i].WithStamp(chunks[i-1].Stamp())
+			}
+			t.Run("first put", func(t *testing.T) {
+				for _, ch := range chunks {
+					_, err := db.Put(context.Background(), tc.mode, ch)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				newItemsCountTest(db.retrievalDataIndex, tc.count)(t)
+				newItemsCountTest(db.postage.chunks, tc.count)(t)
+				newItemsCountTest(db.postage.counts, tc.batches)(t)
+			})
+
+			t.Run("second put", func(t *testing.T) {
+				for _, ch := range chunks {
+					exists, err := db.Put(context.Background(), tc.mode, ch)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !exists[0] {
+						t.Fatalf("expected chunk to exists in db")
+					}
+				}
+				newItemsCountTest(db.retrievalDataIndex, tc.count)(t)
+				newItemsCountTest(db.postage.chunks, tc.count)(t)
+				newItemsCountTest(db.postage.counts, tc.batches)(t)
+			})
+		})
+	}
+}
+
+func TestPutPostageOverissue(t *testing.T) {
+	for _, mode := range []storage.ModePut{storage.ModePutRequest, storage.ModePutSync, storage.ModePutUpload} {
+		for depth := 0; depth < int(swarm.MaxPO); depth++ {
+			for oi := 0; oi <= depth; oi++ {
+				t.Run(fmt.Sprintf("mode: %v,overissued depth: %v,batch depth:%v", mode, oi, depth), func(t *testing.T) {
+					db := newTestDB(t, nil)
+					db.postage.batchStore.(*mockbatchstore.MockBatchStore).WithGet(func(_ []byte) (*postage.Batch, error) { return &postage.Batch{Depth: uint8(depth)}, nil })
+
+					chunk := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), oi)
+					stamp := chunk.Stamp()
+					head := binary.BigEndian.Uint32(chunk.Address().Bytes()[:4])
+					order := depth - oi
+					max := 1 << order
+					seed := (head << oi) >> (32 - order)
+					rem := (head << oi) >> oi
+					prefix := head - rem
+					chunks := make([]swarm.Chunk, max)
+					for i := 0; i < max; i++ {
+						_, err := db.Put(context.Background(), mode, chunk)
+						if err != nil {
+							t.Fatal(err)
+						}
+						chunks[i] = chunk
+						chunk = generateTestRandomChunk()
+						addr := chunk.Address().Bytes()
+						balanced := ((seed + uint32(i+1)) % uint32(max)) << (32 - depth)
+						shift := depth
+						random := (binary.BigEndian.Uint32(addr[:4]) << shift) >> shift
+						head = prefix + balanced + random
+						binary.BigEndian.PutUint32(addr[:4], head)
+						chunk = swarm.NewChunk(swarm.NewAddress(addr), chunk.Data()).WithStamp(stamp)
+					}
+
+					_, err := db.Put(context.Background(), mode, chunk)
+					if !errors.Is(err, ErrBatchOverissued) {
+						t.Fatalf("expected error %v, got %v", ErrBatchOverissued, err)
+					}
+					newItemsCountTest(db.retrievalDataIndex, max)(t)
+					newItemsCountTest(db.postage.chunks, max)(t)
+					newItemsCountTest(db.postage.counts, 1)(t)
+
+					t.Run("second put", func(t *testing.T) {
+						for _, ch := range chunks {
+							exists, err := db.Put(context.Background(), mode, ch)
+							if err != nil {
+								t.Fatal(err)
+							}
+							if !exists[0] {
+								t.Fatalf("expected chunk to exists in db")
+							}
+						}
+						newItemsCountTest(db.retrievalDataIndex, max)(t)
+						newItemsCountTest(db.postage.chunks, max)(t)
+						newItemsCountTest(db.postage.counts, 1)(t)
+					})
+				})
+			}
+		}
+	}
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -52,6 +52,7 @@ import (
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
 	mockinmem "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/tracing"
@@ -323,7 +324,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	lo := &localstore.Options{
 		Capacity: o.DBCapacity,
 	}
-	storer, err := localstore.New(path, swarmAddress.Bytes(), lo, logger)
+	storer, err := localstore.New(path, swarmAddress.Bytes(), lo, mockbatchstore.New(), logger)
 	if err != nil {
 		return nil, fmt.Errorf("localstore: %w", err)
 	}

--- a/pkg/postage/export_test.go
+++ b/pkg/postage/export_test.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import "github.com/ethersphere/bee/pkg/swarm"
+
+func (st *StampIssuer) Inc(a swarm.Address) error {
+	return st.inc(a)
+}

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -1,0 +1,107 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/storage"
+)
+
+const (
+	postagePrefix = "postage"
+)
+
+var (
+	// ErrNotFound is the error returned when issuer with given batch ID does not exist.
+	ErrNotFound = errors.New("not found")
+)
+
+// Service handles postage batches
+// stores the active batches.
+type Service struct {
+	lock    sync.Mutex
+	store   storage.StateStorer
+	chainID int64
+	issuers []*StampIssuer
+}
+
+// NewService constructs a new Service.
+func NewService(store storage.StateStorer, chainID int64) *Service {
+	return &Service{
+		store:   store,
+		chainID: chainID,
+	}
+}
+
+// Add adds a stamp issuer to the active issuers.
+func (ps *Service) Add(st *StampIssuer) {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+	ps.issuers = append(ps.issuers, st)
+}
+
+// StampIssuers returns the currently active stamp issuers.
+func (ps *Service) StampIssuers() []*StampIssuer {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+	return ps.issuers
+}
+
+// GetStampIssuer finds a stamp issuer by batch ID.
+func (ps *Service) GetStampIssuer(batchID []byte) (*StampIssuer, error) {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+	for _, st := range ps.issuers {
+		if bytes.Equal(batchID, st.batchID) {
+			return st, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// Load loads all active batches (stamp issuers) from the statestore.
+func (ps *Service) Load() error {
+	n := 0
+	if err := ps.store.Iterate(ps.key(), func(key, _ []byte) (stop bool, err error) {
+		n++
+		return false, nil
+	}); err != nil {
+		return err
+	}
+	for i := 0; i < n; i++ {
+		st := &StampIssuer{}
+		err := ps.store.Get(ps.keyForIndex(i), st)
+		if err != nil {
+			return err
+		}
+		ps.Add(st)
+	}
+	return nil
+}
+
+// Save saves all the active stamp issuers to statestore.
+func (ps *Service) Save() error {
+	for i, st := range ps.issuers {
+		if err := ps.store.Put(ps.keyForIndex(i), st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// keyForIndex returns the statestore key for an issuer
+func (ps *Service) keyForIndex(i int) string {
+	return fmt.Sprintf(ps.key()+"%d", i)
+}
+
+// key returns the statestore base key for an issuer
+// to disambiguate batches on different chains, chainID is part of the key
+func (ps *Service) key() string {
+	return fmt.Sprintf(postagePrefix+"%d", ps.chainID)
+}

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -1,0 +1,82 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage_test
+
+import (
+	crand "crypto/rand"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
+)
+
+// TestSaveLoad tests the idempotence of saving and loading the postage.Service
+// with all the active stamp issuers.
+func TestSaveLoad(t *testing.T) {
+	store := storemock.NewStateStore()
+	saved := func(id int64) *postage.Service {
+		ps := postage.NewService(store, id)
+		for i := 0; i < 16; i++ {
+			ps.Add(newTestStampIssuer(t))
+		}
+		if err := ps.Save(); err != nil {
+			t.Fatal(err)
+		}
+		return ps
+	}
+	loaded := func(id int64) *postage.Service {
+		ps := postage.NewService(store, id)
+		if err := ps.Load(); err != nil {
+			t.Fatal(err)
+		}
+		return ps
+	}
+	test := func(id int64) {
+		psS := saved(id)
+		psL := loaded(id)
+		if !reflect.DeepEqual(psS.StampIssuers(), psL.StampIssuers()) {
+			t.Fatalf("load(save(service)) != service\n%v\n%v", psS.StampIssuers(), psL.StampIssuers())
+		}
+	}
+	test(0)
+	test(1)
+}
+
+func TestGetStampIssuer(t *testing.T) {
+	store := storemock.NewStateStore()
+	ps := postage.NewService(store, int64(0))
+	ids := make([][]byte, 8)
+	for i := range ids {
+		id := make([]byte, 32)
+		_, err := io.ReadFull(crand.Reader, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[i] = id
+		if i == 0 {
+			continue
+		}
+		ps.Add(postage.NewStampIssuer(string(id), "", id, 16, 8))
+	}
+	t.Run("found", func(t *testing.T) {
+		for _, id := range ids[1:] {
+			st, err := ps.GetStampIssuer(id)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if st.Label() != string(id) {
+				t.Fatalf("wrong issuer returned")
+			}
+		}
+	})
+	t.Run("not found", func(t *testing.T) {
+		_, err := ps.GetStampIssuer(ids[0])
+		if err != postage.ErrNotFound {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+}

--- a/pkg/postage/stamp.go
+++ b/pkg/postage/stamp.go
@@ -1,0 +1,136 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math/big"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// StampSize is the number of bytes in the serialisation of a stamp
+const StampSize = 97
+
+var (
+	// ErrOwnerMismatch is the error given for invalid signatures.
+	ErrOwnerMismatch = errors.New("owner mismatch")
+	// ErrStampInvalid is the error given if stamp cannot deserialise.
+	ErrStampInvalid = errors.New("invalid stamp")
+)
+
+// Batch represents a postage batch, a payment on the blockchain.
+type Batch struct {
+	ID    []byte   // batch ID
+	Value *big.Int // overall balance of the batch
+	Start uint64   // blocknumber the batch was created
+	Owner []byte   // owner's ethereum address
+	Depth uint8    // batch depth, i.e., size = 2^{depth}
+}
+
+// MarshalBinary serialises a postage batch to a byte slice len 117.
+func (b *Batch) MarshalBinary() ([]byte, error) {
+	out := make([]byte, 93)
+	copy(out, b.ID)
+	value := b.Value.Bytes()
+	copy(out[64-len(value):], value)
+	binary.BigEndian.PutUint64(out[64:72], b.Start)
+	copy(out[72:], b.Owner)
+	out[92] = b.Depth
+	return out, nil
+}
+
+// UnmarshalBinary deserialises the batch.
+// Unsafe on slice index (len(buf) = 117) as only internally used in db.
+func (b *Batch) UnmarshalBinary(buf []byte) error {
+	b.ID = buf[:32]
+	b.Value = big.NewInt(0).SetBytes(buf[32:64])
+	b.Start = binary.BigEndian.Uint64(buf[64:72])
+	b.Owner = buf[72:92]
+	b.Depth = buf[92]
+	return nil
+}
+
+// Valid checks the validity of the postage stamp; in particular:
+// - authenticity - check batch is valid on the blockchain
+// - authorisation - the batch owner is the stamp signer
+// the validity  check is only meaningful in its association of a chunk
+// this chunk address needs to be given as argument
+func (s *Stamp) Valid(chunkAddr swarm.Address, ownerAddr []byte) error {
+	toSign, err := toSignDigest(chunkAddr, s.batchID)
+	if err != nil {
+		return err
+	}
+	signerPubkey, err := crypto.Recover(s.sig, toSign)
+	if err != nil {
+		return err
+	}
+	signerAddr, err := crypto.NewEthereumAddress(*signerPubkey)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(signerAddr, ownerAddr) {
+		return ErrOwnerMismatch
+	}
+	return nil
+}
+
+var _ swarm.Stamp = (*Stamp)(nil)
+
+// Stamp represents a postage stamp as attached to a chunk.
+type Stamp struct {
+	batchID []byte // postage batch ID
+	sig     []byte // common r[32]s[32]v[1]-style 65 byte ECDSA signature
+}
+
+// MewStamp constructs a stamp
+func NewStamp(batchID, sig []byte) *Stamp {
+	return &Stamp{batchID, sig}
+}
+
+// BatchID
+func (s *Stamp) BatchID() []byte {
+	return s.batchID
+}
+
+// Sig
+func (s *Stamp) Sig() []byte {
+	return s.sig
+}
+
+// MarshalBinary gives the byte slice serialisation of a stamp: batchID[32]|Signature[65].
+func (s *Stamp) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, StampSize)
+	copy(buf, s.batchID)
+	copy(buf[32:], s.sig)
+	return buf, nil
+}
+
+// UnmarshalBinary parses a serialised stamp into id and signature.
+func (s *Stamp) UnmarshalBinary(buf []byte) error {
+	if len(buf) != StampSize {
+		return ErrStampInvalid
+	}
+	s.batchID = buf[:32]
+	s.sig = buf[32:]
+	return nil
+}
+
+// toSignDigest creates a digest to represent the stamp which is to be signed by the owner.
+func toSignDigest(addr swarm.Address, id []byte) ([]byte, error) {
+	h := swarm.NewHasher()
+	_, err := h.Write(addr.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	_, err = h.Write(id)
+	if err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage_test
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"io"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+)
+
+// TestStampMarshalling tests the idempotence  of binary marshal/unmarshals for Stamps.
+func TestStampMarshalling(t *testing.T) {
+
+	sExp := postagetesting.NewStamp()
+	buf, _ := sExp.MarshalBinary()
+	if len(buf) != postage.StampSize {
+		t.Fatalf("invalid length for serialised stamp. expected %d, got  %d", postage.StampSize, len(buf))
+	}
+	s := postage.NewStamp(nil, nil)
+	if err := s.UnmarshalBinary(buf); err != nil {
+		t.Fatalf("unexpected error unmarshalling stamp: %v", err)
+	}
+	if !bytes.Equal(sExp.BatchID(), s.BatchID()) {
+		t.Fatalf("id mismatch, expected %x, got %x", sExp.BatchID(), s.BatchID())
+	}
+	if !bytes.Equal(sExp.Sig(), s.Sig()) {
+		t.Fatalf("sig mismatch, expected %x, got %x", sExp.Sig(), s.Sig())
+	}
+
+}
+
+// TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a Batch.
+func TestBatchMarshalling(t *testing.T) {
+	a := newTestBatch(t, nil)
+	buf, err := a.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buf) != 93 {
+		t.Fatalf("invalid length for serialised batch. expected 93, got %d", len(buf))
+	}
+	b := &postage.Batch{}
+	if err := b.UnmarshalBinary(buf); err != nil {
+		t.Fatalf("unexpected error unmarshalling batch: %v", err)
+	}
+	if !bytes.Equal(b.ID, a.ID) {
+		t.Fatalf("id mismatch, expected %x, got %x", a.ID, b.ID)
+	}
+	if !bytes.Equal(b.Owner, a.Owner) {
+		t.Fatalf("owner mismatch, expected %x, got %x", a.Owner, b.Owner)
+	}
+	if a.Value.Uint64() != b.Value.Uint64() {
+		t.Fatalf("value mismatch, expected %d, got %d", a.Value.Uint64(), b.Value.Uint64())
+	}
+	if a.Start != b.Start {
+		t.Fatalf("start mismatch, expected %d, got %d", a.Start, b.Start)
+	}
+	if a.Depth != b.Depth {
+		t.Fatalf("depth mismatch, expected %d, got %d", a.Depth, b.Depth)
+	}
+
+}
+
+func newTestBatch(t *testing.T, owner []byte) *postage.Batch {
+	t.Helper()
+	id := make([]byte, 32)
+	_, err := io.ReadFull(crand.Reader, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value64 := rand.Uint64()
+	start64 := rand.Uint64()
+	if owner == nil {
+		owner = make([]byte, 20)
+		_, err = io.ReadFull(crand.Reader, owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	depth := uint8(16)
+	return &postage.Batch{
+		ID:    id,
+		Value: big.NewInt(0).SetUint64(value64),
+		Start: start64,
+		Owner: owner,
+		Depth: depth,
+	}
+}

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"errors"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var (
+	// ErrBucketFull is the error when a collision bucket is full.
+	ErrBucketFull = errors.New("bucket full")
+)
+
+// Stamper connects a stampissuer with a signer.
+// A Stamper is created for each upload session.
+type Stamper struct {
+	issuer *StampIssuer
+	signer crypto.Signer
+}
+
+// NewStamper constructs a Stamper.
+func NewStamper(st *StampIssuer, signer crypto.Signer) *Stamper {
+	return &Stamper{st, signer}
+}
+
+// Stamp takes chunk, see if the chunk can included in the batch and
+// signs it with the owner of the batch of this Stamp issuer.
+func (st *Stamper) Stamp(addr swarm.Address) (*Stamp, error) {
+	toSign, err := toSignDigest(addr, st.issuer.batchID)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := st.signer.Sign(toSign)
+	if err != nil {
+		return nil, err
+	}
+	if err := st.issuer.inc(addr); err != nil {
+		return nil, err
+	}
+	return NewStamp(st.issuer.batchID, sig), nil
+}

--- a/pkg/postage/stamper_test.go
+++ b/pkg/postage/stamper_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage_test
+
+import (
+	crand "crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// TestStamperStamping tests if the stamp created by the stamper is valid.
+func TestStamperStamping(t *testing.T) {
+	privKey, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	owner, err := crypto.NewEthereumAddress(privKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.NewDefaultSigner(privKey)
+	createStamp := func(t *testing.T, stamper *postage.Stamper) (swarm.Address, *postage.Stamp) {
+		t.Helper()
+		h := make([]byte, 32)
+		_, err = io.ReadFull(crand.Reader, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chunkAddr := swarm.NewAddress(h)
+		stamp, err := stamper.Stamp(chunkAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return chunkAddr, stamp
+	}
+
+	// tests a valid stamp
+	t.Run("valid stamp", func(t *testing.T) {
+		st := newTestStampIssuer(t)
+		stamper := postage.NewStamper(st, signer)
+		chunkAddr, stamp := createStamp(t, stamper)
+		if err := stamp.Valid(chunkAddr, owner); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// invalid stamp, incorrect chunk address (it still returns postage.ErrOwnerMismatch)
+	t.Run("invalid stamp", func(t *testing.T) {
+		st := newTestStampIssuer(t)
+		stamper := postage.NewStamper(st, signer)
+		chunkAddr, stamp := createStamp(t, stamper)
+		a := chunkAddr.Bytes()
+		a[0] ^= 0xff
+		if err := stamp.Valid(swarm.NewAddress(a), owner); err != postage.ErrOwnerMismatch {
+			t.Fatalf("expected ErrOwnerMismatch, got %v", err)
+		}
+	})
+
+	// tests that Stamps returns with postage.ErrBucketFull iff
+	// issuer has the corresponding collision bucket filled]
+	t.Run("bucket full", func(t *testing.T) {
+		b := newTestBatch(t, owner)
+		st := postage.NewStampIssuer("", "", b.ID, b.Depth, 8)
+		stamper := postage.NewStamper(st, signer)
+		// issue 1 stamp
+		chunkAddr, _ := createStamp(t, stamper)
+		// issue another 255
+		// collision depth is 8, committed batch depth is 16, bucket volume 2^8
+		for i := 0; i < 255; i++ {
+			h := make([]byte, 32)
+			_, err = io.ReadFull(crand.Reader, h)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// generate a chunks matching on the first 8 bits,
+			// i.e., fall into the same collision bucket
+			h[0] = chunkAddr.Bytes()[0]
+			// calling Inc we pretend a stamp was issued to the address
+			err = st.Inc(swarm.NewAddress(h))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		// the bucket should now be full, not allowing a stamp for the  pivot chunk
+		_, err := stamper.Stamp(chunkAddr)
+		if err != postage.ErrBucketFull {
+			t.Fatalf("expected ErrBucketFull, got %v", err)
+		}
+	})
+
+	// tests return with ErrOwnerMismatch
+	t.Run("owner mismatch", func(t *testing.T) {
+		owner[0] ^= 0xff // bitflip the owner first byte, this case must come last!
+		st := newTestStampIssuer(t)
+		stamper := postage.NewStamper(st, signer)
+		chunkAddr, stamp := createStamp(t, stamper)
+		if err := stamp.Valid(chunkAddr, owner); err != postage.ErrOwnerMismatch {
+			t.Fatalf("expected ErrOwnerMismatch, got %v", err)
+		}
+	})
+
+}

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"encoding/binary"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// StampIssuer is a local extension of a batch issuing stamps for uploads.
+// A StampIssuer instance extends a batch with bucket collision tracking
+// embedded in multiple Stampers, can be used concurrently.
+type StampIssuer struct {
+	label       string     // label to identify the batch period/importance
+	keyID       string     // owner identity
+	batchID     []byte     // the batch stamps are issued from
+	batchDepth  uint8      // batch depth: batch size = 2^{depth}
+	bucketDepth uint8      // bucket depth: the depth of collision buckets uniformity
+	mu          sync.Mutex // mutex for buckets
+	buckets     []uint32   // collision buckets: counts per neighbourhoods limited to 2^{batchdepth-bucketdepth}
+}
+
+// NewStampIssuer constructs a StampIssuer as an extension of a batch for local upload.
+func NewStampIssuer(label string, keyID string, batchID []byte, batchDepth, bucketDepth uint8) *StampIssuer {
+	return &StampIssuer{
+		label:       label,
+		keyID:       keyID,
+		batchID:     batchID,
+		batchDepth:  batchDepth,
+		bucketDepth: bucketDepth,
+		buckets:     make([]uint32, 1<<bucketDepth),
+	}
+}
+
+// inc increments the count in the correct collision bucket
+// for a newly stamped chunk with address addr
+func (st *StampIssuer) inc(addr swarm.Address) error {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	b := toBucket(st.bucketDepth, addr)
+	if st.buckets[b] == 1<<(st.batchDepth-st.bucketDepth) {
+		return ErrBucketFull
+	}
+	st.buckets[b]++
+	return nil
+}
+
+// toBucket calculates the index of the collision bucket for a swarm address
+// using depth as collision bucket depth
+func toBucket(depth uint8, addr swarm.Address) uint32 {
+	i := binary.BigEndian.Uint32(addr.Bytes()[:4])
+	return i >> (32 - depth)
+}
+
+// Label returns the label of the issuer.
+func (st *StampIssuer) Label() string {
+	return st.label
+}
+
+// MarshalBinary gives the byte slice serialisation of a StampIssuer:
+// = label[32]|keyID[32]|batchID[32]|batchDepth[1]|bucketDepth[1]|size_0[4]|size_1[4]|....
+func (st *StampIssuer) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, 32+32+32+1+1+(1<<(st.bucketDepth+2)))
+	label := []byte(st.label)
+	copy(buf[32-len(label):32], label)
+	keyID := []byte(st.keyID)
+	copy(buf[64-len(keyID):64], keyID)
+	copy(buf[64:96], st.batchID)
+	buf[96] = st.batchDepth
+	buf[97] = st.bucketDepth
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for i, addr := range st.buckets {
+		offset := 98 + i*4
+		binary.BigEndian.PutUint32(buf[offset:offset+4], addr)
+	}
+	return buf, nil
+}
+
+// UnmarshalBinary parses a serialised StampIssuer into the receiver struct.
+func (st *StampIssuer) UnmarshalBinary(buf []byte) error {
+	st.label = toString(buf[:32])
+	st.keyID = toString(buf[32:64])
+	st.batchID = buf[64:96]
+	st.batchDepth = buf[96]
+	st.bucketDepth = buf[97]
+	st.buckets = make([]uint32, 1<<st.bucketDepth)
+	// not using lock as unmarshal is init
+	for i := range st.buckets {
+		offset := 98 + i*4
+		st.buckets[i] = binary.BigEndian.Uint32(buf[offset : offset+4])
+	}
+	return nil
+}
+
+func toString(buf []byte) string {
+	i := 0
+	var c byte
+	for i, c = range buf {
+		if c != 0 {
+			break
+		}
+	}
+	return string(buf[i:])
+}

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage_test
+
+import (
+	crand "crypto/rand"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// TestStampIssuerMarshalling tests the idempotence  of binary marshal/unmarshal.
+func TestStampIssuerMarshalling(t *testing.T) {
+	st := newTestStampIssuer(t)
+	buf, err := st.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	st0 := &postage.StampIssuer{}
+	err = st0.UnmarshalBinary(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(st, st0) {
+		t.Fatalf("unmarshal(marshal(StampIssuer)) != StampIssuer \n%v\n%v", st, st0)
+	}
+}
+
+func newTestStampIssuer(t *testing.T) *postage.StampIssuer {
+	t.Helper()
+	id := make([]byte, 32)
+	_, err := io.ReadFull(crand.Reader, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := postage.NewStampIssuer("label", "keyID", id, 16, 8)
+	addr := make([]byte, 32)
+	for i := 0; i < 1<<8; i++ {
+		_, err := io.ReadFull(crand.Reader, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = st.Inc(swarm.NewAddress(addr))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return st
+}

--- a/pkg/postage/testing/stamp.go
+++ b/pkg/postage/testing/stamp.go
@@ -1,0 +1,22 @@
+package testing
+
+import (
+	crand "crypto/rand"
+	"io"
+
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+func NewStamp() *postage.Stamp {
+	id := make([]byte, 32)
+	_, err := io.ReadFull(crand.Reader, id)
+	if err != nil {
+		panic(err.Error())
+	}
+	sig := make([]byte, 65)
+	_, err = io.ReadFull(crand.Reader, sig)
+	if err != nil {
+		panic(err.Error())
+	}
+	return postage.NewStamp(id, sig)
+}

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/pullsync/pullstorage"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 	stesting "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -341,7 +342,7 @@ func newTestDB(t testing.TB, o *localstore.Options) (baseKey []byte, db *localst
 	}
 
 	logger := logging.New(ioutil.Discard, 0)
-	db, err := localstore.New("", baseKey, o, logger)
+	db, err := localstore.New("", baseKey, o, mockbatchstore.New(), logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -12,14 +12,14 @@ import (
 	"testing"
 	"time"
 
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-
 	"github.com/ethersphere/bee/pkg/localstore"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/pusher"
 	"github.com/ethersphere/bee/pkg/pushsync"
 	pushsyncmock "github.com/ethersphere/bee/pkg/pushsync/mock"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/topology/mock"
@@ -345,7 +345,7 @@ func createChunk() swarm.Chunk {
 func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
 	t.Helper()
 	logger := logging.New(ioutil.Discard, 0)
-	storer, err := localstore.New("", addr.Bytes(), nil, logger)
+	storer, err := localstore.New("", addr.Bytes(), nil, mockbatchstore.New(), logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethersphere/bee/pkg/pushsync"
 	"github.com/ethersphere/bee/pkg/pushsync/pb"
 	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
+	mockbatchstore "github.com/ethersphere/bee/pkg/storage/mock/batchstore"
 	mockvalidator "github.com/ethersphere/bee/pkg/storage/mock/validator"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -405,7 +406,7 @@ func createPushSyncNode(t *testing.T, addr swarm.Address, recorder *streamtest.R
 	t.Helper()
 	logger := logging.New(ioutil.Discard, 0)
 
-	storer, err := localstore.New("", addr.Bytes(), nil, logger)
+	storer, err := localstore.New("", addr.Bytes(), nil, mockbatchstore.New(), logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/shed/db.go
+++ b/pkg/shed/db.go
@@ -101,35 +101,36 @@ func (db *DB) Put(key, value []byte) (err error) {
 // Get wraps LevelDB Get method to increment metrics counter.
 func (db *DB) Get(key []byte) (value []byte, err error) {
 	value, err = db.ldb.Get(key, nil)
-	if errors.Is(err, leveldb.ErrNotFound) {
-		db.metrics.GetNotFoundCounter.Inc()
-		return nil, err
-	} else {
-		db.metrics.GetFailCounter.Inc()
-	}
 	db.metrics.GetCounter.Inc()
+	if err != nil {
+		db.metrics.GetFailCounter.Inc()
+		if errors.Is(err, leveldb.ErrNotFound) {
+			db.metrics.GetNotFoundCounter.Inc()
+		}
+		return nil, err
+	}
 	return value, nil
 }
 
 // Has wraps LevelDB Has method to increment metrics counter.
 func (db *DB) Has(key []byte) (yes bool, err error) {
 	yes, err = db.ldb.Has(key, nil)
+	db.metrics.HasCounter.Inc()
 	if err != nil {
 		db.metrics.HasFailCounter.Inc()
 		return false, err
 	}
-	db.metrics.HasCounter.Inc()
 	return yes, nil
 }
 
 // Delete wraps LevelDB Delete method to increment metrics counter.
 func (db *DB) Delete(key []byte) (err error) {
 	err = db.ldb.Delete(key, nil)
+	db.metrics.DeleteCounter.Inc()
 	if err != nil {
 		db.metrics.DeleteFailCounter.Inc()
 		return err
 	}
-	db.metrics.DeleteCounter.Inc()
 	return nil
 }
 
@@ -142,11 +143,11 @@ func (db *DB) NewIterator() iterator.Iterator {
 // WriteBatch wraps LevelDB Write method to increment metrics counter.
 func (db *DB) WriteBatch(batch *leveldb.Batch) (err error) {
 	err = db.ldb.Write(batch, nil)
+	db.metrics.WriteBatchCounter.Inc()
 	if err != nil {
 		db.metrics.WriteBatchFailCounter.Inc()
 		return err
 	}
-	db.metrics.WriteBatchCounter.Inc()
 	return nil
 }
 

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -18,6 +18,7 @@ package shed
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -45,6 +46,39 @@ type Item struct {
 	BinID           uint64
 	PinCounter      uint64 // maintains the no of time a chunk is pinned
 	Tag             uint32
+	BatchID         []byte  // postage batch ID
+	Sig             []byte  // postage stamp
+	Counts          *Counts // postage batch counts
+}
+
+type Counts struct {
+	Counts []byte
+}
+
+func (c *Counts) String() string {
+	counts := make([]uint32, len(c.Counts)/4)
+	for i := range counts {
+		counts[i] = c.add(i, 0, true)
+	}
+	return fmt.Sprintf("%v", counts)
+}
+
+func (c *Counts) Inc(i int) uint32 {
+	return c.add(i, 1, true)
+}
+func (c *Counts) Dec(i int) uint32 {
+	return c.add(i, 1, false)
+}
+
+func (c *Counts) add(i int, d uint32, add bool) uint32 {
+	count := binary.BigEndian.Uint32(c.Counts[4*i : 4*i+4]) // deserialise
+	if add {
+		count += d
+	} else {
+		count -= d
+	}
+	binary.BigEndian.PutUint32(c.Counts[4*i:4*i+4], count)
+	return count
 }
 
 // Merge is a helper method to construct a new
@@ -71,6 +105,15 @@ func (i Item) Merge(i2 Item) Item {
 	}
 	if i.Tag == 0 {
 		i.Tag = i2.Tag
+	}
+	if i.Sig == nil {
+		i.Sig = i2.Sig
+	}
+	if i.BatchID == nil {
+		i.BatchID = i2.BatchID
+	}
+	if i.Counts == nil {
+		i.Counts = i2.Counts
 	}
 	return i
 }
@@ -185,6 +228,7 @@ func (f Index) Fill(items []Item) (err error) {
 			return fmt.Errorf("decode value: %w", err)
 		}
 		items[i] = v.Merge(item)
+		// items[i] = item.Merge(v)
 	}
 	return nil
 }

--- a/pkg/storage/mock/batchstore/batchstore.go
+++ b/pkg/storage/mock/batchstore/batchstore.go
@@ -1,0 +1,28 @@
+package localstore
+
+import (
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func New() *MockBatchStore {
+	tbs := &MockBatchStore{}
+	return tbs.WithGet(func(batchID []byte) (*postage.Batch, error) {
+		return &postage.Batch{ID: batchID, Depth: swarm.MaxPO - 2}, nil
+	})
+}
+
+// var _ BatchStore = (*MockBatchStore)(nil)
+
+type MockBatchStore struct {
+	getf func(batchID []byte) (*postage.Batch, error)
+}
+
+func (tbs *MockBatchStore) WithGet(getf func(batchID []byte) (*postage.Batch, error)) *MockBatchStore {
+	tbs.getf = getf
+	return tbs
+}
+
+func (tbs *MockBatchStore) Get(batchID []byte) (*postage.Batch, error) {
+	return tbs.getf(batchID)
+}

--- a/pkg/storage/testing/chunk.go
+++ b/pkg/storage/testing/chunk.go
@@ -20,7 +20,9 @@ import (
 	"math/rand"
 	"time"
 
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
+	swarmtesting "github.com/ethersphere/bee/pkg/swarm/test"
 )
 
 func init() {
@@ -40,7 +42,16 @@ func GenerateTestRandomChunk() swarm.Chunk {
 	_, _ = rand.Read(data)
 	key := make([]byte, swarm.SectionSize)
 	_, _ = rand.Read(key)
-	return swarm.NewChunk(swarm.NewAddress(key), data)
+	stamp := postagetesting.NewStamp()
+	return swarm.NewChunk(swarm.NewAddress(key), data).WithStamp(stamp)
+}
+
+func GenerateTestRandomChunkAt(target swarm.Address, po int) swarm.Chunk {
+	data := make([]byte, swarm.ChunkSize)
+	_, _ = rand.Read(data)
+	addr := swarmtesting.RandomAddressAt(target, po)
+	stamp := postagetesting.NewStamp()
+	return swarm.NewChunk(addr, data).WithStamp(stamp)
 }
 
 // GenerateTestRandomChunks generates a slice of random

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -7,6 +7,7 @@ package swarm
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -119,7 +120,17 @@ type Chunk interface {
 	WithPinCounter(p uint64) Chunk
 	TagID() uint32
 	WithTagID(t uint32) Chunk
+	Stamp() Stamp
+	WithStamp(Stamp) Chunk
 	Equal(Chunk) bool
+}
+
+// Stamp interface for postage.Stamp to avoid circular dependency
+type Stamp interface {
+	BatchID() []byte
+	Sig() []byte
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
 }
 
 type chunk struct {
@@ -127,6 +138,7 @@ type chunk struct {
 	sdata      []byte
 	pinCounter uint64
 	tagID      uint32
+	stamp      Stamp
 }
 
 func NewChunk(addr Address, data []byte) Chunk {
@@ -146,6 +158,11 @@ func (c *chunk) WithTagID(t uint32) Chunk {
 	return c
 }
 
+func (c *chunk) WithStamp(stamp Stamp) Chunk {
+	c.stamp = stamp
+	return c
+}
+
 func (c *chunk) Address() Address {
 	return c.addr
 }
@@ -160,6 +177,10 @@ func (c *chunk) PinCounter() uint64 {
 
 func (c *chunk) TagID() uint32 {
 	return c.tagID
+}
+
+func (c *chunk) Stamp() Stamp {
+	return c.stamp
 }
 
 func (c *chunk) String() string {

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -327,7 +327,7 @@ func (s *traversalService) checkIsManifest(
 	m, err = manifest.NewManifestReference(
 		metadata.MimeType,
 		e.Reference(),
-		loadsave.New(s.storer, storage.ModePutRequest, false),
+		loadsave.New(s.storer, storage.ModePutRequest, false, nil),
 	)
 	if err != nil {
 		if err == manifest.ErrInvalidManifestType {

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -136,7 +136,7 @@ func TestTraversalBytes(t *testing.T) {
 
 			bytesData := generateSampleData(tc.dataSize)
 
-			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			address, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(bytesData), int64(len(bytesData)))
 			if err != nil {
 				t.Fatal(err)
@@ -208,7 +208,7 @@ func TestTraversalFiles(t *testing.T) {
 
 			bytesData := generateSampleData(tc.filesSize)
 
-			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			fr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(bytesData), int64(len(bytesData)))
 			if err != nil {
 				t.Fatal(err)
@@ -223,7 +223,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			mr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(metadataBytes), int64(len(metadataBytes)))
 			if err != nil {
 				t.Fatal(err)
@@ -235,7 +235,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			reference, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)))
 			if err != nil {
 				t.Fatal(err)
@@ -462,7 +462,7 @@ func TestTraversalManifest(t *testing.T) {
 			ctx := context.Background()
 
 			var dirManifest manifest.Interface
-			ls := loadsave.New(mockStorer, storage.ModePutRequest, false)
+			ls := loadsave.New(mockStorer, storage.ModePutRequest, false, nil)
 			switch tc.manifestType {
 			case manifest.ManifestSimpleContentType:
 				dirManifest, err = manifest.NewSimpleManifest(ls)
@@ -482,7 +482,7 @@ func TestTraversalManifest(t *testing.T) {
 			for _, f := range tc.files {
 				bytesData := generateSampleData(f.size)
 
-				pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+				pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 				fr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(bytesData), int64(len(bytesData)))
 				if err != nil {
 					t.Fatal(err)
@@ -499,7 +499,7 @@ func TestTraversalManifest(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+				pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 				mr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(metadataBytes), int64(len(metadataBytes)))
 				if err != nil {
 					t.Fatal(err)
@@ -511,7 +511,7 @@ func TestTraversalManifest(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+				pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 				reference, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)))
 				if err != nil {
 					t.Fatal(err)
@@ -539,7 +539,7 @@ func TestTraversalManifest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			mr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(metadataBytes), int64(len(metadataBytes)))
 			if err != nil {
 				t.Fatal(err)
@@ -552,7 +552,7 @@ func TestTraversalManifest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false)
+			pipe = builder.NewPipelineBuilder(ctx, mockStorer, storage.ModePutUpload, false, nil)
 			manifestFileReference, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(fileEntryBytes), int64(len(fileEntryBytes)))
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
this incomplete PR implements preliminary changes to localstore related to postage stamps as captured in architecture proposals #895 and #898

missing 
- migrations
- test for `postageBatchChunksIndex`
- count for chunks of batch in node's neighbourhood (for validation)

potential technical debt:
 - stamp should be compulsory argument of `swarm.NewChunk`
