### PR TITLE
Compensated Balances error suppression fix

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -435,7 +435,9 @@ func (a *Accounting) SurplusBalance(peer swarm.Address) (balance int64, err erro
 func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, err error) {
 	balance, err := a.Balance(peer)
 	if err != nil {
-		return 0, err
+		if !errors.Is(err, ErrPeerNoBalance) {
+			return 0, err
+		}
 	}
 	surplus, err := a.SurplusBalance(peer)
 	if err != nil {

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -450,6 +450,7 @@ func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, 
 		}
 	}
 
+	// if surplus is 0 and peer has no balance, propagate ErrPeerNoBalance
 	if surplus == 0 && errors.Is(err, ErrPeerNoBalance) {
 		return 0, err
 	}

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -433,18 +433,25 @@ func (a *Accounting) SurplusBalance(peer swarm.Address) (balance int64, err erro
 
 // CompensatedBalance returns balance decreased by surplus balance
 func (a *Accounting) CompensatedBalance(peer swarm.Address) (compensated int64, err error) {
+
+	surplus, err := a.SurplusBalance(peer)
+	if err != nil {
+		return 0, err
+	}
+
+	if surplus < 0 {
+		return 0, ErrInvalidValue
+	}
+
 	balance, err := a.Balance(peer)
 	if err != nil {
 		if !errors.Is(err, ErrPeerNoBalance) {
 			return 0, err
 		}
 	}
-	surplus, err := a.SurplusBalance(peer)
-	if err != nil {
+
+	if surplus == 0 && errors.Is(err, ErrPeerNoBalance) {
 		return 0, err
-	}
-	if surplus < 0 {
-		return 0, ErrInvalidValue
 	}
 	// Compensated balance is balance decreased by surplus balance
 	compensated, err = subtractI64mU64(balance, uint64(surplus))


### PR DESCRIPTION
Right now, if the peer only has surplus balance (never had any interactions with a peer only received a settlement that went into surplus) with a peer, we would not show it's balance on the balances endpoint, because of error propagation. 
We currently don't have a scenario where this could happen.
If we used pre-settlements for any reason in the future, this change would avoid not showing peers that only pre-settled yet.
