### PR TITLE
pushsync: clean up

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -146,10 +146,14 @@ LOOP:
 				// for now ignoring the receipt and checking only for error
 				_, err = s.pushSyncer.PushChunkToClosest(ctx, ch)
 				if err != nil {
-					if !errors.Is(err, topology.ErrNotFound) {
-						logger.Debugf("pusher: error push to closest: %v", err)
+					if errors.Is(err, topology.ErrWantSelf) {
+						// we are the closest ones - this is fine. set the chunk as synced
+					} else if errors.Is(err, topology.ErrNotFound) {
+						logger.Debugf("pusher: no peers found: %v", err)
+					} else {
+						// some other error occured - return
+						return
 					}
-					return
 				}
 				err = s.setChunkAsSynced(ctx, ch)
 				if err != nil {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -229,10 +229,6 @@ LOOP:
 	}
 }
 
-func (s *Service) setChunkAsSynced(ctx context.Context, ch swarm.Chunk) error {
-	return nil
-}
-
 func (s *Service) Close() error {
 	s.logger.Info("pusher shutting down")
 	close(s.quit)

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -127,6 +127,7 @@ LOOP:
 				var (
 					err       error
 					startTime = time.Now()
+					t         *tags.Tag
 				)
 				defer func() {
 					if err == nil {
@@ -152,7 +153,7 @@ LOOP:
 						// this is to make sure that the sent number does not diverge from the synced counter
 						// the edge case is on the uploader node, in the case where the uploader node is
 						// connected to other nodes, but is the closest one to the chunk.
-						t, err := s.tag.Get(ch.TagID())
+						t, err = s.tag.Get(ch.TagID())
 						if err == nil && t != nil {
 							err = t.Inc(tags.StateSent)
 							if err != nil {
@@ -170,7 +171,7 @@ LOOP:
 					return
 				}
 
-				t, err := s.tag.Get(ch.TagID())
+				t, err = s.tag.Get(ch.TagID())
 				if err == nil && t != nil {
 					err = t.Inc(tags.StateSynced)
 					if err != nil {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -169,11 +169,13 @@ LOOP:
 					err = t.Inc(tags.StateSynced)
 					if err != nil {
 						err = fmt.Errorf("pusher: increment synced: %v", err)
+						return
 					}
 					if setSent {
 						err = t.Inc(tags.StateSent)
 						if err != nil {
 							err = fmt.Errorf("pusher: increment sent: %w", err)
+							return
 						}
 					}
 				}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -96,8 +96,8 @@ func TestPushChunkToClosest(t *testing.T) {
 	// chunk data to upload
 	chunk := testingc.FixtureChunk("7000")
 	// create a pivot node and a mocked closest node
-	pivotNode := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000")   // base is 0000
-	closestPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000") // binary 0110 -> po 1
+	pivotNode := swarm.MustParseHexAddress("0000")   // base is 0000
+	closestPeer := swarm.MustParseHexAddress("6000") // binary 0110 -> po 1
 	callbackC := make(chan struct{}, 1)
 	// peer is the node responding to the chunk receipt message
 	// mock should return ErrWantSelf since there's no one to forward to
@@ -181,10 +181,10 @@ func TestPushChunkToNextClosest(t *testing.T) {
 	chunk := testingc.FixtureChunk("7000")
 
 	// create a pivot node and a mocked closest node
-	pivotNode := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
+	pivotNode := swarm.MustParseHexAddress("0000") // base is 0000
 
-	peer1 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer1 := swarm.MustParseHexAddress("6000")
+	peer2 := swarm.MustParseHexAddress("5000")
 	peers := []swarm.Address{
 		peer1,
 		peer2,
@@ -225,7 +225,6 @@ func TestPushChunkToNextClosest(t *testing.T) {
 	// pivot node needs the streamer since the chunk is intercepted by
 	// the chunk worker, then gets sent by opening a new stream
 	psPivot, storerPivot, pivotTags, pivotAccounting := createPushSyncNode(t, pivotNode, recorder, nil,
-		mock.WithClosestPeerErr(topology.ErrNotFound),
 		mock.WithPeers(peers...),
 	)
 	defer storerPivot.Close()

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -87,14 +87,18 @@ func (d *mock) Peers() []swarm.Address {
 
 func (d *mock) ClosestPeer(_ swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
-		return d.closestPeer, d.closestPeerErr
+		if d.closestPeerErr != nil {
+			return d.closestPeer, d.closestPeerErr
+		}
+		if !d.closestPeer.Equal(swarm.ZeroAddress) {
+			return d.closestPeer, nil
+		}
 	}
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
 	skipPeer := false
-
 	for _, p := range d.peers {
 		for _, a := range skipPeers {
 			if a.Equal(p) {
@@ -113,7 +117,6 @@ func (d *mock) ClosestPeer(_ swarm.Address, skipPeers ...swarm.Address) (peerAdd
 	if peerAddr.IsZero() {
 		return peerAddr, topology.ErrNotFound
 	}
-
 	return peerAddr, nil
 }
 


### PR DESCRIPTION
There's quite a bit of overlap in pushsync package logic. `handler` makes use of the same logic as `PushToClosest`. This PR changes the package to reuse that logic. It will also make use of the retry logic which is present in the `PushToClosest` method, resulting in retries when forwarding pushed chunks.

Also, some tests needed some clean up since they resulted in flow control events which are unnatural to the package in production.