### PR TITLE
Simplify JSON response extraction in tests

### DIFF
--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -8,7 +8,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -279,12 +278,12 @@ Disallow: /`),
 			// tar all the test case files
 			tarReader := tarFiles(t, tc.files)
 
-			var respBytes []byte
+			var resp api.FileUploadResponse
 
 			options := []jsonhttptest.Option{
 				jsonhttptest.WithRequestBody(tarReader),
 				jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
-				jsonhttptest.WithPutResponseBody(&respBytes),
+				jsonhttptest.WithUnmarshalJSONResponse(&resp),
 			}
 			if tc.indexFilenameOption != nil {
 				options = append(options, tc.indexFilenameOption)
@@ -298,15 +297,6 @@ Disallow: /`),
 
 			// verify directory tar upload response
 			jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusOK, options...)
-
-			read := bytes.NewReader(respBytes)
-
-			// get the reference
-			var resp api.FileUploadResponse
-			err := json.NewDecoder(read).Decode(&resp)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			if resp.Reference.String() == "" {
 				t.Fatalf("expected file reference, did not got any")

--- a/pkg/api/file_test.go
+++ b/pkg/api/file_test.go
@@ -346,12 +346,9 @@ func TestRangeRequests(t *testing.T) {
 
 			uploadReference := upload.reference
 
-			var respBytes []byte
-
 			jsonhttptest.Request(t, client, http.MethodPost, upload.uploadEndpoint, http.StatusOK,
 				jsonhttptest.WithRequestBody(upload.reader),
 				jsonhttptest.WithRequestHeader("Content-Type", upload.contentType),
-				jsonhttptest.WithPutResponseBody(&respBytes),
 			)
 
 			for _, tc := range ranges {

--- a/pkg/api/pin_bzz_test.go
+++ b/pkg/api/pin_bzz_test.go
@@ -5,8 +5,6 @@
 package api_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -71,19 +69,12 @@ func TestPinBzzHandler(t *testing.T) {
 
 		expectedChunkCount := 7
 
-		var respBytes []byte
+		// get the reference as everytime it will change because of random encryption key
+		var resp api.ListPinnedChunksResponse
 
 		jsonhttptest.Request(t, client, http.MethodGet, pinChunksResource, http.StatusOK,
-			jsonhttptest.WithPutResponseBody(&respBytes),
+			jsonhttptest.WithUnmarshalJSONResponse(&resp),
 		)
-
-		read := bytes.NewReader(respBytes)
-
-		var resp api.ListPinnedChunksResponse
-		err := json.NewDecoder(read).Decode(&resp)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		if expectedChunkCount != len(resp.Chunks) {
 			t.Fatalf("expected to find %d pinned chunks, got %d", expectedChunkCount, len(resp.Chunks))


### PR DESCRIPTION
Switches to using `jsonhttptest.WithUnmarshalJSONResponse` instead of `jsonhttptest.WithPutResponseBody` in tests (I was not aware of first function at the time of writing tests, although I did look for it).