### PR TITLE
Simplify public tags API response

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -40,7 +40,7 @@ paths:
         - Bytes
       parameters:
         - in: header
-          name: swarm-tag-uid
+          name: swarm-tag
           schema:
             $ref: 'SwarmCommon.yaml#/components/schemas/Uid'
           required: false
@@ -140,7 +140,7 @@ paths:
         - Chunk
       parameters:
         - in: header
-          name: swarm-tag-uid
+          name: swarm-tag
           schema:
             $ref: 'SwarmCommon.yaml#/components/schemas/Uid'
           required: false
@@ -192,7 +192,7 @@ paths:
           required: false
           description: Filename
         - in: header
-          name: swarm-tag-uid
+          name: swarm-tag
           schema:
             $ref: 'SwarmCommon.yaml#/components/schemas/Uid'
           required: false
@@ -280,7 +280,7 @@ paths:
         - Collection
       parameters:
         - in: header
-          name: swarm-tag-uid
+          name: swarm-tag
           schema:
             $ref: 'SwarmCommon.yaml#/components/schemas/Uid'
           required: false

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -412,6 +412,23 @@ paths:
           description: Default response
 
   '/tags':
+    get:
+      summary: Get list of tags
+      tags:
+        - Tag
+      responses:
+        '200':
+          description: List of tags
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/TagsList'
+        '403':
+          $ref: 'SwarmCommon.yaml#/components/responses/403'
+        '500':
+           $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response
     post:
       summary: 'Create Tag'
       tags:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -203,6 +203,14 @@ components:
         startedAt:
           $ref: '#/components/schemas/DateTime'
 
+    TagsList:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/NewTagResponse'
+
     P2PUnderlay:
       type: string
       example: "/ip4/127.0.0.1/tcp/1634/p2p/16Uiu2HAmTm17toLDaPYzRyjKn27iCB76yjKnJ5DjQXneFmifFvaX"

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -166,12 +166,22 @@ components:
     NewTagRequest:
       type: object
       properties:
-        name:
-          type: string
         address:
           $ref: '#/components/schemas/SwarmAddress'
 
     NewTagResponse:
+      type: object
+      properties:
+        uid:
+          $ref: '#/components/schemas/Uid'
+        startedAt:
+          $ref: '#/components/schemas/DateTime'
+        stored:
+          type: integer
+        synced:
+          type: integer
+
+    NewTagDebugResponse:
       type: object
       properties:
         total:
@@ -188,10 +198,6 @@ components:
           type: integer
         uid:
           $ref: '#/components/schemas/Uid'
-        anonymous:
-          type: boolean
-        name:
-          type: string
         address:
           $ref: '#/components/schemas/SwarmAddress'
         startedAt:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -176,7 +176,9 @@ components:
           $ref: '#/components/schemas/Uid'
         startedAt:
           $ref: '#/components/schemas/DateTime'
-        stored:
+        total:
+          type: integer
+        processed:
           type: integer
         synced:
           type: integer

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -572,4 +572,32 @@ paths:
         '500':
            $ref: 'SwarmCommon.yaml#/components/responses/500'
         default:
-          description: Default response 
+          description: Default response
+
+  '/tags/{uid}':
+    get:
+      summary: 'Get Tag information using Uid'
+      tags:
+        - Tag
+      parameters:
+        - in: path
+          name: uid
+          schema:
+            $ref: 'SwarmCommon.yaml#/components/schemas/Uid'
+          required: true
+          description: Uid
+      responses:
+        '200':
+          description: Tag info
+          content:
+            application/json:
+              schema:
+                $ref: 'SwarmCommon.yaml#/components/schemas/NewTagDebugResponse'
+        '400':
+          $ref: 'SwarmCommon.yaml#/components/responses/400'
+        '403':
+          $ref: 'SwarmCommon.yaml#/components/responses/403'
+        '500':
+          $ref: 'SwarmCommon.yaml#/components/responses/500'
+        default:
+          description: Default response

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -132,9 +132,7 @@ func (s *server) Close() error {
 func (s *server) getOrCreateTag(tagUid string) (*tags.Tag, bool, error) {
 	// if tag ID is not supplied, create a new tag
 	if tagUid == "" {
-		tagName := fmt.Sprintf("unnamed_tag_%d", time.Now().Unix())
-		var err error
-		tag, err := s.Tags.Create(tagName, 0)
+		tag, err := s.Tags.Create(0)
 		if err != nil {
 			return nil, false, fmt.Errorf("cannot create tag: %w", err)
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	SwarmPinHeader           = "Swarm-Pin"
-	SwarmTagUidHeader        = "Swarm-Tag-Uid"
+	SwarmTagHeader           = "Swarm-Tag"
 	SwarmEncryptHeader       = "Swarm-Encrypt"
 	SwarmIndexDocumentHeader = "Swarm-Index-Document"
 	SwarmErrorDocumentHeader = "Swarm-Error-Document"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -295,3 +295,10 @@ func calculateNumberOfChunks(contentLength int64, isEncrypted bool) int64 {
 
 	return int64(totalChunks) + 1
 }
+
+func requestCalculateNumberOfChunks(r *http.Request) int64 {
+	if !strings.Contains(r.Header.Get(contentTypeHeader), "multipart") && r.ContentLength > 0 {
+		return calculateNumberOfChunks(r.ContentLength, requestEncrypt(r))
+	}
+	return 0
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/ethersphere/bee/pkg/encryption"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
@@ -276,15 +277,15 @@ func requestPipelineFn(s storage.Storer, r *http.Request) pipelineFunc {
 // calculateNumberOfChunks calculates the number of chunks in an arbitrary
 // content length.
 func calculateNumberOfChunks(contentLength int64, isEncrypted bool) int64 {
-	if contentLength < 4096 {
+	if contentLength < swarm.ChunkSize {
 		return 1
 	}
-	branchingFactor := 128
+	branchingFactor := swarm.Branches
 	if isEncrypted {
-		branchingFactor = 64
+		branchingFactor = encryption.EncryptionBranches
 	}
 
-	dataChunks := math.Ceil(float64(contentLength) / float64(4096))
+	dataChunks := math.Ceil(float64(contentLength) / float64(swarm.ChunkSize))
 	totalChunks := dataChunks
 	intermediate := dataChunks / float64(branchingFactor)
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/ethersphere/bee/pkg/encryption"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
@@ -277,12 +276,12 @@ func requestPipelineFn(s storage.Storer, r *http.Request) pipelineFunc {
 // calculateNumberOfChunks calculates the number of chunks in an arbitrary
 // content length.
 func calculateNumberOfChunks(contentLength int64, isEncrypted bool) int64 {
-	if contentLength < swarm.ChunkSize {
+	if contentLength <= swarm.ChunkSize {
 		return 1
 	}
 	branchingFactor := swarm.Branches
 	if isEncrypted {
-		branchingFactor = encryption.EncryptionBranches
+		branchingFactor = swarm.EncryptedBranches
 	}
 
 	dataChunks := math.Ceil(float64(contentLength) / float64(swarm.ChunkSize))

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -181,3 +181,40 @@ func TestParseName(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateNumberOfChunks is a unit test for
+// the chunk-number-according-to-content-length calculation.
+func TestCalculateNumberOfChunks(t *testing.T) {
+	for _, tc := range []struct{ len, chunks int64 }{
+		{len: 1000, chunks: 1},
+		{len: 5000, chunks: 3},
+		{len: 10000, chunks: 4},
+		{len: 100000, chunks: 26},
+		{len: 1000000, chunks: 248},
+		{len: 325839339210, chunks: 79550620 + 621490 + 4856 + 38 + 1},
+	} {
+		res := api.CalculateNumberOfChunks(tc.len, false)
+		if res != tc.chunks {
+			t.Fatalf("expected result for %d bytes to be %d got %d", tc.len, tc.chunks, res)
+		}
+	}
+}
+
+// TestCalculateNumberOfChunksEncrypted is a unit test for
+// the chunk-number-according-to-content-length calculation with encryption
+// (branching factor=64)
+func TestCalculateNumberOfChunksEncrypted(t *testing.T) {
+	for _, tc := range []struct{ len, chunks int64 }{
+		{len: 1000, chunks: 1},
+		{len: 5000, chunks: 3},
+		{len: 10000, chunks: 4},
+		{len: 100000, chunks: 26},
+		{len: 1000000, chunks: 245 + 4 + 1},
+		{len: 325839339210, chunks: 79550620 + 1242979 + 19422 + 304 + 5 + 1},
+	} {
+		res := api.CalculateNumberOfChunks(tc.len, true)
+		if res != tc.chunks {
+			t.Fatalf("expected result for %d bytes to be %d got %d", tc.len, tc.chunks, res)
+		}
+	}
+}

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -24,7 +24,7 @@ type bytesPostResponse struct {
 func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
 
-	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagUidHeader))
+	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagHeader))
 	if err != nil {
 		logger.Debugf("bytes upload: get or create tag: %v", err)
 		logger.Error("bytes upload: get or create tag")
@@ -52,8 +52,8 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagUidHeader)
+	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
+	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
 	jsonhttp.OK(w, bytesPostResponse{
 		Reference: address,
 	})

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -34,6 +34,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !created {
+		// only in the case when tag is sent via header (i.e. not created by this request)
 		if estimatedTotalChunks := requestCalculateNumberOfChunks(r); estimatedTotalChunks > 0 {
 			err = tag.IncN(tags.TotalChunks, estimatedTotalChunks)
 			if err != nil {

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -34,7 +34,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		err error
 	)
 
-	if h := r.Header.Get(SwarmTagUidHeader); h != "" {
+	if h := r.Header.Get(SwarmTagHeader); h != "" {
 		tag, err = s.getTag(h)
 		if err != nil {
 			s.Logger.Debugf("chunk upload: get tag: %v", err)
@@ -119,10 +119,10 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 			jsonhttp.InternalServerError(w, "increment tag")
 			return
 		}
-		w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+		w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
 	}
 
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagUidHeader)
+	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
 	jsonhttp.OK(w, chunkAddressResponse{Reference: address})
 }
 

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -51,7 +51,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagUidHeader))
+	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagHeader))
 	if err != nil {
 		logger.Debugf("dir upload: get or create tag: %v", err)
 		logger.Error("dir upload: get or create tag")
@@ -80,7 +80,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
+	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
 	jsonhttp.OK(w, fileUploadResponse{
 		Reference: reference,
 	})

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -162,6 +162,7 @@ func storeDir(ctx context.Context, encrypt bool, reader io.ReadCloser, log loggi
 		}
 
 		if !tagCreated {
+			// only in the case when tag is sent via header (i.e. not created by this request)
 			// for each file
 			if estimatedTotalChunks := calculateNumberOfChunks(fileInfo.size, encrypt); estimatedTotalChunks > 0 {
 				err = tag.IncN(tags.TotalChunks, estimatedTotalChunks)
@@ -217,6 +218,7 @@ func storeDir(ctx context.Context, encrypt bool, reader io.ReadCloser, log loggi
 
 	storeSizeFn := []manifest.StoreSizeFunc{}
 	if !tagCreated {
+		// only in the case when tag is sent via header (i.e. not created by this request)
 		// each content that is saved for manifest
 		storeSizeFn = append(storeSizeFn, func(dataSize int64) error {
 			if estimatedTotalChunks := calculateNumberOfChunks(dataSize, encrypt); estimatedTotalChunks > 0 {

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -39,3 +39,7 @@ var (
 func (s *Server) ResolveNameOrAddress(str string) (swarm.Address, error) {
 	return s.resolveNameOrAddress(str)
 }
+
+func CalculateNumberOfChunks(contentLength int64, isEncrypted bool) int64 {
+	return calculateNumberOfChunks(contentLength, isEncrypted)
+}

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -15,6 +15,7 @@ type (
 	FileUploadResponse       = fileUploadResponse
 	TagResponse              = tagResponse
 	TagRequest               = tagRequest
+	ListTagsResponse         = listTagsResponse
 	PinnedChunk              = pinnedChunk
 	ListPinnedChunksResponse = listPinnedChunksResponse
 	UpdatePinCounter         = updatePinCounter

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -60,7 +60,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagUidHeader))
+	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagHeader))
 	if err != nil {
 		logger.Debugf("file upload: get or create tag: %v", err)
 		logger.Error("file upload: get or create tag")
@@ -210,8 +210,8 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%q", reference.String()))
-	w.Header().Set(SwarmTagUidHeader, fmt.Sprint(tag.Uid))
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagUidHeader)
+	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
+	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
 	jsonhttp.OK(w, fileUploadResponse{
 		Reference: reference,
 	})

--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -70,6 +70,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !created {
+		// only in the case when tag is sent via header (i.e. not created by this request)
 		if estimatedTotalChunks := requestCalculateNumberOfChunks(r); estimatedTotalChunks > 0 {
 			err = tag.IncN(tags.TotalChunks, estimatedTotalChunks)
 			if err != nil {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -119,6 +119,7 @@ func (s *server) setupRouting() {
 	handle(router, "/tags", web.ChainHandlers(
 		s.gatewayModeForbidEndpointHandler,
 		web.FinalHandler(jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.listTagsHandler),
 			"POST": web.ChainHandlers(
 				jsonhttp.NewMaxBodyBytesHandler(1024),
 				web.FinalHandlerFunc(s.createTagHandler),

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -7,7 +7,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -20,13 +19,11 @@ import (
 )
 
 type tagRequest struct {
-	Name    string        `json:"name,omitempty"`
 	Address swarm.Address `json:"address,omitempty"`
 }
 
 type tagResponse struct {
 	Uid       uint32    `json:"uid"`
-	Name      string    `json:"name"`
 	StartedAt time.Time `json:"startedAt"`
 	Stored    int64     `json:"stored"`
 	Synced    int64     `json:"synced"`
@@ -35,7 +32,6 @@ type tagResponse struct {
 func newTagResponse(tag *tags.Tag) tagResponse {
 	return tagResponse{
 		Uid:       tag.Uid,
-		Name:      tag.Name,
 		StartedAt: tag.StartedAt,
 		Stored:    tag.Stored,
 		Synced:    tag.Seen + tag.Synced,
@@ -65,11 +61,7 @@ func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if tagr.Name == "" {
-		tagr.Name = fmt.Sprintf("unnamed_tag_%d", time.Now().Unix())
-	}
-
-	tag, err := s.Tags.Create(tagr.Name, 0)
+	tag, err := s.Tags.Create(0)
 	if err != nil {
 		s.Logger.Debugf("create tag: tag create error: %v", err)
 		s.Logger.Error("create tag: tag create error")

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -214,7 +214,7 @@ func (s *server) listTagsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tagList, err := s.Tags.List(r.Context(), offset, limit)
+	tagList, err := s.Tags.ListAll(r.Context(), offset, limit)
 	if err != nil {
 		s.Logger.Debugf("list tags: listing: %v", err)
 		s.Logger.Errorf("list tags: listing")

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -25,30 +25,20 @@ type tagRequest struct {
 }
 
 type tagResponse struct {
-	Total     int64         `json:"total"`
-	Split     int64         `json:"split"`
-	Seen      int64         `json:"seen"`
-	Stored    int64         `json:"stored"`
-	Sent      int64         `json:"sent"`
-	Synced    int64         `json:"synced"`
-	Uid       uint32        `json:"uid"`
-	Name      string        `json:"name"`
-	Address   swarm.Address `json:"address"`
-	StartedAt time.Time     `json:"startedAt"`
+	Uid       uint32    `json:"uid"`
+	Name      string    `json:"name"`
+	StartedAt time.Time `json:"startedAt"`
+	Stored    int64     `json:"stored"`
+	Synced    int64     `json:"synced"`
 }
 
 func newTagResponse(tag *tags.Tag) tagResponse {
 	return tagResponse{
-		Total:     tag.Total,
-		Split:     tag.Split,
-		Seen:      tag.Seen,
-		Stored:    tag.Stored,
-		Sent:      tag.Sent,
-		Synced:    tag.Synced,
 		Uid:       tag.Uid,
 		Name:      tag.Name,
-		Address:   tag.Address,
 		StartedAt: tag.StartedAt,
+		Stored:    tag.Stored,
+		Synced:    tag.Seen + tag.Synced,
 	}
 }
 

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -25,7 +25,8 @@ type tagRequest struct {
 type tagResponse struct {
 	Uid       uint32    `json:"uid"`
 	StartedAt time.Time `json:"startedAt"`
-	Stored    int64     `json:"stored"`
+	Total     int64     `json:"total"`
+	Processed int64     `json:"processed"`
 	Synced    int64     `json:"synced"`
 }
 
@@ -37,7 +38,8 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 	return tagResponse{
 		Uid:       tag.Uid,
 		StartedAt: tag.StartedAt,
-		Stored:    tag.Stored,
+		Total:     tag.Total,
+		Processed: tag.Stored,
 		Synced:    tag.Seen + tag.Synced,
 	}
 }

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -64,7 +64,7 @@ func TestTags(t *testing.T) {
 				Message: "cannot get tag",
 				Code:    http.StatusBadRequest,
 			}),
-			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, "invalid_id.jpg"), // the value should be uint32
+			jsonhttptest.WithRequestHeader(api.SwarmTagHeader, "invalid_id.jpg"), // the value should be uint32
 		)
 	})
 
@@ -102,7 +102,7 @@ func TestTags(t *testing.T) {
 		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
-			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
+			jsonhttptest.WithRequestHeader(api.SwarmTagHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
 		)
 
 		isTagFoundInResponse(t, rcvdHeaders, &tr)
@@ -184,7 +184,7 @@ func TestTags(t *testing.T) {
 		// upload content with tag
 		jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
-			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, fmt.Sprint(tagId)),
+			jsonhttptest.WithRequestHeader(api.SwarmTagHeader, fmt.Sprint(tagId)),
 		)
 
 		// call done split
@@ -226,7 +226,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithRequestHeader("Content-Type", "application/octet-stream"),
 		)
 
-		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagUidHeader))
+		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagHeader))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -248,7 +248,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
 		)
 
-		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagUidHeader))
+		tagId, err := strconv.Atoi(respHeaders.Get(api.SwarmTagHeader))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -264,7 +264,7 @@ func TestTags(t *testing.T) {
 		)
 
 		sentHeaders := make(http.Header)
-		sentHeaders.Set(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10))
+		sentHeaders.Set(api.SwarmTagHeader, strconv.FormatUint(uint64(tr.Uid), 10))
 
 		g := mockbytes.New(0, mockbytes.MockTypeStandard).WithModulus(255)
 		dataChunk, err := g.SequentialBytes(swarm.ChunkSize)
@@ -283,7 +283,7 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithExpectedJSONResponse(fileUploadResponse{
 				Reference: rootAddress,
 			}),
-			jsonhttptest.WithRequestHeader(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
+			jsonhttptest.WithRequestHeader(api.SwarmTagHeader, strconv.FormatUint(uint64(tr.Uid), 10)),
 		)
 		id := isTagFoundInResponse(t, rcvdHeaders, nil)
 
@@ -304,7 +304,7 @@ func TestTags(t *testing.T) {
 func isTagFoundInResponse(t *testing.T, headers http.Header, tr *api.TagResponse) uint32 {
 	t.Helper()
 
-	idStr := headers.Get(api.SwarmTagUidHeader)
+	idStr := headers.Get(api.SwarmTagHeader)
 	if idStr == "" {
 		t.Fatalf("could not find tag id header in chunk upload response")
 	}

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -374,10 +374,13 @@ func tagValueTest(t *testing.T, id uint32, split, stored, seen, sent, synced, to
 		jsonhttptest.WithUnmarshalJSONResponse(&tag),
 	)
 
-	if tag.Stored != stored {
-		t.Errorf("tag stored count mismatch. got %d want %d", tag.Stored, stored)
+	if tag.Processed != stored {
+		t.Errorf("tag processed count mismatch. got %d want %d", tag.Processed, stored)
 	}
 	if tag.Synced != seen+synced {
 		t.Errorf("tag synced count mismatch. got %d want %d (seen: %d, synced: %d)", tag.Synced, seen+synced, seen, synced)
+	}
+	if tag.Total != total {
+		t.Errorf("tag total count mismatch. got %d want %d", tag.Total, total)
 	}
 }

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -363,26 +363,10 @@ func tagValueTest(t *testing.T, id uint32, split, stored, seen, sent, synced, to
 		jsonhttptest.WithUnmarshalJSONResponse(&tag),
 	)
 
-	if tag.Split != split {
-		t.Errorf("tag split count mismatch. got %d want %d", tag.Split, split)
-	}
 	if tag.Stored != stored {
 		t.Errorf("tag stored count mismatch. got %d want %d", tag.Stored, stored)
 	}
-	if tag.Seen != seen {
-		t.Errorf("tag seen count mismatch. got %d want %d", tag.Seen, seen)
-	}
-	if tag.Sent != sent {
-		t.Errorf("tag sent count mismatch. got %d want %d", tag.Sent, sent)
-	}
-	if tag.Synced != synced {
-		t.Errorf("tag synced count mismatch. got %d want %d", tag.Synced, synced)
-	}
-	if tag.Total != total {
-		t.Errorf("tag total count mismatch. got %d want %d", tag.Total, total)
-	}
-
-	if !tag.Address.Equal(address) {
-		t.Errorf("address mismatch: expected %s got %s", address.String(), tag.Address.String())
+	if tag.Synced != seen+synced {
+		t.Errorf("tag synced count mismatch. got %d want %d (seen: %d, synced: %d)", tag.Synced, seen+synced, seen, synced)
 	}
 }

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -41,7 +40,6 @@ func TestTags(t *testing.T) {
 		chunksResource = "/chunks"
 		tagsResource   = "/tags"
 		chunk          = testingc.GenerateTestRandomChunk()
-		someTagName    = "file.jpg"
 		mockStatestore = statestore.NewStateStore()
 		logger         = logging.New(ioutil.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
@@ -51,30 +49,12 @@ func TestTags(t *testing.T) {
 		})
 	)
 
-	t.Run("create unnamed tag", func(t *testing.T) {
+	t.Run("create tag", func(t *testing.T) {
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
 			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
 			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
-
-		if !strings.Contains(tr.Name, "unnamed_tag_") {
-			t.Fatalf("expected tag name to contain %s but is %s instead", "unnamed_tag_", tr.Name)
-		}
-	})
-
-	t.Run("create tag with name", func(t *testing.T) {
-		tr := api.TagResponse{}
-		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
-			jsonhttptest.WithJSONRequestBody(api.TagRequest{
-				Name: someTagName,
-			}),
-			jsonhttptest.WithUnmarshalJSONResponse(&tr),
-		)
-
-		if tr.Name != someTagName {
-			t.Fatalf("expected tag name to be %s but is %s instead", someTagName, tr.Name)
-		}
 	})
 
 	t.Run("create tag with invalid id", func(t *testing.T) {
@@ -110,15 +90,9 @@ func TestTags(t *testing.T) {
 		// create a tag using the API
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
-			jsonhttptest.WithJSONRequestBody(api.TagResponse{
-				Name: someTagName,
-			}),
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
 			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
-
-		if tr.Name != someTagName {
-			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
-		}
 
 		_ = jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
@@ -157,9 +131,7 @@ func TestTags(t *testing.T) {
 		// create a tag through API
 		tRes := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
-			jsonhttptest.WithJSONRequestBody(api.TagResponse{
-				Name: someTagName,
-			}),
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
 			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 
@@ -201,9 +173,7 @@ func TestTags(t *testing.T) {
 		// create a tag through API
 		tRes := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
-			jsonhttptest.WithJSONRequestBody(api.TagResponse{
-				Name: someTagName,
-			}),
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
 			jsonhttptest.WithUnmarshalJSONResponse(&tRes),
 		)
 		tagId := tRes.Uid
@@ -289,14 +259,9 @@ func TestTags(t *testing.T) {
 		// create a tag using the API
 		tr := api.TagResponse{}
 		jsonhttptest.Request(t, client, http.MethodPost, tagsResource, http.StatusCreated,
-			jsonhttptest.WithJSONRequestBody(api.TagResponse{
-				Name: someTagName,
-			}),
+			jsonhttptest.WithJSONRequestBody(api.TagRequest{}),
 			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
-		if tr.Name != someTagName {
-			t.Fatalf("sent tag name %s does not match received tag name %s", someTagName, tr.Name)
-		}
 
 		sentHeaders := make(http.Header)
 		sentHeaders.Set(api.SwarmTagUidHeader, strconv.FormatUint(uint64(tr.Uid), 10))

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -341,7 +341,7 @@ func TestTags(t *testing.T) {
 		if tagToVerify.Uid != tr.Uid {
 			t.Fatalf("expected tag id to be %d but is %d", tagToVerify.Uid, tr.Uid)
 		}
-		tagValueTest(t, id, 3, 3, 1, 0, 0, 0, swarm.ZeroAddress, client)
+		tagValueTest(t, id, 3, 3, 1, 0, 0, 3, swarm.ZeroAddress, client)
 	})
 }
 

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -25,6 +25,7 @@ type (
 	SwapCashoutResponse               = swapCashoutResponse
 	SwapCashoutStatusResponse         = swapCashoutStatusResponse
 	SwapCashoutStatusResult           = swapCashoutStatusResult
+	TagResponse                       = tagResponse
 )
 
 var (

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -145,6 +145,10 @@ func (s *server) setupRouting() {
 		})
 	}
 
+	router.Handle("/tags/{id}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.getTagHandler),
+	})
+
 	baseRouter.Handle("/", web.ChainHandlers(
 		httpaccess.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, s.Tracer, "debug api access"),
 		handlers.CompressHandler,

--- a/pkg/debugapi/tag.go
+++ b/pkg/debugapi/tag.go
@@ -24,7 +24,6 @@ type tagResponse struct {
 	Sent      int64         `json:"sent"`
 	Synced    int64         `json:"synced"`
 	Uid       uint32        `json:"uid"`
-	Name      string        `json:"name"`
 	Address   swarm.Address `json:"address"`
 	StartedAt time.Time     `json:"startedAt"`
 }
@@ -38,7 +37,6 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 		Sent:      tag.Sent,
 		Synced:    tag.Synced,
 		Uid:       tag.Uid,
-		Name:      tag.Name,
 		Address:   tag.Address,
 		StartedAt: tag.StartedAt,
 	}

--- a/pkg/debugapi/tag.go
+++ b/pkg/debugapi/tag.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/tags"
+	"github.com/gorilla/mux"
+)
+
+type tagResponse struct {
+	Total     int64         `json:"total"`
+	Split     int64         `json:"split"`
+	Seen      int64         `json:"seen"`
+	Stored    int64         `json:"stored"`
+	Sent      int64         `json:"sent"`
+	Synced    int64         `json:"synced"`
+	Uid       uint32        `json:"uid"`
+	Name      string        `json:"name"`
+	Address   swarm.Address `json:"address"`
+	StartedAt time.Time     `json:"startedAt"`
+}
+
+func newTagResponse(tag *tags.Tag) tagResponse {
+	return tagResponse{
+		Total:     tag.Total,
+		Split:     tag.Split,
+		Seen:      tag.Seen,
+		Stored:    tag.Stored,
+		Sent:      tag.Sent,
+		Synced:    tag.Synced,
+		Uid:       tag.Uid,
+		Name:      tag.Name,
+		Address:   tag.Address,
+		StartedAt: tag.StartedAt,
+	}
+}
+
+func (s *server) getTagHandler(w http.ResponseWriter, r *http.Request) {
+	idStr := mux.Vars(r)["id"]
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		s.Logger.Debugf("get tag: parse id  %s: %v", idStr, err)
+		s.Logger.Error("get tag: parse id")
+		jsonhttp.BadRequest(w, "invalid id")
+		return
+	}
+
+	tag, err := s.Tags.Get(uint32(id))
+	if err != nil {
+		if errors.Is(err, tags.ErrNotFound) {
+			s.Logger.Debugf("get tag: tag not present: %v, id %s", err, idStr)
+			s.Logger.Error("get tag: tag not present")
+			jsonhttp.NotFound(w, "tag not present")
+			return
+		}
+		s.Logger.Debugf("get tag: tag %v: %v", idStr, err)
+		s.Logger.Errorf("get tag: %v", idStr)
+		jsonhttp.InternalServerError(w, "cannot get tag")
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
+	jsonhttp.OK(w, newTagResponse(tag))
+}

--- a/pkg/debugapi/tag_test.go
+++ b/pkg/debugapi/tag_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/logging"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/mock"
+	testingc "github.com/ethersphere/bee/pkg/storage/testing"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/tags"
+)
+
+func tagsWithIdResource(id uint32) string { return fmt.Sprintf("/tags/%d", id) }
+
+func TestTags(t *testing.T) {
+	var (
+		logger         = logging.New(ioutil.Discard, 0)
+		chunk          = testingc.GenerateTestRandomChunk()
+		mockStorer     = mock.NewStorer()
+		mockStatestore = statestore.NewStateStore()
+		tagsStore      = tags.NewTags(mockStatestore, logger)
+		testServer     = newTestServer(t, testServerOptions{
+			Storer: mockStorer,
+			Tags:   tagsStore,
+		})
+	)
+
+	_, err := mockStorer.Put(context.Background(), storage.ModePutUpload, chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("all", func(t *testing.T) {
+		tag, err := tagsStore.Create("", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_ = tag.Inc(tags.StateSplit)
+		_ = tag.Inc(tags.StateStored)
+		_ = tag.Inc(tags.StateSeen)
+		_ = tag.Inc(tags.StateSent)
+		_ = tag.Inc(tags.StateSynced)
+
+		_, err = tag.DoneSplit(chunk.Address())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tagValueTest(t, tag.Uid, 1, 1, 1, 1, 1, 1, chunk.Address(), testServer.Client)
+	})
+}
+
+func tagValueTest(t *testing.T, id uint32, split, stored, seen, sent, synced, total int64, address swarm.Address, client *http.Client) {
+	t.Helper()
+
+	tag := debugapi.TagResponse{}
+	jsonhttptest.Request(t, client, http.MethodGet, tagsWithIdResource(id), http.StatusOK,
+		jsonhttptest.WithUnmarshalJSONResponse(&tag),
+	)
+
+	if tag.Split != split {
+		t.Errorf("tag split count mismatch. got %d want %d", tag.Split, split)
+	}
+	if tag.Stored != stored {
+		t.Errorf("tag stored count mismatch. got %d want %d", tag.Stored, stored)
+	}
+	if tag.Seen != seen {
+		t.Errorf("tag seen count mismatch. got %d want %d", tag.Seen, seen)
+	}
+	if tag.Sent != sent {
+		t.Errorf("tag sent count mismatch. got %d want %d", tag.Sent, sent)
+	}
+	if tag.Synced != synced {
+		t.Errorf("tag synced count mismatch. got %d want %d", tag.Synced, synced)
+	}
+	if tag.Total != total {
+		t.Errorf("tag total count mismatch. got %d want %d", tag.Total, total)
+	}
+
+	if !tag.Address.Equal(address) {
+		t.Errorf("address mismatch: expected %s got %s", address.String(), tag.Address.String())
+	}
+}

--- a/pkg/debugapi/tag_test.go
+++ b/pkg/debugapi/tag_test.go
@@ -43,7 +43,7 @@ func TestTags(t *testing.T) {
 	}
 
 	t.Run("all", func(t *testing.T) {
-		tag, err := tagsStore.Create("", 0)
+		tag, err := tagsStore.Create(0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -21,17 +21,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-
-	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 const (
 	KeyLength     = 32
 	ReferenceSize = 64
-)
-
-const (
-	EncryptionBranches = swarm.Branches / 2
 )
 
 type Key []byte

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -21,11 +21,17 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
+
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 const (
 	KeyLength     = 32
 	ReferenceSize = 64
+)
+
+const (
+	EncryptionBranches = swarm.Branches / 2
 )
 
 type Key []byte

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -40,7 +40,7 @@ func TestModeSetSyncNormalTag(t *testing.T) {
 	logger := logging.New(ioutil.Discard, 0)
 	db := newTestDB(t, &Options{Tags: tags.NewTags(mockStatestore, logger)})
 
-	tag, err := db.tags.Create("test", 1)
+	tag, err := db.tags.Create(1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -27,6 +27,10 @@ var (
 	ErrMissingReference = errors.New("manifest: missing reference")
 )
 
+// StoreSizeFunc is a callback on every content size that will be stored by
+// the Store function.
+type StoreSizeFunc func(int64) error
+
 // Interface for operations with manifest.
 type Interface interface {
 	// Type returns manifest implementation type information
@@ -40,7 +44,7 @@ type Interface interface {
 	// HasPrefix tests whether the specified prefix path exists.
 	HasPrefix(context.Context, string) (bool, error)
 	// Store stores the manifest, returning the resulting address.
-	Store(context.Context) (swarm.Address, error)
+	Store(context.Context, ...StoreSizeFunc) (swarm.Address, error)
 	// IterateAddresses is used to iterate over chunks addresses for
 	// the manifest.
 	IterateAddresses(context.Context, swarm.AddressIterFunc) error

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -82,7 +82,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 	mtags, p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
 	defer storer.Close()
 
-	ta, err := mtags.Create("test", 1)
+	ta, err := mtags.Create(1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -111,7 +111,7 @@ func TestPushChunkToClosest(t *testing.T) {
 	psPivot, storerPivot, pivotTags, pivotAccounting := createPushSyncNode(t, pivotNode, recorder, nil, mock.WithClosestPeer(closestPeer))
 	defer storerPivot.Close()
 
-	ta, err := pivotTags.Create("test", 1)
+	ta, err := pivotTags.Create(1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestPushChunkToNextClosest(t *testing.T) {
 	)
 	defer storerPivot.Close()
 
-	ta, err := pivotTags.Create("test", 1)
+	ta, err := pivotTags.Create(1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -19,6 +19,7 @@ const (
 	SpanSize                = 8
 	SectionSize             = 32
 	Branches                = 128
+	EncryptedBranches       = Branches / 2
 	BmtBranches             = 128
 	ChunkSize               = SectionSize * Branches
 	HashSize                = 32

--- a/pkg/tags/tag.go
+++ b/pkg/tags/tag.go
@@ -60,7 +60,6 @@ type Tag struct {
 	Synced int64 // number of chunks synced with proof
 
 	Uid       uint32        // a unique identifier for this tag
-	Name      string        // a name tag for this tag
 	Address   swarm.Address // the associated swarm hash for this tag
 	StartedAt time.Time     // tag started to calculate ETA
 
@@ -73,10 +72,9 @@ type Tag struct {
 }
 
 // NewTag creates a new tag, and returns it
-func NewTag(ctx context.Context, uid uint32, s string, total int64, tracer *tracing.Tracer, stateStore storage.StateStorer, logger logging.Logger) *Tag {
+func NewTag(ctx context.Context, uid uint32, total int64, tracer *tracing.Tracer, stateStore storage.StateStorer, logger logging.Logger) *Tag {
 	t := &Tag{
 		Uid:        uid,
-		Name:       s,
 		StartedAt:  time.Now(),
 		Total:      total,
 		stateStore: stateStore,
@@ -259,7 +257,6 @@ func (tag *Tag) MarshalBinary() (data []byte, err error) {
 	n = binary.PutVarint(intBuffer, int64(len(tag.Address.Bytes())))
 	buffer = append(buffer, intBuffer[:n]...)
 	buffer = append(buffer, tag.Address.Bytes()...)
-	buffer = append(buffer, []byte(tag.Name)...)
 
 	return buffer, nil
 }
@@ -288,7 +285,6 @@ func (tag *Tag) UnmarshalBinary(buffer []byte) error {
 	if t > 0 {
 		tag.Address = swarm.NewAddress(buffer[:t])
 	}
-	tag.Name = string(buffer[t:])
 
 	return nil
 }

--- a/pkg/tags/tag.go
+++ b/pkg/tags/tag.go
@@ -100,7 +100,7 @@ func (t *Tag) FinishRootSpan() {
 }
 
 // IncN increments the count for a state
-func (t *Tag) IncN(state State, n int) error {
+func (t *Tag) IncN(state State, n int64) error {
 	var v *int64
 	switch state {
 	case TotalChunks:
@@ -116,7 +116,7 @@ func (t *Tag) IncN(state State, n int) error {
 	case StateSynced:
 		v = &t.Synced
 	}
-	atomic.AddInt64(v, int64(n))
+	atomic.AddInt64(v, n)
 
 	// check if syncing is over and persist the tag
 	if state == StateSynced {

--- a/pkg/tags/tag_test.go
+++ b/pkg/tags/tag_test.go
@@ -176,8 +176,7 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(10 * 5 * n)
 	for i := 0; i < 10; i++ {
-		s := string([]byte{uint8(i)})
-		tag, err := ts.Create(s, int64(n))
+		tag, err := ts.Create(int64(n))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -223,7 +222,7 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 func TestMarshallingWithAddr(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
 	logger := logging.New(ioutil.Discard, 0)
-	tg := NewTag(context.Background(), 111, "test/tag", 10, nil, mockStatestore, logger)
+	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)
 	tg.Address = swarm.NewAddress([]byte{0, 1, 2, 3, 4, 5, 6})
 
 	for _, f := range allStates {
@@ -248,10 +247,6 @@ func TestMarshallingWithAddr(t *testing.T) {
 		t.Fatalf("tag uids not equal. want %d got %d", tg.Uid, unmarshalledTag.Uid)
 	}
 
-	if unmarshalledTag.Name != tg.Name {
-		t.Fatalf("tag names not equal. want %s got %s", tg.Name, unmarshalledTag.Name)
-	}
-
 	for _, state := range allStates {
 		uv, tv := unmarshalledTag.Get(state), tg.Get(state)
 		if uv != tv {
@@ -260,7 +255,7 @@ func TestMarshallingWithAddr(t *testing.T) {
 	}
 
 	if unmarshalledTag.TotalCounter() != tg.TotalCounter() {
-		t.Fatalf("tag names not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
+		t.Fatalf("tag total counters not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
 	}
 
 	if len(unmarshalledTag.Address.Bytes()) != len(tg.Address.Bytes()) {
@@ -276,7 +271,7 @@ func TestMarshallingWithAddr(t *testing.T) {
 func TestMarshallingNoAddr(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
 	logger := logging.New(ioutil.Discard, 0)
-	tg := NewTag(context.Background(), 111, "test/tag", 10, nil, mockStatestore, logger)
+	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)
 	for _, f := range allStates {
 		err := tg.Inc(f)
 		if err != nil {
@@ -299,10 +294,6 @@ func TestMarshallingNoAddr(t *testing.T) {
 		t.Fatalf("tag uids not equal. want %d got %d", tg.Uid, unmarshalledTag.Uid)
 	}
 
-	if unmarshalledTag.Name != tg.Name {
-		t.Fatalf("tag names not equal. want %s got %s", tg.Name, unmarshalledTag.Name)
-	}
-
 	for _, state := range allStates {
 		uv, tv := unmarshalledTag.Get(state), tg.Get(state)
 		if uv != tv {
@@ -311,7 +302,7 @@ func TestMarshallingNoAddr(t *testing.T) {
 	}
 
 	if unmarshalledTag.TotalCounter() != tg.TotalCounter() {
-		t.Fatalf("tag names not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
+		t.Fatalf("tag total counters not equal. want %d got %d", tg.TotalCounter(), unmarshalledTag.TotalCounter())
 	}
 
 	if len(unmarshalledTag.Address.Bytes()) != len(tg.Address.Bytes()) {

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -185,7 +185,7 @@ func (ts *Tags) ListAll(ctx context.Context, offset, limit int) (t []*Tag, err e
 		}
 	}
 
-	if len(t) > 0 {
+	if limit == 0 {
 		return
 	}
 

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -162,7 +162,7 @@ func (ts *Tags) UnmarshalJSON(value []byte) error {
 	return err
 }
 
-func (ts *Tags) List(ctx context.Context, offset, limit int) (t []*Tag, err error) {
+func (ts *Tags) ListAll(ctx context.Context, offset, limit int) (t []*Tag, err error) {
 	if limit > maxPage {
 		limit = maxPage
 	}

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -52,10 +52,10 @@ func NewTags(stateStore storage.StateStorer, logger logging.Logger) *Tags {
 	}
 }
 
-// Create creates a new tag, stores it by the name and returns it
-// it returns an error if the tag with this name already exists
-func (ts *Tags) Create(s string, total int64) (*Tag, error) {
-	t := NewTag(context.Background(), TagUidFunc(), s, total, nil, ts.stateStore, ts.logger)
+// Create creates a new tag, stores it by the UID and returns it
+// it returns an error if the tag with this UID already exists
+func (ts *Tags) Create(total int64) (*Tag, error) {
+	t := NewTag(context.Background(), TagUidFunc(), total, nil, ts.stateStore, ts.logger)
 
 	if _, loaded := ts.tags.LoadOrStore(t.Uid, t); loaded {
 		return nil, errExists

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -76,7 +76,7 @@ func TestListAll(t *testing.T) {
 	}
 
 	// tags are from sync.Map
-	tagList1, err := ts1.ListAll(context.Background(), 0, maxPage)
+	tagList1, err := ts1.ListAll(context.Background(), 0, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestListAll(t *testing.T) {
 	}
 
 	// first tags are from sync.Map
-	tagList2, err := ts2.ListAll(context.Background(), 0, maxPage)
+	tagList2, err := ts2.ListAll(context.Background(), 0, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -29,10 +29,10 @@ func TestAll(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
 	logger := logging.New(ioutil.Discard, 0)
 	ts := NewTags(mockStatestore, logger)
-	if _, err := ts.Create("1", 1); err != nil {
+	if _, err := ts.Create(1); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ts.Create("2", 1); err != nil {
+	if _, err := ts.Create(1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -50,7 +50,7 @@ func TestAll(t *testing.T) {
 		t.Fatalf("expected tag 1 Total to be 1 got %d", n)
 	}
 
-	if _, err := ts.Create("3", 1); err != nil {
+	if _, err := ts.Create(1); err != nil {
 		t.Fatal(err)
 	}
 	all = ts.All()
@@ -64,7 +64,7 @@ func TestPersistence(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
 	logger := logging.New(ioutil.Discard, 0)
 	ts := NewTags(mockStatestore, logger)
-	ta, err := ts.Create("one", 1)
+	ta, err := ts.Create(1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
relates to: #1147

Changes to public `/tags/{id}` API.

The current tags API response returns following object:
```json
{
  "uid": 1066766601,
  "name": "unnamed_tag_1611322188",
  "startedAt": "2021-01-22T14:29:48+01:00",
  "address": "<hash>",
  "total": 26,
  "split": 26,
  "seen": 4,
  "stored": 26,
  "sent": 33,
  "synced": 22
}
```

Suggested change to this response would produce following object:
```json
{
  "uid": 1066766601,
  "startedAt": "2021-01-22T14:29:48+01:00",
  "total": 26,    // the total number of chunks for upload(s) related with this tag (estimated until tag is done)
  "processed": 26,    // the total number of chunks stored and queued for sending
  "synced": 26    // the total number of chunks that are synced with the network (now of before)
}
```

Idea behind this is to have 2 names that would represent number of chunks that are directly uploaded through request and the number of chunks that have completed syncing to the network (are were already present, i.e. already pushed previously).
In this change the `synced` is no longer actual value from the internal tag value, but represents `seen` + `synced` count.

I have considered several different combinations for these 2 properties. Any suggestion for changes (that may be more user-friendly) are welcome.

In addition to change to public API, original tag response is added to Debug API.

For the public API, the "address" is no longer returned. The address will be populated in the case where tag is automatically created by the system, during upload to `/bytes`, `/files`, or `/dirs` endpoint. (In this same case, after upload is completed (but may not yet be synced), the `split` counter will be copied into `total` and address added.)

The "name" has been completely removed from the tag.

Update (2021-01-29):
- changed "Swarm-Tag-Uid" header name to "Swarm-Tag"
- added endpoint to public API, `GET /tags`, which can be used to list tags from the node
  - this endpoint accepts `offset` and `limit`
  - since the tags exists in-memory until they are "done", and then in the statestore after, the listing first returns entries from memory, and then from statestore (ignoring ones already returned from memory)
    - addition of new tags while using `offset` will mess up ordering, and some may be skipped or returned more than once, but this limitation is because of the ID type that was chosen for the tags


Update (2021-02-02):
- renamed `stored` response field to `processed`
- returned `total` field in response
- the `total` field (for manually created tags) will always be populated with calculated number of chunks for upload
  - this only works in the case when tag is manually created and used for upload
  - for bytes content just from `Content-Length` header
  - for files based on calculation from `Content-Length` header with `2` additional chunks, for file metadata content, and for collection entry for those two addresses
  - for dirs upload for each file content from TAR archive calculated based on file size with 2 additional (for metadata and collection entry, as well with additional chunks produced in the process of saving manifest content with 2 additional (for manifest file metadata and collection entry)