### PR TITLE
postage/events: pkg for postage events and syncing with events

### DIFF
--- a/pkg/postage/events/events.go
+++ b/pkg/postage/events/events.go
@@ -1,0 +1,161 @@
+package events
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+var (
+	contractAddress      = common.HexToAddress("0x147B8eb97fD247D06C4006D269c90C1908Fb5D54")
+	contractABI          = parseABI("{}")
+	contractEventDigests = digestSig(eventSignatures)
+)
+
+var (
+	eventSignatures = []string{
+		"BatchCreated(bytes32,uint256,address,uint256)",
+		"BatchTopUp(bytes32,uint256)",
+		"BatchDepthIncrease(bytes32,uint256",
+		"PriceUpdate(uint256)",
+	}
+	eventNames = []string{
+		"BatchCreated",
+		"BatchTopUp",
+		"BatchDepthIncrease",
+		"PriceUpdate",
+	}
+)
+
+func eventTypes(i int) postage.Event {
+	switch i {
+	case 0:
+		return &batchCreatedEvent{}
+	case 1:
+		return &batchTopUpEvent{}
+	case 2:
+		return &batchDepthIncreaseEvent{}
+	case 3:
+		return &priceUpdateEvent{}
+	default:
+		return nil
+	}
+}
+
+// event BatchCreated(bytes32 indexed batchId, uint256 initialBalance, address owner, uint256 depth);
+type batchCreatedEvent struct {
+	batchID [32]byte
+	balance *big.Int
+	owner   common.Address
+	depth   *big.Int
+}
+
+func (e *batchCreatedEvent) Update(s postage.EventUpdater) error {
+	return s.Create(e.batchID[:], e.owner[:], e.balance, uint8(e.depth.Uint64()))
+}
+
+// event BatchTopUp(bytes32 indexed batchId, uint256 topupAmount);
+type batchTopUpEvent struct {
+	batchID [32]byte
+	amount  *big.Int
+}
+
+func (e *batchTopUpEvent) Update(s postage.EventUpdater) error {
+	return s.TopUp(e.batchID[:], e.amount)
+}
+
+// event BatchDepthIncrease(bytes32 indexed batchId, uint256 newDepth);
+type batchDepthIncreaseEvent struct {
+	batchID [32]byte
+	depth   *big.Int
+}
+
+func (e *batchDepthIncreaseEvent) Update(s postage.EventUpdater) error {
+	return s.UpdateDepth(e.batchID[:], uint8(e.depth.Uint64()))
+
+}
+
+// event PriceUpdate(uint256 price);
+type priceUpdateEvent struct {
+	price *big.Int
+}
+
+func (e *priceUpdateEvent) Update(s postage.EventUpdater) error {
+	return s.UpdatePrice(e.price)
+}
+
+// parse reifies the event log type as a struct
+//  weakly unsafe in that if there is another event, nil is returned
+func parse(log types.Log) postage.Event {
+	sigdigest := log.Topics[0].Hex()
+	for i, digest := range contractEventDigests {
+		if digest == sigdigest {
+			ev := eventTypes(i)
+			if err := contractABI.Unpack(ev, eventNames[i], log.Data); err != nil {
+				return nil
+			}
+			return ev
+		}
+	}
+	return nil
+}
+
+func parseABI(json string) abi.ABI {
+	cabi, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("error creating ABI for postage contract: %v", err))
+	}
+	return cabi
+}
+
+func digestSig(sigs []string) []string {
+	digests := make([]string, 4)
+	for i, s := range sigs {
+		h, err := crypto.LegacyKeccak256([]byte(s))
+		if err != nil {
+			panic(fmt.Sprintf("error digesting signatures: %v", err))
+		}
+		digests[i] = hex.EncodeToString(h)
+	}
+	return digests
+}
+
+var _ postage.Events = (*Events)(nil)
+
+// Events provides an iterator listening to postage events
+type Events struct {
+	lis    postage.Listener
+	logger logging.Logger
+}
+
+// New is constructor for Events
+func New(lis postage.Listener, logger logging.Logger) *Events {
+	return &Events{lis, logger}
+}
+
+// Each starts the forever loop that keeps the batch Store in sync with the blockchain
+// takes a postage.Listener interface as argument and uses it as an iterator
+func (e Events) Each(from uint64, f func(uint64, postage.Event) error) func() {
+	update := func(ev types.Log) error {
+		return f(ev.BlockNumber, parse(ev))
+	}
+	quit := make(chan struct{})
+	stop := func() { close(quit) }
+	// Listener Listen call is the forever loop listening to blockchain events
+	go e.listen(from, quit, update)
+	return stop
+}
+
+func (e Events) listen(from uint64, quit chan struct{}, update func(types.Log) error) {
+	if err := e.lis.Listen(from, quit, update); err != nil {
+		e.logger.Errorf("error syncing batches with the blockchain: %v", err)
+	}
+}

--- a/pkg/postage/events/events_test.go
+++ b/pkg/postage/events/events_test.go
@@ -1,0 +1,53 @@
+package events_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+func TestSync(t *testing.T) {
+
+}
+
+type testEvents struct {
+	in    <-chan string
+	out   chan string
+	err   chan error
+	block uint64
+}
+
+func (te *testEvents) Create(id []byte, owner []byte, amount *big.Int, depth uint8) error {
+	ev := fmt.Sprintf("%d:create(%x,%x,%s,%d)", te.block, id, owner, amount, depth)
+	te.out <- ev
+	return nil
+}
+
+func (te *testEvents) TopUp(id []byte, amount *big.Int) error {
+	ev := fmt.Sprintf("%d:topup(%x,%s)", te.block, id, amount)
+	te.out <- ev
+	return nil
+}
+
+func (te *testEvents) UpdateDepth(id []byte, depth uint8) error {
+	ev := fmt.Sprintf("%d:depth(%x,%d)", te.block, id, depth)
+	te.out <- ev
+	return nil
+}
+
+func (te *testEvents) UpdatePrice(price *big.Int) error {
+	ev := fmt.Sprintf("%d:price(%s)", te.block, price)
+	te.out <- ev
+	return nil
+}
+
+//
+func (te *testEvents) LastBlock() uint64 {
+	return te.block
+}
+func (te *testEvents) Update(block uint64, ev postage.Event) error {
+	te.block = block
+	return ev.Update(te)
+}

--- a/pkg/postage/events/export_test.go
+++ b/pkg/postage/events/export_test.go
@@ -1,0 +1,8 @@
+package events
+
+type (
+	BatchCreatedEvent       = batchCreatedEvent
+	BatchTopUpEvent         = batchTopUpEvent
+	BatchDepthIncreaseEvent = batchDepthIncreaseEvent
+	PriceUpdateEvent        = priceUpdateEvent
+)

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -1,0 +1,41 @@
+package postage
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// EventUpdater interface definitions reflect the updates triggered by events emitted by
+// the postage contract on the blockchain
+type EventUpdater interface {
+	Create(id []byte, owner []byte, amount *big.Int, depth uint8) error
+	TopUp(id []byte, amount *big.Int) error
+	UpdateDepth(id []byte, depth uint8) error
+	UpdatePrice(price *big.Int) error
+}
+
+// Event is the interface subsuming all postage contract blockchain events
+//
+// postage contract event  | golang Event              | Update call on EventUpdater
+// ------------------------+---------------------------+---------------------------
+// BatchCreated            | batchCreatedEvent         | Create
+// BatchTopUp              | batchTopUpEvent           | TopUp
+// BatchDepthIncrease      | batchDepthIncreaseEvent   | UpdateDepth
+// PriceUpdate             | priceUpdateEvent          | UpdatePrice
+type Event interface {
+	Update(s EventUpdater) error
+}
+
+// Events provides an iterator for postage events
+type Events interface {
+	Each(from uint64, update func(block uint64, ev Event) error) func()
+}
+
+// Listener provides a blockchain event iterator
+type Listener interface {
+	// - it starts at block from
+	// - it terminates  with no error when quit channel is closed
+	// - if the update function returns an error, the call returns with that error
+	Listen(from uint64, quit chan struct{}, update func(types.Log) error) error
+}


### PR DESCRIPTION
this incomplete PR implements the go side of postage events and syncing with these events as per #920
see AP https://hackmd.io/o8RGsNwZSN6IE0lkBAZCPw?both

known to be missing: 
- tests (unclear to me how to mock `types.Log` events without ethclient calls on actual contracts.
- handling of reorgs `types.Log.Removed` field and/or 'n-block confirmation delay'