### PR TITLE
Perform preemptive retry for chunk retrieval

### DIFF
--- a/pkg/retrieval/export_test.go
+++ b/pkg/retrieval/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package retrieval
+
+import (
+	"context"
+
+	"github.com/ethersphere/bee/pkg/p2p"
+)
+
+func (s *Service) Handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) error {
+	return s.handler(ctx, p, stream)
+}

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -106,6 +106,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 		sps := newSkipPeersService()
 
 		ticker := time.NewTicker(retrieveRetryIntervalDuration)
+		defer ticker.Stop()
 
 		var (
 			peerAttempt int

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -134,11 +134,9 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 				// break
 			case chunk := <-resultC:
 				peersResults++
-
 				return chunk, nil
 			case <-errC:
 				peersResults++
-
 				break
 			case <-ctx.Done():
 				logger.Tracef("retrieval: failed to get chunk %s: %v", addr, ctx.Err())

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -158,7 +158,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 
 			select {
 			case <-ticker.C:
-				break
+				// break
 			case result := <-resultC:
 				if result.err != nil {
 					return nil, result.err

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -144,6 +144,11 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 						}
 
 						logger.Debugf("retrieval: failed to get chunk %s from peer %s: %v", addr, peer, err)
+
+						select {
+						case resultC <- retrieveChunkResult{err: storage.ErrNotFound}:
+						default:
+						}
 						return
 					}
 
@@ -161,6 +166,10 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 				// break
 			case result := <-resultC:
 				if result.err != nil {
+					if errors.Is(result.err, storage.ErrNotFound) {
+						break
+					}
+
 					return nil, result.err
 				}
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -119,9 +119,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 			if peerAttempt != maxPeers {
 				wgChan.Add(peerAttempt - maxPeers)
 			}
-		}()
-
-		go func() {
 			wgChan.Wait()
 
 			close(resultC)

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -138,7 +138,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 				peersResults++
 			case <-ctx.Done():
 				logger.Tracef("retrieval: failed to get chunk %s: %v", addr, ctx.Err())
-				return nil, ctx.Err()
+				return nil, fmt.Errorf("retrieval: %w", ctx.Err())
 			}
 
 			// all results received

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -188,7 +188,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 				return result.chunk, nil
 			case <-ctx.Done():
 				logger.Tracef("retrieval: failed to get chunk %s: %v", addr, ctx.Err())
-				return nil, storage.ErrNotFound
+				return nil, ctx.Err()
 			}
 
 			// all results received

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -133,7 +133,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 			case <-ticker.C:
 				// break
 			case chunk := <-resultC:
-				peersResults++
 				return chunk, nil
 			case <-errC:
 				peersResults++

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -137,7 +137,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address) (swarm.
 				return chunk, nil
 			case <-errC:
 				peersResults++
-				break
 			case <-ctx.Done():
 				logger.Tracef("retrieval: failed to get chunk %s: %v", addr, ctx.Err())
 				return nil, ctx.Err()

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package retrieval
+
+import (
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type skipPeersService struct {
+	addresses []swarm.Address
+
+	mu sync.Mutex
+}
+
+func newSkipPeersService() *skipPeersService {
+	return &skipPeersService{
+		addresses: make([]swarm.Address, 0),
+	}
+}
+
+func (s *skipPeersService) Addresses() []swarm.Address {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append(s.addresses[:0:0], s.addresses...)
+}
+
+func (s *skipPeersService) AddAddressToSkip(address swarm.Address) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, a := range s.addresses {
+		if a.Equal(address) {
+			return
+		}
+	}
+
+	s.addresses = append(s.addresses, address)
+}

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -10,26 +10,23 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-type skipPeersService struct {
+type skipPeers struct {
 	addresses []swarm.Address
-
-	mu sync.Mutex
+	mu        sync.Mutex
 }
 
-func newSkipPeersService() *skipPeersService {
-	return &skipPeersService{
-		addresses: make([]swarm.Address, 0),
-	}
+func newSkipPeers() *skipPeers {
+	return &skipPeers{}
 }
 
-func (s *skipPeersService) Addresses() []swarm.Address {
+func (s *skipPeers) All() []swarm.Address {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	return append(s.addresses[:0:0], s.addresses...)
 }
 
-func (s *skipPeersService) AddAddressToSkip(address swarm.Address) {
+func (s *skipPeers) Add(address swarm.Address) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 


### PR DESCRIPTION
relates to: #1081 

During chunk retrievals some peers may take more time to respond. Current process is to wait max possible time for client to respond with the chunk (if they manage to find it), and only when time passes (or client responds with an error) do we try to contact next peer (up to maximum number of peers configured).

This change adds additional time duration (that is less than maximum timeout for client to respond). If that duration passes, and the contacted peer has not provided response, we preemptively make another request to some other peer. This is in an attempt to mitigate problem with peers that are slow with their responses.

Current code will wait for any started retrieve request to complete, in order to credit any peer with successful delivery.

The configuration now is to attempt to contact maximum `5` peers. Each of them will have `10` seconds to respond with requested chunk. If `5` seconds (of those `10`) pass, and peer has not responded with requested chunk, node will contact next peer for the chunk.
This reduces maximum possible wait time for chunk retrieval from possible maximum of `50` seconds, to `30` seconds.

Currently selected timeout of `5` seconds for switching to next peer was arbitrary. If anyone has other suggestion, we can make the change.