### PR TITLE
don't hold global chequebook lock while sending cheque

### DIFF
--- a/pkg/settlement/swap/chequebook/chequebook.go
+++ b/pkg/settlement/swap/chequebook/chequebook.go
@@ -221,7 +221,7 @@ func (s *service) reserveTotalIssued(ctx context.Context, amount *big.Int) error
 	return nil
 }
 
-func (s *service) unreserveTotalIssued(ctx context.Context, amount *big.Int) {
+func (s *service) unreserveTotalIssued(amount *big.Int) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.totalIssuedReserved = s.totalIssuedReserved.Sub(s.totalIssuedReserved, amount)
@@ -234,7 +234,7 @@ func (s *service) Issue(ctx context.Context, beneficiary common.Address, amount 
 	if err != nil {
 		return err
 	}
-	defer s.unreserveTotalIssued(ctx, amount)
+	defer s.unreserveTotalIssued(amount)
 
 	var cumulativePayout *big.Int
 	lastCheque, err := s.LastCheque(beneficiary)


### PR DESCRIPTION
currently all operations for signing and sending a cheque happen under one global lock on the chequebook. while already not ideal already, this has devastating throughput effects with clef (where signing takes longer).

this PR puts only the shared state under that lock. there is no explicit per peer lock for the other part as settlement is called under that peers accounting lock anyway.