### PR TITLE
Resolve peer topology inconsistencies

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -194,13 +194,14 @@ func TestDoubleConnectOnAllAddresses(t *testing.T) {
 
 	s1, overlay1 := newService(t, 1, libp2pServiceOpts{})
 
-	s2, overlay2 := newService(t, 1, libp2pServiceOpts{})
-
 	addrs, err := s1.Addresses()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, addr := range addrs {
+		// creating new remote host for each address
+		s2, overlay2 := newService(t, 1, libp2pServiceOpts{})
+
 		if _, err := s2.Connect(ctx, addr); err != nil {
 			t.Fatal(err)
 		}
@@ -221,6 +222,8 @@ func TestDoubleConnectOnAllAddresses(t *testing.T) {
 
 		expectPeers(t, s2)
 		expectPeersEventually(t, s1)
+
+		s2.Close()
 	}
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -425,9 +425,13 @@ func (s *Service) Blocklist(overlay swarm.Address, duration time.Duration) error
 	return nil
 }
 
+func buildHostAddress(peerID libp2ppeer.ID) (ma.Multiaddr, error) {
+	return ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID.Pretty()))
+}
+
 func buildUnderlayAddress(addr ma.Multiaddr, peerID libp2ppeer.ID) (ma.Multiaddr, error) {
 	// Build host multiaddress
-	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID.Pretty()))
+	hostAddr, err := buildHostAddress(peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +446,14 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return nil, fmt.Errorf("addr from p2p: %w", err)
 	}
 
-	if _, found := s.peers.isConnected(info.ID, addr); found {
+	hostAddr, err := buildHostAddress(info.ID)
+	if err != nil {
+		return nil, fmt.Errorf("build host address: %w", err)
+	}
+
+	remoteAddr := addr.Decapsulate(hostAddr)
+
+	if _, found := s.peers.isConnected(info.ID, remoteAddr); found {
 		return nil, p2p.ErrAlreadyConnected
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -442,7 +442,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		return nil, fmt.Errorf("addr from p2p: %w", err)
 	}
 
-	if _, found := s.peers.overlay(info.ID); found {
+	if _, found := s.peers.isConnected(info.ID, addr); found {
 		return nil, p2p.ErrAlreadyConnected
 	}
 

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -166,7 +166,10 @@ func (r *peerRegistry) overlay(peerID libp2ppeer.ID) (swarm.Address, bool) {
 
 func (r *peerRegistry) isConnected(peerID libp2ppeer.ID, remoteAddr ma.Multiaddr) (swarm.Address, bool) {
 	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	overlay, found := r.overlays[peerID]
+
 	if found && remoteAddr != nil {
 		// check connection remote address
 		if conns, ok := r.connections[peerID]; ok {
@@ -180,7 +183,7 @@ func (r *peerRegistry) isConnected(peerID libp2ppeer.ID, remoteAddr ma.Multiaddr
 			}
 		}
 	}
-	r.mu.RUnlock()
+
 	return overlay, found
 }
 

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -164,16 +164,15 @@ func (r *peerRegistry) overlay(peerID libp2ppeer.ID) (swarm.Address, bool) {
 	return overlay, found
 }
 
-func (r *peerRegistry) isConnected(peerID libp2ppeer.ID, addr ma.Multiaddr) (swarm.Address, bool) {
+func (r *peerRegistry) isConnected(peerID libp2ppeer.ID, remoteAddr ma.Multiaddr) (swarm.Address, bool) {
 	r.mu.RLock()
 	overlay, found := r.overlays[peerID]
-	if found {
+	if found && remoteAddr != nil {
 		// check connection remote address
 		if conns, ok := r.connections[peerID]; ok {
 			found = false
 			for c := range conns {
-				dAddr := addr.Decapsulate(c.RemoteMultiaddr())
-				if !addr.Equal(dAddr) {
+				if c.RemoteMultiaddr().Equal(remoteAddr) {
 					// we ARE connected to the peer on expected address
 					found = true
 					break


### PR DESCRIPTION
relates to: #1034 

Change the way how we check if some peer is connected.

In addition to checking `libp2p` peer ID, it also checks if that peer is connected through expected address (see related issue for more in-depth explanation of the problem). Only in the case when both parts are same can we say for sure that we have multiple connections to same peer.

One additional change was to one test, `TestDoubleConnectOnAllAddresses`, which was failing most of the times (few times it passed). Change involves actually changing when the other "peer" is created, and we create new peer for each address that we test for. This was done because there does not seem to be a way to make sure connection to other peer is completely terminated.
What was happening was that once a connection is created to address to a peer, even if `Disconnect` is called, on the next attempt to connect to the same peer, the `libp2p` library may end up using previous address for connection, which will then cause this new function not to recognize peer as already connected.