### PR TITLE
Windows service support

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -44,11 +44,6 @@ func (c *command) initStartCmd() (err error) {
 				return cmd.Help()
 			}
 
-			isWindowsService, err := isWindowsService()
-			if err != nil {
-				return fmt.Errorf("failed to determine if we are running in service: %w", err)
-			}
-
 			var logger logging.Logger
 			switch v := strings.ToLower(c.config.GetString(optionNameVerbosity)); v {
 			case "0", "silent":
@@ -65,6 +60,11 @@ func (c *command) initStartCmd() (err error) {
 				logger = logging.New(cmd.OutOrStdout(), logrus.TraceLevel)
 			default:
 				return fmt.Errorf("unknown verbosity level %q", v)
+			}
+
+			isWindowsService, err := isWindowsService()
+			if err != nil {
+				return fmt.Errorf("failed to determine if we are running in service: %w", err)
 			}
 
 			// If the resolver is specified, resolve all connection strings

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -44,6 +44,11 @@ func (c *command) initStartCmd() (err error) {
 				return cmd.Help()
 			}
 
+			isWindowsService, err := isWindowsService()
+			if err != nil {
+				return fmt.Errorf("failed to determine if we are running in service: %w", err)
+			}
+
 			var logger logging.Logger
 			switch v := strings.ToLower(c.config.GetString(optionNameVerbosity)); v {
 			case "0", "silent":
@@ -167,12 +172,6 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 					case <-done:
 					}
 				},
-			}
-
-			isWindowsService, err := p.IsWindowsService()
-			if err != nil {
-				logger.Errorf("failed to determine if we are running in service: %v", err)
-				return fmt.Errorf("failed to check if is Windows service: %w", err)
 			}
 
 			if isWindowsService {

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -67,6 +67,14 @@ func (c *command) initStartCmd() (err error) {
 				return fmt.Errorf("failed to determine if we are running in service: %w", err)
 			}
 
+			if isWindowsService {
+				var err error
+				logger, err = createWindowsEventLogger("BeeSvc", logger)
+				if err != nil {
+					return fmt.Errorf("failed to create windows logger %w", err)
+				}
+			}
+
 			// If the resolver is specified, resolve all connection strings
 			// and fail on any errors.
 			var resolverCfgs []multiresolver.ConnectionConfig

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	serviceName = "BeeSvc"
+	serviceName = "SwarmBeeSvc"
 )
 
 func (c *command) initStartCmd() (err error) {

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -34,6 +34,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	serviceName = "BeeSvc"
+)
+
 func (c *command) initStartCmd() (err error) {
 
 	cmd := &cobra.Command{
@@ -69,7 +73,7 @@ func (c *command) initStartCmd() (err error) {
 
 			if isWindowsService {
 				var err error
-				logger, err = createWindowsEventLogger("BeeSvc", logger)
+				logger, err = createWindowsEventLogger(serviceName, logger)
 				if err != nil {
 					return fmt.Errorf("failed to create windows logger %w", err)
 				}
@@ -184,7 +188,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 
 			if isWindowsService {
 				s, err := service.New(p, &service.Config{
-					Name:        "BeeSvc",
+					Name:        serviceName,
 					DisplayName: "Bee",
 					Description: "Bee, Swarm client.",
 				})

--- a/cmd/bee/cmd/start_unix.go
+++ b/cmd/bee/cmd/start_unix.go
@@ -6,6 +6,6 @@
 
 package cmd
 
-func (p *program) IsWindowsService() (bool, error) {
+func isWindowsService() (bool, error) {
 	return false, nil
 }

--- a/cmd/bee/cmd/start_unix.go
+++ b/cmd/bee/cmd/start_unix.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package cmd
+
+func (p *program) IsWindowsService() (bool, error) {
+	return false, nil
+}

--- a/cmd/bee/cmd/start_unix.go
+++ b/cmd/bee/cmd/start_unix.go
@@ -6,6 +6,16 @@
 
 package cmd
 
+import (
+	"errors"
+
+	"github.com/ethersphere/bee/pkg/logging"
+)
+
 func isWindowsService() (bool, error) {
 	return false, nil
+}
+
+func createWindowsEventLogger(svcName string, logger logging.Logger) (logging.Logger, error) {
+	return nil, errors.New("cannot create Windows event logger")
 }

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -7,9 +7,92 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
+
 	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/debug"
+	"golang.org/x/sys/windows/svc/eventlog"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/sirupsen/logrus"
 )
 
 func isWindowsService() (bool, error) {
 	return svc.IsWindowsService()
+}
+
+func createWindowsEventLogger(svcName string, logger logging.Logger) (logging.Logger, error) {
+	el, err := eventlog.Open(svcName)
+	if err != nil {
+		return nil, err
+	}
+
+	winlog := &windowsEventLogger{
+		logger: logger,
+		winlog: el,
+	}
+
+	return winlog, nil
+}
+
+type windowsEventLogger struct {
+	logger logging.Logger
+	winlog debug.Log
+}
+
+func (l *windowsEventLogger) Tracef(format string, args ...interface{}) {
+	// ignore
+}
+
+func (l *windowsEventLogger) Trace(args ...interface{}) {
+	// ignore
+}
+
+func (l *windowsEventLogger) Debugf(format string, args ...interface{}) {
+	// ignore
+}
+
+func (l *windowsEventLogger) Debug(args ...interface{}) {
+	// ignore
+}
+
+func (l *windowsEventLogger) Infof(format string, args ...interface{}) {
+	l.winlog.Info(1, fmt.Sprintf(format, args...))
+}
+
+func (l *windowsEventLogger) Info(args ...interface{}) {
+	l.winlog.Info(1, fmt.Sprint(args...))
+}
+
+func (l *windowsEventLogger) Warningf(format string, args ...interface{}) {
+	l.winlog.Warning(2, fmt.Sprintf(format, args...))
+}
+
+func (l *windowsEventLogger) Warning(args ...interface{}) {
+	l.winlog.Warning(2, fmt.Sprint(args...))
+}
+
+func (l *windowsEventLogger) Errorf(format string, args ...interface{}) {
+	l.winlog.Error(3, fmt.Sprintf(format, args...))
+}
+
+func (l *windowsEventLogger) Error(args ...interface{}) {
+	l.winlog.Error(3, fmt.Sprint(args...))
+}
+
+func (l *windowsEventLogger) WithField(key string, value interface{}) *logrus.Entry {
+	return l.logger.WithField(key, value)
+}
+
+func (l *windowsEventLogger) WithFields(fields logrus.Fields) *logrus.Entry {
+	return l.logger.WithFields(fields)
+}
+
+func (l *windowsEventLogger) WriterLevel(level logrus.Level) *io.PipeWriter {
+	return l.NewEntry().WriterLevel(level)
+}
+
+func (l *windowsEventLogger) NewEntry() *logrus.Entry {
+	return l.logger.NewEntry()
 }

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -10,6 +10,6 @@ import (
 	"golang.org/x/sys/windows/svc"
 )
 
-func (p *program) IsWindowsService() (bool, error) {
+func isWindowsService() (bool, error) {
 	return svc.IsWindowsService()
 }

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package cmd
+
+import (
+	"golang.org/x/sys/windows/svc"
+)
+
+func (p *program) IsWindowsService() (bool, error) {
+	return svc.IsWindowsService()
+}

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -58,27 +58,27 @@ func (l *windowsEventLogger) Debug(args ...interface{}) {
 }
 
 func (l *windowsEventLogger) Infof(format string, args ...interface{}) {
-	l.winlog.Info(1, fmt.Sprintf(format, args...))
+	l.winlog.Info(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Info(args ...interface{}) {
-	l.winlog.Info(1, fmt.Sprint(args...))
+	l.winlog.Info(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) Warningf(format string, args ...interface{}) {
-	l.winlog.Warning(2, fmt.Sprintf(format, args...))
+	l.winlog.Warning(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Warning(args ...interface{}) {
-	l.winlog.Warning(2, fmt.Sprint(args...))
+	l.winlog.Warning(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) Errorf(format string, args ...interface{}) {
-	l.winlog.Error(3, fmt.Sprintf(format, args...))
+	l.winlog.Error(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Error(args ...interface{}) {
-	l.winlog.Error(3, fmt.Sprint(args...))
+	l.winlog.Error(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) WithField(key string, value interface{}) *logrus.Entry {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2
 	github.com/ipfs/go-log/v2 v2.1.1 // indirect
+	github.com/kardianos/service v1.2.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.10.0
 	github.com/libp2p/go-libp2p-autonat v0.3.0 // indirect
@@ -62,7 +63,7 @@ require (
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	google.golang.org/protobuf v1.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/kardianos/service v1.2.0 h1:bGuZ/epo3vrt8IPC7mnKQolqFeYJb7Cs8Rk4PSOBB/g=
+github.com/kardianos/service v1.2.0/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -1194,8 +1196,8 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Adds support for running Bee as a service.

This change similar to previous one, main thing here is that we add support for writing logs to Windows Event Log, which is only enabled if we are running as Windows service. The #943 was making usage of `github.com/kardianos/service` library fully, while these changes only use it if we detect that Bee is running as Windows service.

The name for the service is `BeeSvc`. This same name must be fixed, and same one must be used when installing service on Windows machine.

To create the service on Windows run:
```
sc.exe create BeeSvc binPath="[INSTALLDIR]bee.exe start --config=[INSTALLDIR]bee.yaml" type=share start=auto displayName="Bee"
```

Note that configuration file must be properly modified, in order for Bee to be able to start properly. I suggest trying to start it from the command line first, before starting the created service.

Does not contain additional required changes, for different packaging methods so that Bee can be installed on Windows. That is planned after this one.