### PR TITLE
localstore: attach stamp to outgoing chunk

### DIFF
--- a/pkg/localstore/subscription_push.go
+++ b/pkg/localstore/subscription_push.go
@@ -74,7 +74,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, stop fun
 					}
 
 					select {
-					case chunks <- swarm.NewChunk(swarm.NewAddress(dataItem.Address), dataItem.Data).WithTagID(item.Tag):
+					case chunks <- swarm.NewChunk(swarm.NewAddress(dataItem.Address), dataItem.Data).WithTagID(item.Tag).WithStamp(dataItem.Stamp):
 						count++
 						// set next iteration start item
 						// when its chunk is successfully sent to channel


### PR DESCRIPTION
Fixes a bug where outgoing chunk on pushsync did not have stamp attached to it