### PR TITLE
add PSS dedicated private key

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -99,7 +99,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 				return err
 			}
 
-			b, err := node.NewBee(c.config.GetString(optionNameP2PAddr), signerConfig.address, *signerConfig.publicKey, signerConfig.keystore, signerConfig.signer, c.config.GetUint64(optionNameNetworkID), logger, signerConfig.libp2pPrivateKey, node.Options{
+			b, err := node.NewBee(c.config.GetString(optionNameP2PAddr), signerConfig.address, *signerConfig.publicKey, signerConfig.keystore, signerConfig.signer, c.config.GetUint64(optionNameNetworkID), logger, signerConfig.libp2pPrivateKey, signerConfig.pssPrivateKey, node.Options{
 				DataDir:                c.config.GetString(optionNameDataDir),
 				DBCapacity:             c.config.GetUint64(optionNameDBCapacity),
 				Password:               signerConfig.password,
@@ -182,6 +182,7 @@ type signerConfig struct {
 	address          swarm.Address
 	publicKey        *ecdsa.PublicKey
 	libp2pPrivateKey *ecdsa.PrivateKey
+	pssPrivateKey    *ecdsa.PrivateKey
 	password         string
 }
 
@@ -207,7 +208,10 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 		}
 		password = string(bytes.Trim(b, "\n"))
 	} else {
-		exists, err := keystore.Exists("swarm")
+		// if libp2p key exists we can assume all required keys exist
+		// so prompt for a password to unlock them
+		// otherwise prompt for new password with confirmation to create them
+		exists, err := keystore.Exists("libp2p")
 		if err != nil {
 			return nil, err
 		}
@@ -291,12 +295,25 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 		logger.Debugf("using existing libp2p key")
 	}
 
+	pssPrivateKey, created, err := keystore.Key("pss", password)
+	if err != nil {
+		return nil, fmt.Errorf("pss key: %w", err)
+	}
+	if created {
+		logger.Debugf("new pss key created")
+	} else {
+		logger.Debugf("using existing pss key")
+	}
+
+	logger.Infof("pss public key %x", crypto.EncodeSecp256k1PublicKey(&pssPrivateKey.PublicKey))
+
 	return &signerConfig{
 		keystore:         keystore,
 		signer:           signer,
 		address:          address,
 		publicKey:        publicKey,
 		libp2pPrivateKey: libp2pPrivateKey,
+		pssPrivateKey:    pssPrivateKey,
 		password:         password,
 	}, nil
 }

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -32,6 +32,8 @@ components:
           $ref: '#/components/schemas/EthereumAddress'
         public_key:
           $ref: '#/components/schemas/PublicKey'
+        pss_public_key:
+          $ref: '#/components/schemas/PublicKey'
 
     Balance:
       type: object

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -32,6 +32,7 @@ type Service interface {
 type server struct {
 	Overlay           swarm.Address
 	PublicKey         ecdsa.PublicKey
+	PSSPublicKey      ecdsa.PublicKey
 	EthereumAddress   common.Address
 	P2P               p2p.DebugService
 	Pingpong          pingpong.Interface
@@ -49,10 +50,11 @@ type server struct {
 	http.Handler
 }
 
-func New(overlay swarm.Address, publicKey ecdsa.PublicKey, ethereumAddress common.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) Service {
+func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) Service {
 	s := &server{
 		Overlay:           overlay,
 		PublicKey:         publicKey,
+		PSSPublicKey:      pssPublicKey,
 		EthereumAddress:   ethereumAddress,
 		P2P:               p2p,
 		Pingpong:          pingpong,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -33,6 +33,7 @@ import (
 type testServerOptions struct {
 	Overlay         swarm.Address
 	PublicKey       ecdsa.PublicKey
+	PSSPublicKey    ecdsa.PublicKey
 	EthereumAddress common.Address
 	P2P             *p2pmock.Service
 	Pingpong        pingpong.Interface
@@ -57,7 +58,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	settlement := settlementmock.NewSettlement(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
-	s := debugapi.New(o.Overlay, o.PublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook)
+	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -16,10 +16,11 @@ import (
 )
 
 type addressesResponse struct {
-	Overlay   swarm.Address         `json:"overlay"`
-	Underlay  []multiaddr.Multiaddr `json:"underlay"`
-	Ethereum  common.Address        `json:"ethereum"`
-	PublicKey string                `json:"public_key"`
+	Overlay      swarm.Address         `json:"overlay"`
+	Underlay     []multiaddr.Multiaddr `json:"underlay"`
+	Ethereum     common.Address        `json:"ethereum"`
+	PublicKey    string                `json:"public_key"`
+	PSSPublicKey string                `json:"pss_public_key"`
 }
 
 func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
@@ -30,9 +31,10 @@ func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonhttp.OK(w, addressesResponse{
-		Overlay:   s.Overlay,
-		Underlay:  underlay,
-		Ethereum:  s.EthereumAddress,
-		PublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PublicKey)),
+		Overlay:      s.Overlay,
+		Underlay:     underlay,
+		Ethereum:     s.EthereumAddress,
+		PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PublicKey)),
+		PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PSSPublicKey)),
 	})
 }

--- a/pkg/debugapi/p2p_test.go
+++ b/pkg/debugapi/p2p_test.go
@@ -25,6 +25,10 @@ func TestAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	pssPrivateKey, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
 	overlay := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 	addresses := []multiaddr.Multiaddr{
 		mustMultiaddr(t, "/ip4/127.0.0.1/tcp/7071/p2p/16Uiu2HAmTBuJT9LvNmBiQiNoTsxE5mtNy6YG3paw79m94CRa9sRb"),
@@ -36,6 +40,7 @@ func TestAddresses(t *testing.T) {
 
 	testServer := newTestServer(t, testServerOptions{
 		PublicKey:       privateKey.PublicKey,
+		PSSPublicKey:    pssPrivateKey.PublicKey,
 		Overlay:         overlay,
 		EthereumAddress: ethereumAddress,
 		P2P: mock.New(mock.WithAddressesFunc(func() ([]multiaddr.Multiaddr, error) {
@@ -46,10 +51,11 @@ func TestAddresses(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/addresses", http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(debugapi.AddressesResponse{
-				Overlay:   overlay,
-				Underlay:  addresses,
-				PublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&privateKey.PublicKey)),
-				Ethereum:  ethereumAddress,
+				Overlay:      overlay,
+				Underlay:     addresses,
+				Ethereum:     ethereumAddress,
+				PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&privateKey.PublicKey)),
+				PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&pssPrivateKey.PublicKey)),
 			}),
 		)
 	})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -112,7 +112,7 @@ type Options struct {
 	SwapEnable             bool
 }
 
-func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, keystore keystore.Service, signer crypto.Signer, networkID uint64, logger logging.Logger, libp2pPrivateKey *ecdsa.PrivateKey, o Options) (*Bee, error) {
+func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, keystore keystore.Service, signer crypto.Signer, networkID uint64, logger logging.Logger, libp2pPrivateKey, pssPrivateKey *ecdsa.PrivateKey, o Options) (*Bee, error) {
 	tracer, tracerCloser, err := tracing.NewTracer(&tracing.Options{
 		Enabled:     o.TracingEnabled,
 		Endpoint:    o.TracingEndpoint,
@@ -344,13 +344,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}
 
-	// instantiate the pss object
-	swarmPrivateKey, _, err := keystore.Key("swarm", o.Password)
-	if err != nil {
-		return nil, fmt.Errorf("swarm key: %w", err)
-	}
-
-	pssService := pss.New(swarmPrivateKey, logger)
+	pssService := pss.New(pssPrivateKey, logger)
 	b.pssCloser = pssService
 
 	traversalService := traversal.NewService(storer)
@@ -437,7 +431,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	if o.DebugAPIAddr != "" {
 		// Debug API server
 
-		debugAPIService := debugapi.New(swarmAddress, publicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
+		debugAPIService := debugapi.New(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)


### PR DESCRIPTION
This PR introduces a dedicated PSS private key, log it to the user and exposes it in debug api /addresses endpoint.

This PR also makes a change to check for libp2p key if it exists when testing if keys are created for the first time. Previously, the swarm key was checked, but it may not be there if clef is used as an external signer, resulting in asking for password twice.