### PR TITLE
Remove "error" from log messages

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -177,7 +177,7 @@ func (k *Kad) manage() {
 						}
 					}
 					k.logger.Debugf("could not connect to peer from kademlia %s: %v", bzzAddr.String(), err)
-					k.logger.Warningf("could not connect to peer from kademlia %s: %v", bzzAddr.ShortString(), err)
+					k.logger.Warningf("could not connect to peer %s: %v", bzzAddr.ShortString(), err)
 					// continue to next
 					return false, false, nil
 				}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -177,7 +177,7 @@ func (k *Kad) manage() {
 						}
 					}
 					k.logger.Debugf("could not connect to peer from kademlia %s: %v", bzzAddr.String(), err)
-					k.logger.Warningf("could not connect to peer %s: %v", bzzAddr.ShortString(), err)
+					k.logger.Warningf("could not connect to peer")
 					// continue to next
 					return false, false, nil
 				}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -176,8 +176,8 @@ func (k *Kad) manage() {
 							k.logger.Debugf("could not remove peer from addressbook: %s", peer.String())
 						}
 					}
-					k.logger.Debugf("error connecting to peer from kademlia %s: %v", bzzAddr.String(), err)
-					k.logger.Warningf("connecting to peer %s: %v", bzzAddr.ShortString(), err)
+					k.logger.Debugf("could not connect to peer from kademlia %s: %v", bzzAddr.String(), err)
+					k.logger.Warningf("could not connect to peer from kademlia %s: %v", bzzAddr.ShortString(), err)
 					// continue to next
 					return false, false, nil
 				}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -339,7 +339,7 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr, 
 			return nil
 		}
 
-		k.logger.Debugf("error connecting to peer %s: %v", peer, err)
+		k.logger.Debugf("could not connect to peer %s: %v", peer, err)
 		retryTime := time.Now().Add(timeToRetry)
 		var e *p2p.ConnectionBackoffError
 		k.waitNextMu.Lock()
@@ -399,7 +399,7 @@ func (k *Kad) announce(ctx context.Context, peer swarm.Address) error {
 		go func(connectedPeer swarm.Address) {
 			defer k.wg.Done()
 			if err := k.discovery.BroadcastPeers(context.Background(), connectedPeer, peer); err != nil {
-				k.logger.Debugf("error gossiping peer %s to peer %s: %v", peer, connectedPeer, err)
+				k.logger.Debugf("could not gossip peer %s to peer %s: %v", peer, connectedPeer, err)
 			}
 		}(connectedPeer)
 
@@ -729,7 +729,7 @@ func (k *Kad) marshal(indent bool) ([]byte, error) {
 func (k *Kad) String() string {
 	b, err := k.marshal(true)
 	if err != nil {
-		k.logger.Errorf("error marshaling kademlia into json: %v", err)
+		k.logger.Errorf("could not marshal kademlia into json: %v", err)
 		return ""
 	}
 	return string(b)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -378,7 +378,7 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 					_ = s.Disconnect(overlay)
 				}
 
-				logger.Debugf("error handle protocol %s/%s: stream %s: peer %s: error: %v", p.Name, p.Version, ss.Name, overlay, err)
+				logger.Debugf("could not handle protocol %s/%s: stream %s: peer %s: error: %v", p.Name, p.Version, ss.Name, overlay, err)
 				return
 			}
 		})

--- a/pkg/pricing/pricing.go
+++ b/pkg/pricing/pricing.go
@@ -76,7 +76,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 
 	var req pb.AnnouncePaymentThreshold
 	if err := r.ReadMsgWithContext(ctx, &req); err != nil {
-		s.logger.Debugf("error receiving payment threshold announcement from peer %v", p.Address)
+		s.logger.Debugf("could not receive payment threshold announcement from peer %v", p.Address)
 		return fmt.Errorf("read request from peer %v: %w", p.Address, err)
 	}
 	s.logger.Tracef("received payment threshold announcement from peer %v of %d", p.Address, req.PaymentThreshold)
@@ -87,7 +87,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 func (s *Service) init(ctx context.Context, p p2p.Peer) error {
 	err := s.AnnouncePaymentThreshold(ctx, p.Address, s.paymentThreshold)
 	if err != nil {
-		s.logger.Warningf("error sending payment threshold announcement to peer %v", p.Address)
+		s.logger.Warningf("could not send payment threshold announcement to peer %v", p.Address)
 	}
 	return err
 }

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -274,7 +274,7 @@ func (p *Puller) syncPeer(ctx context.Context, peer swarm.Address, po, d uint8) 
 		cursors, err := p.syncer.GetCursors(ctx, peer)
 		if err != nil {
 			if logMore {
-				p.logger.Debugf("error getting cursors from peer %s: %v", peer.String(), err)
+				p.logger.Debugf("could not get cursors from peer %s: %v", peer.String(), err)
 			}
 			delete(p.syncPeers[po], peer.String())
 			return
@@ -366,7 +366,7 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		err = p.addPeerInterval(peer, bin, s, top)
 		if err != nil {
 			p.metrics.HistWorkerErrCounter.Inc()
-			p.logger.Errorf("error persisting interval for peer, quitting")
+			p.logger.Errorf("could not persist interval for peer %s, quitting", peer)
 			return
 		}
 	}


### PR DESCRIPTION
This PR was created based on a short discussion with @crtahlin , where he was unsure about whether the bee node ran smoothly (assumingly based on seeing the word "error" in log messages)