### PR TITLE
api: use hex encoding in postage api

### DIFF
--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -23,11 +23,6 @@ func (b batchID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(b))
 }
 
-func (b batchID) UnmarshalJSON(d []byte) error {
-	_, err := hex.DecodeString(string(d))
-	return err
-}
-
 type postageCreateResponse struct {
 	BatchID batchID `json:"batchID"`
 }

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -24,7 +24,7 @@ func (b batchID) MarshalJSON() ([]byte, error) {
 }
 
 func (b batchID) UnmarshalJSON(d []byte) error {
-	b, err := hex.DecodeString(string(d))
+	_, err := hex.DecodeString(string(d))
 	return err
 }
 

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/postage/postagecontract"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
 )
 
 type postageCreateResponse struct {
-	BatchID []byte `json:"batchID"`
+	BatchID swarm.Address `json:"batchID"`
 }
 
 func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -55,6 +56,6 @@ func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonhttp.OK(w, &postageCreateResponse{
-		BatchID: batchID,
+		BatchID: swarm.NewAddress(batchID),
 	})
 }

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -5,6 +5,8 @@
 package api
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"net/http"
@@ -12,12 +14,22 @@ import (
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/postage/postagecontract"
-	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
 )
 
+type batchID []byte
+
+func (b batchID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(b))
+}
+
+func (b batchID) UnmarshalJSON(d []byte) error {
+	b, err := hex.DecodeString(string(d))
+	return err
+}
+
 type postageCreateResponse struct {
-	BatchID swarm.Address `json:"batchID"`
+	BatchID batchID `json:"batchID"`
 }
 
 func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -56,6 +68,6 @@ func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonhttp.OK(w, &postageCreateResponse{
-		BatchID: swarm.NewAddress(batchID),
+		BatchID: batchID,
 	})
 }

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/postage/postagecontract"
 	contractMock "github.com/ethersphere/bee/pkg/postage/postagecontract/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestPostageCreateStamp(t *testing.T) {
@@ -49,7 +50,7 @@ func TestPostageCreateStamp(t *testing.T) {
 
 		jsonhttptest.Request(t, client, http.MethodPost, createBatch(initialBalance, depth, label), http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageCreateResponse{
-				BatchID: batchID,
+				BatchID: swarm.NewAddress(batchID),
 			}),
 		)
 	})

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/postage/postagecontract"
 	contractMock "github.com/ethersphere/bee/pkg/postage/postagecontract/mock"
-	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestPostageCreateStamp(t *testing.T) {
@@ -50,7 +49,7 @@ func TestPostageCreateStamp(t *testing.T) {
 
 		jsonhttptest.Request(t, client, http.MethodPost, createBatch(initialBalance, depth, label), http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageCreateResponse{
-				BatchID: swarm.NewAddress(batchID),
+				BatchID: batchID,
 			}),
 		)
 	})


### PR DESCRIPTION
api returned base64 encoded id instead of hex.