### PR TITLE
postage: bigger page size

### DIFF
--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	blockPage = 500 // how many blocks to sync every time
-	tailSize  = 4   // how many blocks to tail from the tip of the chain
+	blockPage = 10000 // how many blocks to sync every time
+	tailSize  = 4     // how many blocks to tail from the tip of the chain
 )
 
 var (


### PR DESCRIPTION
increase page size to 10000. should allow syncing goerli <1min.

might be too big for real usage.