### PR TITLE
fix funding addr for both linux and mac bee-get-addr

### DIFF
--- a/packaging/bee-get-addr
+++ b/packaging/bee-get-addr
@@ -21,7 +21,7 @@ After you fix configuration run 'sudo bee-get-addr' again.
         ETH_ADDRESS=$(echo "$RESP" | grep ethereum | cut -d' ' -f6 | tr -d '"')
         echo "
 Please make sure there is sufficient eth and bzz available on $ETH_ADDRESS address.
-You can get both goerli eth and goerli bzz from https://faucet.ethswarm.org?address=$ETH_ADDRESS
+You can get both Goerli ETH and Goerli BZZ now via the bzzaar at https://bzz.ethswarm.org/?transaction=buy&amount=%d&slippage=30&receiver=0x$ETH_ADDRESS
 
 After you get the funds start service with 'systemctl start bee.service'.
         "

--- a/packaging/homebrew/bee-get-addr
+++ b/packaging/homebrew/bee-get-addr
@@ -13,7 +13,7 @@ After you fix configuration run 'bee-get-addr' again.
         ETH_ADDRESS=$(echo "$RESP" | grep ethereum | cut -d' ' -f6 | tr -d '"')
         echo "
 Please make sure there is sufficient eth and bzz available on $ETH_ADDRESS address.
-You can get both goerli eth and goerli bzz from https://faucet.ethswarm.org?address=$ETH_ADDRESS
+You can get both Goerli ETH and Goerli BZZ now via the bzzaar at https://bzz.ethswarm.org/?transaction=buy&amount=%d&slippage=30&receiver=0x$ETH_ADDRESS
 
 After you get the funds start service with 'brew services start swarm-bee'.
         "


### PR DESCRIPTION
Changed funding URL to bzzaar for `bee-get-addr` script