### PR TITLE
fix all set-env and add-path

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -99,7 +99,7 @@ jobs:
           cp $(k3d get-kubeconfig --name='k3s-default') ~/.kube/config
       - name: Increase REPLICA to 5
         run: |
-          echo "::set-env name=REPLICA::5"
+          echo "REPLICA=5" >> $GITHUB_ENV
       - name: Set testing cluster (Node connection) 5 bee nodes
         run: |
           echo -e "127.0.0.10\tregistry.localhost" | sudo tee -a /etc/hosts
@@ -122,7 +122,7 @@ jobs:
           docker push ethersphere/bee:latest
       - name: Set IMAGE_DIGEST variable
         if: success()
-        run: echo "::set-env name=IMAGE_DIGEST::$(docker inspect --format='{{index .RepoDigests 0}}' ethersphere/bee:latest | cut -d'@' -f 2 | tr -d '\n')"
+        run: echo "IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ethersphere/bee:latest | cut -d'@' -f 2 | tr -d '\n')" >> $GITHUB_ENV
       - name: Trigger ArgoCD
         if: success()
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,14 +18,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-    - name: Setup env
-      run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
     - name: Set git to use LF
       # make sure that line endings are not converted on windows
       # as gofmt linter will report that they need to be changed

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -17,10 +17,10 @@ jobs:
           if [ $DAYS -eq 0 ]; then
             echo "There are new commits..."
             echo "Last commit from $AUTHOR, URL => $URL"
-            echo ::set-env name=GHA_REPO_RUN::true
+            echo "GHA_REPO_RUN=true" >> $GITHUB_ENV
           else
             echo "No new commits, exiting..."
-            echo ::set-env name=GHA_REPO_RUN::false
+            echo "GHA_REPO_RUN=false" >> $GITHUB_ENV
           fi
       - name: Trigger ArgoCD
         if: env.GHA_REPO_RUN == 'true'

--- a/.github/workflows/slash-beekeeper.yml
+++ b/.github/workflows/slash-beekeeper.yml
@@ -101,7 +101,7 @@ jobs:
           cp $(k3d get-kubeconfig --name='k3s-default') ~/.kube/config
       - name: Increase REPLICA to 5
         run: |
-          echo "::set-env name=REPLICA::5"
+          echo "REPLICA=5" >> $GITHUB_ENV
       - name: Set testing cluster (Node connection) 5 bee nodes
         run: |
           echo -e "127.0.0.10\tregistry.localhost" | sudo tee -a /etc/hosts


### PR DESCRIPTION
Github action deprecated usage of command `::set-env` and `::add-path`

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

There is new way of [defining ENV variables and PATH](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)
New version of setup-go `actions/setup-go@v2` sets all needed ENV variables