### PR TITLE
If P2P connection exists compare overlay address

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -336,13 +336,11 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr, 
 	i, err := k.p2p.Connect(ctx, ma)
 	if err != nil {
 		if errors.Is(err, p2p.ErrAlreadyConnected) {
-			if i == nil || swarm.ZeroAddress.Equal(i.Overlay) || i.Overlay.Equal(peer) {
-				return nil
-			}
-
 			if !i.Overlay.Equal(peer) {
 				return errOverlayMismatch
 			}
+
+			return nil
 		}
 
 		k.logger.Debugf("could not connect to peer %s: %v", peer, err)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -336,7 +336,13 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr, 
 	i, err := k.p2p.Connect(ctx, ma)
 	if err != nil {
 		if errors.Is(err, p2p.ErrAlreadyConnected) {
-			return nil
+			if i == nil || swarm.ZeroAddress.Equal(i.Overlay) || i.Overlay.Equal(peer) {
+				return nil
+			}
+
+			if !i.Overlay.Equal(peer) {
+				return errOverlayMismatch
+			}
 		}
 
 		k.logger.Debugf("could not connect to peer %s: %v", peer, err)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -453,8 +453,12 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 
 	remoteAddr := addr.Decapsulate(hostAddr)
 
-	if _, found := s.peers.isConnected(info.ID, remoteAddr); found {
-		return nil, p2p.ErrAlreadyConnected
+	if overlay, found := s.peers.isConnected(info.ID, remoteAddr); found {
+		address = &bzz.Address{
+			Overlay:  overlay,
+			Underlay: addr,
+		}
+		return address, p2p.ErrAlreadyConnected
 	}
 
 	if err := s.connectionBreaker.Execute(func() error { return s.host.Connect(ctx, *info) }); err != nil {


### PR DESCRIPTION
If (for some reason) peer changes its Swarm network address (`overlay` address), and then joins again, because it will have same P2P peer ID, some peer may be marked as already connected even though it is not.

Handling of `p2p.ErrAlreadyConnected` error is changed to actually check if the already connected `overlay` address matches to the one we are trying to connect. If that is in fact the case, we correct that is the same peer, otherwise we return an error or try to connect again.