### PR TITLE
forbid PSS API endpoints in the Gateway mode

### DIFF
--- a/pkg/api/gatewaymode_test.go
+++ b/pkg/api/gatewaymode_test.go
@@ -48,6 +48,11 @@ func TestGatewayMode(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodGet, "/tags", http.StatusForbidden, forbiddenResponseOption)
 	})
 
+	t.Run("pss endpoints", func(t *testing.T) {
+		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/test-topic/ab", http.StatusForbidden, forbiddenResponseOption)
+		jsonhttptest.Request(t, client, http.MethodGet, "/pss/subscribe/test-topic", http.StatusForbidden, forbiddenResponseOption)
+	})
+
 	t.Run("pinning", func(t *testing.T) {
 		headerOption := jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "true")
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -90,14 +90,20 @@ func (s *server) setupRouting() {
 		),
 	})
 
-	handle(router, "/pss/send/{topic}/{targets}", jsonhttp.MethodHandler{
-		"POST": web.ChainHandlers(
-			jsonhttp.NewMaxBodyBytesHandler(swarm.ChunkSize),
-			web.FinalHandlerFunc(s.pssPostHandler),
-		),
-	})
+	handle(router, "/pss/send/{topic}/{targets}", web.ChainHandlers(
+		s.gatewayModeForbidEndpointHandler,
+		web.FinalHandler(jsonhttp.MethodHandler{
+			"POST": web.ChainHandlers(
+				jsonhttp.NewMaxBodyBytesHandler(swarm.ChunkSize),
+				web.FinalHandlerFunc(s.pssPostHandler),
+			),
+		})),
+	)
 
-	handle(router, "/pss/subscribe/{topic}", http.HandlerFunc(s.pssWsHandler))
+	handle(router, "/pss/subscribe/{topic}", web.ChainHandlers(
+		s.gatewayModeForbidEndpointHandler,
+		web.FinalHandlerFunc(s.pssWsHandler),
+	))
 
 	handle(router, "/tags", web.ChainHandlers(
 		s.gatewayModeForbidEndpointHandler,


### PR DESCRIPTION
As noticed by @acud and confirmed by @zelig https://beehive.ethswarm.org/swarm/pl/mrjeug54n7gwfcd3qmrxrtwnrw.