### PR TITLE
localstore: simplify and fix

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -103,7 +103,7 @@ func (db *DB) gc() (collectedCount uint64, done bool, err error) {
 		if gcSize-collectedCount <= target {
 			return true, nil
 		}
-		gcSizeChange, err := db.setRemove(batch, item)
+		gcSizeChange, err := db.setRemove(batch, item, false)
 		if err != nil {
 			return true, nil
 		}

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -519,7 +519,7 @@ func TestSetNow(t *testing.T) {
 	}
 }
 
-func testIndexCounts(t *testing.T, pushIndex, pullIndex, gcIndex, gcExcludeIndex, pinIndex, retrievalDataIndex, retrievalAccessIndex int, indexInfo map[string]int) {
+func testIndexCounts(t *testing.T, pushIndex, pullIndex, gcIndex, pinIndex, retrievalDataIndex, retrievalAccessIndex int, indexInfo map[string]int) {
 	t.Helper()
 	if indexInfo["pushIndex"] != pushIndex {
 		t.Fatalf("pushIndex count mismatch. got %d want %d", indexInfo["pushIndex"], pushIndex)
@@ -531,10 +531,6 @@ func testIndexCounts(t *testing.T, pushIndex, pullIndex, gcIndex, gcExcludeIndex
 
 	if indexInfo["gcIndex"] != gcIndex {
 		t.Fatalf("gcIndex count mismatch. got %d want %d", indexInfo["gcIndex"], gcIndex)
-	}
-
-	if indexInfo["gcExcludeIndex"] != gcExcludeIndex {
-		t.Fatalf("gcExcludeIndex count mismatch. got %d want %d", indexInfo["gcExcludeIndex"], gcExcludeIndex)
 	}
 
 	if indexInfo["pinIndex"] != pinIndex {
@@ -573,7 +569,7 @@ func TestDBDebugIndexes(t *testing.T) {
 	}
 
 	// for reference: testIndexCounts(t *testing.T, pushIndex, pullIndex, gcIndex, gcExcludeIndex, pinIndex, retrievalDataIndex, retrievalAccessIndex int, indexInfo map[string]int)
-	testIndexCounts(t, 1, 1, 0, 0, 0, 1, 0, indexCounts)
+	testIndexCounts(t, 1, 1, 0, 0, 1, 0, indexCounts)
 
 	// set the chunk for pinning and expect the index count to grow
 	err = db.Set(context.Background(), storage.ModeSetPin, ch.Address())
@@ -587,19 +583,6 @@ func TestDBDebugIndexes(t *testing.T) {
 	}
 
 	// assert that there's a pin and gc exclude entry now
-	testIndexCounts(t, 1, 1, 0, 1, 1, 1, 0, indexCounts)
-
-	// set the chunk as accessed and expect the access index to grow
-	err = db.Set(context.Background(), storage.ModeSetAccess, ch.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-	indexCounts, err = db.DebugIndices()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// assert that there's a pin and gc exclude entry now
-	testIndexCounts(t, 1, 1, 0, 1, 1, 1, 1, indexCounts)
+	testIndexCounts(t, 1, 1, 0, 1, 1, 0, indexCounts)
 
 }

--- a/pkg/localstore/mode_get_test.go
+++ b/pkg/localstore/mode_get_test.go
@@ -100,6 +100,7 @@ func TestModeGetRequest(t *testing.T) {
 
 		t.Run("gc index", newGCIndexTest(db, ch, uploadTimestamp, uploadTimestamp, 1, nil))
 
+		t.Run("access count", newItemsCountTest(db.retrievalAccessIndex, 1))
 		t.Run("gc index count", newItemsCountTest(db.gcIndex, 1))
 
 		t.Run("gc size", newIndexGCSizeTest(db))
@@ -130,6 +131,7 @@ func TestModeGetRequest(t *testing.T) {
 
 		t.Run("gc index", newGCIndexTest(db, ch, uploadTimestamp, accessTimestamp, 1, nil))
 
+		t.Run("access count", newItemsCountTest(db.retrievalAccessIndex, 1))
 		t.Run("gc index count", newItemsCountTest(db.gcIndex, 1))
 
 		t.Run("gc size", newIndexGCSizeTest(db))

--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -79,7 +79,8 @@ func (db *DB) set(mode storage.ModeSet, addrs ...swarm.Address) (err error) {
 
 	case storage.ModeSetPin:
 		for _, addr := range addrs {
-			c, err := db.setPin(batch, addr)
+			item := addressToItem(addr)
+			c, err := db.setPin(batch, item)
 			if err != nil {
 				return err
 			}
@@ -237,9 +238,7 @@ func (db *DB) setRemove(batch *leveldb.Batch, item shed.Item, check bool) (gcSiz
 // setPin increments pin counter for the chunk by updating
 // pin index and sets the chunk to be excluded from garbage collection.
 // Provided batch is updated.
-func (db *DB) setPin(batch *leveldb.Batch, addr swarm.Address) (gcSizeChange int64, err error) {
-	item := addressToItem(addr)
-
+func (db *DB) setPin(batch *leveldb.Batch, item shed.Item) (gcSizeChange int64, err error) {
 	// Get the existing pin counter of the chunk
 	i, err := db.pinIndex.Get(item)
 	item.PinCounter = i.PinCounter

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -19,77 +19,11 @@ package localstore
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/logging"
-	"github.com/ethersphere/bee/pkg/shed"
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/tags"
-	tagtesting "github.com/ethersphere/bee/pkg/tags/testing"
 	"github.com/syndtr/goleveldb/leveldb"
 )
-
-// TestModeSetAccess validates ModeSetAccess index values on the provided DB.
-// here we try to set a normal tag (that should be handled by pushsync)
-// as a result we should expect the tag value to remain in the pull index
-// and we expect that the tag should not be incremented by pull sync set
-func TestModeSetSyncNormalTag(t *testing.T) {
-	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
-	db := newTestDB(t, &Options{Tags: tags.NewTags(mockStatestore, logger)})
-
-	tag, err := db.tags.Create("test", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ch := generateTestRandomChunk().WithTagID(tag.Uid)
-	_, err = db.Put(context.Background(), storage.ModePutUpload, ch)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = tag.Inc(tags.StateStored) // so we don't get an error on tag.Status later on
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	item, err := db.pullIndex.Get(shed.Item{
-		Address: ch.Address().Bytes(),
-		BinID:   1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if item.Tag != tag.Uid {
-		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
-	}
-
-	err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	item, err = db.pullIndex.Get(shed.Item{
-		Address: ch.Address().Bytes(),
-		BinID:   1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// expect the same tag Uid because when we set pull sync on a normal tag
-	// the tag Uid should remain untouched in pull index
-	if item.Tag != tag.Uid {
-		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
-	}
-
-	// 1 stored (because incremented manually in test), 1 sent, 1 synced, 1 total
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 1, 1, 1)
-}
 
 // TestModeSetRemove validates ModeSetRemove index values on the provided DB.
 func TestModeSetRemove(t *testing.T) {

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -21,12 +21,10 @@ import (
 	"errors"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"github.com/ethersphere/bee/pkg/logging"
-	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-
 	"github.com/ethersphere/bee/pkg/shed"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/tags"
 	tagtesting "github.com/ethersphere/bee/pkg/tags/testing"
@@ -34,42 +32,6 @@ import (
 )
 
 // TestModeSetAccess validates ModeSetAccess index values on the provided DB.
-func TestModeSetAccess(t *testing.T) {
-	for _, tc := range multiChunkTestCases {
-		t.Run(tc.name, func(t *testing.T) {
-			db := newTestDB(t, nil)
-
-			chunks := generateTestRandomChunks(tc.count)
-
-			wantTimestamp := time.Now().UTC().UnixNano()
-			defer setNow(func() (t int64) {
-				return wantTimestamp
-			})()
-
-			err := db.Set(context.Background(), storage.ModeSetAccess, chunkAddresses(chunks)...)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			binIDs := make(map[uint8]uint64)
-
-			for _, ch := range chunks {
-				po := db.po(ch.Address())
-				binIDs[po]++
-
-				newPullIndexTest(db, ch, binIDs[po], nil)(t)
-				newGCIndexTest(db, ch, wantTimestamp, wantTimestamp, binIDs[po], nil)(t)
-			}
-
-			t.Run("gc index count", newItemsCountTest(db.gcIndex, tc.count))
-
-			t.Run("pull index count", newItemsCountTest(db.pullIndex, tc.count))
-
-			t.Run("gc size", newIndexGCSizeTest(db))
-		})
-	}
-}
-
 // here we try to set a normal tag (that should be handled by pushsync)
 // as a result we should expect the tag value to remain in the pull index
 // and we expect that the tag should not be incremented by pull sync set

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -51,43 +51,184 @@ func TestPinning(t *testing.T) {
 func TestPinCounter(t *testing.T) {
 	chunk := generateTestRandomChunk()
 	db := newTestDB(t, nil)
-
-	// pin once
-	err := db.Set(context.Background(), storage.ModeSetPin, swarm.NewAddress(chunk.Address().Bytes()))
+	addr := chunk.Address()
+	ctx := context.Background()
+	_, err := db.Put(ctx, storage.ModePutUpload, chunk)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pinCounter, err := db.PinCounter(swarm.NewAddress(chunk.Address().Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pinCounter != 1 {
-		t.Fatalf("want pin counter %d but got %d", 1, pinCounter)
-	}
-
-	// pin twice
-	err = db.Set(context.Background(), storage.ModeSetPin, swarm.NewAddress(chunk.Address().Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	pinCounter, err = db.PinCounter(swarm.NewAddress(chunk.Address().Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pinCounter != 2 {
-		t.Fatalf("want pin counter %d but got %d", 2, pinCounter)
-	}
-
-	err = db.Set(context.Background(), storage.ModeSetUnpin, swarm.NewAddress(chunk.Address().Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = db.PinCounter(swarm.NewAddress(chunk.Address().Bytes()))
-	if err != nil {
+	var pinCounter uint64
+	t.Run("+1 after first pin", func(t *testing.T) {
+		err := db.Set(ctx, storage.ModeSetPin, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pinCounter, err = db.PinCounter(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pinCounter != 1 {
+			t.Fatalf("want pin counter %d but got %d", 1, pinCounter)
+		}
+	})
+	t.Run("2 after second pin", func(t *testing.T) {
+		err = db.Set(ctx, storage.ModeSetPin, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pinCounter, err = db.PinCounter(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pinCounter != 2 {
+			t.Fatalf("want pin counter %d but got %d", 2, pinCounter)
+		}
+	})
+	t.Run("1 after first unpin", func(t *testing.T) {
+		err = db.Set(ctx, storage.ModeSetUnpin, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pinCounter, err = db.PinCounter(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pinCounter != 1 {
+			t.Fatalf("want pin counter %d but got %d", 1, pinCounter)
+		}
+	})
+	t.Run("not found after second unpin", func(t *testing.T) {
+		err = db.Set(ctx, storage.ModeSetUnpin, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = db.PinCounter(addr)
 		if !errors.Is(err, storage.ErrNotFound) {
 			t.Fatal(err)
 		}
+	})
+}
+
+// Pin a file, upload chunks to go past the gc limit to trigger GC,
+// check if the pinned files are still around and removed from gcIndex
+func TestPinIndexes(t *testing.T) {
+	ctx := context.Background()
+
+	db := newTestDB(t, &Options{
+		Capacity: 150,
+	})
+
+	ch := generateTestRandomChunk()
+	addr := ch.Address()
+	_, err := db.Put(ctx, storage.ModePutUpload, ch)
+	if err != nil {
+		t.Fatal(err)
 	}
+	runCountsTest(t, "putUpload", db, 1, 0, 1, 1, 0, 0)
+
+	err = db.Set(ctx, storage.ModeSetSync, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setSync", db, 1, 1, 0, 1, 0, 1)
+
+	err = db.Set(ctx, storage.ModeSetPin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setPin", db, 1, 1, 0, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetPin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setPin 2", db, 1, 1, 0, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetUnpin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setUnPin", db, 1, 1, 0, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetUnpin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setUnPin 2", db, 1, 1, 0, 1, 0, 1)
+
+}
+
+func TestPinIndexesSync(t *testing.T) {
+	ctx := context.Background()
+
+	db := newTestDB(t, &Options{
+		Capacity: 150,
+	})
+
+	ch := generateTestRandomChunk()
+	addr := ch.Address()
+	_, err := db.Put(ctx, storage.ModePutUpload, ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "putUpload", db, 1, 0, 1, 1, 0, 0)
+
+	err = db.Set(ctx, storage.ModeSetPin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setPin", db, 1, 0, 1, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetPin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setPin 2", db, 1, 0, 1, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetUnpin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setUnPin", db, 1, 0, 1, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetUnpin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setUnPin 2", db, 1, 0, 1, 1, 0, 0)
+
+	err = db.Set(ctx, storage.ModeSetPin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setPin 3", db, 1, 0, 1, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetSync, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setSync", db, 1, 1, 0, 1, 1, 0)
+
+	err = db.Set(ctx, storage.ModeSetUnpin, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "setUnPin", db, 1, 1, 0, 1, 0, 1)
+
+}
+
+func runCountsTest(t *testing.T, name string, db *DB, r, a, push, pull, pin, gc int) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		t.Helper()
+		t.Run("retrieval data Index count", newItemsCountTest(db.retrievalDataIndex, r))
+		t.Run("retrieval access Index count", newItemsCountTest(db.retrievalAccessIndex, a))
+		t.Run("push Index count", newItemsCountTest(db.pushIndex, push))
+		t.Run("pull Index count", newItemsCountTest(db.pullIndex, pull))
+		t.Run("pin Index count", newItemsCountTest(db.pinIndex, pin))
+		t.Run("gc index count", newItemsCountTest(db.gcIndex, gc))
+		t.Run("gc size", newIndexGCSizeTest(db))
+	})
 }
 
 func TestPaging(t *testing.T) {

--- a/pkg/localstore/postage.go
+++ b/pkg/localstore/postage.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// ErrOverissued is returned if number of chunks found in neighbourhood extrapolates to overissued stamp
+	// ErrBatchOverissued is returned if number of chunks found in neighbourhood extrapolates to overissued stamp
 	// count(batch, po) > 1<< (depth(batch) - po)
 	ErrBatchOverissued = errors.New("postage batch overissued")
 	ErrBatchNotFound   = errors.New("postage batch not found or expired")
@@ -167,14 +167,3 @@ func (p *postageBatches) deleteInBatch(batch *leveldb.Batch, item shed.Item) err
 	}
 	return nil
 }
-
-// func (p *postageBatches) moveChunksToGC(batch *leveldb.Batch, batchID []byte, po int) error {
-// 	return p.chunks.Iterate(func(item shed.Item) (stop bool, err error) {
-// 		if p.po(item.Address) > po {
-// 			return true, nil
-// 		}
-// 		// put to gc queue
-// 		return false, nil
-// 	}, &shed.IterateOptions{StartFrom: &shed.Item{BatchID: batchID}})
-
-// }

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -1,0 +1,149 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package localstore
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+const minBatchSize = 500
+
+// Reseerve should move under postage pkg
+type Reserve interface {
+	SubscribeToDepth() (sub <-chan uint8, cancel func())
+	SubscribeToExpiredBatches() (sub <-chan []byte, cancel func())
+}
+
+// reserve is the localstore component that manages the fate of chunks
+// dictated by the postage batchstore reserve based on a priority ordering of batches
+type reserve struct {
+	db     *DB
+	depth  uint8
+	mu     sync.RWMutex
+	cancel func()
+}
+
+// NewReserve
+func newReserve(db *DB, res Reserve) *reserve {
+	stateSub, stateCancel := res.SubscribeToDepth()
+	batchSub, batchCancel := res.SubscribeToExpiredBatches()
+	cancel := func() {
+		stateCancel()
+		batchCancel()
+	}
+	r := &reserve{
+		db:     db,
+		cancel: cancel,
+	}
+	go r.unreserveBins(stateSub)
+	go r.unreserveBatches(batchSub)
+	return r
+}
+
+// Close terminates the async forever loops
+func (r *reserve) Close() error {
+	r.cancel()
+	return nil
+}
+
+// WithinRadius returns true iff the given address is within the nodes area of responsibility
+func (r *reserve) WithinRadius(addr []byte) bool {
+	return swarm.Proximity(r.db.baseKey, addr) < r.getDepth()
+}
+
+// unreserveBins is called as an async forever loop
+// whenever there is a depth change, the reserve unpins all chunks with oldDepth<=po<newDepth
+// if only the reserve pinned the chunk, it will automatically appear in the GC index
+func (r *reserve) unreserveBins(sub <-chan uint8) {
+	for newDepth := range sub {
+		oldDepth := r.setDepth(newDepth)
+		for po := newDepth; po < oldDepth; po++ {
+			r.unreserveBin(po)
+		}
+	}
+}
+
+// unreserveBatches is called as an async forever loop
+// whenever a batch expires, its chunks are unpinned
+// if only the reserve pinned the chunk, it will automatically appear in the GC index
+func (r *reserve) unreserveBatches(sub <-chan []byte) {
+	// sub is clossed when the subscription is cancelled
+	// then the go routine terminates
+	for b := range sub {
+		// TODO: handle error
+		_ = r.db.postage.unreserveBatch(b, swarm.MaxPO)
+	}
+}
+
+// unreserveBin subscribes to the pull index for the bin and
+// unpins all chunks in the bin
+// in order to avoid race on pinning, chunks of batches belonging to po-s are atomically unpinned
+func (r *reserve) unreserveBin(bin uint8) {
+	free := make(chan struct{}, 1)
+	lock := struct{}{}
+	var lockc chan struct{}
+	var batches map[string]bool
+	ctx := context.Background()
+	// until must be given so that the channel is closed
+	// by the time this is called depth is already  set so new chunks in these bins will not be reserved
+	until, err := r.db.LastPullSubscriptionBinID(bin)
+	if err != nil {
+		panic(err)
+	}
+	sub, _, stop := r.db.SubscribePull(ctx, bin, 0, until)
+	// the goroutine terminates when sub channel is closed by cancelling the subscription
+	// closes the pull subscription too
+	defer stop()
+	for {
+		select {
+		case item, more := <-sub:
+			if !more {
+				sub = nil
+			}
+			batches[string(item.BatchID)] = true
+			// when collected enough batches or we run out of chunks, allow unreserve
+			// note: since sub is not blocking, this does not delay unreserving bins
+			if len(batches) == minBatchSize || sub == nil {
+				lockc = free
+			}
+		case <-lockc:
+			go func() {
+				for batchID := range batches {
+					// handle error
+					_ = r.db.postage.unreserveBatch([]byte(batchID), bin)
+				}
+				free <- lock
+			}()
+			// terminate if sub finished
+			if sub == nil {
+				return
+			}
+			// reset the map
+			batches = make(map[string]bool)
+			// disable unreserve until enough batches and previous call returns
+			lockc = nil
+		}
+	}
+}
+
+// getDepth is read accessor to depth
+func (r *reserve) getDepth() uint8 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.depth
+}
+
+// setDepth is write accessor to depth
+// returns old depth
+func (r *reserve) setDepth(d uint8) uint8 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	oldDepth := r.depth
+	r.depth = d
+	return oldDepth
+}

--- a/pkg/localstore/subscription_pull.go
+++ b/pkg/localstore/subscription_pull.go
@@ -96,6 +96,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 					select {
 					case chunkDescriptors <- storage.Descriptor{
 						Address: swarm.NewAddress(item.Address),
+						BatchID: item.BatchID,
 						BinID:   item.BinID,
 					}:
 						if until > 0 && item.BinID == until {

--- a/pkg/shed/index.go
+++ b/pkg/shed/index.go
@@ -48,6 +48,7 @@ type Item struct {
 	Tag             uint32
 	BatchID         []byte  // postage batch ID
 	Sig             []byte  // postage stamp
+	Radius          uint8   // postage batch reserve radius, po upto and excluding which chunks are unpinned
 	Counts          *Counts // postage batch counts
 }
 
@@ -111,6 +112,9 @@ func (i Item) Merge(i2 Item) Item {
 	}
 	if i.BatchID == nil {
 		i.BatchID = i2.BatchID
+	}
+	if i.Radius == 0 {
+		i.Radius = i2.Radius
 	}
 	if i.Counts == nil {
 		i.Counts = i2.Counts

--- a/pkg/storage/mock/batchstore/batchstore.go
+++ b/pkg/storage/mock/batchstore/batchstore.go
@@ -26,3 +26,11 @@ func (tbs *MockBatchStore) WithGet(getf func(batchID []byte) (*postage.Batch, er
 func (tbs *MockBatchStore) Get(batchID []byte) (*postage.Batch, error) {
 	return tbs.getf(batchID)
 }
+
+func (tbs *MockBatchStore) SubscribeToDepth() (sub <-chan uint8, cancel func()) {
+	return nil, nil
+}
+
+func (tbs *MockBatchStore) SubscribeToExpiredBatches() (sub <-chan []byte, cancel func()) {
+	return nil, nil
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -115,6 +115,7 @@ const (
 // is provided by subscribing to pull index.
 type Descriptor struct {
 	Address swarm.Address
+	BatchID []byte
 	BinID   uint64
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -84,8 +84,6 @@ type ModeSet int
 
 func (m ModeSet) String() string {
 	switch m {
-	case ModeSetAccess:
-		return "Access"
 	case ModeSetSync:
 		return "Sync"
 	case ModeSetRemove:


### PR DESCRIPTION
this PR is out of place. 
the changes herein are the result of working on reserve design. 
This substantially simplifies localstore design, paving the way for a cleaner implementation for index updates 

It contains also some importatnt fixes wrt pinning and gc 