### PR TITLE
api: dont create tag on chunk upload

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -140,12 +140,16 @@ func (s *server) getOrCreateTag(tagUid string) (*tags.Tag, bool, error) {
 		}
 		return tag, true, nil
 	}
+	t, err := s.getTag(tagUid)
+	return t, false, err
+}
+
+func (s *server) getTag(tagUid string) (*tags.Tag, error) {
 	uid, err := strconv.Atoi(tagUid)
 	if err != nil {
-		return nil, false, fmt.Errorf("cannot parse taguid: %w", err)
+		return nil, fmt.Errorf("cannot parse taguid: %w", err)
 	}
-	t, err := s.Tags.Get(uint32(uid))
-	return t, false, err
+	return s.Tags.Get(uint32(uid))
 }
 
 func (s *server) resolveNameOrAddress(str string) (swarm.Address, error) {

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -45,7 +45,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			s.Logger.Debugf("chunk upload: get tag: %v", err)
 			s.Logger.Error("chunk upload: get tag")
-			jsonhttp.InternalServerError(w, "cannot get tag")
+			jsonhttp.BadRequest(w, "cannot get tag")
 			return
 
 		}

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -106,7 +106,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			s.Logger.Debugf("chunk upload: increment tag", err)
 			s.Logger.Error("chunk upload: increment tag")
-			jsonhttp.BadRequest(w, "increment tag")
+			jsonhttp.InternalServerError(w, "increment tag")
 			return
 		}
 		w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -35,11 +35,22 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tag, _ := s.getTag(r.Header.Get(SwarmTagUidHeader))
-	ctx := r.Context()
+	var (
+		tag *tags.Tag
+		ctx = r.Context()
+	)
 
-	// add the tag to the context if it exists
-	if tag != nil {
+	if h := r.Header.Get(SwarmTagUidHeader); h != "" {
+		tag, err = s.getTag(h)
+		if err != nil {
+			s.Logger.Debugf("chunk upload: get tag: %v", err)
+			s.Logger.Error("chunk upload: get tag")
+			jsonhttp.InternalServerError(w, "cannot get tag")
+			return
+
+		}
+
+		// add the tag to the context if it exists
 		ctx = sctx.SetTag(r.Context(), tag)
 
 		// increment the StateSplit here since we dont have a splitter for the file upload

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -111,18 +111,18 @@ func (s *server) setupRouting() {
 		web.FinalHandler(jsonhttp.MethodHandler{
 			"POST": web.ChainHandlers(
 				jsonhttp.NewMaxBodyBytesHandler(1024),
-				web.FinalHandlerFunc(s.createTag),
+				web.FinalHandlerFunc(s.createTagHandler),
 			),
 		})),
 	)
 	handle(router, "/tags/{id}", web.ChainHandlers(
 		s.gatewayModeForbidEndpointHandler,
 		web.FinalHandler(jsonhttp.MethodHandler{
-			"GET":    http.HandlerFunc(s.getTag),
-			"DELETE": http.HandlerFunc(s.deleteTag),
+			"GET":    http.HandlerFunc(s.getTagHandler),
+			"DELETE": http.HandlerFunc(s.deleteTagHandler),
 			"PATCH": web.ChainHandlers(
 				jsonhttp.NewMaxBodyBytesHandler(1024),
-				web.FinalHandlerFunc(s.doneSplit),
+				web.FinalHandlerFunc(s.doneSplitHandler),
 			),
 		})),
 	)

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -52,7 +52,7 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 	}
 }
 
-func (s *server) createTag(w http.ResponseWriter, r *http.Request) {
+func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
@@ -90,7 +90,7 @@ func (s *server) createTag(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.Created(w, newTagResponse(tag))
 }
 
-func (s *server) getTag(w http.ResponseWriter, r *http.Request) {
+func (s *server) getTagHandler(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 
 	id, err := strconv.Atoi(idStr)
@@ -119,7 +119,7 @@ func (s *server) getTag(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, newTagResponse(tag))
 }
 
-func (s *server) deleteTag(w http.ResponseWriter, r *http.Request) {
+func (s *server) deleteTagHandler(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 
 	id, err := strconv.Atoi(idStr)
@@ -148,7 +148,7 @@ func (s *server) deleteTag(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.NoContent(w)
 }
 
-func (s *server) doneSplit(w http.ResponseWriter, r *http.Request) {
+func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 
 	id, err := strconv.Atoi(idStr)

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -78,11 +78,11 @@ func TestTags(t *testing.T) {
 	})
 
 	t.Run("create tag with invalid id", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, chunksResource(chunk.Address()), http.StatusInternalServerError,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksResource(chunk.Address()), http.StatusBadRequest,
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
 				Message: "cannot get tag",
-				Code:    http.StatusInternalServerError,
+				Code:    http.StatusBadRequest,
 			}),
 			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, "invalid_id.jpg"), // the value should be uint32
 		)


### PR DESCRIPTION
We now create a tag on each individual chunk upload.
This behavior is now changed to never create a new tag, but detect whether an existing tag uid was given in the header. In case it was provided - it will increment the appropriate fields, otherwise it will not create a new tag. Returns an error if the given tag id was not found.

related to #877