### PR TITLE
Balanced peers in kademlia

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -170,7 +170,7 @@ func (k *Kad) generateCommonBinPrefixes() {
 			for l := i + 1; l < i+k.bitSuffixLength+1; l++ {
 				index, pos := l/8, l%8
 
-				if hasBit(bitSufixes[j], 0) {
+				if hasBit(bitSufixes[j], uint8(bitSuffixPos)) {
 					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
 				} else {
 					pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"math/bits"
 	"sync"
 	"time"
 
@@ -41,35 +43,38 @@ type binSaturationFunc func(bin uint8, peers, connected *pslice.PSlice) (saturat
 
 // Options for injecting services to Kademlia.
 type Options struct {
-	SaturationFunc binSaturationFunc
-	Bootnodes      []ma.Multiaddr
-	StandaloneMode bool
-	BootnodeMode   bool
+	SaturationFunc  binSaturationFunc
+	Bootnodes       []ma.Multiaddr
+	StandaloneMode  bool
+	BootnodeMode    bool
+	BitSuffixLength int
 }
 
 // Kad is the Swarm forwarding kademlia implementation.
 type Kad struct {
-	base           swarm.Address         // this node's overlay address
-	discovery      discovery.Driver      // the discovery driver
-	addressBook    addressbook.Interface // address book to get underlays
-	p2p            p2p.Service           // p2p service to connect to nodes with
-	saturationFunc binSaturationFunc     // pluggable saturation function
-	connectedPeers *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
-	knownPeers     *pslice.PSlice        // both are po aware slice of addresses
-	bootnodes      []ma.Multiaddr
-	depth          uint8                // current neighborhood depth
-	depthMu        sync.RWMutex         // protect depth changes
-	manageC        chan struct{}        // trigger the manage forever loop to connect to new peers
-	waitNext       map[string]retryInfo // sanction connections to a peer, key is overlay string and value is a retry information
-	waitNextMu     sync.Mutex           // synchronize map
-	peerSig        []chan struct{}
-	peerSigMtx     sync.Mutex
-	logger         logging.Logger // logger
-	standalone     bool           // indicates whether the node is working in standalone mode
-	bootnode       bool           // indicates whether the node is working in bootnode mode
-	quit           chan struct{}  // quit channel
-	done           chan struct{}  // signal that `manage` has quit
-	wg             sync.WaitGroup
+	base              swarm.Address         // this node's overlay address
+	discovery         discovery.Driver      // the discovery driver
+	addressBook       addressbook.Interface // address book to get underlays
+	p2p               p2p.Service           // p2p service to connect to nodes with
+	saturationFunc    binSaturationFunc     // pluggable saturation function
+	bitSuffixLength   int                   // additional depth of common prefix for bin
+	commonBinPrefixes [][]swarm.Address     // list of address prefixes for each bin
+	connectedPeers    *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
+	knownPeers        *pslice.PSlice        // both are po aware slice of addresses
+	bootnodes         []ma.Multiaddr
+	depth             uint8                // current neighborhood depth
+	depthMu           sync.RWMutex         // protect depth changes
+	manageC           chan struct{}        // trigger the manage forever loop to connect to new peers
+	waitNext          map[string]retryInfo // sanction connections to a peer, key is overlay string and value is a retry information
+	waitNextMu        sync.Mutex           // synchronize map
+	peerSig           []chan struct{}
+	peerSigMtx        sync.Mutex
+	logger            logging.Logger // logger
+	standalone        bool           // indicates whether the node is working in standalone mode
+	bootnode          bool           // indicates whether the node is working in bootnode mode
+	quit              chan struct{}  // quit channel
+	done              chan struct{}  // signal that `manage` has quit
+	wg                sync.WaitGroup
 }
 
 type retryInfo struct {
@@ -82,27 +87,112 @@ func New(base swarm.Address, addressbook addressbook.Interface, discovery discov
 	if o.SaturationFunc == nil {
 		o.SaturationFunc = binSaturated
 	}
-
-	k := &Kad{
-		base:           base,
-		discovery:      discovery,
-		addressBook:    addressbook,
-		p2p:            p2p,
-		saturationFunc: o.SaturationFunc,
-		connectedPeers: pslice.New(int(swarm.MaxBins)),
-		knownPeers:     pslice.New(int(swarm.MaxBins)),
-		bootnodes:      o.Bootnodes,
-		manageC:        make(chan struct{}, 1),
-		waitNext:       make(map[string]retryInfo),
-		logger:         logger,
-		standalone:     o.StandaloneMode,
-		bootnode:       o.BootnodeMode,
-		quit:           make(chan struct{}),
-		done:           make(chan struct{}),
-		wg:             sync.WaitGroup{},
+	if o.BitSuffixLength <= 0 {
+		o.BitSuffixLength = nnLowWatermark
 	}
 
+	k := &Kad{
+		base:              base,
+		discovery:         discovery,
+		addressBook:       addressbook,
+		p2p:               p2p,
+		saturationFunc:    o.SaturationFunc,
+		bitSuffixLength:   o.BitSuffixLength,
+		commonBinPrefixes: make([][]swarm.Address, int(swarm.MaxBins)),
+		connectedPeers:    pslice.New(int(swarm.MaxBins)),
+		knownPeers:        pslice.New(int(swarm.MaxBins)),
+		bootnodes:         o.Bootnodes,
+		manageC:           make(chan struct{}, 1),
+		waitNext:          make(map[string]retryInfo),
+		logger:            logger,
+		standalone:        o.StandaloneMode,
+		bootnode:          o.BootnodeMode,
+		quit:              make(chan struct{}),
+		done:              make(chan struct{}),
+		wg:                sync.WaitGroup{},
+	}
+
+	k.generateCommonBinPrefixes()
+
 	return k
+}
+
+func (k *Kad) generateCommonBinPrefixes() {
+	bitCombinationsCount := int(math.Pow(2, float64(k.bitSuffixLength)))
+	bitSufixes := make([]uint8, bitCombinationsCount)
+
+	for i := 0; i < bitCombinationsCount; i++ {
+		bitSufixes[i] = uint8(i)
+	}
+
+	addr := swarm.MustParseHexAddress(k.base.String())
+	addrBytes := addr.Bytes()
+	_ = addrBytes
+
+	binPrefixes := k.commonBinPrefixes
+
+	// copy base address
+	for i := range binPrefixes {
+		binPrefixes[i] = make([]swarm.Address, bitCombinationsCount)
+	}
+
+	for i := range binPrefixes {
+		for j := range binPrefixes[i] {
+			pseudoAddrBytes := make([]byte, len(k.base.Bytes()))
+			copy(pseudoAddrBytes, k.base.Bytes())
+			binPrefixes[i][j] = swarm.NewAddress(pseudoAddrBytes)
+		}
+	}
+
+	// set pseudo suffix
+	for i := range binPrefixes {
+		for j := range binPrefixes[i] {
+			pseudoAddrBytes := binPrefixes[i][j].Bytes()
+
+			bitSuffixPos := k.bitSuffixLength - 1
+			for l := i; l < i+k.bitSuffixLength; l++ {
+				index, pos := l/8, l%8
+
+				if hasBit(bitSufixes[j], uint8(bitSuffixPos)) {
+					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
+				} else {
+					pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
+				}
+
+				bitSuffixPos--
+			}
+		}
+	}
+
+	for i := range binPrefixes {
+		for j := range binPrefixes[i] {
+			pseudoAddrBytes := binPrefixes[i][j].Bytes()
+			// clear rest of the bits
+			for l := i + k.bitSuffixLength; l < len(pseudoAddrBytes)*8; l++ {
+				index, pos := l/8, l%8
+				pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
+			}
+		}
+	}
+
+}
+
+// Clears the bit at pos in n.
+func clearBit(n uint8, pos uint8) uint8 {
+	mask := ^(uint8(1) << pos)
+	n &= mask
+	return n
+}
+
+// Sets the bit at pos in the integer n.
+func setBit(n uint8, pos uint8) uint8 {
+	n |= (1 << pos)
+	return n
+}
+
+func hasBit(n uint8, pos uint8) bool {
+	val := n & (1 << pos)
+	return (val > 0)
 }
 
 // manage is a forever loop that manages the connection to new peers

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -152,8 +152,7 @@ func (k *Kad) generateCommonBinPrefixes() {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
 			// flip first bit for bin
-			binFirstBitPos := uint8(i)
-			indexByte, posBit := binFirstBitPos/8, binFirstBitPos%8
+			indexByte, posBit := i/8, i%8
 			if hasBit(bits.Reverse8(pseudoAddrBytes[indexByte]), uint8(posBit)) {
 				pseudoAddrBytes[indexByte] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[indexByte]), uint8(posBit)))
 			} else {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -275,6 +275,12 @@ func (k *Kad) manage() {
 								continue
 							}
 
+							closestKnownPeerPO := swarm.Proximity(closestKnownPeer.Bytes(), pseudoAddr.Bytes())
+
+							if int(closestKnownPeerPO) != i+k.bitSuffixLength {
+								continue
+							}
+
 							peer := closestKnownPeer
 
 							bzzAddr, err := k.addressBook.Get(peer)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	nnLowWatermark      = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
-	maxConnAttempts     = 3 // when there is maxConnAttempts failed connect calls for a given peer it is considered non-connectable
-	maxBootnodeAttempts = 3 // how many attempts to dial to bootnodes before giving up
+	nnLowWatermark         = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
+	maxConnAttempts        = 3 // when there is maxConnAttempts failed connect calls for a given peer it is considered non-connectable
+	maxBootnodeAttempts    = 3 // how many attempts to dial to bootnodes before giving up
+	defaultBitSuffixLength = 2 // the number of bits used to create pseudo addresses for balancing
 )
 
 var (
@@ -86,6 +87,9 @@ type retryInfo struct {
 func New(base swarm.Address, addressbook addressbook.Interface, discovery discovery.Driver, p2p p2p.Service, logger logging.Logger, o Options) *Kad {
 	if o.SaturationFunc == nil {
 		o.SaturationFunc = binSaturated
+	}
+	if o.BitSuffixLength == 0 {
+		o.BitSuffixLength = defaultBitSuffixLength
 	}
 
 	k := &Kad{

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -147,16 +147,30 @@ func (k *Kad) generateCommonBinPrefixes() {
 		}
 	}
 
+	// flip first bit
+	baseHasBitFirst := hasBit(k.base.Bytes()[0], 0)
+	for i := range binPrefixes {
+		for j := range binPrefixes[i] {
+			pseudoAddrBytes := binPrefixes[i][j].Bytes()
+
+			if baseHasBitFirst {
+				pseudoAddrBytes[0] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[0]), 0))
+			} else {
+				pseudoAddrBytes[0] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[0]), 0))
+			}
+		}
+	}
+
 	// set pseudo suffix
 	for i := range binPrefixes {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
 			bitSuffixPos := k.bitSuffixLength - 1
-			for l := i; l < i+k.bitSuffixLength; l++ {
+			for l := i + 1; l < i+k.bitSuffixLength+1; l++ {
 				index, pos := l/8, l%8
 
-				if hasBit(bitSufixes[j], uint8(bitSuffixPos)) {
+				if hasBit(bitSufixes[j], 0) {
 					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
 				} else {
 					pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
@@ -171,7 +185,7 @@ func (k *Kad) generateCommonBinPrefixes() {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 			// clear rest of the bits
-			for l := i + k.bitSuffixLength; l < len(pseudoAddrBytes)*8; l++ {
+			for l := i + k.bitSuffixLength + 1; l < len(pseudoAddrBytes)*8; l++ {
 				index, pos := l/8, l%8
 				pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
 			}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -87,9 +87,6 @@ func New(base swarm.Address, addressbook addressbook.Interface, discovery discov
 	if o.SaturationFunc == nil {
 		o.SaturationFunc = binSaturated
 	}
-	if o.BitSuffixLength <= 0 {
-		o.BitSuffixLength = nnLowWatermark
-	}
 
 	k := &Kad{
 		base:              base,
@@ -112,7 +109,9 @@ func New(base swarm.Address, addressbook addressbook.Interface, discovery discov
 		wg:                sync.WaitGroup{},
 	}
 
-	k.generateCommonBinPrefixes()
+	if k.bitSuffixLength > 0 {
+		k.generateCommonBinPrefixes()
+	}
 
 	return k
 }
@@ -231,7 +230,110 @@ func (k *Kad) manage() {
 			if k.standalone {
 				continue
 			}
-			err := k.knownPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+
+			// attempt balanced connection first
+			err := func() error {
+				// for each bin
+				for i := range k.commonBinPrefixes {
+					skipConnectedPeers := make([]swarm.Address, 0)
+					skipKnownPeers := make([]swarm.Address, 0)
+
+					// and each pseudo address
+					for j := range k.commonBinPrefixes[i] {
+						pseudoAddr := k.commonBinPrefixes[i][j]
+
+						closestConnectedPeer, err := closestPeer(k.connectedPeers, pseudoAddr, skipConnectedPeers...)
+						if err != nil {
+							if errors.Is(err, topology.ErrNotFound) {
+								break
+							}
+
+							k.logger.Errorf("closest connected peer: %v", err)
+							continue
+						}
+
+						skipConnectedPeers = append(skipConnectedPeers, closestConnectedPeer)
+
+						// check proximity
+						po := swarm.Proximity(closestConnectedPeer.Bytes(), pseudoAddr.Bytes())
+
+						if int(po) < i+k.bitSuffixLength {
+							// connect to closest known peer
+
+							closestKnownPeer, err := closestPeer(k.knownPeers, pseudoAddr, skipKnownPeers...)
+							if err != nil {
+								if errors.Is(err, topology.ErrNotFound) {
+									break
+								}
+
+								k.logger.Errorf("closest known peer: %v", err)
+								continue
+							}
+
+							skipKnownPeers = append(skipKnownPeers, closestKnownPeer)
+
+							if k.connectedPeers.Exists(closestKnownPeer) {
+								continue
+							}
+
+							peer := closestKnownPeer
+
+							bzzAddr, err := k.addressBook.Get(peer)
+							if err != nil {
+								if err == addressbook.ErrNotFound {
+									k.logger.Debugf("failed to get address book entry for peer: %s", peer.String())
+									peerToRemove = peer
+									return errMissingAddressBookEntry
+								}
+								// either a peer is not known in the address book, in which case it
+								// should be removed, or that some severe I/O problem is at hand
+								return err
+							}
+
+							err = k.connect(ctx, peer, bzzAddr.Underlay, po)
+							if err != nil {
+								if errors.Is(err, errOverlayMismatch) {
+									k.knownPeers.Remove(peer, po)
+									if err := k.addressBook.Remove(peer); err != nil {
+										k.logger.Debugf("could not remove peer from addressbook: %s", peer.String())
+									}
+								}
+								k.logger.Debugf("peer not reachable from kademlia %s: %v", bzzAddr.String(), err)
+								k.logger.Warningf("peer not reachable when attempting to connect")
+								// continue to next
+								return nil
+							}
+
+							k.waitNextMu.Lock()
+							k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
+							k.waitNextMu.Unlock()
+
+							k.connectedPeers.Add(peer, po)
+
+							k.depthMu.Lock()
+							k.depth = recalcDepth(k.connectedPeers)
+							k.depthMu.Unlock()
+
+							k.logger.Debugf("connected to peer: %s for bin: %d", peer, i)
+
+							k.notifyPeerSig()
+						}
+					}
+				}
+				return nil
+			}()
+			k.logger.Tracef("kademlia balanced connector took %s to finish", time.Since(start))
+
+			if err != nil {
+				if errors.Is(err, errMissingAddressBookEntry) {
+					po := swarm.Proximity(k.base.Bytes(), peerToRemove.Bytes())
+					k.knownPeers.Remove(peerToRemove, po)
+				} else {
+					k.logger.Errorf("kademlia manage loop iterator: %v", err)
+				}
+			}
+
+			err = k.knownPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
 
 				if k.connectedPeers.Exists(peer) {
 					return false, false, nil
@@ -635,6 +737,55 @@ func (k *Kad) notifyPeerSig() {
 		default:
 		}
 	}
+}
+
+func isIn(a swarm.Address, addresses []p2p.Peer) bool {
+	for _, v := range addresses {
+		if v.Address.Equal(a) {
+			return true
+		}
+	}
+	return false
+}
+
+func closestPeer(peers *pslice.PSlice, addr swarm.Address, skipPeers ...swarm.Address) (swarm.Address, error) {
+	closest := swarm.Address{}
+	err := peers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+		for _, a := range skipPeers {
+			if a.Equal(peer) {
+				return false, false, nil
+			}
+		}
+		if closest.IsZero() {
+			closest = peer
+			return false, false, nil
+		}
+		dcmp, err := swarm.DistanceCmp(addr.Bytes(), closest.Bytes(), peer.Bytes())
+		if err != nil {
+			return false, false, err
+		}
+		switch dcmp {
+		case 0:
+			// do nothing
+		case -1:
+			// current peer is closer
+			closest = peer
+		case 1:
+			// closest is already closer to chunk
+			// do nothing
+		}
+		return false, false, nil
+	})
+	if err != nil {
+		return swarm.Address{}, err
+	}
+
+	// check if found
+	if closest.IsZero() {
+		return swarm.Address{}, topology.ErrNotFound
+	}
+
+	return closest, nil
 }
 
 // ClosestPeer returns the closest peer to a given address.

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -187,19 +187,19 @@ func (k *Kad) generateCommonBinPrefixes() {
 }
 
 // Clears the bit at pos in n.
-func clearBit(n uint8, pos uint8) uint8 {
+func clearBit(n, pos uint8) uint8 {
 	mask := ^(uint8(1) << pos)
 	n &= mask
 	return n
 }
 
 // Sets the bit at pos in the integer n.
-func setBit(n uint8, pos uint8) uint8 {
+func setBit(n, pos uint8) uint8 {
 	n |= (1 << pos)
 	return n
 }
 
-func hasBit(n uint8, pos uint8) bool {
+func hasBit(n, pos uint8) bool {
 	val := n & (1 << pos)
 	return (val > 0)
 }
@@ -755,15 +755,6 @@ func (k *Kad) notifyPeerSig() {
 		default:
 		}
 	}
-}
-
-func isIn(a swarm.Address, addresses []p2p.Peer) bool {
-	for _, v := range addresses {
-		if v.Address.Equal(a) {
-			return true
-		}
-	}
-	return false
 }
 
 func closestPeer(peers *pslice.PSlice, addr swarm.Address, skipPeers ...swarm.Address) (swarm.Address, error) {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -890,7 +890,7 @@ func (k *Kad) IsBalanced(bin uint8) bool {
 		return false
 	}
 
-	binCheckBitLen := int(bin) + k.bitSuffixLength + 1
+	binCheckBitLen := int(bin) + k.bitSuffixLength
 
 	connectedBalancedPeers := 0
 

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -151,17 +151,6 @@ func (k *Kad) generateCommonBinPrefixes() {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
-			// flip bits before
-			for l := 0; l < i+1; l++ {
-				index, pos := l/8, l%8
-
-				if hasBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)) {
-					pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
-				} else {
-					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
-				}
-			}
-
 			// set pseudo suffix
 			bitSuffixPos := k.bitSuffixLength - 1
 			for l := i + 1; l < i+k.bitSuffixLength+1; l++ {
@@ -890,6 +879,53 @@ func (k *Kad) NeighborhoodDepth() uint8 {
 
 func (k *Kad) neighborhoodDepth() uint8 {
 	return k.depth
+}
+
+// IsBalanced returns if Kademlia is balanced to bin.
+func (k *Kad) IsBalanced(bin uint8) bool {
+	k.depthMu.RLock()
+	defer k.depthMu.RUnlock()
+
+	if int(bin) > len(k.commonBinPrefixes) {
+		return false
+	}
+
+	binCheckBitLen := int(bin) + k.bitSuffixLength + 1
+
+	connectedBalancedPeers := 0
+
+	// for each pseudo address
+	for i := range k.commonBinPrefixes[bin] {
+		pseudoAddr := k.commonBinPrefixes[bin][i]
+
+		err := k.connectedPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+
+			pseudoAddrBytes := pseudoAddr.Bytes()
+			peerBytes := peer.Bytes()
+
+			for j := 1; j < binCheckBitLen; j++ {
+				index, pos := j/8, j%8
+
+				pahb := hasBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos))
+				phb := hasBit(bits.Reverse8(peerBytes[index]), uint8(pos))
+
+				if pahb != phb {
+					// starting bits do not match, go to next peer
+					return false, false, nil
+				}
+			}
+
+			connectedBalancedPeers++
+
+			// we have found peer for pseudo address
+			return true, false, nil
+		})
+		if err != nil {
+			return false
+		}
+	}
+
+	return connectedBalancedPeers >= len(k.commonBinPrefixes[bin])
 }
 
 // MarshalJSON returns a JSON representation of Kademlia.

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -147,16 +147,19 @@ func (k *Kad) generateCommonBinPrefixes() {
 		}
 	}
 
-	// flip first bit
-	baseHasBitFirst := hasBit(k.base.Bytes()[0], 0)
+	// flip bits before
 	for i := range binPrefixes {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
-			if baseHasBitFirst {
-				pseudoAddrBytes[0] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[0]), 0))
-			} else {
-				pseudoAddrBytes[0] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[0]), 0))
+			for l := 0; l < i+1; l++ {
+				index, pos := l/8, l%8
+
+				if hasBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)) {
+					pseudoAddrBytes[index] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
+				} else {
+					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
+				}
 			}
 		}
 	}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -259,9 +259,9 @@ func (k *Kad) manage() {
 						skipConnectedPeers = append(skipConnectedPeers, closestConnectedPeer)
 
 						// check proximity
-						po := swarm.Proximity(closestConnectedPeer.Bytes(), pseudoAddr.Bytes())
+						closestConnectedPO := swarm.Proximity(closestConnectedPeer.Bytes(), pseudoAddr.Bytes())
 
-						if int(po) < i+k.bitSuffixLength {
+						if int(closestConnectedPO) < i+k.bitSuffixLength {
 							// connect to closest known peer
 
 							closestKnownPeer, err := closestPeer(k.knownPeers, pseudoAddr, skipKnownPeers...)
@@ -293,6 +293,8 @@ func (k *Kad) manage() {
 								// should be removed, or that some severe I/O problem is at hand
 								return err
 							}
+
+							po := swarm.Proximity(k.base.Bytes(), peer.Bytes())
 
 							err = k.connect(ctx, peer, bzzAddr.Underlay, po)
 							if err != nil {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -151,6 +151,15 @@ func (k *Kad) generateCommonBinPrefixes() {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
+			// flip first bit for bin
+			binFirstBitPos := uint8(i)
+			indexByte, posBit := binFirstBitPos/8, binFirstBitPos%8
+			if hasBit(bits.Reverse8(pseudoAddrBytes[indexByte]), uint8(posBit)) {
+				pseudoAddrBytes[indexByte] = bits.Reverse8(clearBit(bits.Reverse8(pseudoAddrBytes[indexByte]), uint8(posBit)))
+			} else {
+				pseudoAddrBytes[indexByte] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[indexByte]), uint8(posBit)))
+			}
+
 			// set pseudo suffix
 			bitSuffixPos := k.bitSuffixLength - 1
 			for l := i + 1; l < i+k.bitSuffixLength+1; l++ {

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -147,11 +147,11 @@ func (k *Kad) generateCommonBinPrefixes() {
 		}
 	}
 
-	// flip bits before
 	for i := range binPrefixes {
 		for j := range binPrefixes[i] {
 			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 
+			// flip bits before
 			for l := 0; l < i+1; l++ {
 				index, pos := l/8, l%8
 
@@ -161,14 +161,8 @@ func (k *Kad) generateCommonBinPrefixes() {
 					pseudoAddrBytes[index] = bits.Reverse8(setBit(bits.Reverse8(pseudoAddrBytes[index]), uint8(pos)))
 				}
 			}
-		}
-	}
 
-	// set pseudo suffix
-	for i := range binPrefixes {
-		for j := range binPrefixes[i] {
-			pseudoAddrBytes := binPrefixes[i][j].Bytes()
-
+			// set pseudo suffix
 			bitSuffixPos := k.bitSuffixLength - 1
 			for l := i + 1; l < i+k.bitSuffixLength+1; l++ {
 				index, pos := l/8, l%8
@@ -181,12 +175,7 @@ func (k *Kad) generateCommonBinPrefixes() {
 
 				bitSuffixPos--
 			}
-		}
-	}
 
-	for i := range binPrefixes {
-		for j := range binPrefixes[i] {
-			pseudoAddrBytes := binPrefixes[i][j].Bytes()
 			// clear rest of the bits
 			for l := i + k.bitSuffixLength + 1; l < len(pseudoAddrBytes)*8; l++ {
 				index, pos := l/8, l%8

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -214,7 +214,7 @@ func TestManageWithBalancing(t *testing.T) {
 			f := *saturationFuncImpl
 			return f(bin, peers, connected)
 		}
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc, nil, 2)
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{SaturationFunc: saturationFunc, BitSuffixLength: 2})
 	)
 
 	// implement satiration function (while having access to Kademlia instance)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -209,8 +209,8 @@ func TestManageWithBalancing(t *testing.T) {
 	var (
 		conns int32 // how many connect calls were made to the p2p mock
 
-		saturationFuncImpl *func(bin uint8, peers, connected *pslice.PSlice) bool
-		saturationFunc     = func(bin uint8, peers, connected *pslice.PSlice) bool {
+		saturationFuncImpl *func(bin uint8, peers, connected *pslice.PSlice) (bool, bool)
+		saturationFunc     = func(bin uint8, peers, connected *pslice.PSlice) (bool, bool) {
 			f := *saturationFuncImpl
 			return f(bin, peers, connected)
 		}
@@ -218,8 +218,8 @@ func TestManageWithBalancing(t *testing.T) {
 	)
 
 	// implement satiration function (while having access to Kademlia instance)
-	sfImpl := func(bin uint8, peers, connected *pslice.PSlice) bool {
-		return kad.IsBalanced(bin)
+	sfImpl := func(bin uint8, peers, connected *pslice.PSlice) (bool, bool) {
+		return kad.IsBalanced(bin), false
 	}
 	saturationFuncImpl = &sfImpl
 

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -167,7 +167,7 @@ func TestManage(t *testing.T) {
 		saturationFunc    = func(bin uint8, peers, connected *pslice.PSlice) (bool, bool) {
 			return saturationVal, overSaturationVal
 		}
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{SaturationFunc: saturationFunc})
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{BitSuffixLength: -1, SaturationFunc: saturationFunc})
 	)
 
 	if err := kad.Start(context.Background()); err != nil {
@@ -216,7 +216,7 @@ func TestBinSaturation(t *testing.T) {
 
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{})
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{BitSuffixLength: -1})
 		peers                    []swarm.Address
 	)
 

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -245,6 +245,12 @@ func TestManageWithBalancing(t *testing.T) {
 
 	waitBalanced(t, kad, 1)
 	waitBalanced(t, kad, 2)
+	waitBalanced(t, kad, 3)
+	waitBalanced(t, kad, 4)
+	waitBalanced(t, kad, 5)
+	waitBalanced(t, kad, 6)
+	waitBalanced(t, kad, 7)
+	waitBalanced(t, kad, 8)
 }
 
 // TestBinSaturation tests the builtin binSaturated function.

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -251,7 +251,10 @@ func TestManageWithBalancing(t *testing.T) {
 	// But, Proximity(one, other) is limited to return MaxPO.
 	// So, when we get to 1 + suffix length near MaxPO, our expected proximity is not returned,
 	// even if the addresses match in the expected number of bits, because of the MaxPO limiting
-	// Right now, suffix length is 2, + 1 = 3, MaxPO is 15, so we can have balanced connections for bin 12, but not bin 13.
+	// Without extendedPO, suffix length is 2, + 1 = 3, MaxPO is 15,
+	// so we could only have balanced connections for up until bin 12, but not bin 13,
+	// as we would be expecting proximity of pseudoaddress-balancedConnection as 16 and get 15 only
+
 	for i := 1; i <= int(swarm.MaxPO); i++ {
 		waitBalanced(t, kad, uint8(i))
 	}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -237,20 +237,25 @@ func TestManageWithBalancing(t *testing.T) {
 	waitBalanced(t, kad, 0)
 
 	// add peers for other bins, enough to have balanced connections
-	for i := 0; i < 100; i++ {
-		prox := i % int(swarm.MaxBins)
-		addr := test.RandomAddressAt(base, prox)
-		addOne(t, signer, kad, ab, addr)
+	for i := 1; i <= int(swarm.MaxPO); i++ {
+		for j := 0; j < 20; j++ {
+			addr := test.RandomAddressAt(base, i)
+			addOne(t, signer, kad, ab, addr)
+		}
+		// sanity check depth
+		kDepth(t, kad, i)
 	}
 
-	waitBalanced(t, kad, 1)
-	waitBalanced(t, kad, 2)
-	waitBalanced(t, kad, 3)
-	waitBalanced(t, kad, 4)
-	waitBalanced(t, kad, 5)
-	waitBalanced(t, kad, 6)
-	waitBalanced(t, kad, 7)
-	waitBalanced(t, kad, 8)
+	// Without introducing ExtendedPO / ExtendedProximity, we could only have balanced connections until a depth of 12
+	// That is because, the proximity expected for a balanced connection is Bin + 1 + suffix length
+	// But, Proximity(one, other) is limited to return MaxPO.
+	// So, when we get to 1 + suffix length near MaxPO, our expected proximity is not returned,
+	// even if the addresses match in the expected number of bits, because of the MaxPO limiting
+	// Right now, suffix length is 2, + 1 = 3, MaxPO is 15, so we can have balanced connections for bin 12, but not bin 13.
+	for i := 1; i <= int(swarm.MaxPO); i++ {
+		waitBalanced(t, kad, uint8(i))
+	}
+
 }
 
 // TestBinSaturation tests the builtin binSaturated function.

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -202,6 +202,51 @@ func TestManage(t *testing.T) {
 	waitCounter(t, &conns, 0)
 }
 
+func TestManageWithBalancing(t *testing.T) {
+	// use "fixed" seed for this
+	rand.Seed(2)
+
+	var (
+		conns int32 // how many connect calls were made to the p2p mock
+
+		saturationFuncImpl *func(bin uint8, peers, connected *pslice.PSlice) bool
+		saturationFunc     = func(bin uint8, peers, connected *pslice.PSlice) bool {
+			f := *saturationFuncImpl
+			return f(bin, peers, connected)
+		}
+		base, kad, ab, _, signer = newTestKademlia(&conns, nil, saturationFunc, nil, 2)
+	)
+
+	// implement satiration function (while having access to Kademlia instance)
+	sfImpl := func(bin uint8, peers, connected *pslice.PSlice) bool {
+		return kad.IsBalanced(bin)
+	}
+	saturationFuncImpl = &sfImpl
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer kad.Close()
+
+	// add peers for bin '0', enough to have balanced connections
+	for i := 0; i < 20; i++ {
+		addr := test.RandomAddressAt(base, 0)
+		addOne(t, signer, kad, ab, addr)
+	}
+
+	waitBalanced(t, kad, 0)
+
+	// add peers for other bins, enough to have balanced connections
+	for i := 0; i < 100; i++ {
+		prox := i % int(swarm.MaxBins)
+		addr := test.RandomAddressAt(base, prox)
+		addOne(t, signer, kad, ab, addr)
+	}
+
+	waitBalanced(t, kad, 1)
+	waitBalanced(t, kad, 2)
+}
+
 // TestBinSaturation tests the builtin binSaturated function.
 // the test must have two phases of adding peers so that the section
 // beyond the first flow control statement gets hit (if po >= depth),
@@ -1032,4 +1077,24 @@ func isIn(addr swarm.Address, addrs []swarm.Address) bool {
 		}
 	}
 	return false
+}
+
+// waitBalanced waits for kademlia to be balanced for specified bin.
+func waitBalanced(t *testing.T, k *kademlia.Kad, bin uint8) {
+	t.Helper()
+
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting to be balanced for bin: %d", int(bin))
+		default:
+		}
+
+		if balanced := k.IsBalanced(bin); balanced {
+			return
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
 }

--- a/pkg/swarm/proximity.go
+++ b/pkg/swarm/proximity.go
@@ -36,3 +36,23 @@ func Proximity(one, other []byte) (ret uint8) {
 	}
 	return MaxPO
 }
+
+func ExtendedProximity(one, other []byte) (ret uint8) {
+	b := ExtendedPO/8 + 1
+	if l := uint8(len(one)); b > l {
+		b = l
+	}
+	if l := uint8(len(other)); b > l {
+		b = l
+	}
+	var m uint8 = 8
+	for i := uint8(0); i < b; i++ {
+		oxo := one[i] ^ other[i]
+		for j := uint8(0); j < m; j++ {
+			if (oxo>>(7-j))&0x01 != 0 {
+				return i*8 + j
+			}
+		}
+	}
+	return ExtendedPO
+}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -25,9 +25,8 @@ const (
 	HashSize                = 32
 	MaxPO             uint8 = 15
 	ExtendedPO        uint8 = MaxPO + 5
-
-	MaxBins           = MaxPO + 1
-	ChunkWithSpanSize = ChunkSize + SpanSize
+	MaxBins                 = MaxPO + 1
+	ChunkWithSpanSize       = ChunkSize + SpanSize
 )
 
 var (

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -24,8 +24,10 @@ const (
 	ChunkSize               = SectionSize * Branches
 	HashSize                = 32
 	MaxPO             uint8 = 15
-	MaxBins                 = MaxPO + 1
-	ChunkWithSpanSize       = ChunkSize + SpanSize
+	ExtendedPO        uint8 = MaxPO + 5
+
+	MaxBins           = MaxPO + 1
+	ChunkWithSpanSize = ChunkSize + SpanSize
 )
 
 var (


### PR DESCRIPTION
relates to: #57 

Using base address for starting node of `00000000` rest of description is made here.
For that base address we have following (random) addresses for different proximities (first 8 here):

```
0 -> "11011011"
1 -> "01011110"
2 -> "00100010"
3 -> "00010111"
4 -> "00001000"
5 -> "00000100"
6 -> "00000010"
7 -> "00000001"
```

Bits in common are what defines bin of some other address in relation to base address.

To have some sort of balancing, we try to have some dispersion of addresses for each bin (proximity).
We define this as bit suffix for bin, and if should be number > 0. If we set it to `1` we would have 2 possibilities, with `2` we have 4, with `3` we have 8, and so on.

For 2 following suffixes are produced for address:

```
00
01
10
11
```

Using this config, for each bin we generate table of "balanced" addresses toward which we aspire to have connections to (this is generated on Kademlia instantiation and is based on node 'base' address). We use prefix for each bin as a staring point, and to it we append each of these suffixes, to create pseudo address prefixes:

```
bin(0)
prefix = ""
balanced prefixes:
'100'
'101'
'110'
'111'

bin(1)
prefix = "0"
balanced prefixes:
'0100'
'0101'
'0110'
'0111'

bin(2)
prefix = "00"
balanced prefixes:
'00100'
'00101'
'00110'
'00111'

...

bin(4)
prefix = "0000"
balanced prefixes:
'0000100'
'0000101'
'0000110'
'0000111'

...
```

The additional bit in these examples comes after the prefix, and is opposite of the bit of the one in the base address. Index of that bit is at `PO + 1`.

With these prepared "balanced" address prefixes, for each bin we can check if we have balanced connections. We also use this information to decide if we want to connect to some other known peer in order to have balanced connected state.

The algorithm to determine if we need to connect to some other peer is done by:

- going over each generated pseudo address (prefix) from each bin
- then finding closest already connected peer to that pseudo address
- if the proximity of that closest connected peer (to pseudo address) is less than 'bin + suffix length'
- we connect to the closest known peer
  - closest known peer is again found in relation to pseudo address
  - and if proximity of it in relation to pseudo address is what we expect for balanced connection we attempt to connect to it

This process is added as separate function just before existing process for connecting to peers in Kademlia, which looks at neighborhood depth to decide if more peer connections need to be made.
