### PR TITLE
Log ethereum address on bee init/start

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -291,6 +291,12 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 		logger.Debugf("using existing libp2p key")
 	}
 
+	overlayEthAddress, err := signer.EthereumAddress()
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("using ethereum address %x", overlayEthAddress)
+
 	return &signerConfig{
 		keystore:         keystore,
 		signer:           signer,

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -306,8 +306,8 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 	}
 
 	logger.Infof("pss public key %x", crypto.EncodeSecp256k1PublicKey(&pssPrivateKey.PublicKey))
-  
-  overlayEthAddress, err := signer.EthereumAddress()
+
+	overlayEthAddress, err := signer.EthereumAddress()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -161,9 +161,6 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 			return nil, err
 		}
 
-		// print ethereum address so users know which address we need to fund
-		logger.Infof("using ethereum address %x", overlayEthAddress)
-
 		chainID, err := swapBackend.ChainID(p2pCtx)
 		if err != nil {
 			logger.Infof("could not connect to backend at %v. In a swap-enabled network a working blockchain node (for goerli network in production) is required. Check your node or specify another node using --swap-endpoint.", o.SwapEndpoint)


### PR DESCRIPTION
Inform the user about her generated Ethereum address as soon as possible when calling `bee init` or `bee start`. Fixes #969 