### PR TITLE
Surplus balances for peers, debug API addons

### DIFF
--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -71,7 +71,50 @@ paths:
           description: Swarm address of peer
       responses:
         '200':
-          description: Peer is known
+          description: Balance with the specific peer
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balance'
+        '404':
+          $ref: 'SwarmCommon.yaml#/components/responses/404'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+ 
+ '/balances/compensated':
+    get:
+      summary: Get the compensated balances with all known peers
+      tags:
+        - Balance
+      responses:
+        '200':
+          description: Own balances compensated by surplus balances with all known peers
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/Balances'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
+
+  '/balances/compensated/{address}':
+    get:
+      summary: Get the compensated balance with a specific peer
+      tags:
+        - Balance
+      parameters:
+        - in: path
+          name: address
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/SwarmAddress'
+          required: true
+          description: Swarm address of peer
+      responses:
+        '200':
+          description: Balance compensated by surplus balance with the specific peer
           content:
             application/json:
               schema:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -83,7 +83,7 @@ paths:
         default:
           description: Default response
  
-  '/balances/consumed':
+  '/consumed':
     get:
       summary: Get the past due consumption balances with all known peers
       tags:
@@ -100,7 +100,7 @@ paths:
         default:
           description: Default response
 
-  '/balances/consumed/{address}':
+  '/consumed/{address}':
     get:
       summary: Get the past due consumption balance with a specific peer
       tags:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -138,6 +138,8 @@ paths:
             application/json:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookAddress'
+        default:
+          description: Default response
 
   '/chequebook/balance':
     get:
@@ -387,6 +389,8 @@ paths:
             application/json:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/BzzTopology'
+        default:
+          description: Default response
 
   '/welcome-message':
     get:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -42,7 +42,7 @@ paths:
 
   '/balances':
     get:
-      summary: Get the balances with all known peers
+      summary: Get the balances with all known peers including prepaid services
       tags:
         - Balance
       responses:
@@ -59,7 +59,7 @@ paths:
 
   '/balances/{address}':
     get:
-      summary: Get the balances with a specific peer
+      summary: Get the balances with a specific peer including prepaid services
       tags:
         - Balance
       parameters:
@@ -83,14 +83,14 @@ paths:
         default:
           description: Default response
  
-  '/balances/compensated':
+  '/balances/consumed':
     get:
-      summary: Get the compensated balances with all known peers
+      summary: Get the past due consumption balances with all known peers
       tags:
         - Balance
       responses:
         '200':
-          description: Own balances compensated by surplus balances with all known peers
+          description: Own past due consumption balances with all known peers
           content:
             application/json:
               schema:
@@ -100,9 +100,9 @@ paths:
         default:
           description: Default response
 
-  '/balances/compensated/{address}':
+  '/balances/consumed/{address}':
     get:
-      summary: Get the compensated balance with a specific peer
+      summary: Get the past due consumption balance with a specific peer
       tags:
         - Balance
       parameters:
@@ -114,7 +114,7 @@ paths:
           description: Swarm address of peer
       responses:
         '200':
-          description: Balance compensated by surplus balance with the specific peer
+          description: Past-due consumption balance with the specific peer
           content:
             application/json:
               schema:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -19,7 +19,7 @@ servers:
         default: 'localhost'
         description: Base address of the local bee node debug API
       port:
-        default: 6060
+        default: 1635
         description: Service port provided in bee node config
 
 paths:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -19,7 +19,7 @@ servers:
         default: 'localhost'
         description: Base address of the local bee node debug API
       port:
-        default: 1635
+        default: 6060
         description: Service port provided in bee node config
 
 paths:
@@ -83,7 +83,7 @@ paths:
         default:
           description: Default response
  
- '/balances/compensated':
+  '/balances/compensated':
     get:
       summary: Get the compensated balances with all known peers
       tags:
@@ -138,8 +138,6 @@ paths:
             application/json:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/ChequebookAddress'
-        default:
-          description: Default response
 
   '/chequebook/balance':
     get:
@@ -389,8 +387,6 @@ paths:
             application/json:
               schema:
                 $ref: 'SwarmCommon.yaml#/components/schemas/BzzTopology'
-        default:
-          description: Default response
 
   '/welcome-message':
     get:

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -449,7 +449,7 @@ func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, 
 		return 0, err
 	}
 	if surplus < 0 {
-		return 0, ErrOverflow
+		return 0, ErrInValue
 	}
 	// Compensated balance is balance decreased by surplus balance
 	compensated, err = subtractI64mU64(balance, uint64(surplus))

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -49,7 +49,7 @@ type Interface interface {
 	Balances() (map[string]int64, error)
 	// CompensatedBalance returns the current balance deducted by current surplus balance for the given peer.
 	CompensatedBalance(peer swarm.Address) (int64, error)
-	// Balance returns the compensated balances for all known peers.
+	// CompensatedBalances returns the compensated balances for all known peers.
 	CompensatedBalances() (map[string]int64, error)
 }
 

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -619,7 +619,6 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 		}
 
 	}
-
 	// if balance is already negative or zero, we credit full amount received to surplus balance and terminate early
 	if currentBalance <= 0 {
 		surplus, err := a.SurplusBalance(peer)

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -619,18 +619,6 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 		}
 
 	}
-	newBalance, err := subtractI64mU64(currentBalance, amount)
-	if err != nil {
-		return err
-	}
-
-	// Don't allow a payment to put us into debt
-	// This is to prevent another node tricking us into settling by settling
-	// first (e.g. send a bouncing cheque to trigger an honest cheque in swap).
-	nextBalance := newBalance
-	if newBalance < 0 {
-		nextBalance = 0
-	}
 
 	// if balance is already negative or zero, we credit full amount received to surplus balance and terminate early
 	if currentBalance <= 0 {
@@ -654,6 +642,18 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 	}
 
 	// if current balance is positive, let's make a partial credit to
+	newBalance, err := subtractI64mU64(currentBalance, amount)
+	if err != nil {
+		return err
+	}
+
+	// Don't allow a payment to put us into debt
+	// This is to prevent another node tricking us into settling by settling
+	// first (e.g. send a bouncing cheque to trigger an honest cheque in swap).
+	nextBalance := newBalance
+	if newBalance < 0 {
+		nextBalance = 0
+	}
 
 	a.logger.Tracef("crediting peer %v with amount %d due to payment, new balance is %d", peer, amount, nextBalance)
 

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -634,10 +634,6 @@ func (a *Accounting) NotifyPayment(peer swarm.Address, amount uint64) error {
 
 	// if balance is already negative or zero, we credit full amount received to surplus balance and terminate early
 	if currentBalance <= 0 {
-		if err != nil {
-			return err
-		}
-
 		surplus, err := a.SurplusBalance(peer)
 		if err != nil {
 			return fmt.Errorf("failed to get surplus balance: %w", err)

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -47,6 +47,10 @@ type Interface interface {
 	SurplusBalance(peer swarm.Address) (int64, error)
 	// Balances returns balances for all known peers.
 	Balances() (map[string]int64, error)
+	// CompensatedBalance returns the current balance deducted by current surplus balance for the given peer.
+	CompensatedBalance(peer swarm.Address) (int64, error)
+	// Balance returns the compensated balances for all known peers.
+	CompensatedBalances() (map[string]int64, error)
 }
 
 // accountingPeer holds all in-memory accounting information for one peer.
@@ -86,6 +90,8 @@ var (
 	ErrPeerNoBalance = errors.New("no balance for peer")
 	// ErrOverflow denotes an arithmetic operation overflowed.
 	ErrOverflow = errors.New("overflow error")
+	// ErrInValue denotes an invalid value read from store
+	ErrInValue = errors.New("invalid value")
 )
 
 // NewAccounting creates a new Accounting instance with the provided options.
@@ -163,10 +169,25 @@ func (a *Accounting) Reserve(ctx context.Context, peer swarm.Address, price uint
 		threshold = 0
 	}
 
+	additionalDebt, err := a.SurplusBalance(peer)
+	if err != nil {
+		return fmt.Errorf("failed to load surplus balance: %w", err)
+	}
+
+	// uint64 conversion of surplusbalance is safe because surplusbalance is always positive
+	if additionalDebt < 0 {
+		return ErrInValue
+	}
+
+	increasedExpectedDebt, err := addI64pU64(expectedDebt, uint64(additionalDebt))
+	if err != nil {
+		return err
+	}
+
 	// If our expected debt is less than earlyPayment away from our payment threshold
 	// and we are actually in debt, trigger settlement.
 	// we pay early to avoid needlessly blocking request later when concurrent requests occur and we are already close to the payment threshold.
-	if expectedDebt >= int64(threshold) && currentBalance < 0 {
+	if increasedExpectedDebt >= int64(threshold) && currentBalance < 0 {
 		err = a.settle(ctx, peer, accountingPeer)
 		if err != nil {
 			return fmt.Errorf("failed to settle with peer %v: %v", peer, err)
@@ -174,11 +195,15 @@ func (a *Accounting) Reserve(ctx context.Context, peer swarm.Address, price uint
 		// if we settled successfully our balance is back at 0
 		// and the expected debt therefore equals next reserved amount
 		expectedDebt = int64(nextReserved)
+		increasedExpectedDebt, err = addI64pU64(expectedDebt, uint64(additionalDebt))
+		if err != nil {
+			return err
+		}
 	}
 
 	// if expectedDebt would still exceed the paymentThreshold at this point block this request
 	// this can happen if there is a large number of concurrent requests to the same peer
-	if expectedDebt > int64(a.paymentThreshold) {
+	if increasedExpectedDebt > int64(a.paymentThreshold) {
 		a.metrics.AccountingBlocksCount.Inc()
 		return ErrOverdraft
 	}
@@ -413,6 +438,28 @@ func (a *Accounting) SurplusBalance(peer swarm.Address) (balance int64, err erro
 	return balance, nil
 }
 
+// CompensatedBalance returns balance decreased by surplus balance
+func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, err error) {
+	balance, err := a.Balance(peer)
+	if err != nil {
+		return 0, err
+	}
+	surplus, err := a.SurplusBalance(peer)
+	if err != nil {
+		return 0, err
+	}
+	if surplus < 0 {
+		return 0, ErrOverflow
+	}
+	// Compensated balance is balance decreased by surplus balance
+	compensated, err = subtractI64mU64(balance, uint64(surplus))
+	if err != nil {
+		return 0, err
+	}
+
+	return compensated, nil
+}
+
 // peerBalanceKey returns the balance storage key for the given peer.
 func peerBalanceKey(peer swarm.Address) string {
 	return fmt.Sprintf("%s%s", balancesPrefix, peer.String())
@@ -472,11 +519,76 @@ func (a *Accounting) Balances() (map[string]int64, error) {
 	return s, nil
 }
 
+// Balances gets balances for all peers from store.
+func (a *Accounting) CompensatedBalances() (map[string]int64, error) {
+	s := make(map[string]int64)
+
+	err := a.store.Iterate(balancesPrefix, func(key, val []byte) (stop bool, err error) {
+		addr, err := balanceKeyPeer(key)
+		if err != nil {
+			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+		}
+		if _, ok := s[addr.String()]; !ok {
+			value, err := a.CompensatedBalance(addr)
+			if err != nil {
+				return false, fmt.Errorf("get peer %s balance: %v", addr.String(), err)
+			}
+
+			s[addr.String()] = value
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = a.store.Iterate(balancesSurplusPrefix, func(key, val []byte) (stop bool, err error) {
+		addr, err := surplusBalanceKeyPeer(key)
+		if err != nil {
+			return false, fmt.Errorf("parse address from key: %s: %v", string(key), err)
+		}
+		if _, ok := s[addr.String()]; !ok {
+			value, err := a.CompensatedBalance(addr)
+			if err != nil {
+				return false, fmt.Errorf("get peer %s balance: %v", addr.String(), err)
+			}
+
+			s[addr.String()] = value
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
 // balanceKeyPeer returns the embedded peer from the balance storage key.
 func balanceKeyPeer(key []byte) (swarm.Address, error) {
 	k := string(key)
 
 	split := strings.SplitAfter(k, balancesPrefix)
+	if len(split) != 2 {
+		return swarm.ZeroAddress, errors.New("no peer in key")
+	}
+
+	addr, err := swarm.ParseHexAddress(split[1])
+	if err != nil {
+		return swarm.ZeroAddress, err
+	}
+
+	return addr, nil
+}
+
+func surplusBalanceKeyPeer(key []byte) (swarm.Address, error) {
+	k := string(key)
+
+	split := strings.SplitAfter(k, balancesSurplusPrefix)
 	if len(split) != 2 {
 		return swarm.ZeroAddress, errors.New("no peer in key")
 	}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -299,16 +299,18 @@ func TestAccountingOverflowNotifyPayment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Notify of incoming payment from same peer, further decreasing balance, this should overflow
+
+	// NotifyPayment for peer should now fill the surplus balance
 	err = acc.NotifyPayment(peer1Addr, math.MaxInt64)
-	if err == nil {
-		t.Fatal("Expected overflow from NotifyPayment")
+	if err != nil {
+		t.Fatalf("Expected no error but got one: %v", err)
 	}
-	// If we had other error, assert fail
+
+	// Notify of incoming payment from same peer, further increasing the surplus balance into an overflow
+	err = acc.NotifyPayment(peer1Addr, 1)
 	if !errors.Is(err, accounting.ErrOverflow) {
 		t.Fatalf("expected overflow error from Debit, got %v", err)
 	}
-
 }
 
 func TestAccountingOverflowDebit(t *testing.T) {

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -14,14 +14,17 @@ import (
 
 // Service is the mock Accounting service.
 type Service struct {
-	lock               sync.Mutex
-	balances           map[string]int64
-	reserveFunc        func(ctx context.Context, peer swarm.Address, price uint64) error
-	releaseFunc        func(peer swarm.Address, price uint64)
-	creditFunc         func(peer swarm.Address, price uint64) error
-	debitFunc          func(peer swarm.Address, price uint64) error
-	balanceFunc        func(swarm.Address) (int64, error)
-	balancesFunc       func() (map[string]int64, error)
+	lock                    sync.Mutex
+	balances                map[string]int64
+	reserveFunc             func(ctx context.Context, peer swarm.Address, price uint64) error
+	releaseFunc             func(peer swarm.Address, price uint64)
+	creditFunc              func(peer swarm.Address, price uint64) error
+	debitFunc               func(peer swarm.Address, price uint64) error
+	balanceFunc             func(swarm.Address) (int64, error)
+	balancesFunc            func() (map[string]int64, error)
+	compensatedBalanceFunc  func(swarm.Address) (int64, error)
+	compensatedBalancesFunc func() (map[string]int64, error)
+
 	balanceSurplusFunc func(swarm.Address) (int64, error)
 }
 
@@ -64,6 +67,20 @@ func WithBalanceFunc(f func(swarm.Address) (int64, error)) Option {
 func WithBalancesFunc(f func() (map[string]int64, error)) Option {
 	return optionFunc(func(s *Service) {
 		s.balancesFunc = f
+	})
+}
+
+// WithCompensatedBalanceFunc sets the mock Balance function
+func WithCompensatedBalanceFunc(f func(swarm.Address) (int64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.compensatedBalanceFunc = f
+	})
+}
+
+// WithCompensatedBalancesFunc sets the mock Balances function
+func WithCompensatedBalancesFunc(f func() (map[string]int64, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.compensatedBalancesFunc = f
 	})
 }
 
@@ -135,6 +152,24 @@ func (s *Service) Balance(peer swarm.Address) (int64, error) {
 func (s *Service) Balances() (map[string]int64, error) {
 	if s.balancesFunc != nil {
 		return s.balancesFunc()
+	}
+	return s.balances, nil
+}
+
+// CompensatedBalance is the mock function wrapper that calls the set implementation
+func (s *Service) CompensatedBalance(peer swarm.Address) (int64, error) {
+	if s.compensatedBalanceFunc != nil {
+		return s.compensatedBalanceFunc(peer)
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.balances[peer.String()], nil
+}
+
+// CompensatedBalances is the mock function wrapper that calls the set implementation
+func (s *Service) CompensatedBalances() (map[string]int64, error) {
+	if s.compensatedBalancesFunc != nil {
+		return s.compensatedBalancesFunc()
 	}
 	return s.balances, nil
 }

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -84,8 +84,8 @@ func (s *server) compensatedBalancesHandler(w http.ResponseWriter, r *http.Reque
 	balances, err := s.Accounting.CompensatedBalances()
 	if err != nil {
 		jsonhttp.InternalServerError(w, errCantBalances)
-		s.Logger.Debugf("debug api: balances: %v", err)
-		s.Logger.Error("debug api: can not get balances")
+		s.Logger.Debugf("debug api: compensated balances: %v", err)
+		s.Logger.Error("debug api: can not get compensated balances")
 		return
 	}
 
@@ -106,8 +106,8 @@ func (s *server) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Re
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: balances peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: balances peer: invalid peer address %s", addr)
+		s.Logger.Debugf("debug api: compensated balances peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Errorf("debug api: compensated balances peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
@@ -118,8 +118,8 @@ func (s *server) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Re
 			jsonhttp.NotFound(w, errNoBalance)
 			return
 		}
-		s.Logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)
-		s.Logger.Errorf("debug api: balances peer: can't get peer %s balance", peer.String())
+		s.Logger.Debugf("debug api: compensated balances peer: get peer %s balance: %v", peer.String(), err)
+		s.Logger.Errorf("debug api: compensated balances peer: can't get peer %s balance", peer.String())
 		jsonhttp.InternalServerError(w, errCantBalance)
 		return
 	}

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -79,3 +79,53 @@ func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 		Balance: balance,
 	})
 }
+
+func (s *server) compensatedBalancesHandler(w http.ResponseWriter, r *http.Request) {
+	balances, err := s.Accounting.CompensatedBalances()
+	if err != nil {
+		jsonhttp.InternalServerError(w, errCantBalances)
+		s.Logger.Debugf("debug api: balances: %v", err)
+		s.Logger.Error("debug api: can not get balances")
+		return
+	}
+
+	balResponses := make([]balanceResponse, len(balances))
+	i := 0
+	for k := range balances {
+		balResponses[i] = balanceResponse{
+			Peer:    k,
+			Balance: balances[k],
+		}
+		i++
+	}
+
+	jsonhttp.OK(w, balancesResponse{Balances: balResponses})
+}
+
+func (s *server) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Request) {
+	addr := mux.Vars(r)["peer"]
+	peer, err := swarm.ParseHexAddress(addr)
+	if err != nil {
+		s.Logger.Debugf("debug api: balances peer: invalid peer address %s: %v", addr, err)
+		s.Logger.Errorf("debug api: balances peer: invalid peer address %s", addr)
+		jsonhttp.NotFound(w, errInvaliAddress)
+		return
+	}
+
+	balance, err := s.Accounting.CompensatedBalance(peer)
+	if err != nil {
+		if errors.Is(err, accounting.ErrPeerNoBalance) {
+			jsonhttp.NotFound(w, errNoBalance)
+			return
+		}
+		s.Logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)
+		s.Logger.Errorf("debug api: balances peer: can't get peer %s balance", peer.String())
+		jsonhttp.InternalServerError(w, errCantBalance)
+		return
+	}
+
+	jsonhttp.OK(w, balanceResponse{
+		Peer:    peer.String(),
+		Balance: balance,
+	})
+}

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -171,8 +171,6 @@ func equalBalances(a, b *debugapi.BalancesResponse) bool {
 	return true
 }
 
-//#####
-
 func TestConsumedBalances(t *testing.T) {
 	balancesFunc := func() (ret map[string]int64, err error) {
 		ret = make(map[string]int64)

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestBalances(t *testing.T) {
-	balancesFunc := func() (ret map[string]int64, err error) {
+	compensatedBalancesFunc := func() (ret map[string]int64, err error) {
 		ret = make(map[string]int64)
 		ret["DEAD"] = 1000000000000000000
 		ret["BEEF"] = -100000000000000000
@@ -27,7 +27,7 @@ func TestBalances(t *testing.T) {
 		return ret, err
 	}
 	testServer := newTestServer(t, testServerOptions{
-		AccountingOpts: []mock.Option{mock.WithBalancesFunc(balancesFunc)},
+		AccountingOpts: []mock.Option{mock.WithCompensatedBalancesFunc(compensatedBalancesFunc)},
 	})
 
 	expected := &debugapi.BalancesResponse{
@@ -61,11 +61,11 @@ func TestBalances(t *testing.T) {
 
 func TestBalancesError(t *testing.T) {
 	wantErr := errors.New("ASDF")
-	balancesFunc := func() (ret map[string]int64, err error) {
+	compensatedBalancesFunc := func() (ret map[string]int64, err error) {
 		return nil, wantErr
 	}
 	testServer := newTestServer(t, testServerOptions{
-		AccountingOpts: []mock.Option{mock.WithBalancesFunc(balancesFunc)},
+		AccountingOpts: []mock.Option{mock.WithCompensatedBalancesFunc(compensatedBalancesFunc)},
 	})
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances", http.StatusInternalServerError,
@@ -78,11 +78,11 @@ func TestBalancesError(t *testing.T) {
 
 func TestBalancesPeers(t *testing.T) {
 	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
-	balanceFunc := func(swarm.Address) (int64, error) {
+	compensatedBalanceFunc := func(swarm.Address) (int64, error) {
 		return 1000000000000000000, nil
 	}
 	testServer := newTestServer(t, testServerOptions{
-		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+		AccountingOpts: []mock.Option{mock.WithCompensatedBalanceFunc(compensatedBalanceFunc)},
 	})
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusOK,
@@ -96,11 +96,11 @@ func TestBalancesPeers(t *testing.T) {
 func TestBalancesPeersError(t *testing.T) {
 	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
 	wantErr := errors.New("Error")
-	balanceFunc := func(swarm.Address) (int64, error) {
+	compensatedBalanceFunc := func(swarm.Address) (int64, error) {
 		return 0, wantErr
 	}
 	testServer := newTestServer(t, testServerOptions{
-		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+		AccountingOpts: []mock.Option{mock.WithCompensatedBalanceFunc(compensatedBalanceFunc)},
 	})
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusInternalServerError,
@@ -113,11 +113,11 @@ func TestBalancesPeersError(t *testing.T) {
 
 func TestBalancesPeersNoBalance(t *testing.T) {
 	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
-	balanceFunc := func(swarm.Address) (int64, error) {
+	compensatedBalanceFunc := func(swarm.Address) (int64, error) {
 		return 0, accounting.ErrPeerNoBalance
 	}
 	testServer := newTestServer(t, testServerOptions{
-		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+		AccountingOpts: []mock.Option{mock.WithCompensatedBalanceFunc(compensatedBalanceFunc)},
 	})
 
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusNotFound,
@@ -169,4 +169,129 @@ func equalBalances(a, b *debugapi.BalancesResponse) bool {
 	}
 
 	return true
+}
+
+//#####
+
+func TestConsumedBalances(t *testing.T) {
+	balancesFunc := func() (ret map[string]int64, err error) {
+		ret = make(map[string]int64)
+		ret["DEAD"] = 1000000000000000000
+		ret["BEEF"] = -100000000000000000
+		ret["PARTY"] = 0
+		return ret, err
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalancesFunc(balancesFunc)},
+	})
+
+	expected := &debugapi.BalancesResponse{
+		[]debugapi.BalanceResponse{
+			{
+				Peer:    "DEAD",
+				Balance: 1000000000000000000,
+			},
+			{
+				Peer:    "BEEF",
+				Balance: -100000000000000000,
+			},
+			{
+				Peer:    "PARTY",
+				Balance: 0,
+			},
+		},
+	}
+
+	// We expect a list of items unordered by peer:
+	var got *debugapi.BalancesResponse
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed", http.StatusOK,
+		jsonhttptest.WithUnmarshalJSONResponse(&got),
+	)
+
+	if !equalBalances(got, expected) {
+		t.Errorf("got balances: %v, expected: %v", got, expected)
+	}
+
+}
+
+func TestConsumedError(t *testing.T) {
+	wantErr := errors.New("ASDF")
+	balancesFunc := func() (ret map[string]int64, err error) {
+		return nil, wantErr
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalancesFunc(balancesFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed", http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantBalances,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
+}
+
+func TestConsumedPeers(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	balanceFunc := func(swarm.Address) (int64, error) {
+		return 1000000000000000000, nil
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed/"+peer, http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.BalanceResponse{
+			Peer:    peer,
+			Balance: 1000000000000000000,
+		}),
+	)
+}
+
+func TestConsumedPeersError(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	wantErr := errors.New("Error")
+	balanceFunc := func(swarm.Address) (int64, error) {
+		return 0, wantErr
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed/"+peer, http.StatusInternalServerError,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrCantBalance,
+			Code:    http.StatusInternalServerError,
+		}),
+	)
+}
+
+func TestConsumedPeersNoBalance(t *testing.T) {
+	peer := "bff2c89e85e78c38bd89fca1acc996afb876c21bf5a8482ad798ce15f1c223fa"
+	balanceFunc := func(swarm.Address) (int64, error) {
+		return 0, accounting.ErrPeerNoBalance
+	}
+	testServer := newTestServer(t, testServerOptions{
+		AccountingOpts: []mock.Option{mock.WithBalanceFunc(balanceFunc)},
+	})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed/"+peer, http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrNoBalance,
+			Code:    http.StatusNotFound,
+		}),
+	)
+}
+
+func TestConsumedInvalidAddress(t *testing.T) {
+	peer := "bad peer address"
+
+	testServer := newTestServer(t, testServerOptions{})
+
+	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed/"+peer, http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: debugapi.ErrInvaliAddress,
+			Code:    http.StatusNotFound,
+		}),
+	)
 }

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -90,6 +90,12 @@ func (s *server) setupRouting() {
 	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.peerBalanceHandler),
 	})
+	router.Handle("/balances/compensated", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.compensatedBalancesHandler),
+	})
+	router.Handle("/balances/compensated/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.compensatedPeerBalanceHandler),
+	})
 
 	router.Handle("/settlements", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.settlementsHandler),

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -84,22 +84,27 @@ func (s *server) setupRouting() {
 			web.FinalHandlerFunc(s.setWelcomeMessageHandler),
 		),
 	})
+
 	router.Handle("/balances", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.balancesHandler),
-	})
-	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.peerBalanceHandler),
-	})
-	router.Handle("/balances/compensated", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.compensatedBalancesHandler),
 	})
-	router.Handle("/balances/compensated/{peer}", jsonhttp.MethodHandler{
+
+	router.Handle("/balances/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.compensatedPeerBalanceHandler),
+	})
+
+	router.Handle("/consumed", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.balancesHandler),
+	})
+
+	router.Handle("/consumed/{peer}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.peerBalanceHandler),
 	})
 
 	router.Handle("/settlements", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.settlementsHandler),
 	})
+
 	router.Handle("/settlements/{peer}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.peerSettlementsHandler),
 	})


### PR DESCRIPTION
This PR involves all changes from:
https://github.com/ethersphere/bee/pull/870

And...

introduces new endpoints:
/consumed
/consumed/{peer}

The /balances/{peer} and /balances endpoints now show balances deducted by surplus balances for easy comparison of balances in integration tests.

The consumed endpoint shows current balance disregarding the surplus balance, as we consider the surplus balance sort of a pre-paid service solution.

The other part of the PR concerns Reserve checking for the balance adjusted by surplus balance so that we avoid an overdraft when a situation occurs, in which our node gets an oversettlement, and keeps reserving balance while the surplus balance does not naturally drain by requests coming from the peer.
In this situation, the other side might have processed transactions in a different order, and might consider our node's surplus balance as debt, which we don't want to increase further if this is the case, rather settle early.