### PR TITLE
Pushsync retry next peer after error

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -511,13 +511,19 @@ func (k *Kad) notifyPeerSig() {
 }
 
 // ClosestPeer returns the closest peer to a given address.
-func (k *Kad) ClosestPeer(addr swarm.Address) (swarm.Address, error) {
+func (k *Kad) ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (swarm.Address, error) {
 	if k.connectedPeers.Length() == 0 {
 		return swarm.Address{}, topology.ErrNotFound
 	}
 
 	closest := k.base
 	err := k.connectedPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+		for _, a := range skipPeers {
+			if a.Equal(peer) {
+				return false, false, nil
+			}
+		}
+
 		dcmp, err := swarm.DistanceCmp(addr.Bytes(), closest.Bytes(), peer.Bytes())
 		if err != nil {
 			return false, false, err

--- a/pkg/kademlia/mock/kademlia.go
+++ b/pkg/kademlia/mock/kademlia.go
@@ -64,7 +64,7 @@ func (m *Mock) AddPeers(ctx context.Context, addr ...swarm.Address) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error) {
+func (m *Mock) ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -315,6 +315,15 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 			continue
 		}
 
+		// if you manage to get a tag, just increment the respective counter
+		t, err := ps.tagger.Get(ch.TagID())
+		if err == nil && t != nil {
+			err = t.Inc(tags.StateSent)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		receiptRTTTimer := time.Now()
 		receipt, err := ps.receiveReceipt(ctx, r)
 		if err != nil {
@@ -327,15 +336,6 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 			continue
 		}
 		ps.metrics.ReceiptRTT.Observe(time.Since(receiptRTTTimer).Seconds())
-
-		// if you manage to get a tag, just increment the respective counter
-		t, err := ps.tagger.Get(ch.TagID())
-		if err == nil && t != nil {
-			err = t.Inc(tags.StateSent)
-			if err != nil {
-				return nil, err
-			}
-		}
 
 		// Check if the receipt is valid
 		if !ch.Address().Equal(swarm.NewAddress(receipt.Address)) {

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -7,6 +7,7 @@ package pushsync_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/localstore"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
 	"github.com/ethersphere/bee/pkg/p2p/streamtest"
 	"github.com/ethersphere/bee/pkg/pushsync"
@@ -178,6 +180,130 @@ func TestPushChunkToClosest(t *testing.T) {
 	case <-callbackC:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("delivery hook was not called")
+	}
+}
+
+func TestPushChunkToNextClosest(t *testing.T) {
+	// chunk data to upload
+	chunkAddress := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
+	chunkData := []byte("1234")
+
+	validator := testValidator(chunkAddress, chunkData, nil)
+
+	// create a pivot node and a mocked closest node
+	pivotNode := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
+
+	peer1 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peers := []swarm.Address{
+		peer1,
+		peer2,
+	}
+
+	// peer is the node responding to the chunk receipt message
+	// mock should return ErrWantSelf since there's no one to forward to
+	psPeer1, storerPeer1, _, peerAccounting1 := createPushSyncNode(t, peer1, nil, validator, mock.WithClosestPeerErr(topology.ErrWantSelf))
+	defer storerPeer1.Close()
+
+	psPeer2, storerPeer2, _, peerAccounting2 := createPushSyncNode(t, peer2, nil, validator, mock.WithClosestPeerErr(topology.ErrWantSelf))
+	defer storerPeer2.Close()
+
+	recorder := streamtest.New(
+		streamtest.WithProtocols(
+			psPeer1.Protocol(),
+			psPeer2.Protocol(),
+		),
+		streamtest.WithMiddlewares(
+			func(h p2p.HandlerFunc) p2p.HandlerFunc {
+				return func(ctx context.Context, peer p2p.Peer, stream p2p.Stream) error {
+					// NOTE: return error for peer1
+					if peer1.Equal(peer.Address) {
+						return fmt.Errorf("peer not reachable: %s", peer.Address.String())
+					}
+
+					if err := h(ctx, peer, stream); err != nil {
+						return err
+					}
+					// close stream after all previous middlewares wrote to it
+					// so that the receiving peer can get all the post messages
+					return stream.Close()
+				}
+			},
+		),
+	)
+
+	// pivot node needs the streamer since the chunk is intercepted by
+	// the chunk worker, then gets sent by opening a new stream
+	psPivot, storerPivot, pivotTags, pivotAccounting := createPushSyncNode(t, pivotNode, recorder, nil,
+		mock.WithClosestPeerErr(topology.ErrNotFound),
+		mock.WithPeers(peers...),
+	)
+	defer storerPivot.Close()
+
+	ta, err := pivotTags.Create("test", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk := swarm.NewChunk(chunkAddress, chunkData).WithTagID(ta.Uid)
+
+	ta1, err := pivotTags.Get(ta.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ta1.Get(tags.StateSent) != 0 || ta1.Get(tags.StateSynced) != 0 {
+		t.Fatalf("tags initialization error")
+	}
+
+	// Trigger the sending of chunk to the closest node
+	receipt, err := psPivot.PushChunkToClosest(context.Background(), chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !chunk.Address().Equal(receipt.Address) {
+		t.Fatal("invalid receipt")
+	}
+
+	// this intercepts the outgoing delivery message
+	waitOnRecordAndTest(t, peer2, recorder, chunkAddress, chunkData)
+
+	// this intercepts the incoming receipt message
+	waitOnRecordAndTest(t, peer2, recorder, chunkAddress, nil)
+
+	ta2, err := pivotTags.Get(ta.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ta2.Get(tags.StateSent) != 1 {
+		t.Fatalf("tags error")
+	}
+
+	balance, err := pivotAccounting.Balance(peer2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if balance != -int64(fixedPrice) {
+		t.Fatalf("unexpected balance on pivot. want %d got %d", -int64(fixedPrice), balance)
+	}
+
+	balance2, err := peerAccounting2.Balance(peer2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if balance2 != int64(fixedPrice) {
+		t.Fatalf("unexpected balance on peer2. want %d got %d", int64(fixedPrice), balance2)
+	}
+
+	balance1, err := peerAccounting1.Balance(peer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if balance1 != 0 {
+		t.Fatalf("unexpected balance on peer1. want %d got %d", 0, balance1)
 	}
 }
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -416,7 +416,9 @@ func createPushSyncNode(t *testing.T, addr swarm.Address, recorder *streamtest.R
 	mockAccounting := accountingmock.NewAccounting()
 	mockPricer := accountingmock.NewPricer(fixedPrice, fixedPrice)
 
-	return pushsync.New(recorder, storer, mockTopology, mtag, validator, logger, mockAccounting, mockPricer, nil), storer, mtag, mockAccounting
+	recorderDisconnecter := streamtest.NewRecorderDisconnecter(recorder)
+
+	return pushsync.New(recorderDisconnecter, storer, mockTopology, mtag, validator, logger, mockAccounting, mockPricer, nil), storer, mtag, mockAccounting
 }
 
 func waitOnRecordAndTest(t *testing.T, peer swarm.Address, recorder *streamtest.Recorder, add swarm.Address, data []byte) {

--- a/pkg/topology/full/full.go
+++ b/pkg/topology/full/full.go
@@ -188,25 +188,25 @@ func (d *driver) Connected(ctx context.Context, addr swarm.Address) error {
 	return d.AddPeers(ctx, addr)
 }
 
-func (_ *driver) Disconnected(swarm.Address) {
+func (*driver) Disconnected(swarm.Address) {
 	// TODO: implement if necessary
 }
 
-func (_ *driver) NeighborhoodDepth() uint8 {
+func (*driver) NeighborhoodDepth() uint8 {
 	return 0
 }
 
 // EachPeer iterates from closest bin to farthest
-func (_ *driver) EachPeer(_ topology.EachPeerFunc) error {
+func (*driver) EachPeer(_ topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
 // EachPeerRev iterates from farthest bin to closest
-func (_ *driver) EachPeerRev(_ topology.EachPeerFunc) error {
+func (*driver) EachPeerRev(_ topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (_ *driver) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
+func (*driver) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
 	//TODO implement if necessary
 	return c, unsubscribe
 }

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -92,7 +92,7 @@ func (d *mock) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
 	return c, unsubscribe
 }
 
-func (_ *mock) NeighborhoodDepth() uint8 {
+func (*mock) NeighborhoodDepth() uint8 {
 	return 0
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -31,6 +31,11 @@ type PeerAdder interface {
 	AddPeers(ctx context.Context, addr ...swarm.Address) error
 }
 
+type Peerer interface {
+	ClosestPeerer
+	EachPeerer
+}
+
 type ClosestPeerer interface {
 	ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -31,13 +31,12 @@ type PeerAdder interface {
 	AddPeers(ctx context.Context, addr ...swarm.Address) error
 }
 
-type Peerer interface {
-	ClosestPeerer
-	EachPeerer
-}
-
 type ClosestPeerer interface {
-	ClosestPeer(addr swarm.Address) (peerAddr swarm.Address, err error)
+	// ClosestPeer returns the closest connected peer we have in relation to a
+	// given chunk address.
+	// This function will ignore peers with addresses provided in skipPeers.
+	// Returns topology.ErrWantSelf in case base is the closest to the chunk.
+	ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
 }
 
 type EachPeerer interface {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -35,7 +35,7 @@ type ClosestPeerer interface {
 	// ClosestPeer returns the closest connected peer we have in relation to a
 	// given chunk address.
 	// This function will ignore peers with addresses provided in skipPeers.
-	// Returns topology.ErrWantSelf in case base is the closest to the chunk.
+	// Returns topology.ErrWantSelf in case base is the closest to the address.
 	ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
 }
 


### PR DESCRIPTION
Updates `pushsync.PushChunkToClosest` function with the change where it will attempt multiple peers if one fails.

Previous code only ever attempted to push to same peer (that was deemed as "closest"), even in the face of problems with that host. This change adds loop which attempts closest peer, and if there are some problems with that peer tries some other closest peer (from the available ones). Depending on the error, it may blocklist the peer for some time (one minute). It will try to maximum of `5` peers. If each of them fails it will return last error that was encountered.

Note that new code still uses original `ClosestPeer` function, in which case it will again be possible that selected peer will be "self". If we want to change this, it would be possible.