### PR TITLE
fix pushsync logs

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -301,7 +301,7 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 		streamer, err := ps.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 		if err != nil {
 			lastErr = fmt.Errorf("new stream for peer %s: %w", peer.String(), err)
-			ps.logger.Debugf("pushsync-push: %w", lastErr)
+			ps.logger.Debugf("pushsync-push: %v", lastErr)
 			continue
 		}
 		deferFuncs = append(deferFuncs, func() { go streamer.FullClose() })
@@ -310,7 +310,7 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 		if err := ps.sendChunkDelivery(ctx, w, ch); err != nil {
 			_ = streamer.Reset()
 			lastErr = fmt.Errorf("chunk deliver to peer %s: %w", peer.String(), err)
-			ps.logger.Debugf("pushsync-push: %w", lastErr)
+			ps.logger.Debugf("pushsync-push: %v", lastErr)
 			if errors.Is(err, context.DeadlineExceeded) {
 				ps.blocklistPeer(peer)
 			}
@@ -331,7 +331,7 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 		if err != nil {
 			_ = streamer.Reset()
 			lastErr = fmt.Errorf("receive receipt from peer %s: %w", peer.String(), err)
-			ps.logger.Debugf("pushsync-push: %w", lastErr)
+			ps.logger.Debugf("pushsync-push: %v", lastErr)
 			if errors.Is(err, context.DeadlineExceeded) {
 				ps.blocklistPeer(peer)
 			}


### PR DESCRIPTION
various push sync logs don't display correctly due to usage of `%w` in logging