### PR TITLE
kademlia: limit bootnode connection attempts

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -250,12 +250,11 @@ func (k *Kad) connectBootnodes(ctx context.Context) {
 
 		if _, err := p2p.Discover(ctx, addr, func(addr ma.Multiaddr) (stop bool, err error) {
 			k.logger.Tracef("connecting to bootnode %s", addr)
-			attempts++
 			if attempts >= maxBootnodeAttempts {
 				return true, nil
 			}
-
 			bzzAddress, err := k.p2p.Connect(ctx, addr)
+			attempts++
 			if err != nil {
 				if !errors.Is(err, p2p.ErrAlreadyConnected) {
 					k.logger.Debugf("connect fail %s: %v", addr, err)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -241,7 +241,7 @@ func (k *Kad) Start(ctx context.Context) error {
 
 func (k *Kad) connectBootnodes(ctx context.Context) {
 	var attempts, connected int
-	const totalAttempts = maxBootnodeAttempts * len(k.bootnodes)
+	var totalAttempts = maxBootnodeAttempts * len(k.bootnodes)
 
 	for _, addr := range k.bootnodes {
 		if attempts >= totalAttempts || connected >= 3 {
@@ -262,6 +262,7 @@ func (k *Kad) connectBootnodes(ctx context.Context) {
 					k.logger.Warningf("connect to bootnode %s", addr)
 					return false, err
 				}
+				k.logger.Debugf("connect to bootnode fail: %v", err)
 				return false, nil
 			}
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	nnLowWatermark  = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
-	maxConnAttempts = 3 // when there is maxConnAttempts failed connect calls for a given peer it is considered non-connectable
+	nnLowWatermark      = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
+	maxConnAttempts     = 3 // when there is maxConnAttempts failed connect calls for a given peer it is considered non-connectable
+	maxBootnodeAttempts = 3 // how many attempts to dial to bootnodes before giving up
 )
 
 var (
@@ -218,6 +219,7 @@ func (k *Kad) manage() {
 			}
 
 			if k.connectedPeers.Length() == 0 {
+				k.logger.Debug("kademlia has no connected peers, trying bootnodes")
 				k.connectBootnodes(ctx)
 			}
 
@@ -238,14 +240,21 @@ func (k *Kad) Start(ctx context.Context) error {
 }
 
 func (k *Kad) connectBootnodes(ctx context.Context) {
-	var count int
+	var attempts, connected int
+	const totalAttempts = maxBootnodeAttempts * len(k.bootnodes)
+
 	for _, addr := range k.bootnodes {
-		if count >= 3 {
+		if attempts >= totalAttempts || connected >= 3 {
 			return
 		}
 
 		if _, err := p2p.Discover(ctx, addr, func(addr ma.Multiaddr) (stop bool, err error) {
 			k.logger.Tracef("connecting to bootnode %s", addr)
+			attempts++
+			if attempts >= maxBootnodeAttempts {
+				return true, nil
+			}
+
 			bzzAddress, err := k.p2p.Connect(ctx, addr)
 			if err != nil {
 				if !errors.Is(err, p2p.ErrAlreadyConnected) {
@@ -260,9 +269,9 @@ func (k *Kad) connectBootnodes(ctx context.Context) {
 				return false, err
 			}
 			k.logger.Tracef("connected to bootnode %s", addr)
-			count++
+			connected++
 			// connect to max 3 bootnodes
-			return count >= 3, nil
+			return connected >= 3, nil
 		}); err != nil {
 			k.logger.Debugf("discover fail %s: %v", addr, err)
 			k.logger.Warningf("discover to bootnode %s", addr)

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -52,9 +52,6 @@ var (
 
 	// ErrWelcomeMessageLength is returned if the welcome message is longer than the maximum length
 	ErrWelcomeMessageLength = fmt.Errorf("handshake welcome message longer than maximum of %d characters", MaxWelcomeMessageLength)
-
-	// ErrLoopbackDialup is returned when a node tries to connect to itself.
-	ErrLoopbackDialup = errors.New("loopback dialup")
 )
 
 // AdvertisableAddressResolver can Resolve a Multiaddress.
@@ -302,10 +299,6 @@ func (s *Service) parseCheckAck(ack *pb.Ack) (*bzz.Address, error) {
 	bzzAddress, err := bzz.ParseAddress(ack.Address.Underlay, ack.Address.Overlay, ack.Address.Signature, s.networkID)
 	if err != nil {
 		return nil, ErrInvalidAck
-	}
-
-	if bzzAddress.Overlay.Equal(s.overlay) {
-		return nil, ErrLoopbackDialup
 	}
 
 	return bzzAddress, nil

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -50,8 +50,11 @@ var (
 	// ErrInvalidSyn is returned if observable address in ack is not a valid..
 	ErrInvalidSyn = errors.New("invalid syn")
 
-	// ErrWelcomeMessageLength is return if the welcome message is longer than the maximum length
+	// ErrWelcomeMessageLength is returned if the welcome message is longer than the maximum length
 	ErrWelcomeMessageLength = fmt.Errorf("handshake welcome message longer than maximum of %d characters", MaxWelcomeMessageLength)
+
+	// ErrLoopbackDialup is returned when a node tries to connect to itself.
+	ErrLoopbackDialup = errors.New("loopback dialup")
 )
 
 // AdvertisableAddressResolver can Resolve a Multiaddress.
@@ -299,6 +302,10 @@ func (s *Service) parseCheckAck(ack *pb.Ack) (*bzz.Address, error) {
 	bzzAddress, err := bzz.ParseAddress(ack.Address.Underlay, ack.Address.Overlay, ack.Address.Signature, s.networkID)
 	if err != nil {
 		return nil, ErrInvalidAck
+	}
+
+	if bzzAddress.Overlay.Equal(s.overlay) {
+		return nil, ErrLoopbackDialup
 	}
 
 	return bzzAddress, nil


### PR DESCRIPTION
our staging cluster is constantly trying to connect to itself, and because attempt counts are not limited the kademlia iterator never returns from the `connectBootnodes` call.

we probably have other connectivity problems, but we don't have enough visibility on what's going on due to insufficient logging which is mended in this PR.

Another problem is that nodes may get their own address from the DNS discovery and try to connect to themselves. I therefore added a check to `parseCheckAck` to check that a node does not try to connect to itself. This verification is done in the Ack, when a node sends his overlay address.