### PR TITLE
IPv6 default host address be same as for IPv4

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	}
 
 	ip4Addr := "0.0.0.0"
-	ip6Addr := "::1"
+	ip6Addr := "::"
 
 	if host != "" {
 		ip := net.ParseIP(host)


### PR DESCRIPTION
relates to: #1074

In IPv6, the all-zeros address is represented by "`::`" (in short notation).