### PR TITLE
Improve checking if file in traversal service

### DIFF
--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -281,6 +281,11 @@ func (s *traversalService) checkIsFile(
 			return
 		}
 
+		// address sizes must match
+		if len(reference.Bytes()) != len(e.Reference().Bytes()) {
+			return
+		}
+
 		// NOTE: any bytes will unmarshall to addresses; we need to check metadata
 
 		// read metadata


### PR DESCRIPTION
relates to: #1079 

Some trie node size from `mantaray` manifest will have size of `128` bytes, which lines up with the size of encrypted `entry.Entry` struct. In that case entry will result in two encrypted addresses (`64` bytes each), which are in itself valid. Since this case happens for trie node for non-encrypted addresses (which should have `32` byte size), we should check of unmarshaled entry address is the same size as actual reference for suspected file.