### PR TITLE
Refactor password prompt to internal package

### DIFF
--- a/cmd/internal/terminal/export_test.go
+++ b/cmd/internal/terminal/export_test.go
@@ -1,0 +1,33 @@
+package terminal
+
+import (
+	"io"
+)
+
+// WithPromptOut sets the out file to write the prompt to.
+func WithPromptOut(out io.Writer) PasswordPrompterOption {
+	return func(fpp *WriterPasswordPrompter) {
+		fpp.out = out
+	}
+}
+
+// WithPromptPasswordReader sets the password reader.
+func WithPromptPasswordReader(pwReader PasswordReader) PasswordPrompterOption {
+	return func(fpp *WriterPasswordPrompter) {
+		fpp.pwReader = pwReader
+	}
+}
+
+// WithConfirmOut sets the out file to write the prompt to.
+func WithConfirmOut(out io.Writer) PasswordConfirmerOption {
+	return func(fpp *WriterPasswordConfirmer) {
+		fpp.out = out
+	}
+}
+
+// WithConfirmPasswordPrompter sets the password reader.
+func WithConfirmPasswordPrompter(pwPrompter PasswordPrompter) PasswordConfirmerOption {
+	return func(fpc *WriterPasswordConfirmer) {
+		fpc.pwPrompter = pwPrompter
+	}
+}

--- a/cmd/internal/terminal/mock/password.go
+++ b/cmd/internal/terminal/mock/password.go
@@ -1,0 +1,68 @@
+package mock
+
+import (
+	"errors"
+
+	"github.com/ethersphere/bee/cmd/internal/terminal"
+)
+
+var (
+	_ terminal.PasswordReader   = (*PasswordReader)(nil)
+	_ terminal.PasswordPrompter = (*PasswordPrompter)(nil)
+)
+
+// PasswordReader mocks the PasswordReader interface.
+type PasswordReader struct {
+	password string
+	err      bool
+}
+
+// NewMockPasswordReader creates the mock PasswordReader.
+func NewMockPasswordReader(password string, returnErr bool) *PasswordReader {
+	return &PasswordReader{password, returnErr}
+}
+
+// ReadPassword implements the PasswordReader interface.
+func (pr *PasswordReader) ReadPassword() (password string, err error) {
+	if pr.err {
+		err = errors.New("failed to read password")
+		return
+	}
+	password = pr.password
+	return
+}
+
+// PasswordPrompter mocks the PasswordPrompter interface.
+type PasswordPrompter struct {
+	pass1         string
+	pass2         string
+	useSecondPass bool
+	err           bool
+	cntUntilErr   int
+}
+
+// NewMockPasswordPrompter creates the mock PasswordPrompter.
+func NewMockPasswordPrompter(pass1, pass2 string, err bool, errorFromCnt int) *PasswordPrompter {
+	return &PasswordPrompter{pass1, pass2, false, err, errorFromCnt}
+}
+
+// PromptPassword implements the PasswordPrompter interface.
+func (pp *PasswordPrompter) PromptPassword(msg string) (password string, err error) {
+	if pp.useSecondPass {
+		password = pp.pass2
+	} else {
+		password = pp.pass1
+	}
+	pp.useSecondPass = !pp.useSecondPass
+
+	if pp.err {
+		if pp.cntUntilErr > 0 {
+			pp.cntUntilErr--
+		} else {
+			err = errors.New("failed to read password")
+		}
+
+	}
+
+	return
+}

--- a/cmd/internal/terminal/password.go
+++ b/cmd/internal/terminal/password.go
@@ -1,0 +1,154 @@
+package terminal
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var (
+	_ PasswordReader    = (*StdinPasswordReader)(nil)
+	_ PasswordReader    = (*FilePasswordReader)(nil)
+	_ PasswordPrompter  = (*WriterPasswordPrompter)(nil)
+	_ PasswordConfirmer = (*WriterPasswordConfirmer)(nil)
+)
+
+// PasswordReader can read a password from a password source.
+type PasswordReader interface {
+	ReadPassword() (password string, err error)
+}
+
+// StdinPasswordReader is a PasswordReader that can read a password from
+// os.Stdin.
+type StdinPasswordReader struct{}
+
+// FilePasswordReader is a PasswordReader that can read a password stored in
+// a file.
+type FilePasswordReader struct {
+	path string
+}
+
+// NewStdinPasswordReader creates a StdinPasswordReader.
+func NewStdinPasswordReader() *StdinPasswordReader { return &StdinPasswordReader{} }
+
+// NewFilePasswordReader creates a FilePasswordReader.
+func NewFilePasswordReader(path string) *FilePasswordReader {
+	return &FilePasswordReader{path}
+}
+
+// ReadPassword implements the PasswordReader interface. It reads the password
+// from os.Stdin.
+func (pr *StdinPasswordReader) ReadPassword() (password string, err error) {
+	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		err = fmt.Errorf("read password: %w", err)
+		return
+	}
+	password = string(b)
+	return
+}
+
+// ReadPassword implements the PasswordReader interface. It opens the
+// configured file and reads the password from it, trimming any newlines found.
+//
+// NOTE: This will read the entire password file into memory.
+func (pr *FilePasswordReader) ReadPassword() (password string, err error) {
+	b, err := ioutil.ReadFile(pr.path)
+	if err != nil {
+		err = fmt.Errorf("read password: %w", err)
+		return
+	}
+	password = string(bytes.Trim(b, "\n"))
+	return
+}
+
+// PasswordPrompter can prompt the user with a message to enter a password, and
+// then read it.
+type PasswordPrompter interface {
+	PromptPassword(msg string) (password string, err error)
+}
+
+// WriterPasswordPrompter is a PasswordPrompter that prompts the user through a
+// io.Writer.
+type WriterPasswordPrompter struct {
+	out      io.Writer
+	pwReader PasswordReader
+}
+
+// PasswordPrompterOption is a function that applies an option to a
+// FilePasswordPrompter.
+type PasswordPrompterOption func(*WriterPasswordPrompter)
+
+// NewPasswordPrompter creates a new FilePasswordPrompter with the given
+// options. Prompt is written to os.Stdout by default
+func NewPasswordPrompter(opts ...PasswordPrompterOption) (fpp *WriterPasswordPrompter) {
+	fpp = &WriterPasswordPrompter{}
+	for _, o := range opts {
+		o(fpp)
+	}
+	if fpp.out == nil {
+		fpp.out = os.Stdout
+	}
+	return
+}
+
+// PromptPassword implements PasswordPrompter. It writes a prompt message to
+// the out file (default os.Stdout) and reads the password throug the
+// configured password reader.
+func (fpp *WriterPasswordPrompter) PromptPassword(msg string) (password string, err error) {
+	fmt.Fprint(fpp.out, msg)
+	return fpp.pwReader.ReadPassword()
+}
+
+// PasswordConfirmer prompts the user with a message to enter a password, then
+// prompts again to confirm it.
+type PasswordConfirmer interface {
+	PromptConfirmPassword(msg, confimMsg string) (password string, err error)
+}
+
+// WriterPasswordConfirmer is a PasswordConfirmer that prompts the user through a
+// io.Writer.
+type WriterPasswordConfirmer struct {
+	out        io.Writer
+	pwPrompter PasswordPrompter
+}
+
+// PasswordConfirmerOption is a function that applies an option to a
+// FilePasswordConfirmer.
+type PasswordConfirmerOption func(*WriterPasswordConfirmer)
+
+// NewPasswordConfirmer will create a FilePasswordConfirmer with the given
+// options. Prompt is written to os.Stdout by default.
+func NewPasswordConfirmer(opts ...PasswordConfirmerOption) (fpc *WriterPasswordConfirmer) {
+	fpc = &WriterPasswordConfirmer{}
+	for _, o := range opts {
+		o(fpc)
+	}
+	if fpc.out == nil {
+		fpc.out = os.Stdout
+	}
+	return
+}
+
+// PromptConfirmPassword implements the PasswordConfirmer interface. It prompts
+// the user to enster a password and then to confirm it. Returns an error if
+// the passwords are not equal.
+func (fpc *WriterPasswordConfirmer) PromptConfirmPassword(msg, confirmMsg string) (password string, err error) {
+	password, err = fpc.pwPrompter.PromptPassword(msg)
+	if err != nil {
+		return
+	}
+	pass2, err := fpc.pwPrompter.PromptPassword(confirmMsg)
+	if err != nil {
+		return
+	}
+	if password != pass2 {
+		err = errors.New("passwords do not match")
+	}
+	return
+}

--- a/cmd/internal/terminal/password_test.go
+++ b/cmd/internal/terminal/password_test.go
@@ -1,0 +1,167 @@
+package terminal_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ethersphere/bee/cmd/internal/terminal"
+	"github.com/ethersphere/bee/cmd/internal/terminal/mock"
+)
+
+func TestFilePasswordReader(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		filePath     string
+		fileContent  string
+		wantPassword string
+		wantErr      bool
+	}{
+		{
+			desc:     "bad password file path",
+			filePath: "notexistant",
+			wantErr:  true,
+		},
+		{
+			desc:         "read password from file",
+			fileContent:  "testpassword",
+			wantPassword: "testpassword",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			if tC.filePath == "" {
+				tf, err := ioutil.TempFile(os.TempDir(), "bee-test")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(tf.Name())
+				tC.filePath = tf.Name()
+				if _, err := tf.Write([]byte(tC.fileContent)); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			fpr := terminal.NewFilePasswordReader(tC.filePath)
+			gotPassword, gotErr := fpr.ReadPassword()
+			if gotErr != nil {
+				if !tC.wantErr {
+					t.Errorf("got error %v", gotErr)
+				}
+				return
+			}
+			if gotPassword != tC.wantPassword {
+				t.Errorf("want: %s, got: %s", tC.wantPassword, gotPassword)
+			}
+		})
+	}
+}
+
+func TestPromptPassword(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		msg           string
+		errorInReader bool
+		wantPassword  string
+		wantError     bool
+	}{
+		{
+			desc:          "error in reader",
+			msg:           "Password: ",
+			errorInReader: true,
+			wantError:     true,
+		},
+		{
+			desc:         "password read",
+			msg:          "Password: ",
+			wantPassword: "test",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			pwReader := mock.NewMockPasswordReader(
+				tC.wantPassword,
+				tC.errorInReader,
+			)
+			pp := terminal.NewPasswordPrompter(
+				terminal.WithPromptOut(ioutil.Discard),
+				terminal.WithPromptPasswordReader(pwReader),
+			)
+			gotPassword, gotError := pp.PromptPassword(tC.msg)
+			if gotError != nil {
+				if !tC.wantError {
+					t.Errorf("got error: %v", gotError)
+				}
+				return
+			}
+			if tC.wantPassword != gotPassword {
+				t.Errorf("want %s, got %s", tC.wantPassword, gotPassword)
+			}
+		})
+	}
+}
+
+func TestPasswordConfirm(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		msg           string
+		confirmMsg    string
+		firstPass     string
+		confirmedPass string
+		errInPrompt   bool
+		cntUntilErr   int
+		wantPassword  string
+		wantError     bool
+	}{
+		{
+			desc:        "error in first prompt read",
+			msg:         "Password: ",
+			confirmMsg:  "Confirm password: ",
+			errInPrompt: true,
+			wantError:   true,
+		},
+		{
+			desc:        "error in second prompt read",
+			msg:         "Password: ",
+			confirmMsg:  "Confirm password: ",
+			errInPrompt: true,
+			cntUntilErr: 1,
+			wantError:   true,
+		},
+		{
+			desc:          "passwords do not match",
+			msg:           "Password: ",
+			confirmMsg:    "Confirm password: ",
+			firstPass:     "test",
+			confirmedPass: "noooooooo",
+			wantError:     true,
+		},
+		{
+			desc:          "passwords match",
+			msg:           "Password: ",
+			confirmMsg:    "Confirm password: ",
+			firstPass:     "test",
+			confirmedPass: "test",
+			wantPassword:  "test",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			pp := mock.NewMockPasswordPrompter(tC.firstPass, tC.confirmedPass, tC.errInPrompt, tC.cntUntilErr)
+			pc := terminal.NewPasswordConfirmer(
+				terminal.WithConfirmOut(ioutil.Discard),
+				terminal.WithConfirmPasswordPrompter(pp),
+			)
+			gotPassword, gotError := pc.PromptConfirmPassword(tC.msg, tC.confirmMsg)
+			if gotError != nil {
+				if !tC.wantError {
+					t.Errorf("got error: %v", gotError)
+				}
+				return
+			}
+			if tC.wantPassword != gotPassword {
+				t.Errorf("want %s, got %s", tC.wantPassword, gotPassword)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Currently, the password prompt is buried in the `bee\cmd\bee` package, is not testable, and is not available to other commands.

This PR reimplements the password prompt functionality in an internal package to `bee\cmd`, with unit tests. It exposes the following interfaces:
- `PasswordReader` - for reading passwords securely from stdin or reading from a (plaintext) file
- `PasswordPrompter` - for generating a prompt and reading from a `PasswordReaded`
- `PasswordConfirmer` - for confirming a password with two prompts (which must match)

Note that this PR does replace terminal functionality (I will do it separately).

Related to #1037 

