### PR TITLE
github: disable pullsync integration tests

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -77,9 +77,6 @@ jobs:
       - name: Test retrieval
         id: retrieval
         run: ./beekeeper check retrieval --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
-      - name: Test pullsync
-        id: pullsync
-        run: ./beekeeper check pullsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
       # - name: Test chunkrepair
       #   id: chunkrepair
       #   run: ./beekeeper check chunkrepair --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
@@ -165,7 +162,6 @@ jobs:
           if ${{ steps.pushsync-bytes.outcome=='failure' }}; then FAILED=pushsync-bytes; fi
           if ${{ steps.pushsync-chunks.outcome=='failure' }}; then FAILED=pushsync-chunks; fi
           if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi
-          if ${{ steps.pullsync.outcome=='failure' }}; then FAILED=pullsync; fi
           # if ${{ steps.chunkrepair.outcome=='failure' }}; then FAILED=chunkrepair; fi
           if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi
           if ${{ steps.gc-chunk.outcome=='failure' }}; then FAILED=gc-chunk; fi

--- a/.github/workflows/slash-beekeeper.yml
+++ b/.github/workflows/slash-beekeeper.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Test retrieval
         id: retrieval
         run: ./beekeeper check retrieval --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
-      - name: Test pullsync
-        id: pullsync
-        run: ./beekeeper check pullsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
       # - name: Test chunkrepair
       #   id: chunkrepair
       #   run: ./beekeeper check chunkrepair --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
@@ -129,7 +126,6 @@ jobs:
           if ${{ steps.pushsync-bytes.outcome=='failure' }}; then FAILED=pushsync-bytes; fi
           if ${{ steps.pushsync-chunks.outcome=='failure' }}; then FAILED=pushsync-chunks; fi
           if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi
-          if ${{ steps.pullsync.outcome=='failure' }}; then FAILED=pullsync; fi
           # if ${{ steps.chunkrepair.outcome=='failure' }}; then FAILED=chunkrepair; fi
           if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi
           if ${{ steps.gc-chunk.outcome=='failure' }}; then FAILED=gc-chunk; fi


### PR DESCRIPTION
pullsync integration tests are not needed at this point, since we cannot ensure that a chunk has designated replicators.