### PR TITLE
swap: fix storage keys

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           echo -e "127.0.0.10\tregistry.localhost" | sudo tee -a /etc/hosts
           for ((i=0; i<REPLICA; i++)); do echo -e "127.0.1.$((i+1))\tbee-${i}.localhost bee-${i}-debug.localhost"; done | sudo tee -a /etc/hosts
-          ./beeinfra.sh install --local -r "${REPLICA}" --bootnode /dnsaddr/localhost --geth --k3s
+          ./beeinfra.sh install --local -r "${REPLICA}" --bootnode /dnsaddr/localhost --geth --k3s --pay-threshold 1000000000000
       - name: Test pingpong
         id: pingpong-1
         run: until ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"; do echo "waiting for pingpong..."; sleep .3; done
@@ -59,7 +59,7 @@ jobs:
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test settlements
         id: settlements-1
-        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}"
+        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" -t 1000000000000
       - name: Test pushsync (bytes)
         id: pushsync-bytes-1
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
@@ -96,7 +96,7 @@ jobs:
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
       - name: Set testing cluster (Node connection and clef enabled)
         run: |
-          ./beeinfra.sh install --local -r "${REPLICA}" --geth --clef --k3s
+          ./beeinfra.sh install --local -r "${REPLICA}" --geth --clef --k3s --pay-threshold 1000000000000
       - name: Test pingpong
         id: pingpong-2
         run: until ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"; do echo "waiting for pingpong..."; sleep .3; done
@@ -105,7 +105,7 @@ jobs:
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test settlements
         id: settlements-2
-        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}"
+        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" -t 1000000000000
       - name: Test pushsync (bytes)
         id: pushsync-bytes-2
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3

--- a/.github/workflows/slash-beekeeper.yml
+++ b/.github/workflows/slash-beekeeper.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo -e "127.0.0.10\tregistry.localhost" | sudo tee -a /etc/hosts
           for ((i=0; i<REPLICA; i++)); do echo -e "127.0.1.$((i+1))\tbee-${i}.localhost bee-${i}-debug.localhost"; done | sudo tee -a /etc/hosts
-          ./beeinfra.sh install --dns-disco --local -r "${REPLICA}" --bootnode /dnsaddr/localhost --geth
+          ./beeinfra.sh install --dns-disco --local -r "${REPLICA}" --bootnode /dnsaddr/localhost --geth --pay-threshold 1000000000000
       - name: Test fullconnectivity
         id: fullconnectivity-1
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
@@ -48,7 +48,7 @@ jobs:
         run: ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test settlements
         id: settlements-1
-        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}"
+        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" -t 1000000000000
       - name: Test pushsync (bytes)
         id: pushsync-bytes-1
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3
@@ -82,7 +82,7 @@ jobs:
           cp $(k3d get-kubeconfig --name='k3s-default') ~/.kube/config
       - name: Set testing cluster (Node connection and clef enabled)
         run: |
-          ./beeinfra.sh install --local -r "${REPLICA}" --geth --clef
+          ./beeinfra.sh install --local -r "${REPLICA}" --geth --clef --pay-threshold 1000000000000
       - name: Test fullconnectivity
         id: fullconnectivity-2
         run: ./beekeeper check fullconnectivity --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
@@ -91,7 +91,7 @@ jobs:
         run: ./beekeeper check pingpong --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}"
       - name: Test settlements
         id: settlements-2
-        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}"
+        run: ./beekeeper check settlements --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" -t 1000000000000
       - name: Test pushsync (bytes)
         id: pushsync-bytes-2
         run: ./beekeeper check pushsync --api-scheme http --debug-api-scheme http --disable-namespace --debug-api-domain localhost --api-domain localhost --node-count "${REPLICA}" --upload-node-count "${REPLICA}" --chunks-per-node 3

--- a/pkg/settlement/swap/chequebook/chequebook.go
+++ b/pkg/settlement/swap/chequebook/chequebook.go
@@ -24,7 +24,7 @@ import (
 type SendChequeFunc func(cheque *SignedCheque) error
 
 const (
-	lastIssuedChequeKeyPrefix = "swap_chequebook_last_issued_cheque"
+	lastIssuedChequeKeyPrefix = "swap_chequebook_last_issued_cheque_"
 	totalIssuedKey            = "swap_chequebook_total_issued_"
 )
 
@@ -201,7 +201,7 @@ func (s *service) WaitForDeposit(ctx context.Context, txHash common.Hash) error 
 
 // lastIssuedChequeKey computes the key where to store the last cheque for a beneficiary.
 func lastIssuedChequeKey(beneficiary common.Address) string {
-	return fmt.Sprintf("%s_%x", lastIssuedChequeKeyPrefix, beneficiary)
+	return fmt.Sprintf("%s%x", lastIssuedChequeKeyPrefix, beneficiary)
 }
 
 func (s *service) reserveTotalIssued(ctx context.Context, amount *big.Int) (*big.Int, error) {

--- a/pkg/settlement/swap/chequebook/chequestore.go
+++ b/pkg/settlement/swap/chequebook/chequestore.go
@@ -78,7 +78,7 @@ func NewChequeStore(
 
 // lastReceivedChequeKey computes the key where to store the last cheque received from a chequebook.
 func lastReceivedChequeKey(chequebook common.Address) string {
-	return fmt.Sprintf("%s_%x", lastReceivedChequePrefix, chequebook)
+	return fmt.Sprintf("%s%x", lastReceivedChequePrefix, chequebook)
 }
 
 // LastCheque returns the last cheque we received from a specific chequebook.

--- a/pkg/settlement/swap/chequebook/chequestore.go
+++ b/pkg/settlement/swap/chequebook/chequestore.go
@@ -78,7 +78,7 @@ func NewChequeStore(
 
 // lastReceivedChequeKey computes the key where to store the last cheque received from a chequebook.
 func lastReceivedChequeKey(chequebook common.Address) string {
-	return fmt.Sprintf("%s%x", lastReceivedChequePrefix, chequebook)
+	return fmt.Sprintf("%s_%x", lastReceivedChequePrefix, chequebook)
 }
 
 // LastCheque returns the last cheque we received from a specific chequebook.
@@ -222,7 +222,7 @@ func keyChequebook(key []byte, prefix string) (chequebook common.Address, err er
 func (s *chequeStore) LastCheques() (map[common.Address]*SignedCheque, error) {
 	result := make(map[common.Address]*SignedCheque)
 	err := s.store.Iterate(lastReceivedChequePrefix, func(key, val []byte) (stop bool, err error) {
-		addr, err := keyChequebook(key, lastReceivedChequePrefix)
+		addr, err := keyChequebook(key, lastReceivedChequePrefix+"_")
 		if err != nil {
 			return false, fmt.Errorf("parse address from key: %s: %w", string(key), err)
 		}


### PR DESCRIPTION
there were some issues with the storage key formatting introduced in breaking pr.
the change is backwards compatible.

one ugly hack is that the key prefix for issued cheques is `swap_chequebook_last_issued_cheque_` but for received ones it is actually `swap_chequebook_last_received_cheque__`. I left it that way because there were already cheques sent on staging since the reset.