### PR TITLE
remove payment tolerance check

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -83,9 +83,6 @@ var (
 	ErrOverdraft = errors.New("attempted overdraft")
 	// ErrDisconnectThresholdExceeded denotes a peer has exceeded the disconnect threshold.
 	ErrDisconnectThresholdExceeded = errors.New("disconnect threshold exceeded")
-	// ErrInvalidPaymentTolerance denotes the payment tolerance is too high
-	// compared to the payment threshold.
-	ErrInvalidPaymentTolerance = errors.New("payment tolerance must be less than half the payment threshold")
 	// ErrPeerNoBalance is the error returned if no balance in store exists for a peer
 	ErrPeerNoBalance = errors.New("no balance for peer")
 	// ErrOverflow denotes an arithmetic operation overflowed.

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -108,10 +108,6 @@ func NewAccounting(
 		return nil, fmt.Errorf("tolerance plus threshold too big: %w", ErrOverflow)
 	}
 
-	if PaymentTolerance > PaymentThreshold/2 {
-		return nil, ErrInvalidPaymentTolerance
-	}
-
 	return &Accounting{
 		accountingPeers:  make(map[string]*accountingPeer),
 		paymentThreshold: PaymentThreshold,

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -729,22 +729,6 @@ func TestAccountingNotifyPayment(t *testing.T) {
 	}
 }
 
-func TestAccountingInvalidPaymentTolerance(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
-
-	store := mock.NewStateStore()
-	defer store.Close()
-
-	_, err := accounting.NewAccounting(testPaymentThreshold, testPaymentThreshold/2+1, 1000, logger, store, nil, nil)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	if err != accounting.ErrInvalidPaymentTolerance {
-		t.Fatalf("got wrong error. got %v wanted %v", err, accounting.ErrInvalidPaymentTolerance)
-	}
-}
-
 type pricingMock struct {
 	called           bool
 	peer             swarm.Address


### PR DESCRIPTION
as payment tolerance is no longer used as a limit for incoming debt we can remove the `PaymentTolerance > PaymentThreshold/2` check.