### PR TITLE
Random manifest obfuscation key only when encrypting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.4
 	github.com/ethersphere/langos v1.0.0
-	github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce
+	github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d
 	github.com/ethersphere/sw3-bindings/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.4
 	github.com/ethersphere/langos v1.0.0
-	github.com/ethersphere/manifest v0.3.5
+	github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce
 	github.com/ethersphere/sw3-bindings/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.20
 	github.com/ethersphere/bmt v0.1.4
 	github.com/ethersphere/langos v1.0.0
-	github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d
+	github.com/ethersphere/manifest v0.3.6
 	github.com/ethersphere/sw3-bindings/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/ethersphere/bmt v0.1.4 h1:+rkWYNtMgDx6bkNqGdWu+U9DgGI1rRZplpSW3YhBr1Q
 github.com/ethersphere/bmt v0.1.4/go.mod h1:Yd8ft1U69WDuHevZc/rwPxUv1rzPSMpMnS6xbU53aY8=
 github.com/ethersphere/langos v1.0.0 h1:NBtNKzXTTRSue95uOlzPN4py7Aofs0xWPzyj4AI1Vcc=
 github.com/ethersphere/langos v1.0.0/go.mod h1:dlcN2j4O8sQ+BlCaxeBu43bgr4RQ+inJ+pHwLeZg5Tw=
-github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce h1:/vxjqMw9jrvOce3W6YlEPUOcRLgVkwM+aJUSFWJS9xU=
-github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
+github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d h1:QOk/cFmLG+ImavJllFnrvsUOyT/TVFQWPw0YfhCN8Qs=
+github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0 h1:QefDtzU94UelICMPXWr7m52E2oj6r018Yc0XLoCWOxw=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0/go.mod h1:ozMVBZZlAirS/FcUpFwzV60v8gC0nVbA/5ZXtCX3xCc=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/ethersphere/bmt v0.1.4 h1:+rkWYNtMgDx6bkNqGdWu+U9DgGI1rRZplpSW3YhBr1Q
 github.com/ethersphere/bmt v0.1.4/go.mod h1:Yd8ft1U69WDuHevZc/rwPxUv1rzPSMpMnS6xbU53aY8=
 github.com/ethersphere/langos v1.0.0 h1:NBtNKzXTTRSue95uOlzPN4py7Aofs0xWPzyj4AI1Vcc=
 github.com/ethersphere/langos v1.0.0/go.mod h1:dlcN2j4O8sQ+BlCaxeBu43bgr4RQ+inJ+pHwLeZg5Tw=
-github.com/ethersphere/manifest v0.3.5 h1:/UMN4X4eKyTCARS9dv2HqqdFCJI2Emu09tivYsp5FZM=
-github.com/ethersphere/manifest v0.3.5/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
+github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce h1:/vxjqMw9jrvOce3W6YlEPUOcRLgVkwM+aJUSFWJS9xU=
+github.com/ethersphere/manifest v0.3.6-0.20201219094757-ca4bdf6230ce/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0 h1:QefDtzU94UelICMPXWr7m52E2oj6r018Yc0XLoCWOxw=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0/go.mod h1:ozMVBZZlAirS/FcUpFwzV60v8gC0nVbA/5ZXtCX3xCc=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/ethersphere/bmt v0.1.4 h1:+rkWYNtMgDx6bkNqGdWu+U9DgGI1rRZplpSW3YhBr1Q
 github.com/ethersphere/bmt v0.1.4/go.mod h1:Yd8ft1U69WDuHevZc/rwPxUv1rzPSMpMnS6xbU53aY8=
 github.com/ethersphere/langos v1.0.0 h1:NBtNKzXTTRSue95uOlzPN4py7Aofs0xWPzyj4AI1Vcc=
 github.com/ethersphere/langos v1.0.0/go.mod h1:dlcN2j4O8sQ+BlCaxeBu43bgr4RQ+inJ+pHwLeZg5Tw=
-github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d h1:QOk/cFmLG+ImavJllFnrvsUOyT/TVFQWPw0YfhCN8Qs=
-github.com/ethersphere/manifest v0.3.6-0.20201219111500-ac38cbddff4d/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
+github.com/ethersphere/manifest v0.3.6 h1:38WgYoXAQyC2lrSTArj+HM62AecX8JfUn1oVr1q+CVg=
+github.com/ethersphere/manifest v0.3.6/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0 h1:QefDtzU94UelICMPXWr7m52E2oj6r018Yc0XLoCWOxw=
 github.com/ethersphere/sw3-bindings/v2 v2.1.0/go.mod h1:ozMVBZZlAirS/FcUpFwzV60v8gC0nVbA/5ZXtCX3xCc=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -99,7 +99,7 @@ func TestBzz(t *testing.T) {
 		}
 
 		// save manifest
-		m, err := manifest.NewDefaultManifest(loadsave.New(storer, storage.ModePutRequest, false))
+		m, err := manifest.NewDefaultManifest(loadsave.New(storer, storage.ModePutRequest, false), false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -61,15 +61,15 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var nonceKey []byte
-	nonce := r.URL.Query().Get("nonce")
-	if nonce != "" {
-		nonceKey, err = hex.DecodeString(nonce)
+	var obfuscationKey []byte
+	oKey := r.URL.Query().Get("obfuscationKey")
+	if oKey != "" {
+		obfuscationKey, err = hex.DecodeString(oKey)
 		if err != nil {
-			logger.Debugf("dir upload: cannot parse nonce: %v", err)
-			logger.Error("dir upload: cannot parse nonce")
+			logger.Debugf("dir upload: cannot obfuscation key: %v", err)
+			logger.Error("dir upload: cannot parse obfuscation key")
 
-			jsonhttp.BadRequest(w, "cannot parse nonce")
+			jsonhttp.BadRequest(w, "cannot parse obfuscation key")
 			return
 		}
 	}
@@ -78,7 +78,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := sctx.SetTag(r.Context(), tag)
 	p := requestPipelineFn(s.Storer, r)
 	l := loadsave.New(s.Storer, requestModePut(r), requestEncrypt(r))
-	reference, err := storeDir(ctx, nonceKey, r.Body, s.Logger, p, l, r.Header.Get(SwarmIndexDocumentHeader), r.Header.Get(SwarmErrorDocumentHeader))
+	reference, err := storeDir(ctx, obfuscationKey, r.Body, s.Logger, p, l, r.Header.Get(SwarmIndexDocumentHeader), r.Header.Get(SwarmErrorDocumentHeader))
 	if err != nil {
 		logger.Debugf("dir upload: store dir err: %v", err)
 		logger.Errorf("dir upload: store dir")
@@ -118,15 +118,15 @@ func validateRequest(r *http.Request) error {
 
 // storeDir stores all files recursively contained in the directory given as a tar
 // it returns the hash for the uploaded manifest corresponding to the uploaded dir
-func storeDir(ctx context.Context, nonceKey []byte, reader io.ReadCloser, log logging.Logger, p pipelineFunc, ls file.LoadSaver, indexFilename string, errorFilename string) (swarm.Address, error) {
+func storeDir(ctx context.Context, obfuscationKey []byte, reader io.ReadCloser, log logging.Logger, p pipelineFunc, ls file.LoadSaver, indexFilename string, errorFilename string) (swarm.Address, error) {
 	logger := tracing.NewLoggerWithTraceID(ctx, log)
 
 	obfuscationKeyFn := func(p []byte) (n int, err error) {
-		if len(nonceKey) == 0 {
+		if len(obfuscationKey) == 0 {
 			return rand.Read(p)
 		}
 
-		n = copy(p, nonceKey)
+		n = copy(p, obfuscationKey)
 		return
 	}
 

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethersphere/bee/pkg/sctx"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tracing"
-	"github.com/ethersphere/manifest/mantaray"
 )
 
 const (
@@ -108,17 +107,7 @@ func validateRequest(r *http.Request) error {
 func storeDir(ctx context.Context, encrypt bool, reader io.ReadCloser, log logging.Logger, p pipelineFunc, ls file.LoadSaver, indexFilename string, errorFilename string) (swarm.Address, error) {
 	logger := tracing.NewLoggerWithTraceID(ctx, log)
 
-	var (
-		dirManifest manifest.Interface
-		err         error
-	)
-
-	if encrypt {
-		// NOTE: will generate random obfuscation key for manifest
-		dirManifest, err = manifest.NewDefaultManifest(ls)
-	} else {
-		dirManifest, err = manifest.NewDefaultManifestWithObfuscationKey(ls, mantaray.ZeroObfuscationKey)
-	}
+	dirManifest, err := manifest.NewDefaultManifest(ls, encrypt)
 	if err != nil {
 		return swarm.ZeroAddress, err
 	}

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -92,16 +92,17 @@ func TestDirs(t *testing.T) {
 	// valid tars
 	for _, tc := range []struct {
 		name                string
+		expectedReference   swarm.Address
+		encrypt             bool
 		wantIndexFilename   string
 		wantErrorFilename   string
-		wantHashReference   swarm.Address
-		obfuscationKey      string
 		indexFilenameOption jsonhttptest.Option
 		errorFilenameOption jsonhttptest.Option
 		files               []f // files in dir for test case
 	}{
 		{
-			name: "non-nested files without extension",
+			name:              "non-nested files without extension",
+			expectedReference: swarm.MustParseHexAddress("126140bb0a33d62c4efb0523db2c26be849fcf458504618de785e2a219bad374"),
 			files: []f{
 				{
 					data:      []byte("first file data"),
@@ -124,7 +125,8 @@ func TestDirs(t *testing.T) {
 			},
 		},
 		{
-			name: "nested files with extension",
+			name:              "nested files with extension",
+			expectedReference: swarm.MustParseHexAddress("cad4b3847bd59532d9e73623d67c52e0c8d4e017d308bbaecb54f2866a91769d"),
 			files: []f{
 				{
 					data:      []byte("robots text"),
@@ -156,7 +158,8 @@ func TestDirs(t *testing.T) {
 			},
 		},
 		{
-			name: "no index filename",
+			name:              "no index filename",
+			expectedReference: swarm.MustParseHexAddress("a85aaea6a34a5c7127a3546196f2111f866fe369c6d6562ed5d3313a99388c03"),
 			files: []f{
 				{
 					data:      []byte("<h1>Swarm"),
@@ -171,6 +174,7 @@ func TestDirs(t *testing.T) {
 		},
 		{
 			name:                "explicit index filename",
+			expectedReference:   swarm.MustParseHexAddress("7d41402220f8e397ddf74d0cf4ac2055e753102bde0d622c45b03cea2b28b023"),
 			wantIndexFilename:   "index.html",
 			indexFilenameOption: jsonhttptest.WithRequestHeader(api.SwarmIndexDocumentHeader, "index.html"),
 			files: []f{
@@ -187,6 +191,7 @@ func TestDirs(t *testing.T) {
 		},
 		{
 			name:                "nested index filename",
+			expectedReference:   swarm.MustParseHexAddress("45249cf9caad842b31b29b831a1ff12aa2b711e7c282fa7a5f8c0fb544143421"),
 			wantIndexFilename:   "index.html",
 			indexFilenameOption: jsonhttptest.WithRequestHeader(api.SwarmIndexDocumentHeader, "index.html"),
 			files: []f{
@@ -203,6 +208,7 @@ func TestDirs(t *testing.T) {
 		},
 		{
 			name:                "explicit index and error filename",
+			expectedReference:   swarm.MustParseHexAddress("2046a4f758e2c0579ab923206a13fb041cec0925a6396f4f772c7ce859b8ca42"),
 			wantIndexFilename:   "index.html",
 			wantErrorFilename:   "error.html",
 			indexFilenameOption: jsonhttptest.WithRequestHeader(api.SwarmIndexDocumentHeader, "index.html"),
@@ -229,7 +235,8 @@ func TestDirs(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid archive paths",
+			name:              "invalid archive paths",
+			expectedReference: swarm.MustParseHexAddress("6e6adb1ce936990cf1b7ecf8f01a8e3e8f939375b9bddb3d666151e0bdc08d4e"),
 			files: []f{
 				{
 					data:      []byte("<h1>Swarm"),
@@ -256,16 +263,14 @@ Disallow: /`),
 			},
 		},
 		{
-			name:              "with nonce key",
-			wantHashReference: swarm.MustParseHexAddress("a85aaea6a34a5c7127a3546196f2111f866fe369c6d6562ed5d3313a99388c03"),
-			obfuscationKey:    "0000",
+			name:    "encrypted",
+			encrypt: true,
 			files: []f{
 				{
-					data:      []byte("<h1>Swarm"),
-					name:      "index.html",
-					dir:       "",
-					filePath:  "./index.html",
-					reference: swarm.MustParseHexAddress("bcb1bfe15c36f1a529a241f4d0c593e5648aa6d40859790894c6facb41a6ef28"),
+					data:     []byte("<h1>Swarm"),
+					name:     "index.html",
+					dir:      "",
+					filePath: "./index.html",
 				},
 			},
 		},
@@ -287,35 +292,30 @@ Disallow: /`),
 			if tc.errorFilenameOption != nil {
 				options = append(options, tc.errorFilenameOption)
 			}
-
-			url := dirUploadResource
-
-			if tc.obfuscationKey != "" {
-				url = url + "?obfuscationKey=" + tc.obfuscationKey
+			if tc.encrypt {
+				options = append(options, jsonhttptest.WithRequestHeader(api.SwarmEncryptHeader, "true"))
 			}
 
 			// verify directory tar upload response
-			jsonhttptest.Request(t, client, http.MethodPost, url, http.StatusOK, options...)
+			jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusOK, options...)
 
 			read := bytes.NewReader(respBytes)
 
-			// get the reference as everytime it may change because of random encryption key
+			// get the reference
 			var resp api.FileUploadResponse
 			err := json.NewDecoder(read).Decode(&resp)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// NOTE: reference may be different each time, due to manifest randomness
-
 			if resp.Reference.String() == "" {
 				t.Fatalf("expected file reference, did not got any")
 			}
 
-			if !swarm.ZeroAddress.Equal(tc.wantHashReference) {
-				// expecting deterministic reference in this case
-				if !resp.Reference.Equal(tc.wantHashReference) {
-					t.Fatalf("expected root reference to match %s, got %s", tc.wantHashReference, resp.Reference)
+			// NOTE: reference will be different each time when encryption is enabled
+			if !tc.encrypt {
+				if !resp.Reference.Equal(tc.expectedReference) {
+					t.Fatalf("expected root reference to match %s, got %s", tc.expectedReference, resp.Reference)
 				}
 			}
 
@@ -356,8 +356,10 @@ Disallow: /`),
 
 				fileReference := entry.Reference()
 
-				if !bytes.Equal(file.reference.Bytes(), fileReference.Bytes()) {
-					t.Fatalf("expected file reference to match %s, got %s", file.reference, fileReference)
+				if !tc.encrypt {
+					if !bytes.Equal(file.reference.Bytes(), fileReference.Bytes()) {
+						t.Fatalf("expected file reference to match %s, got %s", file.reference, fileReference)
+					}
 				}
 
 				jsonhttptest.Request(t, client, http.MethodGet, fileDownloadResource(fileReference.String()), http.StatusOK,

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -95,7 +95,7 @@ func TestDirs(t *testing.T) {
 		wantIndexFilename   string
 		wantErrorFilename   string
 		wantHashReference   swarm.Address
-		nonceKey            string
+		obfuscationKey      string
 		indexFilenameOption jsonhttptest.Option
 		errorFilenameOption jsonhttptest.Option
 		files               []f // files in dir for test case
@@ -258,7 +258,7 @@ Disallow: /`),
 		{
 			name:              "with nonce key",
 			wantHashReference: swarm.MustParseHexAddress("a85aaea6a34a5c7127a3546196f2111f866fe369c6d6562ed5d3313a99388c03"),
-			nonceKey:          "0000",
+			obfuscationKey:    "0000",
 			files: []f{
 				{
 					data:      []byte("<h1>Swarm"),
@@ -290,8 +290,8 @@ Disallow: /`),
 
 			url := dirUploadResource
 
-			if tc.nonceKey != "" {
-				url = url + "?nonce=" + tc.nonceKey
+			if tc.obfuscationKey != "" {
+				url = url + "?obfuscationKey=" + tc.obfuscationKey
 			}
 
 			// verify directory tar upload response

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -6,7 +6,6 @@ package api_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -281,7 +280,7 @@ func TestRangeRequests(t *testing.T) {
 			uploadEndpoint:   "/dirs",
 			downloadEndpoint: "/bzz",
 			filepath:         "/ipsum/lorem.txt",
-			reference:        "",
+			reference:        "96c68b99304b0868189e5c1d6c10be1984d93e88aab0384907f6b8814f60150b",
 			reader: tarFiles(t, []f{
 				{
 					data:      data,
@@ -354,25 +353,6 @@ func TestRangeRequests(t *testing.T) {
 				jsonhttptest.WithRequestHeader("Content-Type", upload.contentType),
 				jsonhttptest.WithPutResponseBody(&respBytes),
 			)
-
-			if uploadReference == "" {
-				// NOTE: reference will be different each time, due to manifest randomness
-
-				read := bytes.NewReader(respBytes)
-
-				// get the reference as everytime it will change because of random encryption key
-				var resp api.FileUploadResponse
-				err := json.NewDecoder(read).Decode(&resp)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if resp.Reference.String() == "" {
-					t.Fatalf("expected file reference, did not got any")
-				}
-
-				uploadReference = resp.Reference.String()
-			}
 
 			for _, tc := range ranges {
 				t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/pin_bzz_test.go
+++ b/pkg/api/pin_bzz_test.go
@@ -20,12 +20,11 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/traversal"
-	"github.com/ethersphere/manifest/mantaray"
 )
 
 func TestPinBzzHandler(t *testing.T) {
 	var (
-		dirUploadResource     = "/dirs"
+		dirUploadResource     = "/dirs?nonce=0000"
 		pinBzzResource        = "/pin/bzz"
 		pinBzzAddressResource = func(addr string) string { return pinBzzResource + "/" + addr }
 		pinChunksResource     = "/pin/chunks"
@@ -40,15 +39,6 @@ func TestPinBzzHandler(t *testing.T) {
 			Tags:      tags.NewTags(mockStatestore, logger),
 		})
 	)
-
-	var (
-		obfuscationKey   = make([]byte, 32)
-		obfuscationKeyFn = func(p []byte) (n int, err error) {
-			n = copy(p, obfuscationKey)
-			return
-		}
-	)
-	mantaray.SetObfuscationKeyFn(obfuscationKeyFn)
 
 	t.Run("pin-bzz-1", func(t *testing.T) {
 		files := []f{

--- a/pkg/api/pin_bzz_test.go
+++ b/pkg/api/pin_bzz_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestPinBzzHandler(t *testing.T) {
 	var (
-		dirUploadResource     = "/dirs?obfuscationKey=0000"
+		dirUploadResource     = "/dirs"
 		pinBzzResource        = "/pin/bzz"
 		pinBzzAddressResource = func(addr string) string { return pinBzzResource + "/" + addr }
 		pinChunksResource     = "/pin/chunks"
@@ -79,7 +79,6 @@ func TestPinBzzHandler(t *testing.T) {
 
 		read := bytes.NewReader(respBytes)
 
-		// get the reference as everytime it will change because of random encryption key
 		var resp api.ListPinnedChunksResponse
 		err := json.NewDecoder(read).Decode(&resp)
 		if err != nil {

--- a/pkg/api/pin_bzz_test.go
+++ b/pkg/api/pin_bzz_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestPinBzzHandler(t *testing.T) {
 	var (
-		dirUploadResource     = "/dirs?nonce=0000"
+		dirUploadResource     = "/dirs?obfuscationKey=0000"
 		pinBzzResource        = "/pin/bzz"
 		pinBzzAddressResource = func(addr string) string { return pinBzzResource + "/" + addr }
 		pinChunksResource     = "/pin/chunks"

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -63,13 +63,13 @@ func NewDefaultManifest(ls file.LoadSaver) (Interface, error) {
 	return NewManifest(DefaultManifestType, ls)
 }
 
-// NewDefaultManifestWithObfuscationKeyFn creates a new manifest with default
-// type with configured obfuscation key function.
-func NewDefaultManifestWithObfuscationKeyFn(
+// NewDefaultManifestWithObfuscationKey creates a new manifest of default
+// type with configured obfuscation key.
+func NewDefaultManifestWithObfuscationKey(
 	ls file.LoadSaver,
-	obfuscationKeyFn func([]byte) (int, error),
+	obfuscationKey []byte,
 ) (Interface, error) {
-	return NewManifestWithObfuscationKeyFn(DefaultManifestType, ls, obfuscationKeyFn)
+	return NewManifestWithObfuscationKey(DefaultManifestType, ls, obfuscationKey)
 }
 
 // NewManifest creates a new manifest.
@@ -87,19 +87,19 @@ func NewManifest(
 	}
 }
 
-// NewManifestWithObfuscationKeyFn creates a new manifest with configured
-// obfuscation key function.
-func NewManifestWithObfuscationKeyFn(
+// NewManifestWithObfuscationKey creates a new manifest with configured
+// obfuscation key.
+func NewManifestWithObfuscationKey(
 	manifestType string,
 	ls file.LoadSaver,
-	obfuscationKeyFn func([]byte) (int, error),
+	obfuscationKey []byte,
 ) (Interface, error) {
 	switch manifestType {
 	case ManifestSimpleContentType:
 		// not supported for 'simple' type
 		return NewSimpleManifest(ls)
 	case ManifestMantarayContentType:
-		return NewMantarayManifestWithObfuscationKeyFn(ls, obfuscationKeyFn)
+		return NewMantarayManifestWithObfuscationKey(ls, obfuscationKey)
 	default:
 		return nil, ErrInvalidManifestType
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -59,47 +59,24 @@ type Entry interface {
 }
 
 // NewDefaultManifest creates a new manifest with default type.
-func NewDefaultManifest(ls file.LoadSaver) (Interface, error) {
-	return NewManifest(DefaultManifestType, ls)
-}
-
-// NewDefaultManifestWithObfuscationKey creates a new manifest of default
-// type with configured obfuscation key.
-func NewDefaultManifestWithObfuscationKey(
+func NewDefaultManifest(
 	ls file.LoadSaver,
-	obfuscationKey []byte,
+	encrypted bool,
 ) (Interface, error) {
-	return NewManifestWithObfuscationKey(DefaultManifestType, ls, obfuscationKey)
+	return NewManifest(DefaultManifestType, ls, encrypted)
 }
 
 // NewManifest creates a new manifest.
 func NewManifest(
 	manifestType string,
 	ls file.LoadSaver,
+	encrypted bool,
 ) (Interface, error) {
 	switch manifestType {
 	case ManifestSimpleContentType:
 		return NewSimpleManifest(ls)
 	case ManifestMantarayContentType:
-		return NewMantarayManifest(ls)
-	default:
-		return nil, ErrInvalidManifestType
-	}
-}
-
-// NewManifestWithObfuscationKey creates a new manifest with configured
-// obfuscation key.
-func NewManifestWithObfuscationKey(
-	manifestType string,
-	ls file.LoadSaver,
-	obfuscationKey []byte,
-) (Interface, error) {
-	switch manifestType {
-	case ManifestSimpleContentType:
-		// not supported for 'simple' type
-		return NewSimpleManifest(ls)
-	case ManifestMantarayContentType:
-		return NewMantarayManifestWithObfuscationKey(ls, obfuscationKey)
+		return NewMantarayManifest(ls, encrypted)
 	default:
 		return nil, ErrInvalidManifestType
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -63,6 +63,15 @@ func NewDefaultManifest(ls file.LoadSaver) (Interface, error) {
 	return NewManifest(DefaultManifestType, ls)
 }
 
+// NewDefaultManifestWithObfuscationKeyFn creates a new manifest with default
+// type with configured obfuscation key function.
+func NewDefaultManifestWithObfuscationKeyFn(
+	ls file.LoadSaver,
+	obfuscationKeyFn func([]byte) (int, error),
+) (Interface, error) {
+	return NewManifestWithObfuscationKeyFn(DefaultManifestType, ls, obfuscationKeyFn)
+}
+
 // NewManifest creates a new manifest.
 func NewManifest(
 	manifestType string,
@@ -73,6 +82,24 @@ func NewManifest(
 		return NewSimpleManifest(ls)
 	case ManifestMantarayContentType:
 		return NewMantarayManifest(ls)
+	default:
+		return nil, ErrInvalidManifestType
+	}
+}
+
+// NewManifestWithObfuscationKeyFn creates a new manifest with configured
+// obfuscation key function.
+func NewManifestWithObfuscationKeyFn(
+	manifestType string,
+	ls file.LoadSaver,
+	obfuscationKeyFn func([]byte) (int, error),
+) (Interface, error) {
+	switch manifestType {
+	case ManifestSimpleContentType:
+		// not supported for 'simple' type
+		return NewSimpleManifest(ls)
+	case ManifestMantarayContentType:
+		return NewMantarayManifestWithObfuscationKeyFn(ls, obfuscationKeyFn)
 	default:
 		return nil, ErrInvalidManifestType
 	}

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -21,7 +21,8 @@ const (
 )
 
 type mantarayManifest struct {
-	trie *mantaray.Node
+	trie           *mantaray.Node
+	obfuscationKey []byte
 
 	ls file.LoadSaver
 }
@@ -34,19 +35,21 @@ func NewMantarayManifest(ls file.LoadSaver) (Interface, error) {
 	}, nil
 }
 
-// NewMantarayManifestWithObfuscationKeyFn creates a new mantaray-based manifest
-// with configured obfuscation key function.
+// NewMantarayManifestWithObfuscationKey creates a new mantaray-based manifest
+// with configured obfuscation key.
 //
 // NOTE: This should only be used in tests.
-func NewMantarayManifestWithObfuscationKeyFn(
+func NewMantarayManifestWithObfuscationKey(
 	ls file.LoadSaver,
-	obfuscationKeyFn func([]byte) (int, error),
+	obfuscationKey []byte,
 ) (Interface, error) {
 	mm := &mantarayManifest{
 		trie: mantaray.New(),
 		ls:   ls,
 	}
-	mantaray.SetObfuscationKeyFn(obfuscationKeyFn)
+	mm.obfuscationKey = append(obfuscationKey[:0:0], obfuscationKey...)
+	// NOTE: it will be copied to all trie nodes
+	mm.trie.SetObfuscationKey(mm.obfuscationKey)
 	return mm, nil
 }
 

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -35,7 +35,7 @@ func NewMantarayManifest(ls file.LoadSaver) (Interface, error) {
 }
 
 // NewMantarayManifestWithObfuscationKeyFn creates a new mantaray-based manifest
-// with configured obfuscation key
+// with configured obfuscation key function.
 //
 // NOTE: This should only be used in tests.
 func NewMantarayManifestWithObfuscationKeyFn(

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -21,35 +21,25 @@ const (
 )
 
 type mantarayManifest struct {
-	trie           *mantaray.Node
-	obfuscationKey []byte
+	trie *mantaray.Node
 
 	ls file.LoadSaver
 }
 
 // NewMantarayManifest creates a new mantaray-based manifest.
-func NewMantarayManifest(ls file.LoadSaver) (Interface, error) {
-	return &mantarayManifest{
-		trie: mantaray.New(),
-		ls:   ls,
-	}, nil
-}
-
-// NewMantarayManifestWithObfuscationKey creates a new mantaray-based manifest
-// with configured obfuscation key.
-//
-// NOTE: This should only be used in tests.
-func NewMantarayManifestWithObfuscationKey(
+func NewMantarayManifest(
 	ls file.LoadSaver,
-	obfuscationKey []byte,
+	encrypted bool,
 ) (Interface, error) {
 	mm := &mantarayManifest{
 		trie: mantaray.New(),
 		ls:   ls,
 	}
-	mm.obfuscationKey = append(obfuscationKey[:0:0], obfuscationKey...)
-	// NOTE: it will be copied to all trie nodes
-	mm.trie.SetObfuscationKey(mm.obfuscationKey)
+	// use empty obfuscation key if not encrypting
+	if !encrypted {
+		// NOTE: it will be copied to all trie nodes
+		mm.trie.SetObfuscationKey(mantaray.ZeroObfuscationKey)
+	}
 	return mm, nil
 }
 

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -265,13 +265,7 @@ func TestTraversalManifest(t *testing.T) {
 		return traversalService.TraverseManifestAddresses
 	}
 
-	var (
-		obfuscationKey   = make([]byte, 32)
-		obfuscationKeyFn = func(p []byte) (n int, err error) {
-			n = copy(p, obfuscationKey)
-			return
-		}
-	)
+	var obfuscationKey = make([]byte, 32)
 
 	testCases := []struct {
 		manifestType        string
@@ -470,7 +464,7 @@ func TestTraversalManifest(t *testing.T) {
 					t.Fatal(err)
 				}
 			case manifest.ManifestMantarayContentType:
-				dirManifest, err = manifest.NewMantarayManifestWithObfuscationKeyFn(ls, obfuscationKeyFn)
+				dirManifest, err = manifest.NewMantarayManifestWithObfuscationKey(ls, obfuscationKey)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/traversal"
-	"github.com/ethersphere/manifest/mantaray"
 )
 
 var (
@@ -463,7 +462,7 @@ func TestTraversalManifest(t *testing.T) {
 					t.Fatal(err)
 				}
 			case manifest.ManifestMantarayContentType:
-				dirManifest, err = manifest.NewMantarayManifestWithObfuscationKey(ls, mantaray.ZeroObfuscationKey)
+				dirManifest, err = manifest.NewMantarayManifest(ls, false)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/traversal"
+	"github.com/ethersphere/manifest/mantaray"
 )
 
 var (
@@ -265,8 +266,6 @@ func TestTraversalManifest(t *testing.T) {
 		return traversalService.TraverseManifestAddresses
 	}
 
-	var obfuscationKey = make([]byte, 32)
-
 	testCases := []struct {
 		manifestType        string
 		files               []file
@@ -464,7 +463,7 @@ func TestTraversalManifest(t *testing.T) {
 					t.Fatal(err)
 				}
 			case manifest.ManifestMantarayContentType:
-				dirManifest, err = manifest.NewMantarayManifestWithObfuscationKey(ls, obfuscationKey)
+				dirManifest, err = manifest.NewMantarayManifestWithObfuscationKey(ls, mantaray.ZeroObfuscationKey)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
relates to: #1006 

Change behavior for upload to `/dirs` endpoint so that non-encrypted uploads will force `mantaray`-based manifest not to use random obfuscation key for each upload. This means that for multiple uploads of the same content to have same root hash will be generated.