### PR TITLE
Add ENS contract address parameter to config

### DIFF
--- a/pkg/resolver/client/ens/ens.go
+++ b/pkg/resolver/client/ens/ens.go
@@ -144,19 +144,19 @@ func wrapDial(endpoint string, contractAddr string) (*ethclient.Client, *goens.R
 	// Dial the eth client.
 	ethCl, err := ethclient.Dial(endpoint)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("wrapdial: dial: %w", err)
 	}
 
 	// Obtain the ENS registry.
 	registry, err := goens.NewRegistryAt(ethCl, common.HexToAddress(contractAddr))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("wrapdial: new registry: %w", err)
 	}
 
 	// Ensure that the ENS registry client is deployed to the given contract address.
 	_, err = registry.Owner("")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("wrapdial: owner: %w", err)
 	}
 
 	return ethCl, registry, nil
@@ -167,18 +167,18 @@ func wrapResolve(registry *goens.Registry, addr common.Address, name string) (st
 	// Ensure the name is registered.
 	ownerAddress, err := registry.Owner(name)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("wrapresolve: owner: %w", err)
 	}
 
 	// If the name is not registered, return an error.
 	if bytes.Equal(ownerAddress.Bytes(), goens.UnknownAddress.Bytes()) {
-		return "", errors.New("name is not registered")
+		return "", fmt.Errorf("wrapresolve: %w", errNameNotRegistered)
 	}
 
 	// Obtain the resolver for this domain name.
 	ensR, err := registry.Resolver(name)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("wrapresolve: resolver: %w", err)
 	}
 
 	// Try and read out the content hash record.

--- a/pkg/resolver/client/ens/ens.go
+++ b/pkg/resolver/client/ens/ens.go
@@ -40,6 +40,8 @@ var (
 	ErrInvalidContentHash = errors.New("invalid swarm content hash")
 	// errNotImplemented denotes that the function has not been implemented.
 	errNotImplemented = errors.New("function not implemented")
+	// errNameNotRegistered denotes that the name is not registered.
+	errNameNotRegistered = errors.New("name is not registered")
 )
 
 // Client is a name resolution client that can connect to ENS via an

--- a/pkg/resolver/client/ens/ens.go
+++ b/pkg/resolver/client/ens/ens.go
@@ -142,51 +142,49 @@ func (c *Client) Close() error {
 }
 
 func wrapDial(endpoint string, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
-
 	// Dial the eth client.
 	ethCl, err := ethclient.Dial(endpoint)
 	if err != nil {
-		return nil, nil, fmt.Errorf("wrapdial: dial: %w", err)
+		return nil, nil, fmt.Errorf("dial: %w", err)
 	}
 
 	// Obtain the ENS registry.
 	registry, err := goens.NewRegistryAt(ethCl, common.HexToAddress(contractAddr))
 	if err != nil {
-		return nil, nil, fmt.Errorf("wrapdial: new registry: %w", err)
+		return nil, nil, fmt.Errorf("new registry: %w", err)
 	}
 
 	// Ensure that the ENS registry client is deployed to the given contract address.
 	_, err = registry.Owner("")
 	if err != nil {
-		return nil, nil, fmt.Errorf("wrapdial: owner: %w", err)
+		return nil, nil, fmt.Errorf("owner: %w", err)
 	}
 
 	return ethCl, registry, nil
 }
 
 func wrapResolve(registry *goens.Registry, addr common.Address, name string) (string, error) {
-
 	// Ensure the name is registered.
 	ownerAddress, err := registry.Owner(name)
 	if err != nil {
-		return "", fmt.Errorf("wrapresolve: owner: %w", err)
+		return "", fmt.Errorf("owner: %w", err)
 	}
 
 	// If the name is not registered, return an error.
 	if bytes.Equal(ownerAddress.Bytes(), goens.UnknownAddress.Bytes()) {
-		return "", fmt.Errorf("wrapresolve: %w", errNameNotRegistered)
+		return "", errNameNotRegistered
 	}
 
 	// Obtain the resolver for this domain name.
 	ensR, err := registry.Resolver(name)
 	if err != nil {
-		return "", fmt.Errorf("wrapresolve: resolver: %w", err)
+		return "", fmt.Errorf("resolver: %w", err)
 	}
 
 	// Try and read out the content hash record.
 	ch, err := ensR.Contenthash()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("contenthash: %w", err)
 	}
 
 	return goens.ContenthashToString(ch)

--- a/pkg/resolver/client/ens/ens.go
+++ b/pkg/resolver/client/ens/ens.go
@@ -5,11 +5,12 @@
 package ens
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	goens "github.com/wealdtech/go-ens/v3"
 
@@ -17,7 +18,10 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-const swarmContentHashPrefix = "/swarm/"
+const (
+	defaultENSContractAddress = "00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
+	swarmContentHashPrefix    = "/swarm/"
+)
 
 // Address is the swarm bzz address.
 type Address = swarm.Address
@@ -41,10 +45,12 @@ var (
 // Client is a name resolution client that can connect to ENS via an
 // Ethereum endpoint.
 type Client struct {
-	endpoint  string
-	ethCl     *ethclient.Client
-	dialFn    func(string) (*ethclient.Client, error)
-	resolveFn func(bind.ContractBackend, string) (string, error)
+	endpoint     string
+	contractAddr string
+	ethCl        *ethclient.Client
+	connectFn    func(string, string) (*ethclient.Client, *goens.Registry, error)
+	resolveFn    func(*goens.Registry, common.Address, string) (string, error)
+	registry     *goens.Registry
 }
 
 // Option is a function that applies an option to a Client.
@@ -54,7 +60,7 @@ type Option func(*Client)
 func NewClient(endpoint string, opts ...Option) (client.Interface, error) {
 	c := &Client{
 		endpoint:  endpoint,
-		dialFn:    ethclient.Dial,
+		connectFn: wrapDial,
 		resolveFn: wrapResolve,
 	}
 
@@ -63,18 +69,30 @@ func NewClient(endpoint string, opts ...Option) (client.Interface, error) {
 		o(c)
 	}
 
-	// Connect to the name resolution service.
-	if c.dialFn == nil {
-		return nil, fmt.Errorf("dialFn: %w", errNotImplemented)
+	// Set the default ENS contract address.
+	if c.contractAddr == "" {
+		c.contractAddr = defaultENSContractAddress
 	}
 
-	ethCl, err := c.dialFn(c.endpoint)
+	// Establish a connection to the ENS.
+	if c.connectFn == nil {
+		return nil, fmt.Errorf("connectFn: %w", errNotImplemented)
+	}
+	ethCl, registry, err := c.connectFn(c.endpoint, c.contractAddr)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", err, ErrFailedToConnect)
 	}
 	c.ethCl = ethCl
+	c.registry = registry
 
 	return c, nil
+}
+
+// WithContractAddress will set the ENS contract address.
+func WithContractAddress(addr string) Option {
+	return func(c *Client) {
+		c.contractAddr = addr
+	}
 }
 
 // IsConnected returns true if there is an active RPC connection with an
@@ -94,7 +112,7 @@ func (c *Client) Resolve(name string) (Address, error) {
 		return swarm.ZeroAddress, fmt.Errorf("resolveFn: %w", errNotImplemented)
 	}
 
-	hash, err := c.resolveFn(c.ethCl, name)
+	hash, err := c.resolveFn(c.registry, common.HexToAddress(c.contractAddr), name)
 	if err != nil {
 		return swarm.ZeroAddress, fmt.Errorf("%v: %w", err, ErrResolveFailed)
 	}
@@ -121,10 +139,44 @@ func (c *Client) Close() error {
 	return nil
 }
 
-func wrapResolve(backend bind.ContractBackend, name string) (string, error) {
+func wrapDial(endpoint string, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
 
-	// Connect to the ENS resolver for the provided name.
-	ensR, err := goens.NewResolver(backend, name)
+	// Dial the eth client.
+	ethCl, err := ethclient.Dial(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Obtain the ENS registry.
+	registry, err := goens.NewRegistryAt(ethCl, common.HexToAddress(contractAddr))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Ensure that the ENS registry client is deployed to the given contract address.
+	_, err = registry.Owner("")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ethCl, registry, nil
+}
+
+func wrapResolve(registry *goens.Registry, addr common.Address, name string) (string, error) {
+
+	// Ensure the name is registered.
+	ownerAddress, err := registry.Owner(name)
+	if err != nil {
+		return "", err
+	}
+
+	// If the name is not registered, return an error.
+	if bytes.Equal(ownerAddress.Bytes(), goens.UnknownAddress.Bytes()) {
+		return "", errors.New("name is not registered")
+	}
+
+	// Obtain the resolver for this domain name.
+	ensR, err := registry.Resolver(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/resolver/client/ens/ens_integration_test.go
+++ b/pkg/resolver/client/ens/ens_integration_test.go
@@ -20,44 +20,51 @@ func TestENSntegration(t *testing.T) {
 	defaultAddr := swarm.MustParseHexAddress("00cb23598c2e520b6a6aae3ddc94fed4435a2909690bdd709bf9d9e7c2aadfad")
 
 	testCases := []struct {
-		desc     string
-		endpoint string
-		name     string
-		wantAdr  swarm.Address
-		wantErr  error
+		desc            string
+		endpoint        string
+		contractAddress string
+		name            string
+		wantAdr         swarm.Address
+		wantErr         error
 	}{
 		// TODO: add a test targeting a resolver with an invalid contenthash
 		// record.
-		{
-			desc:     "invalid resolver endpoint",
-			endpoint: "example.com",
-			wantErr:  ens.ErrFailedToConnect,
-		},
+		// {
+		// 	desc:     "invalid resolver endpoint",
+		// 	endpoint: "example.com",
+		// 	wantErr:  ens.ErrFailedToConnect,
+		// },
 		{
 			desc:    "no domain",
 			name:    "idonthaveadomain",
 			wantErr: ens.ErrResolveFailed,
 		},
-		{
-			desc:    "no eth domain",
-			name:    "centralized.com",
-			wantErr: ens.ErrResolveFailed,
-		},
-		{
-			desc:    "not registered",
-			name:    "unused.test.swarm.eth",
-			wantErr: ens.ErrResolveFailed,
-		},
-		{
-			desc:    "no content hash",
-			name:    "nocontent.resolver.test.swarm.eth",
-			wantErr: ens.ErrResolveFailed,
-		},
-		{
-			desc:    "ok",
-			name:    "example.resolver.test.swarm.eth",
-			wantAdr: defaultAddr,
-		},
+		// {
+		// 	desc:    "no eth domain",
+		// 	name:    "centralized.com",
+		// 	wantErr: ens.ErrResolveFailed,
+		// },
+		// {
+		// 	desc:    "not registered",
+		// 	name:    "unused.test.swarm.eth",
+		// 	wantErr: ens.ErrResolveFailed,
+		// },
+		// {
+		// 	desc:    "no content hash",
+		// 	name:    "nocontent.resolver.test.swarm.eth",
+		// 	wantErr: ens.ErrResolveFailed,
+		// },
+		// {
+		// 	desc:            "invalid contract address",
+		// 	contractAddress: "0xFFFFFFFF",
+		// 	name:            "example.resolver.test.swarm.eth",
+		// 	wantErr:         ens.ErrFailedToConnect,
+		// },
+		// {
+		// 	desc:    "ok",
+		// 	name:    "example.resolver.test.swarm.eth",
+		// 	wantAdr: defaultAddr,
+		// },
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
@@ -65,9 +72,9 @@ func TestENSntegration(t *testing.T) {
 				tC.endpoint = defaultEndpoint
 			}
 
-			ensClient, err := ens.NewClient(tC.endpoint)
+			ensClient, err := ens.NewClient(tC.endpoint, ens.WithContractAddress(tC.contractAddress))
 			if err != nil {
-				if !errors.Is(err, ens.ErrFailedToConnect) {
+				if !errors.Is(err, tC.wantErr) {
 					t.Errorf("got %v, want %v", err, tC.wantErr)
 				}
 				return

--- a/pkg/resolver/client/ens/ens_integration_test.go
+++ b/pkg/resolver/client/ens/ens_integration_test.go
@@ -29,42 +29,42 @@ func TestENSntegration(t *testing.T) {
 	}{
 		// TODO: add a test targeting a resolver with an invalid contenthash
 		// record.
-		// {
-		// 	desc:     "invalid resolver endpoint",
-		// 	endpoint: "example.com",
-		// 	wantErr:  ens.ErrFailedToConnect,
-		// },
+		{
+			desc:     "invalid resolver endpoint",
+			endpoint: "example.com",
+			wantErr:  ens.ErrFailedToConnect,
+		},
 		{
 			desc:    "no domain",
 			name:    "idonthaveadomain",
 			wantErr: ens.ErrResolveFailed,
 		},
-		// {
-		// 	desc:    "no eth domain",
-		// 	name:    "centralized.com",
-		// 	wantErr: ens.ErrResolveFailed,
-		// },
-		// {
-		// 	desc:    "not registered",
-		// 	name:    "unused.test.swarm.eth",
-		// 	wantErr: ens.ErrResolveFailed,
-		// },
-		// {
-		// 	desc:    "no content hash",
-		// 	name:    "nocontent.resolver.test.swarm.eth",
-		// 	wantErr: ens.ErrResolveFailed,
-		// },
-		// {
-		// 	desc:            "invalid contract address",
-		// 	contractAddress: "0xFFFFFFFF",
-		// 	name:            "example.resolver.test.swarm.eth",
-		// 	wantErr:         ens.ErrFailedToConnect,
-		// },
-		// {
-		// 	desc:    "ok",
-		// 	name:    "example.resolver.test.swarm.eth",
-		// 	wantAdr: defaultAddr,
-		// },
+		{
+			desc:    "no eth domain",
+			name:    "centralized.com",
+			wantErr: ens.ErrResolveFailed,
+		},
+		{
+			desc:    "not registered",
+			name:    "unused.test.swarm.eth",
+			wantErr: ens.ErrResolveFailed,
+		},
+		{
+			desc:    "no content hash",
+			name:    "nocontent.resolver.test.swarm.eth",
+			wantErr: ens.ErrResolveFailed,
+		},
+		{
+			desc:            "invalid contract address",
+			contractAddress: "0xFFFFFFFF",
+			name:            "example.resolver.test.swarm.eth",
+			wantErr:         ens.ErrFailedToConnect,
+		},
+		{
+			desc:    "ok",
+			name:    "example.resolver.test.swarm.eth",
+			wantAdr: defaultAddr,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {

--- a/pkg/resolver/client/ens/ens_test.go
+++ b/pkg/resolver/client/ens/ens_test.go
@@ -8,9 +8,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
+	goens "github.com/wealdtech/go-ens/v3"
 
 	"github.com/ethersphere/bee/pkg/resolver/client/ens"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -20,29 +21,30 @@ func TestNewENSClient(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		endpoint     string
-		dialFn       func(string) (*ethclient.Client, error)
+		address      string
+		connectFn    func(string, string) (*ethclient.Client, *goens.Registry, error)
 		wantErr      error
 		wantEndpoint string
 	}{
 		{
-			desc:     "nil dial function",
-			endpoint: "someaddress.net",
-			dialFn:   nil,
-			wantErr:  ens.ErrNotImplemented,
+			desc:      "nil dial function",
+			endpoint:  "someaddress.net",
+			connectFn: nil,
+			wantErr:   ens.ErrNotImplemented,
 		},
 		{
 			desc:     "error in dial function",
 			endpoint: "someaddress.com",
-			dialFn: func(string) (*ethclient.Client, error) {
-				return nil, errors.New("dial error")
+			connectFn: func(s1, s2 string) (*ethclient.Client, *goens.Registry, error) {
+				return nil, nil, errors.New("dial error")
 			},
 			wantErr: ens.ErrFailedToConnect,
 		},
 		{
 			desc:     "regular endpoint",
 			endpoint: "someaddress.org",
-			dialFn: func(string) (*ethclient.Client, error) {
-				return &ethclient.Client{}, nil
+			connectFn: func(s1, s2 string) (*ethclient.Client, *goens.Registry, error) {
+				return &ethclient.Client{}, nil, nil
 			},
 			wantEndpoint: "someaddress.org",
 		},
@@ -50,7 +52,8 @@ func TestNewENSClient(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			cl, err := ens.NewClient(tC.endpoint,
-				ens.WithDialFunc(tC.dialFn),
+				ens.WithConnectFunc(tC.connectFn),
+				ens.WithContractAddress(tC.address),
 			)
 			if err != nil {
 				if !errors.Is(err, tC.wantErr) {
@@ -75,8 +78,8 @@ func TestClose(t *testing.T) {
 		ethCl := ethclient.NewClient(rpc.DialInProc(rpcServer))
 
 		cl, err := ens.NewClient("",
-			ens.WithDialFunc(func(string) (*ethclient.Client, error) {
-				return ethCl, nil
+			ens.WithConnectFunc(func(endpoint, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
+				return ethCl, nil, nil
 			}),
 		)
 		if err != nil {
@@ -94,8 +97,8 @@ func TestClose(t *testing.T) {
 	})
 	t.Run("not connected", func(t *testing.T) {
 		cl, err := ens.NewClient("",
-			ens.WithDialFunc(func(string) (*ethclient.Client, error) {
-				return nil, nil
+			ens.WithConnectFunc(func(endpoint, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
+				return nil, nil, nil
 			}),
 		)
 		if err != nil {
@@ -114,13 +117,16 @@ func TestClose(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
-	addr := swarm.MustParseHexAddress("aaabbbcc")
+	testContractAddrString := "00000000000C2E074eC69A0dFb2997BA6C702e1B"
+	testContractAddr := common.HexToAddress(testContractAddrString)
+	testSwarmAddr := swarm.MustParseHexAddress("aaabbbcc")
 
 	testCases := []struct {
-		desc      string
-		name      string
-		resolveFn func(bind.ContractBackend, string) (string, error)
-		wantErr   error
+		desc         string
+		name         string
+		contractAddr string
+		resolveFn    func(*goens.Registry, common.Address, string) (string, error)
+		wantErr      error
 	}{
 		{
 			desc:      "nil resolve function",
@@ -129,38 +135,48 @@ func TestResolve(t *testing.T) {
 		},
 		{
 			desc: "resolve function internal error",
-			resolveFn: func(bind.ContractBackend, string) (string, error) {
+			resolveFn: func(*goens.Registry, common.Address, string) (string, error) {
 				return "", errors.New("internal error")
 			},
 			wantErr: ens.ErrResolveFailed,
 		},
 		{
 			desc: "resolver returns empty string",
-			resolveFn: func(bind.ContractBackend, string) (string, error) {
+			resolveFn: func(*goens.Registry, common.Address, string) (string, error) {
 				return "", nil
 			},
 			wantErr: ens.ErrInvalidContentHash,
 		},
 		{
 			desc: "resolve does not prefix address with /swarm",
-			resolveFn: func(bind.ContractBackend, string) (string, error) {
-				return addr.String(), nil
+			resolveFn: func(*goens.Registry, common.Address, string) (string, error) {
+				return testSwarmAddr.String(), nil
 			},
 			wantErr: ens.ErrInvalidContentHash,
 		},
 		{
 			desc: "resolve returns prefixed address",
-			resolveFn: func(bind.ContractBackend, string) (string, error) {
-				return ens.SwarmContentHashPrefix + addr.String(), nil
+			resolveFn: func(*goens.Registry, common.Address, string) (string, error) {
+				return ens.SwarmContentHashPrefix + testSwarmAddr.String(), nil
 			},
 			wantErr: ens.ErrInvalidContentHash,
+		},
+		{
+			desc: "expect properly set contract address",
+			resolveFn: func(b *goens.Registry, c common.Address, s string) (string, error) {
+				if c != testContractAddr {
+					return "", errors.New("invalid contract address")
+				}
+				return ens.SwarmContentHashPrefix + testSwarmAddr.String(), nil
+			},
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			cl, err := ens.NewClient("example.com",
-				ens.WithDialFunc(func(string) (*ethclient.Client, error) {
-					return nil, nil
+				ens.WithContractAddress(testContractAddrString),
+				ens.WithConnectFunc(func(endpoint, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
+					return nil, nil, nil
 				}),
 				ens.WithResolveFunc(tC.resolveFn),
 			)

--- a/pkg/resolver/client/ens/export_test.go
+++ b/pkg/resolver/client/ens/export_test.go
@@ -5,23 +5,24 @@
 package ens
 
 import (
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	goens "github.com/wealdtech/go-ens/v3"
 )
 
 const SwarmContentHashPrefix = swarmContentHashPrefix
 
 var ErrNotImplemented = errNotImplemented
 
-// WithDialFunc will set the Dial function implementaton.
-func WithDialFunc(fn func(ep string) (*ethclient.Client, error)) Option {
+// WithConnectFunc will set the Dial function implementaton.
+func WithConnectFunc(fn func(endpoint string, contractAddr string) (*ethclient.Client, *goens.Registry, error)) Option {
 	return func(c *Client) {
-		c.dialFn = fn
+		c.connectFn = fn
 	}
 }
 
 // WithResolveFunc will set the Resolve function implementation.
-func WithResolveFunc(fn func(backend bind.ContractBackend, input string) (string, error)) Option {
+func WithResolveFunc(fn func(registry *goens.Registry, addr common.Address, input string) (string, error)) Option {
 	return func(c *Client) {
 		c.resolveFn = fn
 	}


### PR DESCRIPTION
# Description

Pass the contract address parameter to the ENS client, allowing for an alternate address for the ENS contracts suite.

Completes #625 