### PR TITLE
Replace log with stdout print on init cmd

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/external"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/crypto/clef"
@@ -176,11 +177,12 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 }
 
 type signerConfig struct {
-	signer           crypto.Signer
-	address          swarm.Address
-	publicKey        *ecdsa.PublicKey
-	libp2pPrivateKey *ecdsa.PrivateKey
-	pssPrivateKey    *ecdsa.PrivateKey
+	signer            crypto.Signer
+	address           swarm.Address
+	publicKey         *ecdsa.PublicKey
+	libp2pPrivateKey  *ecdsa.PrivateKey
+	pssPrivateKey     *ecdsa.PrivateKey
+	overlayEthAddress common.Address
 }
 
 func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (config *signerConfig, err error) {
@@ -312,10 +314,11 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 	logger.Infof("using ethereum address %x", overlayEthAddress)
 
 	return &signerConfig{
-		signer:           signer,
-		address:          address,
-		publicKey:        publicKey,
-		libp2pPrivateKey: libp2pPrivateKey,
-		pssPrivateKey:    pssPrivateKey,
+		signer:            signer,
+		address:           address,
+		publicKey:         publicKey,
+		libp2pPrivateKey:  libp2pPrivateKey,
+		pssPrivateKey:     pssPrivateKey,
+		overlayEthAddress: overlayEthAddress,
 	}, nil
 }


### PR DESCRIPTION
# Issue

Print bee initialization results to stdout instead of logging them. These include:
1. Swarm public key
2. PSS public key
3. Ethereum overlay address of the node

## Enhancments

Use different outputs for the print (to be consumed the user or machine clients):

Pretty output:

```
Swarm Public Key:         0x0399952b2d1aacd9dec71f42e08419402a51bf238f4793ff1b8a1c39c2c8b8f6fc
PSS Public Key:           0x0302053a6edbabeb1516b491e4efaad783e5fe8702bc0f2ece2332003961f443bc
Overlay Ethereum Address: 0xbfe535b409aa4c26426170043e683fb3c2bd6ef3
```

Bare output (for easy consumption by shell):
```
0x0399952b2d1aacd9dec71f42e08419402a51bf238f4793ff1b8a1c39c2c8b8f6fc
0x0302053a6edbabeb1516b491e4efaad783e5fe8702bc0f2ece2332003961f443bc
0xbfe535b409aa4c26426170043e683fb3c2bd6ef3
```

JSON Output for ease of consumption by non shell clients:
```
{
    "swarm_pubkey": "0x0399952b2d1aacd9dec71f42e08419402a51bf238f4793ff1b8a1c39c2c8b8f6fc",
    "pss_pubkey": "0x0302053a6edbabeb1516b491e4efaad783e5fe8702bc0f2ece2332003961f443bc",
    "eth_address": "0xbfe535b409aa4c26426170043e683fb3c2bd6ef3"
}
```

## Notes
IMO the `cmd` code is starting to smell and could use a refactor.