### PR TITLE
check eth balance on initial startup and show required funds

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -202,6 +202,6 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
 	cmd.Flags().String(optionNameSwapEndpoint, "http://localhost:8545", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory address")
-	cmd.Flags().String(optionNameSwapInitialDeposit, "10000000000000000", "initial deposit if deploying a new chequebook")
+	cmd.Flags().String(optionNameSwapInitialDeposit, "100000000000000000", "initial deposit if deploying a new chequebook")
 	cmd.Flags().Bool(optionNameSwapEnable, true, "enable swap")
 }

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -82,7 +82,11 @@ func checkBalance(
 			select {
 			case <-time.After(backoffDuration):
 			case <-timeoutCtx.Done():
-				return fmt.Errorf("insufficient token for initial deposit")
+				if insufficientERC20 {
+					return fmt.Errorf("insufficient token for initial deposit")
+				} else {
+					return fmt.Errorf("insufficient eth for initial deposit")
+				}
 			}
 			continue
 		}

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -60,7 +60,7 @@ func checkBalance(
 		minimumEth := gasPrice.Mul(gasPrice, big.NewInt(2000000))
 
 		insufficientERC20 := erc20Balance.Cmp(swapInitialDeposit) < 0
-		insufficientETH := ethBalance.Cmp(minimumEth) == 0
+		insufficientETH := ethBalance.Cmp(minimumEth) < 0
 
 		if insufficientERC20 || insufficientETH {
 			neededERC20, mod := new(big.Int).DivMod(swapInitialDeposit, big.NewInt(10000000000000000), new(big.Int))

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -85,7 +85,7 @@ func checkBalance(
 				if insufficientERC20 {
 					return fmt.Errorf("insufficient BZZ for initial deposit")
 				} else {
-					return fmt.Errorf("insufficient eth for initial deposit")
+					return fmt.Errorf("insufficient ETH for initial deposit")
 				}
 			}
 			continue

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -70,9 +70,9 @@ func checkBalance(
 			}
 
 			if insufficientETH && insufficientERC20 {
-				logger.Warningf("cannot continue until there is sufficient ETH and at least %d BZZ available on %x", neededERC20, overlayEthAddress)
+				logger.Warningf("cannot continue until there is sufficient ETH (for Gas) and at least %d BZZ available on %x", neededERC20, overlayEthAddress)
 			} else if insufficientETH {
-				logger.Warningf("cannot continue until there is sufficient ETH available on %x", overlayEthAddress)
+				logger.Warningf("cannot continue until there is sufficient ETH (for Gas) available on %x", overlayEthAddress)
 			} else {
 				logger.Warningf("cannot continue until there is at least %d BZZ available on %x", neededERC20, overlayEthAddress)
 			}

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -40,17 +40,44 @@ func checkBalance(
 	}
 
 	for {
-		balance, err := erc20Token.BalanceOf(&bind.CallOpts{
+		erc20Balance, err := erc20Token.BalanceOf(&bind.CallOpts{
 			Context: timeoutCtx,
 		}, overlayEthAddress)
 		if err != nil {
 			return err
 		}
 
-		if balance.Cmp(swapInitialDeposit) < 0 {
-			logger.Warningf("cannot continue until there is sufficient ETH and BZZ available on %x", overlayEthAddress)
+		ethBalance, err := swapBackend.BalanceAt(timeoutCtx, overlayEthAddress, nil)
+		if err != nil {
+			return err
+		}
+
+		gasPrice, err := swapBackend.SuggestGasPrice(timeoutCtx)
+		if err != nil {
+			return err
+		}
+
+		minimumEth := gasPrice.Mul(gasPrice, big.NewInt(2000000))
+
+		insufficientERC20 := erc20Balance.Cmp(swapInitialDeposit) < 0
+		insufficientETH := ethBalance.Cmp(minimumEth) == 0
+
+		if insufficientERC20 || insufficientETH {
+			neededERC20, mod := new(big.Int).DivMod(swapInitialDeposit, big.NewInt(10000000000000000), new(big.Int))
+			if mod.Cmp(big.NewInt(0)) > 0 {
+				// always round up the division as the bzzaar cannot handle decimals
+				neededERC20.Add(neededERC20, big.NewInt(1))
+			}
+
+			if insufficientETH && insufficientERC20 {
+				logger.Warningf("cannot continue until there is sufficient ETH and at least %d BZZ available on %x", neededERC20, overlayEthAddress)
+			} else if insufficientETH {
+				logger.Warningf("cannot continue until there is sufficient ETH available on %x", overlayEthAddress)
+			} else {
+				logger.Warningf("cannot continue until there is at least %d BZZ available on %x", neededERC20, overlayEthAddress)
+			}
 			if chainId == 5 {
-				logger.Warningf("get your Goerli ETH and Goerli BZZ now via the bzzaar at https://bzz.ethswarm.org/?transaction=buy&amount=%d&slippage=30&receiver=0x%x", new(big.Int).Div(swapInitialDeposit, big.NewInt(10000000000000000)), overlayEthAddress)
+				logger.Warningf("get your Goerli ETH and Goerli BZZ now via the bzzaar at https://bzz.ethswarm.org/?transaction=buy&amount=%d&slippage=30&receiver=0x%x", neededERC20, overlayEthAddress)
 			}
 			select {
 			case <-time.After(backoffDuration):

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -83,7 +83,7 @@ func checkBalance(
 			case <-time.After(backoffDuration):
 			case <-timeoutCtx.Done():
 				if insufficientERC20 {
-					return fmt.Errorf("insufficient token for initial deposit")
+					return fmt.Errorf("insufficient BZZ for initial deposit")
 				} else {
 					return fmt.Errorf("insufficient eth for initial deposit")
 				}

--- a/pkg/settlement/swap/transaction/backend.go
+++ b/pkg/settlement/swap/transaction/backend.go
@@ -21,6 +21,7 @@ type Backend interface {
 	TransactionByHash(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 	BlockNumber(ctx context.Context) (uint64, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	BalanceAt(ctx context.Context, address common.Address, block *big.Int) (*big.Int, error)
 }
 
 func IsSynced(ctx context.Context, backend Backend, maxDelay time.Duration) (bool, error) {

--- a/pkg/settlement/swap/transaction/backendmock/backend.go
+++ b/pkg/settlement/swap/transaction/backendmock/backend.go
@@ -25,6 +25,7 @@ type backendMock struct {
 	transactionByHash  func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
 	blockNumber        func(ctx context.Context) (uint64, error)
 	headerByNumber     func(ctx context.Context, number *big.Int) (*types.Header, error)
+	balanceAt          func(ctx context.Context, address common.Address, block *big.Int) (*big.Int, error)
 }
 
 func (m *backendMock) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
@@ -102,6 +103,13 @@ func (m *backendMock) BlockNumber(ctx context.Context) (uint64, error) {
 func (m *backendMock) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	if m.headerByNumber != nil {
 		return m.headerByNumber(ctx, number)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *backendMock) BalanceAt(ctx context.Context, address common.Address, block *big.Int) (*big.Int, error) {
+	if m.balanceAt != nil {
+		return m.balanceAt(ctx, address, block)
 	}
 	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
due to obtaining gETH and gBZZ no longer being the same operation, users might run into the scenario of having BZZ on their overlay but no ETH.

This PR
* checks there is sufficient ETH available on initial startup (previously only BZZ was checked).
* shows how much BZZ is needed (this might not be obvious to the user if the deposit amount is not specified manually)
* rounds up BZZ for the bazaar link if not an exact number of BZZ
* increases default deposit to 10 BZZ