### PR TITLE
fix address property name in openapi schema

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -16,7 +16,7 @@ components:
     Address:
       type: object
       properties:
-        Address:
+        address:
           $ref: '#/components/schemas/SwarmAddress'
 
     Addresses:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -166,9 +166,9 @@ components:
     NewTagRequest:
       type: object
       properties:
-        Name:
+        name:
           type: string
-        Address:
+        address:
           $ref: '#/components/schemas/SwarmAddress'
 
     NewTagResponse:


### PR DESCRIPTION
When using the `/peers` `GET` endpoint I found that the documentation is with uppercase but the actual value returned is in lowercase. This PR fixes the schema definition from where the documentation is generated.