### PR TITLE
validators/callbacks reorg to enable pss mailboxing

### DIFF
--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -65,7 +65,7 @@ func TestPssWebsocketSingleHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.TryUnwrap(context.Background(), tc)
+	p.TryUnwrap(tc)
 
 	waitMessage(t, msgContent, payload, &mtx)
 }
@@ -103,7 +103,7 @@ func TestPssWebsocketSingleHandlerDeregister(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.TryUnwrap(context.Background(), tc)
+	p.TryUnwrap(tc)
 
 	waitMessage(t, msgContent, nil, &mtx)
 }
@@ -146,7 +146,7 @@ func TestPssWebsocketMultiHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.TryUnwrap(context.Background(), tc)
+	p.TryUnwrap(tc)
 
 	waitMessage(t, msgContent, nil, &mtx)
 	waitMessage(t, msgContent2, nil, &mtx)
@@ -275,7 +275,7 @@ func TestPssPingPong(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond) // wait to see that the websocket is kept alive
 
-	p.TryUnwrap(context.Background(), tc)
+	p.TryUnwrap(tc)
 
 	waitMessage(t, msgContent, nil, &mtx)
 }
@@ -399,7 +399,7 @@ func (m *mpss) Register(_ pss.Topic, _ pss.Handler) func() {
 }
 
 // TryUnwrap tries to unwrap a wrapped trojan message.
-func (m *mpss) TryUnwrap(_ context.Context, _ swarm.Chunk) {
+func (m *mpss) TryUnwrap(_ swarm.Chunk) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/pss/pss.go
+++ b/pkg/pss/pss.go
@@ -31,7 +31,7 @@ type Interface interface {
 	// Register a Handler for a given Topic.
 	Register(Topic, Handler) func()
 	// TryUnwrap tries to unwrap a wrapped trojan message.
-	TryUnwrap(context.Context, swarm.Chunk)
+	TryUnwrap(swarm.Chunk)
 
 	SetPushSyncer(pushSyncer pushsync.PushSyncer)
 	io.Closer
@@ -128,10 +128,11 @@ func (p *pss) topics() []Topic {
 }
 
 // TryUnwrap allows unwrapping a chunk as a trojan message and calling its handlers based on the topic.
-func (p *pss) TryUnwrap(ctx context.Context, c swarm.Chunk) {
+func (p *pss) TryUnwrap(c swarm.Chunk) {
 	if len(c.Data()) < swarm.ChunkWithSpanSize {
 		return // chunk not full
 	}
+	ctx := context.Background()
 	topic, msg, err := Unwrap(ctx, p.key, c, p.topics())
 	if err != nil {
 		return // cannot unwrap

--- a/pkg/pss/pss_test.go
+++ b/pkg/pss/pss_test.go
@@ -75,8 +75,6 @@ type topicMessage struct {
 // TestDeliver verifies that registering a handler on pss for a given topic and then submitting a trojan chunk with said topic to it
 // results in the execution of the expected handler func
 func TestDeliver(t *testing.T) {
-	ctx := context.Background()
-
 	privkey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +106,7 @@ func TestDeliver(t *testing.T) {
 	p.Register(topic, handler)
 
 	// call pss TryUnwrap on chunk and verify test topic variable value changes
-	p.TryUnwrap(ctx, chunk)
+	p.TryUnwrap(chunk)
 
 	var message topicMessage
 	select {
@@ -172,7 +170,7 @@ func TestRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.TryUnwrap(context.Background(), chunk1)
+	p.TryUnwrap(chunk1)
 
 	waitHandlerCallback(t, &msgChan, 1)
 
@@ -181,7 +179,7 @@ func TestRegister(t *testing.T) {
 
 	// register another topic handler on the same topic
 	cleanup := p.Register(topic1, h3)
-	p.TryUnwrap(context.Background(), chunk1)
+	p.TryUnwrap(chunk1)
 
 	waitHandlerCallback(t, &msgChan, 2)
 
@@ -191,7 +189,7 @@ func TestRegister(t *testing.T) {
 
 	cleanup() // remove the last handler
 
-	p.TryUnwrap(context.Background(), chunk1)
+	p.TryUnwrap(chunk1)
 
 	waitHandlerCallback(t, &msgChan, 1)
 
@@ -203,7 +201,7 @@ func TestRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.TryUnwrap(context.Background(), chunk2)
+	p.TryUnwrap(chunk2)
 
 	waitHandlerCallback(t, &msgChan, 1)
 

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
-
 	"github.com/ethersphere/bee/pkg/pullsync/pb"
 	"github.com/ethersphere/bee/pkg/pullsync/pullstorage"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -57,12 +56,13 @@ type Interface interface {
 }
 
 type Syncer struct {
-	streamer p2p.Streamer
-	metrics  metrics
-	logger   logging.Logger
-	storage  pullstorage.Storer
-	quit     chan struct{}
-	wg       sync.WaitGroup
+	streamer  p2p.Streamer
+	metrics   metrics
+	logger    logging.Logger
+	storage   pullstorage.Storer
+	quit      chan struct{}
+	wg        sync.WaitGroup
+	validator swarm.ValidatorWithCallback
 
 	ruidMtx sync.Mutex
 	ruidCtx map[uint32]func()
@@ -71,15 +71,16 @@ type Syncer struct {
 	io.Closer
 }
 
-func New(streamer p2p.Streamer, storage pullstorage.Storer, logger logging.Logger) *Syncer {
+func New(streamer p2p.Streamer, storage pullstorage.Storer, validator swarm.ValidatorWithCallback, logger logging.Logger) *Syncer {
 	return &Syncer{
-		streamer: streamer,
-		storage:  storage,
-		metrics:  newMetrics(),
-		logger:   logger,
-		ruidCtx:  make(map[uint32]func()),
-		wg:       sync.WaitGroup{},
-		quit:     make(chan struct{}),
+		streamer:  streamer,
+		storage:   storage,
+		metrics:   newMetrics(),
+		validator: validator,
+		logger:    logger,
+		ruidCtx:   make(map[uint32]func()),
+		wg:        sync.WaitGroup{},
+		quit:      make(chan struct{}),
 	}
 }
 
@@ -212,8 +213,17 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		delete(wantChunks, addr.String())
 		s.metrics.DbOpsCounter.Inc()
 		s.metrics.DeliveryCounter.Inc()
-		if err = s.storage.Put(ctx, storage.ModePutSync, swarm.NewChunk(addr, delivery.Data)); err != nil {
+
+		chunk := swarm.NewChunk(addr, delivery.Data)
+		valid, callback := s.validator.ValidWithCallback(chunk)
+		if !valid {
+			return 0, ru.Ruid, swarm.ErrInvalidChunk
+		}
+		if err = s.storage.Put(ctx, storage.ModePutSync, chunk); err != nil {
 			return 0, ru.Ruid, fmt.Errorf("delivery put: %w", err)
+		}
+		if callback != nil {
+			go callback()
 		}
 	}
 	return offer.Topmost, ru.Ruid, nil

--- a/pkg/recovery/repair.go
+++ b/pkg/recovery/repair.go
@@ -16,27 +16,26 @@ import (
 )
 
 const (
-	// RecoveryTopicText is the string used to construct the recovery topic.
-	RecoveryTopicText = "RECOVERY"
+	// TopicText is the string used to construct the recovery topic.
+	TopicText = "RECOVERY"
 )
 
 var (
-	// RecoveryTopic is the topic used for repairing globally pinned chunks.
-	RecoveryTopic = pss.NewTopic(RecoveryTopicText)
+	// Topic is the topic used for repairing globally pinned chunks.
+	Topic = pss.NewTopic(TopicText)
 )
 
-// RecoveryHook defines code to be executed upon failing to retrieve chunks.
-type RecoveryHook func(chunkAddress swarm.Address, targets pss.Targets) error
+// Callback defines code to be executed upon failing to retrieve chunks.
+type Callback func(chunkAddress swarm.Address, targets pss.Targets)
 
-// NewRecoveryHook returns a new RecoveryHook with the sender function defined.
-func NewRecoveryHook(pssSender pss.Sender) RecoveryHook {
-	privk := crypto.Secp256k1PrivateKeyFromBytes([]byte(RecoveryTopicText))
+// NewsCallback returns a new Callback with the sender function defined.
+func NewCallback(pssSender pss.Sender) Callback {
+	privk := crypto.Secp256k1PrivateKeyFromBytes([]byte(TopicText))
 	recipient := privk.PublicKey
-	return func(chunkAddress swarm.Address, targets pss.Targets) error {
+	return func(chunkAddress swarm.Address, targets pss.Targets) {
 		payload := chunkAddress
 		ctx := context.Background()
-		err := pssSender.Send(ctx, RecoveryTopic, payload.Bytes(), &recipient, targets)
-		return err
+		_ = pssSender.Send(ctx, Topic, payload.Bytes(), &recipient, targets)
 	}
 }
 

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -31,7 +31,7 @@ var testTimeout = 5 * time.Second
 // TestDelivery tests that a naive request -> delivery flow works.
 func TestDelivery(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
-	mockValidator := swarm.NewChunkValidator(mock.NewValidator(true))
+	mockValidator := mock.NewValidator(true)
 	mockStorer := storemock.NewStorer()
 	reqAddr, err := swarm.ParseHexAddress("00112233")
 	if err != nil {
@@ -135,7 +135,7 @@ func TestDelivery(t *testing.T) {
 func TestRetrieveChunk(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 
-	mockValidator := swarm.NewChunkValidator(mock.NewValidator(true))
+	mockValidator := mock.NewValidator(true)
 	pricer := accountingmock.NewPricer(1, 1)
 
 	// requesting a chunk from downstream peer is expected

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/sha3"
@@ -28,6 +29,10 @@ const (
 
 var (
 	NewHasher = sha3.NewLegacyKeccak256
+)
+
+var (
+	ErrInvalidChunk = errors.New("invalid chunk")
 )
 
 // Address represents an address in Swarm metric space of
@@ -163,29 +168,4 @@ func (c *chunk) String() string {
 
 func (c *chunk) Equal(cp Chunk) bool {
 	return c.Address().Equal(cp.Address()) && bytes.Equal(c.Data(), cp.Data())
-}
-
-type Validator interface {
-	Validate(ch Chunk) (valid bool)
-}
-
-type chunkValidator struct {
-	set []Validator
-	Validator
-}
-
-func NewChunkValidator(v ...Validator) Validator {
-	return &chunkValidator{
-		set: v,
-	}
-}
-
-func (c *chunkValidator) Validate(ch Chunk) bool {
-	for _, v := range c.set {
-		if v.Validate(ch) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/swarm/validator.go
+++ b/pkg/swarm/validator.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package swarm
+
+type Validator interface {
+	Validate(ch Chunk) (valid bool)
+}
+
+type ValidatorWithCallback interface {
+	ValidWithCallback(ch Chunk) (valid bool, callback func())
+	Validator
+}
+
+var _ Validator = (*validatorWithCallback)(nil)
+
+type validatorWithCallback struct {
+	v        Validator
+	callback func(Chunk)
+}
+
+func (v *validatorWithCallback) Validate(ch Chunk) bool {
+	valid := v.v.Validate(ch)
+	if valid {
+		go v.callback(ch)
+	}
+	return valid
+}
+
+var _ ValidatorWithCallback = (*multiValidator)(nil)
+
+type multiValidator struct {
+	validators []Validator
+	callbacks  []func(Chunk)
+}
+
+func NewMultiValidator(validators []Validator, callbacks ...func(Chunk)) ValidatorWithCallback {
+	return &multiValidator{validators, callbacks}
+}
+
+func (mv *multiValidator) Validate(ch Chunk) bool {
+	for _, v := range mv.validators {
+		if v.Validate(ch) {
+			return true
+		}
+	}
+
+	return false
+}
+func (mv *multiValidator) ValidWithCallback(ch Chunk) (bool, func()) {
+	for i, v := range mv.validators {
+		if v.Validate(ch) {
+			if i < len(mv.callbacks) {
+				return true, func() { mv.callbacks[i](ch) }
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION


- api, pss: pss.TryUnwrap  takes no context
- netstore: has no validator, (FIXME: chunk API needs validation)
   recovery simplified
- recovery: renames, callback is async and results in no error
- pullsync: add validator with callback (FIXME: always called)
- pushsync: add validator with callbakck ,
   called async, called only if peer is closest node, tested
- swarm: validator.go, multiValidator implements ValidatorWithCallback