### PR TITLE
Postage BatchStore and BatchService

### DIFF
--- a/pkg/postage/batch.go
+++ b/pkg/postage/batch.go
@@ -18,7 +18,8 @@ type Batch struct {
 	Depth uint8    // batch depth, i.e., size = 2^{depth}
 }
 
-// MarshalBinary serialises a postage batch to a byte slice len 117.
+// MarshalBinary implements BinaryMarshaller. It will attempt to serialize the
+// postage batch to a byte slice.
 func (b *Batch) MarshalBinary() ([]byte, error) {
 	out := make([]byte, 93)
 	copy(out, b.ID)
@@ -30,8 +31,8 @@ func (b *Batch) MarshalBinary() ([]byte, error) {
 	return out, nil
 }
 
-// UnmarshalBinary deserialises the batch.
-// Unsafe on slice index (len(buf) = 117) as only internally used in db.
+// UnmarshalBinary implements BinaryUnmarshaller. It will attempt deserialize
+// the given byte slice into the batch.
 func (b *Batch) UnmarshalBinary(buf []byte) error {
 	b.ID = buf[:32]
 	b.Value = big.NewInt(0).SetBytes(buf[32:64])

--- a/pkg/postage/batch.go
+++ b/pkg/postage/batch.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"encoding/binary"
+	"math/big"
+)
+
+// Batch represents a postage batch, a payment on the blockchain.
+type Batch struct {
+	ID    []byte   // batch ID
+	Value *big.Int // overall balance of the batch
+	Start uint64   // block number the batch was created
+	Owner []byte   // owner's ethereum address
+	Depth uint8    // batch depth, i.e., size = 2^{depth}
+}
+
+// MarshalBinary serialises a postage batch to a byte slice len 117.
+func (b *Batch) MarshalBinary() ([]byte, error) {
+	out := make([]byte, 93)
+	copy(out, b.ID)
+	value := b.Value.Bytes()
+	copy(out[64-len(value):], value)
+	binary.BigEndian.PutUint64(out[64:72], b.Start)
+	copy(out[72:], b.Owner)
+	out[92] = b.Depth
+	return out, nil
+}
+
+// UnmarshalBinary deserialises the batch.
+// Unsafe on slice index (len(buf) = 117) as only internally used in db.
+func (b *Batch) UnmarshalBinary(buf []byte) error {
+	b.ID = buf[:32]
+	b.Value = big.NewInt(0).SetBytes(buf[32:64])
+	b.Start = binary.BigEndian.Uint64(buf[64:72])
+	b.Owner = buf[72:92]
+	b.Depth = buf[92]
+	return nil
+}

--- a/pkg/postage/batch_test.go
+++ b/pkg/postage/batch_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package postage_test
 
 import (

--- a/pkg/postage/batch_test.go
+++ b/pkg/postage/batch_test.go
@@ -1,0 +1,41 @@
+package postage_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+)
+
+// TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a Batch.
+func TestBatchMarshalling(t *testing.T) {
+	a := postagetesting.MustNewBatch()
+
+	buf, err := a.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buf) != 93 {
+		t.Fatalf("invalid length for serialised batch. expected 93, got %d", len(buf))
+	}
+	b := &postage.Batch{}
+	if err := b.UnmarshalBinary(buf); err != nil {
+		t.Fatalf("unexpected error unmarshalling batch: %v", err)
+	}
+	if !bytes.Equal(b.ID, a.ID) {
+		t.Fatalf("id mismatch, expected %x, got %x", a.ID, b.ID)
+	}
+	if !bytes.Equal(b.Owner, a.Owner) {
+		t.Fatalf("owner mismatch, expected %x, got %x", a.Owner, b.Owner)
+	}
+	if a.Value.Uint64() != b.Value.Uint64() {
+		t.Fatalf("value mismatch, expected %d, got %d", a.Value.Uint64(), b.Value.Uint64())
+	}
+	if a.Start != b.Start {
+		t.Fatalf("start mismatch, expected %d, got %d", a.Start, b.Start)
+	}
+	if a.Depth != b.Depth {
+		t.Fatalf("depth mismatch, expected %d, got %d", a.Depth, b.Depth)
+	}
+}

--- a/pkg/postage/batch_test.go
+++ b/pkg/postage/batch_test.go
@@ -12,7 +12,8 @@ import (
 	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 )
 
-// TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a Batch.
+// TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a
+// Batch.
 func TestBatchMarshalling(t *testing.T) {
 	a := postagetesting.MustNewBatch()
 

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -13,8 +13,7 @@ import (
 	"github.com/ethersphere/bee/pkg/postage"
 )
 
-// BatchService implements the EventUpdater interface.
-type BatchService struct {
+type batchService struct {
 	cs     *postage.ChainState
 	storer postage.Storer
 	logger logging.Logger
@@ -22,7 +21,7 @@ type BatchService struct {
 
 // New will create a new BatchService.
 func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, error) {
-	b := &BatchService{
+	b := &batchService{
 		storer: storer,
 		logger: logger,
 	}
@@ -37,7 +36,7 @@ func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, er
 }
 
 // Create will create a new batch and store it in the BatchStore.
-func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) error {
+func (svc *batchService) Create(id, owner []byte, value *big.Int, depth uint8) error {
 	b := &postage.Batch{
 		ID:    id,
 		Owner: owner,
@@ -57,7 +56,7 @@ func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 
 // TopUp implements the EventUpdater interface. It tops ups a batch with the
 // given ID with the given amount of BZZ.
-func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
+func (svc *batchService) TopUp(id []byte, amount *big.Int) error {
 	b, err := svc.storer.Get(id)
 	if err != nil {
 		return fmt.Errorf("get: %w", err)
@@ -76,7 +75,7 @@ func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
 
 // UpdateDepth implements the EventUpdater inteface. It sets the new depth of a
 // batch with the given ID.
-func (svc *BatchService) UpdateDepth(id []byte, depth uint8) error {
+func (svc *batchService) UpdateDepth(id []byte, depth uint8) error {
 	b, err := svc.storer.Get(id)
 	if err != nil {
 		return fmt.Errorf("get: %w", err)
@@ -95,7 +94,7 @@ func (svc *BatchService) UpdateDepth(id []byte, depth uint8) error {
 
 // UpdatePrice implements the EventUpdater interface. It sets the current
 // price from the chain in the service chain state.
-func (svc *BatchService) UpdatePrice(price *big.Int) error {
+func (svc *batchService) UpdatePrice(price *big.Int) error {
 	svc.cs.Price = price
 
 	if err := svc.storer.PutChainState(svc.cs); err != nil {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -35,7 +35,8 @@ func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, er
 	return b, nil
 }
 
-// Create will create a new batch and store it in the BatchStore.
+// Create will create a new batch with the given ID, owner value and depth and
+// stores it in the BatchStore.
 func (svc *batchService) Create(id, owner []byte, value *big.Int, depth uint8) error {
 	b := &postage.Batch{
 		ID:    id,
@@ -55,7 +56,7 @@ func (svc *batchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 }
 
 // TopUp implements the EventUpdater interface. It tops ups a batch with the
-// given ID with the given amount of BZZ.
+// given ID with the given amount.
 func (svc *batchService) TopUp(id []byte, amount *big.Int) error {
 	b, err := svc.storer.Get(id)
 	if err != nil {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -29,7 +29,7 @@ func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, er
 
 	cs, err := storer.GetChainState()
 	if err != nil {
-		return nil, fmt.Errorf("new batch service: %v", err)
+		return nil, fmt.Errorf("get chain state: %w", err)
 	}
 	b.cs = cs
 
@@ -48,7 +48,7 @@ func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 
 	err := svc.storer.Put(b)
 	if err != nil {
-		return fmt.Errorf("CreateBatch: %w", err)
+		return fmt.Errorf("put: %w", err)
 	}
 
 	svc.logger.Debugf("created batch id %s", hex.EncodeToString(b.ID))
@@ -60,14 +60,14 @@ func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
 	b, err := svc.storer.Get(id)
 	if err != nil {
-		return fmt.Errorf("TopUp: %w", err)
+		return fmt.Errorf("get: %w", err)
 	}
 
 	b.Value.Add(b.Value, amount)
 
 	err = svc.storer.Put(b)
 	if err != nil {
-		return fmt.Errorf("TopUp: %w", err)
+		return fmt.Errorf("put: %w", err)
 	}
 
 	svc.logger.Debugf("topped up batch id %s with %v", hex.EncodeToString(b.ID), b.Value)
@@ -79,14 +79,14 @@ func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
 func (svc *BatchService) UpdateDepth(id []byte, depth uint8) error {
 	b, err := svc.storer.Get(id)
 	if err != nil {
-		return err
+		return fmt.Errorf("get: %w", err)
 	}
 
 	b.Depth = depth
 
 	err = svc.storer.Put(b)
 	if err != nil {
-		return fmt.Errorf("update depth: %w", err)
+		return fmt.Errorf("put: %w", err)
 	}
 
 	svc.logger.Debugf("updated depth of batch id %s to %d", hex.EncodeToString(b.ID), b.Depth)
@@ -99,7 +99,7 @@ func (svc *BatchService) UpdatePrice(price *big.Int) error {
 	svc.cs.Price = price
 
 	if err := svc.storer.PutChainState(svc.cs); err != nil {
-		return fmt.Errorf("update price: %w", err)
+		return fmt.Errorf("put chain state: %w", err)
 	}
 
 	svc.logger.Debugf("updated chain price to %s", svc.cs.Price)

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -51,7 +51,7 @@ func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 		return fmt.Errorf("CreateBatch: %w", err)
 	}
 
-	svc.logger.Debugf("created batch id %x", hex.EncodeToString(b.ID))
+	svc.logger.Debugf("created batch id %s", hex.EncodeToString(b.ID))
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
 		return fmt.Errorf("TopUp: %w", err)
 	}
 
-	svc.logger.Debugf("topped up batch id %x with %v", hex.EncodeToString(b.ID), b.Value)
+	svc.logger.Debugf("topped up batch id %s with %v", hex.EncodeToString(b.ID), b.Value)
 	return nil
 }
 
@@ -89,7 +89,7 @@ func (svc *BatchService) UpdateDepth(id []byte, depth uint8) error {
 		return fmt.Errorf("update depth: %w", err)
 	}
 
-	svc.logger.Debugf("updated depth of batch id %x to %d", hex.EncodeToString(b.ID), b.Depth)
+	svc.logger.Debugf("updated depth of batch id %s to %d", hex.EncodeToString(b.ID), b.Depth)
 	return nil
 }
 

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -22,7 +22,7 @@ type BatchService struct {
 
 // New will create a new BatchService.
 func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, error) {
-	b := BatchService{
+	b := &BatchService{
 		storer: storer,
 		logger: logger,
 	}
@@ -33,12 +33,12 @@ func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, er
 	}
 	b.cs = cs
 
-	return &b, nil
+	return b, nil
 }
 
 // Create will create a new batch and store it in the BatchStore.
 func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) error {
-	b := postage.Batch{
+	b := &postage.Batch{
 		ID:    id,
 		Owner: owner,
 		Value: value,
@@ -46,7 +46,7 @@ func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) e
 		Depth: depth,
 	}
 
-	err := svc.storer.Put(&b)
+	err := svc.storer.Put(b)
 	if err != nil {
 		return fmt.Errorf("CreateBatch: %w", err)
 	}

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package batchservice
 
 import (

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -1,0 +1,103 @@
+package batchservice
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+// BatchService implements the EventUpdater interface.
+type BatchService struct {
+	cs     *postage.ChainState
+	storer postage.Storer
+	logger logging.Logger
+}
+
+// New will create a new BatchService.
+func New(storer postage.Storer, logger logging.Logger) (postage.EventUpdater, error) {
+	b := BatchService{
+		storer: storer,
+		logger: logger,
+	}
+
+	cs, err := storer.GetChainState()
+	if err != nil {
+		return nil, fmt.Errorf("new batch service: %v", err)
+	}
+	b.cs = cs
+
+	return &b, nil
+}
+
+// Create will create a new batch and store it in the BatchStore.
+func (svc *BatchService) Create(id, owner []byte, value *big.Int, depth uint8) error {
+	b := postage.Batch{
+		ID:    id,
+		Owner: owner,
+		Value: value,
+		Start: svc.cs.Block,
+		Depth: depth,
+	}
+
+	err := svc.storer.Put(&b)
+	if err != nil {
+		return fmt.Errorf("CreateBatch: %w", err)
+	}
+
+	svc.logger.Debugf("created batch id %x", hex.EncodeToString(b.ID))
+	return nil
+}
+
+// TopUp implements the EventUpdater interface. It tops ups a batch with the
+// given ID with the given amount of BZZ.
+func (svc *BatchService) TopUp(id []byte, amount *big.Int) error {
+	b, err := svc.storer.Get(id)
+	if err != nil {
+		return fmt.Errorf("TopUp: %w", err)
+	}
+
+	b.Value.Add(b.Value, amount)
+
+	err = svc.storer.Put(b)
+	if err != nil {
+		return fmt.Errorf("TopUp: %w", err)
+	}
+
+	svc.logger.Debugf("topped up batch id %x with %v", hex.EncodeToString(b.ID), b.Value)
+	return nil
+}
+
+// UpdateDepth implements the EventUpdater inteface. It sets the new depth of a
+// batch with the given ID.
+func (svc *BatchService) UpdateDepth(id []byte, depth uint8) error {
+	b, err := svc.storer.Get(id)
+	if err != nil {
+		return err
+	}
+
+	b.Depth = depth
+
+	err = svc.storer.Put(b)
+	if err != nil {
+		return fmt.Errorf("update depth: %w", err)
+	}
+
+	svc.logger.Debugf("updated depth of batch id %x to %d", hex.EncodeToString(b.ID), b.Depth)
+	return nil
+}
+
+// UpdatePrice implements the EventUpdater interface. It sets the current
+// price from the chain in the service chain state.
+func (svc *BatchService) UpdatePrice(price *big.Int) error {
+	svc.cs.Price = price
+
+	if err := svc.storer.PutChainState(svc.cs); err != nil {
+		return fmt.Errorf("update price: %w", err)
+	}
+
+	svc.logger.Debugf("updated chain price to %s", svc.cs.Price)
+	return nil
+}

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -1,0 +1,268 @@
+package batchservice_test
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"math/big"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/postage/batchservice"
+	"github.com/ethersphere/bee/pkg/postage/batchstore/mock"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+)
+
+var (
+	testLog = logging.New(ioutil.Discard, 0)
+	testErr = errors.New("fails")
+)
+
+func TestNewBatchService(t *testing.T) {
+	t.Run("expect get error", func(t *testing.T) {
+		store := mock.New(
+			mock.WithGetErr(testErr, 0),
+		)
+		_, err := batchservice.New(store, testLog)
+		if err == nil {
+			t.Fatal("expected get error")
+		}
+	})
+
+	t.Run("passes", func(t *testing.T) {
+		testChainState := postagetesting.NewChainState()
+		store := mock.New(
+			mock.WithChainState(testChainState),
+		)
+		_, err := batchservice.New(store, testLog)
+		if err != nil {
+			t.Fatalf("new batch service: %v", err)
+		}
+	})
+}
+
+func TestBatchServiceCreate(t *testing.T) {
+	testBatch := postagetesting.MustNewBatch()
+	testChainState := postagetesting.NewChainState()
+
+	t.Run("expect put create put error", func(t *testing.T) {
+		svc, _ := testNewStoreAndService(
+			t,
+			mock.WithChainState(testChainState),
+			mock.WithPutErr(testErr, 0),
+		)
+
+		if err := svc.Create(
+			testBatch.ID,
+			testBatch.Owner,
+			testBatch.Value,
+			testBatch.Depth,
+		); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("passes", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(
+			t,
+			mock.WithChainState(testChainState),
+		)
+
+		if err := svc.Create(
+			testBatch.ID,
+			testBatch.Owner,
+			testBatch.Value,
+			testBatch.Depth,
+		); err != nil {
+			t.Fatalf("got error %v", err)
+		}
+
+		got, err := batchStore.Get(testBatch.ID)
+		if err != nil {
+			t.Fatalf("batch store get: %v", err)
+		}
+
+		if !bytes.Equal(got.ID, testBatch.ID) {
+			t.Fatalf("batch id: want %v, got %v", testBatch.ID, got.ID)
+		}
+		if !bytes.Equal(got.Owner, testBatch.Owner) {
+			t.Fatalf("batch owner: want %v, got %v", testBatch.Owner, got.Owner)
+		}
+		if got.Value.Cmp(testBatch.Value) != 0 {
+			t.Fatalf("batch value: want %v, got %v", testBatch.Value.String(), got.Value.String())
+		}
+		if got.Depth != testBatch.Depth {
+			t.Fatalf("batch depth: want %v, got %v", got.Depth, testBatch.Depth)
+		}
+		if got.Start != testChainState.Block {
+			t.Fatalf("batch start block different form chain state: want %v, got %v", got.Start, testChainState.Block)
+		}
+
+	})
+
+}
+
+func TestBatchServiceTopUp(t *testing.T) {
+	testBatch := postagetesting.MustNewBatch()
+	testTopUpAmount := big.NewInt(10000000000000)
+
+	t.Run("expect get error", func(t *testing.T) {
+		svc, _ := testNewStoreAndService(
+			t,
+			// NOTE: we skip the error on the first get call in batchservice.New.
+			mock.WithGetErr(testErr, 1),
+		)
+
+		if err := svc.TopUp(testBatch.ID, testTopUpAmount); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("expect put error", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(
+			t,
+			mock.WithPutErr(testErr, 1),
+		)
+		putBatch(t, batchStore, testBatch)
+
+		if err := svc.TopUp(testBatch.ID, testTopUpAmount); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("passes", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(t)
+		putBatch(t, batchStore, testBatch)
+
+		want := testBatch.Value
+		want.Add(want, testTopUpAmount)
+
+		if err := svc.TopUp(testBatch.ID, testTopUpAmount); err != nil {
+			t.Fatalf("top up: %v", err)
+		}
+
+		got, err := batchStore.Get(testBatch.ID)
+		if err != nil {
+			t.Fatalf("batch store get: %v", err)
+		}
+
+		if got.Value.Cmp(want) != 0 {
+			t.Fatalf("topped up amount: got %v, want %v", got.Value, want)
+		}
+
+	})
+}
+
+func TestBatchServiceUpdateDepth(t *testing.T) {
+	const testNewDepth = 30
+	testBatch := postagetesting.MustNewBatch()
+
+	t.Run("expect get error", func(t *testing.T) {
+		svc, _ := testNewStoreAndService(
+			t,
+			mock.WithGetErr(testErr, 1),
+		)
+
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth); err == nil {
+			t.Fatal("expected get error")
+		}
+	})
+
+	t.Run("expect put error", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(
+			t,
+			mock.WithPutErr(testErr, 1),
+		)
+		putBatch(t, batchStore, testBatch)
+
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth); err == nil {
+			t.Fatal("expected put error")
+		}
+	})
+
+	t.Run("passes", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(t)
+		putBatch(t, batchStore, testBatch)
+
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth); err != nil {
+			t.Fatalf("update depth: %v", err)
+		}
+
+		val, err := batchStore.Get(testBatch.ID)
+		if err != nil {
+			t.Fatalf("batch store get: %v", err)
+		}
+
+		if val.Depth != testNewDepth {
+			t.Fatalf("wrong batch depth set: want %v, got %v", testNewDepth, val.Depth)
+		}
+	})
+}
+
+func TestBatchServiceUpdatePrice(t *testing.T) {
+	testChainState := postagetesting.NewChainState()
+	testChainState.Price = big.NewInt(100000)
+	testNewPrice := big.NewInt(20000000)
+
+	t.Run("expect put error", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(
+			t,
+			mock.WithChainState(testChainState),
+			mock.WithPutErr(testErr, 1),
+		)
+		putChainState(t, batchStore, testChainState)
+
+		if err := svc.UpdatePrice(testNewPrice); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("passes", func(t *testing.T) {
+		svc, batchStore := testNewStoreAndService(
+			t,
+			mock.WithChainState(testChainState),
+		)
+
+		if err := svc.UpdatePrice(testNewPrice); err != nil {
+			t.Fatalf("update price: %v", err)
+		}
+
+		cs, err := batchStore.GetChainState()
+		if err != nil {
+			t.Fatalf("batch store get chain state: %v", err)
+		}
+
+		if cs.Price.Cmp(testNewPrice) != 0 {
+			t.Fatalf("bad price: want %v, got %v", cs.Price, testNewPrice)
+		}
+	})
+}
+
+func testNewStoreAndService(t *testing.T, opts ...mock.Option) (postage.EventUpdater, postage.Storer) {
+	t.Helper()
+
+	store := mock.New(opts...)
+	svc, err := batchservice.New(store, testLog)
+	if err != nil {
+		t.Fatalf("new batch service: %v", err)
+	}
+
+	return svc, store
+}
+
+func putBatch(t *testing.T, store postage.Storer, b *postage.Batch) {
+	t.Helper()
+
+	if err := store.Put(b); err != nil {
+		t.Fatalf("store put batch: %v", err)
+	}
+}
+
+func putChainState(t *testing.T, store postage.Storer, cs *postage.ChainState) {
+	t.Helper()
+
+	if err := store.PutChainState(cs); err != nil {
+		t.Fatalf("store put chain state: %v", err)
+	}
+}

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -51,7 +51,7 @@ func TestBatchServiceCreate(t *testing.T) {
 	testChainState := postagetesting.NewChainState()
 
 	t.Run("expect put create put error", func(t *testing.T) {
-		svc, _ := testNewStoreAndService(
+		svc, _ := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
 			mock.WithPutErr(testErr, 0),
@@ -68,7 +68,7 @@ func TestBatchServiceCreate(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(
+		svc, batchStore := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
 		)
@@ -112,7 +112,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	testTopUpAmount := big.NewInt(10000000000000)
 
 	t.Run("expect get error", func(t *testing.T) {
-		svc, _ := testNewStoreAndService(
+		svc, _ := newTestStoreAndService(
 			t,
 			// NOTE: we skip the error on the first get call in batchservice.New.
 			mock.WithGetErr(testErr, 1),
@@ -124,7 +124,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	})
 
 	t.Run("expect put error", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(
+		svc, batchStore := newTestStoreAndService(
 			t,
 			mock.WithPutErr(testErr, 1),
 		)
@@ -136,7 +136,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(t)
+		svc, batchStore := newTestStoreAndService(t)
 		putBatch(t, batchStore, testBatch)
 
 		want := testBatch.Value
@@ -163,7 +163,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	testBatch := postagetesting.MustNewBatch()
 
 	t.Run("expect get error", func(t *testing.T) {
-		svc, _ := testNewStoreAndService(
+		svc, _ := newTestStoreAndService(
 			t,
 			mock.WithGetErr(testErr, 1),
 		)
@@ -174,7 +174,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	})
 
 	t.Run("expect put error", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(
+		svc, batchStore := newTestStoreAndService(
 			t,
 			mock.WithPutErr(testErr, 1),
 		)
@@ -186,7 +186,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(t)
+		svc, batchStore := newTestStoreAndService(t)
 		putBatch(t, batchStore, testBatch)
 
 		if err := svc.UpdateDepth(testBatch.ID, testNewDepth); err != nil {
@@ -210,7 +210,7 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 	testNewPrice := big.NewInt(20000000)
 
 	t.Run("expect put error", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(
+		svc, batchStore := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
 			mock.WithPutErr(testErr, 1),
@@ -223,7 +223,7 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore := testNewStoreAndService(
+		svc, batchStore := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
 		)
@@ -243,7 +243,7 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 	})
 }
 
-func testNewStoreAndService(t *testing.T, opts ...mock.Option) (postage.EventUpdater, postage.Storer) {
+func newTestStoreAndService(t *testing.T, opts ...mock.Option) (postage.EventUpdater, postage.Storer) {
 	t.Helper()
 
 	store := mock.New(opts...)

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package batchservice_test
 
 import (

--- a/pkg/postage/batchstore/export_test.go
+++ b/pkg/postage/batchstore/export_test.go
@@ -4,6 +4,8 @@
 
 package batchstore
 
+// StateKey is the localstore key for the chain state.
 const StateKey = stateKey
 
+// BatchKey returns the index key for the batch ID used in the by-ID batch index.
 var BatchKey = batchKey

--- a/pkg/postage/batchstore/export_test.go
+++ b/pkg/postage/batchstore/export_test.go
@@ -2,12 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package postage
+package batchstore
 
-import (
-	"github.com/ethersphere/bee/pkg/swarm"
-)
+const StateKey = stateKey
 
-func (st *StampIssuer) Inc(a swarm.Address) error {
-	return st.inc(a)
-}
+var BatchKey = batchKey

--- a/pkg/postage/batchstore/mock/store.go
+++ b/pkg/postage/batchstore/mock/store.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+var _ postage.Storer = (*BatchStore)(nil)
+
+// BatchStore is a mock BatchStorer
+type BatchStore struct {
+	cs             *postage.ChainState
+	id             []byte
+	batch          *postage.Batch
+	getErr         error
+	getErrDelayCnt int
+	putErr         error
+	putErrDelayCnt int
+}
+
+// Option is a an option passed to New
+type Option func(*BatchStore)
+
+// New creates a new mock BatchStore
+func New(opts ...Option) *BatchStore {
+	var bs BatchStore
+
+	for _, o := range opts {
+		o(&bs)
+	}
+
+	return &bs
+}
+
+// WithChainState the initial ChainStore
+func WithChainState(cs *postage.ChainState) Option {
+	return func(bs *BatchStore) {
+		bs.cs = cs
+	}
+}
+
+// WithGetErr will set the get error returned by the ChainStore mock. The error
+// will be returned on each subsequent call after delayCnt calls to Get have
+// been made.
+func WithGetErr(err error, delayCnt int) Option {
+	return func(bs *BatchStore) {
+		bs.getErr = err
+		bs.getErrDelayCnt = delayCnt
+	}
+}
+
+// WithPutErr will set the put error returned by the ChainStore mock. The error
+// will be returned on each subsequent call after delayCnt calls to Put have
+// been made.
+func WithPutErr(err error, delayCnt int) Option {
+	return func(bs *BatchStore) {
+		bs.putErr = err
+		bs.putErrDelayCnt = delayCnt
+	}
+}
+
+// Get mocks the Get method from the BatchStore
+func (bs *BatchStore) Get(id []byte) (*postage.Batch, error) {
+	if bs.getErr != nil {
+		if bs.getErrDelayCnt == 0 {
+			return nil, bs.getErr
+		}
+		bs.getErrDelayCnt--
+	}
+	if !bytes.Equal(bs.id, id) {
+		return nil, errors.New("no such id")
+	}
+	return bs.batch, nil
+}
+
+// Put mocks the Put method from the BatchStore
+func (bs *BatchStore) Put(batch *postage.Batch) error {
+	if bs.putErr != nil {
+		if bs.putErrDelayCnt == 0 {
+			return bs.putErr
+		}
+		bs.putErrDelayCnt--
+	}
+	bs.batch = batch
+	bs.id = batch.ID
+	return nil
+}
+
+// GetChainState mocks the GetChainState method from the BatchStore
+func (bs *BatchStore) GetChainState() (*postage.ChainState, error) {
+	if bs.getErr != nil {
+		if bs.getErrDelayCnt == 0 {
+			return nil, bs.getErr
+		}
+		bs.getErrDelayCnt--
+	}
+	return bs.cs, nil
+}
+
+// PutChainState mocks the PutChainState method from the BatchStore
+func (bs *BatchStore) PutChainState(cs *postage.ChainState) error {
+	if bs.putErr != nil {
+		if bs.putErrDelayCnt == 0 {
+			return bs.putErr
+		}
+		bs.putErrDelayCnt--
+	}
+	bs.cs = cs
+	return nil
+}

--- a/pkg/postage/batchstore/mock/store.go
+++ b/pkg/postage/batchstore/mock/store.go
@@ -29,13 +29,13 @@ type Option func(*BatchStore)
 
 // New creates a new mock BatchStore
 func New(opts ...Option) *BatchStore {
-	var bs BatchStore
+	bs := &BatchStore{}
 
 	for _, o := range opts {
-		o(&bs)
+		o(bs)
 	}
 
-	return &bs
+	return bs
 }
 
 // WithChainState the initial ChainStore

--- a/pkg/postage/batchstore/mock/store.go
+++ b/pkg/postage/batchstore/mock/store.go
@@ -38,7 +38,7 @@ func New(opts ...Option) *BatchStore {
 	return bs
 }
 
-// WithChainState the initial ChainStore
+// WithChainState will set the initial chainstate in the ChainStore mock.
 func WithChainState(cs *postage.ChainState) Option {
 	return func(bs *BatchStore) {
 		bs.cs = cs

--- a/pkg/postage/batchstore/mock/store_test.go
+++ b/pkg/postage/batchstore/mock/store_test.go
@@ -19,7 +19,9 @@ func TestBatchStoreGet(t *testing.T) {
 	batchStore := mock.New(
 		mock.WithGetErr(errors.New("fails"), 3),
 	)
-	batchStore.Put(testBatch)
+	if err := batchStore.Put(testBatch); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := batchStore.Get(postagetesting.MustNewID()); err == nil {
 		t.Fatal("expected error")

--- a/pkg/postage/batchstore/mock/store_test.go
+++ b/pkg/postage/batchstore/mock/store_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage/batchstore/mock"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+)
+
+func TestBatchStoreGet(t *testing.T) {
+	const testCnt = 3
+
+	testBatch := postagetesting.MustNewBatch()
+	batchStore := mock.New(
+		mock.WithGetErr(errors.New("fails"), 3),
+	)
+	batchStore.Put(testBatch)
+
+	if _, err := batchStore.Get(postagetesting.MustNewID()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	for i := 0; i < testCnt-1; i++ {
+		if _, err := batchStore.Get(testBatch.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := batchStore.Get(postagetesting.MustNewID()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestBatchStorePut(t *testing.T) {
+	const testCnt = 3
+
+	testBatch := postagetesting.MustNewBatch()
+	batchStore := mock.New(
+		mock.WithPutErr(errors.New("fails"), 3),
+	)
+
+	for i := 0; i < testCnt; i++ {
+		if err := batchStore.Put(testBatch); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := batchStore.Put(testBatch); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -11,8 +11,7 @@ import (
 
 const (
 	batchKeyPrefix = "batchKeyPrefix"
-	// valueKeyPrefix = "valueKeyPrefix"
-	stateKey = "stateKey"
+	stateKey       = "stateKey"
 )
 
 type store struct {

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -15,15 +15,15 @@ const (
 )
 
 type store struct {
-	store storage.StateStorer // State store backend to persist batches
+	store storage.StateStorer // State store backend to persist batches.
 }
 
-// New constructs a new postage batch store
+// New constructs a new postage batch store.
 func New(st storage.StateStorer) postage.Storer {
 	return &store{st}
 }
 
-// Get returns a batch from the batchstore with the given ID
+// Get returns a batch from the batchstore with the given ID.
 func (s *store) Get(id []byte) (*postage.Batch, error) {
 	b := &postage.Batch{}
 	err := s.store.Get(batchKey(id), b)
@@ -31,19 +31,19 @@ func (s *store) Get(id []byte) (*postage.Batch, error) {
 	return b, err
 }
 
-// Put stores a given batch in the batchstore with the given ID
+// Put stores a given batch in the batchstore with the given ID.
 func (s *store) Put(b *postage.Batch) error {
 	return s.store.Put(batchKey(b.ID), b)
 }
 
 // PutChainState implements BatchStorer. It stores the chain state in the batch
-// store
+// store.
 func (s *store) PutChainState(state *postage.ChainState) error {
 	return s.store.Put(stateKey, state)
 }
 
 // GetChainState implements BatchStorer. It returns the stored chain state from
-// the batch store
+// the batch store.
 func (s *store) GetChainState() (*postage.ChainState, error) {
 	cs := &postage.ChainState{}
 	err := s.store.Get(stateKey, cs)
@@ -51,7 +51,7 @@ func (s *store) GetChainState() (*postage.ChainState, error) {
 	return cs, err
 }
 
-// batchKey returns the index key for the batch ID used in the by-ID batch index
+// batchKey returns the index key for the batch ID used in the by-ID batch index.
 func batchKey(id []byte) string {
 	return batchKeyPrefix + string(id)
 }

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package batchstore
+
+import (
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/storage"
+)
+
+const (
+	batchKeyPrefix = "batchKeyPrefix"
+	// valueKeyPrefix = "valueKeyPrefix"
+	stateKey = "stateKey"
+)
+
+type store struct {
+	store storage.StateStorer // State store backend to persist batches
+}
+
+// New constructs a new postage batch store
+func New(st storage.StateStorer) postage.Storer {
+	return &store{st}
+}
+
+// Get returns a batch from the batchstore with the given ID
+func (s *store) Get(id []byte) (*postage.Batch, error) {
+	var b postage.Batch
+	err := s.store.Get(batchKey(id), &b)
+	return &b, err
+}
+
+// Put stores a given batch in the batchstore with the given ID
+func (s *store) Put(b *postage.Batch) error {
+	return s.store.Put(batchKey(b.ID), b)
+}
+
+// PutChainState implements BatchStorer. It stores the chain state in the batch
+// store
+func (s *store) PutChainState(state *postage.ChainState) error {
+	return s.store.Put(stateKey, state)
+}
+
+// GetChainState implements BatchStorer. It returns the stored chain state from
+// the batch store
+func (s *store) GetChainState() (*postage.ChainState, error) {
+	var cs postage.ChainState
+	err := s.store.Get(stateKey, &cs)
+	return &cs, err
+}
+
+// batchKey returns the index key for the batch ID used in the by-ID batch index
+func batchKey(id []byte) string {
+	return batchKeyPrefix + string(id)
+}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -25,9 +25,10 @@ func New(st storage.StateStorer) postage.Storer {
 
 // Get returns a batch from the batchstore with the given ID
 func (s *store) Get(id []byte) (*postage.Batch, error) {
-	var b postage.Batch
-	err := s.store.Get(batchKey(id), &b)
-	return &b, err
+	b := &postage.Batch{}
+	err := s.store.Get(batchKey(id), b)
+
+	return b, err
 }
 
 // Put stores a given batch in the batchstore with the given ID
@@ -44,9 +45,10 @@ func (s *store) PutChainState(state *postage.ChainState) error {
 // GetChainState implements BatchStorer. It returns the stored chain state from
 // the batch store
 func (s *store) GetChainState() (*postage.ChainState, error) {
-	var cs postage.ChainState
-	err := s.store.Get(stateKey, &cs)
-	return &cs, err
+	cs := &postage.ChainState{}
+	err := s.store.Get(stateKey, cs)
+
+	return cs, err
 }
 
 // batchKey returns the index key for the batch ID used in the by-ID batch index

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package batchstore_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/postage/batchstore"
+	postagetest "github.com/ethersphere/bee/pkg/postage/testing"
+	"github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/storage"
+)
+
+func TestBatchStoreGet(t *testing.T) {
+	testBatch := postagetest.MustNewBatch()
+	key := batchstore.BatchKey(testBatch.ID)
+
+	stateStore := mock.NewStateStore()
+	batchStore := batchstore.New(stateStore)
+
+	stateStorePut(t, stateStore, key, testBatch)
+	got := batchStoreGetBatch(t, batchStore, testBatch.ID)
+	postagetest.CompareBatches(t, testBatch, got)
+}
+
+func TestBatchStorePut(t *testing.T) {
+	testBatch := postagetest.MustNewBatch()
+	key := batchstore.BatchKey(testBatch.ID)
+
+	stateStore := mock.NewStateStore()
+	batchStore := batchstore.New(stateStore)
+
+	batchStorePutBatch(t, batchStore, testBatch)
+
+	var got postage.Batch
+	stateStoreGet(t, stateStore, key, &got)
+	postagetest.CompareBatches(t, testBatch, &got)
+}
+
+func TestBatchStoreGetChainState(t *testing.T) {
+	testChainState := postagetest.NewChainState()
+
+	stateStore := mock.NewStateStore()
+	bStore := batchstore.New(stateStore)
+
+	stateStorePut(t, stateStore, batchstore.StateKey, testChainState)
+	got := batchStoreGetChainState(t, bStore)
+	postagetest.CompareChainState(t, testChainState, got)
+}
+
+func TestBatchStorePutChainState(t *testing.T) {
+	testChainState := postagetest.NewChainState()
+
+	stateStore := mock.NewStateStore()
+	bStore := batchstore.New(stateStore)
+
+	batchStorePutChainState(t, bStore, testChainState)
+	var got postage.ChainState
+	stateStoreGet(t, stateStore, batchstore.StateKey, &got)
+	postagetest.CompareChainState(t, testChainState, &got)
+}
+
+func stateStoreGet(t *testing.T, st storage.StateStorer, k string, v interface{}) {
+	if err := st.Get(k, v); err != nil {
+		t.Fatalf("store get batch: %v", err)
+	}
+}
+
+func stateStorePut(t *testing.T, st storage.StateStorer, k string, v interface{}) {
+	if err := st.Put(k, v); err != nil {
+		t.Fatalf("store put batch: %v", err)
+	}
+}
+
+func batchStoreGetBatch(t *testing.T, st postage.Storer, id []byte) *postage.Batch {
+	t.Helper()
+	b, err := st.Get(id)
+	if err != nil {
+		t.Fatalf("postage storer get: %v", err)
+	}
+	return b
+}
+
+func batchStorePutBatch(t *testing.T, st postage.Storer, b *postage.Batch) {
+	t.Helper()
+	if err := st.Put(b); err != nil {
+		t.Fatalf("postage storer put: %v", err)
+	}
+}
+
+func batchStorePutChainState(t *testing.T, st postage.Storer, cs *postage.ChainState) {
+	t.Helper()
+	if err := st.PutChainState(cs); err != nil {
+		t.Fatalf("postage storer put chain state: %v", err)
+	}
+}
+
+func batchStoreGetChainState(t *testing.T, st postage.Storer) *postage.ChainState {
+	t.Helper()
+	cs, err := st.GetChainState()
+	if err != nil {
+		t.Fatalf("postage storer get chain state: %v", err)
+	}
+	return cs
+}

--- a/pkg/postage/chainstate.go
+++ b/pkg/postage/chainstate.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package postage
 
 import "math/big"

--- a/pkg/postage/chainstate.go
+++ b/pkg/postage/chainstate.go
@@ -1,0 +1,10 @@
+package postage
+
+import "math/big"
+
+// ChainState contains data the batch service reads from the chain
+type ChainState struct {
+	Block uint64   `json:"block"` // The block number of the last postage event
+	Total *big.Int `json:"total"` // Cumulative amount paid per stamp
+	Price *big.Int `json:"price"` // Bzz/chunk/block normalised price
+}

--- a/pkg/postage/chainstate.go
+++ b/pkg/postage/chainstate.go
@@ -6,9 +6,9 @@ package postage
 
 import "math/big"
 
-// ChainState contains data the batch service reads from the chain
+// ChainState contains data the batch service reads from the chain.
 type ChainState struct {
-	Block uint64   `json:"block"` // The block number of the last postage event
-	Total *big.Int `json:"total"` // Cumulative amount paid per stamp
-	Price *big.Int `json:"price"` // Bzz/chunk/block normalised price
+	Block uint64   `json:"block"` // The block number of the last postage event.
+	Total *big.Int `json:"total"` // Cumulative amount paid per stamp.
+	Price *big.Int `json:"price"` // Bzz/chunk/block normalised price.
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -9,7 +9,7 @@ import (
 )
 
 // EventUpdater interface definitions reflect the updates triggered by events
-// emitted by the postage contract on the blockchain
+// emitted by the postage contract on the blockchain.
 type EventUpdater interface {
 	Create(id []byte, owner []byte, amount *big.Int, depth uint8) error
 	TopUp(id []byte, amount *big.Int) error
@@ -17,8 +17,8 @@ type EventUpdater interface {
 	UpdatePrice(price *big.Int) error
 }
 
-// Storer represents the persistence layer for batches on the current
-// (highest available) block
+// Storer represents the persistence layer for batches on the current (highest
+// available) block.
 type Storer interface {
 	Get(id []byte) (*Batch, error)
 	Put(*Batch) error
@@ -26,7 +26,7 @@ type Storer interface {
 	GetChainState() (*ChainState, error)
 }
 
-// Listener provides a blockchain event iterator
+// Listener provides a blockchain event iterator.
 type Listener interface {
 	Listen(from uint64, updater EventUpdater) error
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postage
+
+import (
+	"math/big"
+)
+
+// EventUpdater interface definitions reflect the updates triggered by events
+// emitted by the postage contract on the blockchain
+type EventUpdater interface {
+	Create(id []byte, owner []byte, amount *big.Int, depth uint8) error
+	TopUp(id []byte, amount *big.Int) error
+	UpdateDepth(id []byte, depth uint8) error
+	UpdatePrice(price *big.Int) error
+}
+
+// Storer represents the persistence layer for batches on the current
+// (highest available) block
+type Storer interface {
+	Get(id []byte) (*Batch, error)
+	Put(*Batch) error
+	PutChainState(*ChainState) error
+	GetChainState() (*ChainState, error)
+}
+
+// Listener provides a blockchain event iterator
+type Listener interface {
+	// - it starts at block from
+	// - it terminates  with no error when quit channel is closed
+	// - if the update function returns an error, the call returns with that error
+	// TODO: remove from, do not leak blockchain internals
+	Listen(from uint64, updater EventUpdater, quit chan struct{}) error
+}

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -28,8 +28,5 @@ type Storer interface {
 
 // Listener provides a blockchain event iterator
 type Listener interface {
-	// - it starts at block from
-	// - if the update function returns an error, the call returns with that error
-	// TODO: remove from, do not leak blockchain internals
 	Listen(from uint64, updater EventUpdater) error
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -29,8 +29,7 @@ type Storer interface {
 // Listener provides a blockchain event iterator
 type Listener interface {
 	// - it starts at block from
-	// - it terminates  with no error when quit channel is closed
 	// - if the update function returns an error, the call returns with that error
 	// TODO: remove from, do not leak blockchain internals
-	Listen(from uint64, updater EventUpdater, quit chan struct{}) error
+	Listen(from uint64, updater EventUpdater) error
 }

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package mock
 
 import "github.com/ethersphere/bee/pkg/postage"

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -6,34 +6,36 @@ package mock
 
 import "github.com/ethersphere/bee/pkg/postage"
 
-func WithMockBatch(id []byte) Option {
-	return optionFunc(func(m *mockPostage) {
+type optionFunc func(*mockPostage)
 
-	})
-}
-
+// Option is an option passed to a mock postage Service.
 type Option interface {
 	apply(*mockPostage)
 }
-type optionFunc func(*mockPostage)
 
 func (f optionFunc) apply(r *mockPostage) { f(r) }
 
+// New creates a new mock postage service.
 func New(o ...Option) postage.Service {
 	m := &mockPostage{}
 	for _, v := range o {
 		v.apply(m)
 	}
 
-	// add the fallback value we have in the api right now.
-	// in the future this needs to go away once batch id becomes
-	// de facto mandatory in the package
+	// Add the fallback value we have in the api right now.
+	// In the future this needs to go away once batch id becomes de facto
+	// mandatory in the package.
 
 	id := make([]byte, 32)
 	st := postage.NewStampIssuer("test fallback", "test identity", id, 24, 6)
 	m.Add(st)
 
 	return m
+}
+
+// WithMockBatch sets the mock batch on the mock postage service.
+func WithMockBatch(id []byte) Option {
+	return optionFunc(func(m *mockPostage) {})
 }
 
 type mockPostage struct {

--- a/pkg/postage/mock/stamper.go
+++ b/pkg/postage/mock/stamper.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package mock
 
 import (

--- a/pkg/postage/mock/stamper.go
+++ b/pkg/postage/mock/stamper.go
@@ -11,10 +11,12 @@ import (
 
 type mockStamper struct{}
 
+// NewStamper returns anew new mock stamper.
 func NewStamper() postage.Stamper {
 	return &mockStamper{}
 }
 
+// Stamp implements the Stamper interface. It returns an empty postage stamp.
 func (mockStamper) Stamp(_ swarm.Address) (*postage.Stamp, error) {
 	return &postage.Stamp{}, nil
 }

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -22,6 +22,7 @@ var (
 	ErrNotFound = errors.New("not found")
 )
 
+// Service is the postage service interface.
 type Service interface {
 	Add(*StampIssuer)
 	StampIssuers() []*StampIssuer

--- a/pkg/postage/stamp.go
+++ b/pkg/postage/stamp.go
@@ -6,9 +6,7 @@ package postage
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
-	"math/big"
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -23,38 +21,6 @@ var (
 	// ErrStampInvalid is the error given if stamp cannot deserialise.
 	ErrStampInvalid = errors.New("invalid stamp")
 )
-
-// Batch represents a postage batch, a payment on the blockchain.
-type Batch struct {
-	ID    []byte   // batch ID
-	Value *big.Int // overall balance of the batch
-	Start uint64   // blocknumber the batch was created
-	Owner []byte   // owner's ethereum address
-	Depth uint8    // batch depth, i.e., size = 2^{depth}
-}
-
-// MarshalBinary serialises a postage batch to a byte slice len 117.
-func (b *Batch) MarshalBinary() ([]byte, error) {
-	out := make([]byte, 93)
-	copy(out, b.ID)
-	value := b.Value.Bytes()
-	copy(out[64-len(value):], value)
-	binary.BigEndian.PutUint64(out[64:72], b.Start)
-	copy(out[72:], b.Owner)
-	out[92] = b.Depth
-	return out, nil
-}
-
-// UnmarshalBinary deserialises the batch.
-// Unsafe on slice index (len(buf) = 117) as only internally used in db.
-func (b *Batch) UnmarshalBinary(buf []byte) error {
-	b.ID = buf[:32]
-	b.Value = big.NewInt(0).SetBytes(buf[32:64])
-	b.Start = binary.BigEndian.Uint64(buf[64:72])
-	b.Owner = buf[72:92]
-	b.Depth = buf[92]
-	return nil
-}
 
 // Valid checks the validity of the postage stamp; in particular:
 // - authenticity - check batch is valid on the blockchain
@@ -88,17 +54,17 @@ type Stamp struct {
 	sig     []byte // common r[32]s[32]v[1]-style 65 byte ECDSA signature
 }
 
-// MewStamp constructs a stamp
+// NewStamp constructs a stamp
 func NewStamp(batchID, sig []byte) *Stamp {
 	return &Stamp{batchID, sig}
 }
 
-// BatchID
+// BatchID returns the batch ID from a stamp
 func (s *Stamp) BatchID() []byte {
 	return s.batchID
 }
 
-// Sig
+// Sig returns the signature of the stamp
 func (s *Stamp) Sig() []byte {
 	return s.sig
 }

--- a/pkg/postage/stamp.go
+++ b/pkg/postage/stamp.go
@@ -54,22 +54,23 @@ type Stamp struct {
 	sig     []byte // common r[32]s[32]v[1]-style 65 byte ECDSA signature
 }
 
-// NewStamp constructs a stamp
+// NewStamp constructs a new stamp from a given batch ID and signature.
 func NewStamp(batchID, sig []byte) *Stamp {
 	return &Stamp{batchID, sig}
 }
 
-// BatchID returns the batch ID from a stamp
+// BatchID returns the batch ID of the stamp.
 func (s *Stamp) BatchID() []byte {
 	return s.batchID
 }
 
-// Sig returns the signature of the stamp
+// Sig returns the signature of the stamp.
 func (s *Stamp) Sig() []byte {
 	return s.sig
 }
 
-// MarshalBinary gives the byte slice serialisation of a stamp: batchID[32]|Signature[65].
+// MarshalBinary gives the byte slice serialisation of a stamp:
+// batchID[32]|Signature[65].
 func (s *Stamp) MarshalBinary() ([]byte, error) {
 	buf := make([]byte, StampSize)
 	copy(buf, s.batchID)
@@ -87,7 +88,8 @@ func (s *Stamp) UnmarshalBinary(buf []byte) error {
 	return nil
 }
 
-// toSignDigest creates a digest to represent the stamp which is to be signed by the owner.
+// toSignDigest creates a digest to represent the stamp which is to be signed by
+// the owner.
 func toSignDigest(addr swarm.Address, id []byte) ([]byte, error) {
 	h := swarm.NewHasher()
 	_, err := h.Write(addr.Bytes())

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -8,18 +8,15 @@ import (
 	"bytes"
 	crand "crypto/rand"
 	"io"
-	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/postage"
-	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 )
 
 // TestStampMarshalling tests the idempotence  of binary marshal/unmarshals for Stamps.
 func TestStampMarshalling(t *testing.T) {
 
-	sExp := postagetesting.NewStamp()
+	sExp := newStamp(t)
 	buf, _ := sExp.MarshalBinary()
 	if len(buf) != postage.StampSize {
 		t.Fatalf("invalid length for serialised stamp. expected %d, got  %d", postage.StampSize, len(buf))
@@ -37,60 +34,19 @@ func TestStampMarshalling(t *testing.T) {
 
 }
 
-// TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a Batch.
-func TestBatchMarshalling(t *testing.T) {
-	a := newTestBatch(t, nil)
-	buf, err := a.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(buf) != 93 {
-		t.Fatalf("invalid length for serialised batch. expected 93, got %d", len(buf))
-	}
-	b := &postage.Batch{}
-	if err := b.UnmarshalBinary(buf); err != nil {
-		t.Fatalf("unexpected error unmarshalling batch: %v", err)
-	}
-	if !bytes.Equal(b.ID, a.ID) {
-		t.Fatalf("id mismatch, expected %x, got %x", a.ID, b.ID)
-	}
-	if !bytes.Equal(b.Owner, a.Owner) {
-		t.Fatalf("owner mismatch, expected %x, got %x", a.Owner, b.Owner)
-	}
-	if a.Value.Uint64() != b.Value.Uint64() {
-		t.Fatalf("value mismatch, expected %d, got %d", a.Value.Uint64(), b.Value.Uint64())
-	}
-	if a.Start != b.Start {
-		t.Fatalf("start mismatch, expected %d, got %d", a.Start, b.Start)
-	}
-	if a.Depth != b.Depth {
-		t.Fatalf("depth mismatch, expected %d, got %d", a.Depth, b.Depth)
+func newStamp(t *testing.T) *postage.Stamp {
+	const idSize = 32
+	const signatureSize = 65
+
+	id := make([]byte, idSize)
+	if _, err := io.ReadFull(crand.Reader, id); err != nil {
+		panic(err)
 	}
 
-}
-
-func newTestBatch(t *testing.T, owner []byte) *postage.Batch {
-	t.Helper()
-	id := make([]byte, 32)
-	_, err := io.ReadFull(crand.Reader, id)
-	if err != nil {
+	sig := make([]byte, signatureSize)
+	if _, err := io.ReadFull(crand.Reader, sig); err != nil {
 		t.Fatal(err)
 	}
-	value64 := rand.Uint64()
-	start64 := rand.Uint64()
-	if owner == nil {
-		owner = make([]byte, 20)
-		_, err = io.ReadFull(crand.Reader, owner)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	depth := uint8(16)
-	return &postage.Batch{
-		ID:    id,
-		Value: big.NewInt(0).SetUint64(value64),
-		Start: start64,
-		Owner: owner,
-		Depth: depth,
-	}
+
+	return postage.NewStamp(id, sig)
 }

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -16,6 +16,7 @@ var (
 	ErrBucketFull = errors.New("bucket full")
 )
 
+// Stamper can issue stamps from the given address.
 type Stamper interface {
 	Stamp(swarm.Address) (*Stamp, error)
 }

--- a/pkg/postage/stamper_test.go
+++ b/pkg/postage/stamper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/postage"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -66,7 +67,10 @@ func TestStamperStamping(t *testing.T) {
 	// tests that Stamps returns with postage.ErrBucketFull iff
 	// issuer has the corresponding collision bucket filled]
 	t.Run("bucket full", func(t *testing.T) {
-		b := newTestBatch(t, owner)
+		b := postagetesting.MustNewBatch(
+			postagetesting.WithOwner(owner),
+		)
+
 		st := postage.NewStampIssuer("", "", b.ID, b.Depth, 8)
 		stamper := postage.NewStamper(st, signer)
 		// issue 1 stamp
@@ -89,7 +93,7 @@ func TestStamperStamping(t *testing.T) {
 			}
 		}
 		// the bucket should now be full, not allowing a stamp for the  pivot chunk
-		_, err := stamper.Stamp(chunkAddr)
+		_, err = stamper.Stamp(chunkAddr)
 		if err != postage.ErrBucketFull {
 			t.Fatalf("expected ErrBucketFull, got %v", err)
 		}

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -15,16 +15,18 @@ import (
 // A StampIssuer instance extends a batch with bucket collision tracking
 // embedded in multiple Stampers, can be used concurrently.
 type StampIssuer struct {
-	label       string     // label to identify the batch period/importance
-	keyID       string     // owner identity
-	batchID     []byte     // the batch stamps are issued from
-	batchDepth  uint8      // batch depth: batch size = 2^{depth}
-	bucketDepth uint8      // bucket depth: the depth of collision buckets uniformity
-	mu          sync.Mutex // mutex for buckets
-	buckets     []uint32   // collision buckets: counts per neighbourhoods limited to 2^{batchdepth-bucketdepth}
+	label       string     // Label to identify the batch period/importance.
+	keyID       string     // Owner identity.
+	batchID     []byte     // The batch stamps are issued from.
+	batchDepth  uint8      // Batch depth: batch size = 2^{depth}.
+	bucketDepth uint8      // Bucket depth: the depth of collision buckets uniformity.
+	mu          sync.Mutex // Mutex for buckets.
+	buckets     []uint32   // Collision buckets: counts per neighbourhoods (limited to 2^{batchdepth-bucketdepth}).
 }
 
-// NewStampIssuer constructs a StampIssuer as an extension of a batch for local upload.
+// NewStampIssuer constructs a StampIssuer as an extension of a batch for local
+// upload.
+//
 // bucketDepth must always be smaller than batchDepth otherwise inc() panics.
 func NewStampIssuer(label, keyID string, batchID []byte, batchDepth, bucketDepth uint8) *StampIssuer {
 	return &StampIssuer{
@@ -37,8 +39,8 @@ func NewStampIssuer(label, keyID string, batchID []byte, batchDepth, bucketDepth
 	}
 }
 
-// inc increments the count in the correct collision bucket
-// for a newly stamped chunk with address addr
+// inc increments the count in the correct collision bucket for a newly stamped
+// chunk with address addr.
 func (st *StampIssuer) inc(addr swarm.Address) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()

--- a/pkg/postage/testing/batch.go
+++ b/pkg/postage/testing/batch.go
@@ -76,7 +76,6 @@ func WithOwner(owner []byte) BatchOption {
 
 // CompareBatches is a testing helper that compares two batches and fails the
 // test if all fields are not equal.
-//
 // Fails on first different value and prints the comparison.
 func CompareBatches(t *testing.T, want, got *postage.Batch) {
 	t.Helper()

--- a/pkg/postage/testing/batch.go
+++ b/pkg/postage/testing/batch.go
@@ -49,29 +49,22 @@ func NewBigInt() *big.Int {
 // MustNewBatch will create a new test batch. Fields that are not supplied will
 // be filled with random data. Panics on errors
 func MustNewBatch(opts ...BatchOption) *postage.Batch {
-	var b postage.Batch
+	b := &postage.Batch{
+		ID:    MustNewID(),
+		Value: NewBigInt(),
+		Start: rand.Uint64(),
+		Depth: defaultDepth,
+	}
 
 	for _, opt := range opts {
-		opt(&b)
+		opt(b)
 	}
 
-	if b.ID == nil {
-		b.ID = MustNewID()
-	}
-	if b.Value == nil {
-		b.Value = NewBigInt()
-	}
-	if b.Value == nil {
-		b.Start = rand.Uint64()
-	}
 	if b.Owner == nil {
 		b.Owner = MustNewAddress()
 	}
-	if b.Depth == 0 {
-		b.Depth = defaultDepth
-	}
 
-	return &b
+	return b
 }
 
 // WithOwner will set the batch owner

--- a/pkg/postage/testing/batch.go
+++ b/pkg/postage/testing/batch.go
@@ -1,0 +1,106 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"io"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+const defaultDepth = 16
+
+// BatchOption is an optional parameter for NewBatch
+type BatchOption func(c *postage.Batch)
+
+// MustNewID will generate a new random ID (32 byte slice). Panics on errors
+func MustNewID() []byte {
+	id := make([]byte, 32)
+	_, err := io.ReadFull(crand.Reader, id)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// MustNewAddress will generate a new random address (20 byte slice). Panics on
+// errors
+func MustNewAddress() []byte {
+	addr := make([]byte, 20)
+	_, err := io.ReadFull(crand.Reader, addr)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+// NewBigInt will generate a new random big int (uint64 base value).
+func NewBigInt() *big.Int {
+	return (new(big.Int)).SetUint64(rand.Uint64())
+}
+
+// MustNewBatch will create a new test batch. Fields that are not supplied will
+// be filled with random data. Panics on errors
+func MustNewBatch(opts ...BatchOption) *postage.Batch {
+	var b postage.Batch
+
+	for _, opt := range opts {
+		opt(&b)
+	}
+
+	if b.ID == nil {
+		b.ID = MustNewID()
+	}
+	if b.Value == nil {
+		b.Value = NewBigInt()
+	}
+	if b.Value == nil {
+		b.Start = rand.Uint64()
+	}
+	if b.Owner == nil {
+		b.Owner = MustNewAddress()
+	}
+	if b.Depth == 0 {
+		b.Depth = defaultDepth
+	}
+
+	return &b
+}
+
+// WithOwner will set the batch owner
+func WithOwner(owner []byte) BatchOption {
+	return func(b *postage.Batch) {
+		b.Owner = owner
+	}
+}
+
+// CompareBatches is a testing helper that compares two batches and returns that
+// fails the test if they are not fully equal.
+//
+// Fails on first different value and prints the comparison.
+func CompareBatches(t *testing.T, want, got *postage.Batch) {
+	t.Helper()
+
+	if !bytes.Equal(want.ID, got.ID) {
+		t.Fatalf("batch ID: want %v, got %v", want.ID, got.ID)
+	}
+	if want.Value.Cmp(got.Value) != 0 {
+		t.Fatalf("value: want %v, got %v", want.Value, got.Value)
+	}
+	if want.Start != got.Start {
+		t.Fatalf("start: want %v, got %b", want.Start, got.Start)
+	}
+	if !bytes.Equal(want.Owner, got.Owner) {
+		t.Fatalf("owner: want %v, got %v", want.Owner, got.Owner)
+	}
+	if want.Depth != got.Depth {
+		t.Fatalf("depth: want %v, got %v", want.Depth, got.Depth)
+	}
+}

--- a/pkg/postage/testing/batch.go
+++ b/pkg/postage/testing/batch.go
@@ -20,7 +20,7 @@ const defaultDepth = 16
 // BatchOption is an optional parameter for NewBatch
 type BatchOption func(c *postage.Batch)
 
-// MustNewID will generate a new random ID (32 byte slice). Panics on errors
+// MustNewID will generate a new random ID (32 byte slice). Panics on errors.
 func MustNewID() []byte {
 	id := make([]byte, 32)
 	_, err := io.ReadFull(crand.Reader, id)
@@ -31,7 +31,7 @@ func MustNewID() []byte {
 }
 
 // MustNewAddress will generate a new random address (20 byte slice). Panics on
-// errors
+// errors.
 func MustNewAddress() []byte {
 	addr := make([]byte, 20)
 	_, err := io.ReadFull(crand.Reader, addr)
@@ -47,7 +47,7 @@ func NewBigInt() *big.Int {
 }
 
 // MustNewBatch will create a new test batch. Fields that are not supplied will
-// be filled with random data. Panics on errors
+// be filled with random data. Panics on errors.
 func MustNewBatch(opts ...BatchOption) *postage.Batch {
 	b := &postage.Batch{
 		ID:    MustNewID(),
@@ -67,15 +67,15 @@ func MustNewBatch(opts ...BatchOption) *postage.Batch {
 	return b
 }
 
-// WithOwner will set the batch owner
+// WithOwner will set the batch owner on a randomized batch.
 func WithOwner(owner []byte) BatchOption {
 	return func(b *postage.Batch) {
 		b.Owner = owner
 	}
 }
 
-// CompareBatches is a testing helper that compares two batches and returns that
-// fails the test if they are not fully equal.
+// CompareBatches is a testing helper that compares two batches and fails the
+// test if all fields are not equal.
 //
 // Fails on first different value and prints the comparison.
 func CompareBatches(t *testing.T, want, got *postage.Batch) {

--- a/pkg/postage/testing/chainstate.go
+++ b/pkg/postage/testing/chainstate.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/postage"
+)
+
+// NewChainState will create a new ChainState with random values
+func NewChainState() *postage.ChainState {
+	return &postage.ChainState{
+		Block: rand.Uint64(),
+		Price: NewBigInt(),
+		Total: NewBigInt(),
+	}
+}
+
+// CompareChainState is a test helper that compares two ChainStates and fails
+// the test if they are not exactly equal.
+//
+// Fails on first difference and returns a descriptive comparison.
+func CompareChainState(t *testing.T, want, got *postage.ChainState) {
+	t.Helper()
+
+	if want.Block != got.Block {
+		t.Fatalf("block: want %v, got %v", want.Block, got.Block)
+	}
+	if want.Price.Cmp(got.Price) != 0 {
+		t.Fatalf("price: want %v, got %v", want.Price, got.Price)
+	}
+	if want.Total.Cmp(got.Total) != 0 {
+		t.Fatalf("total: want %v, got %v", want.Total, got.Total)
+	}
+}

--- a/pkg/postage/testing/chainstate.go
+++ b/pkg/postage/testing/chainstate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/postage"
 )
 
-// NewChainState will create a new ChainState with random values
+// NewChainState will create a new ChainState with random values.
 func NewChainState() *postage.ChainState {
 	return &postage.ChainState{
 		Block: rand.Uint64(),

--- a/pkg/postage/testing/chainstate.go
+++ b/pkg/postage/testing/chainstate.go
@@ -22,7 +22,6 @@ func NewChainState() *postage.ChainState {
 
 // CompareChainState is a test helper that compares two ChainStates and fails
 // the test if they are not exactly equal.
-//
 // Fails on first difference and returns a descriptive comparison.
 func CompareChainState(t *testing.T, want, got *postage.ChainState) {
 	t.Helper()

--- a/pkg/postage/testing/stamp.go
+++ b/pkg/postage/testing/stamp.go
@@ -14,7 +14,7 @@ import (
 const signatureSize = 65
 
 // MustNewSignature will create a new random signature (65 byte slice). Panics
-// on errors
+// on errors.
 func MustNewSignature() []byte {
 	sig := make([]byte, signatureSize)
 	_, err := io.ReadFull(crand.Reader, sig)
@@ -24,7 +24,8 @@ func MustNewSignature() []byte {
 	return sig
 }
 
-// MustNewStamp will generate a postage stamp with random data. Panics on errors
+// MustNewStamp will generate a postage stamp with random data. Panics on
+// errors.
 func MustNewStamp() *postage.Stamp {
 	return postage.NewStamp(MustNewID(), MustNewSignature())
 }

--- a/pkg/postage/testing/stamp.go
+++ b/pkg/postage/testing/stamp.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package testing
 
 import (
@@ -7,16 +11,20 @@ import (
 	"github.com/ethersphere/bee/pkg/postage"
 )
 
-func NewStamp() *postage.Stamp {
-	id := make([]byte, 32)
-	_, err := io.ReadFull(crand.Reader, id)
+const signatureSize = 65
+
+// MustNewSignature will create a new random signature (65 byte slice). Panics
+// on errors
+func MustNewSignature() []byte {
+	sig := make([]byte, signatureSize)
+	_, err := io.ReadFull(crand.Reader, sig)
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
-	sig := make([]byte, 65)
-	_, err = io.ReadFull(crand.Reader, sig)
-	if err != nil {
-		panic(err.Error())
-	}
-	return postage.NewStamp(id, sig)
+	return sig
+}
+
+// MustNewStamp will generate a postage stamp with random data. Panics on errors
+func MustNewStamp() *postage.Stamp {
+	return postage.NewStamp(MustNewID(), MustNewSignature())
 }


### PR DESCRIPTION
# Description

This PR tracks the initial implementation to the postage `BatchStorer` and `EventUpdater` interfaces

- `BatchStore` handles storage of batches and `ChainState` via a storer interface
- `BatchService` implements the `postage.EventUpdater` interface and manages the business logic of postage batches

This should provide the skeleton for further features in the `postage` package.

related to #1046 #922 and parts of #934