### PR TITLE
api: unexport api struct fields

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -65,13 +65,13 @@ type Service interface {
 }
 
 type server struct {
-	Tags        *tags.Tags
-	Storer      storage.Storer
-	Resolver    resolver.Interface
-	Pss         pss.Interface
-	Traversal   traversal.Service
-	Logger      logging.Logger
-	Tracer      *tracing.Tracer
+	tags        *tags.Tags
+	storer      storage.Storer
+	resolver    resolver.Interface
+	pss         pss.Interface
+	traversal   traversal.Service
+	logger      logging.Logger
+	tracer      *tracing.Tracer
 	feedFactory feeds.Factory
 	Options
 	http.Handler
@@ -95,15 +95,15 @@ const (
 // New will create a and initialize a new API service.
 func New(tags *tags.Tags, storer storage.Storer, resolver resolver.Interface, pss pss.Interface, traversalService traversal.Service, feedFactory feeds.Factory, logger logging.Logger, tracer *tracing.Tracer, o Options) Service {
 	s := &server{
-		Tags:        tags,
-		Storer:      storer,
-		Resolver:    resolver,
-		Pss:         pss,
-		Traversal:   traversalService,
+		tags:        tags,
+		storer:      storer,
+		resolver:    resolver,
+		pss:         pss,
+		traversal:   traversalService,
 		feedFactory: feedFactory,
 		Options:     o,
-		Logger:      logger,
-		Tracer:      tracer,
+		logger:      logger,
+		tracer:      tracer,
 		metrics:     newMetrics(),
 		quit:        make(chan struct{}),
 	}
@@ -115,7 +115,7 @@ func New(tags *tags.Tags, storer storage.Storer, resolver resolver.Interface, ps
 
 // Close hangs up running websockets on shutdown.
 func (s *server) Close() error {
-	s.Logger.Info("api shutting down")
+	s.logger.Info("api shutting down")
 	close(s.quit)
 
 	done := make(chan struct{})
@@ -138,7 +138,7 @@ func (s *server) Close() error {
 func (s *server) getOrCreateTag(tagUid string) (*tags.Tag, bool, error) {
 	// if tag ID is not supplied, create a new tag
 	if tagUid == "" {
-		tag, err := s.Tags.Create(0)
+		tag, err := s.tags.Create(0)
 		if err != nil {
 			return nil, false, fmt.Errorf("cannot create tag: %w", err)
 		}
@@ -153,11 +153,11 @@ func (s *server) getTag(tagUid string) (*tags.Tag, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse taguid: %w", err)
 	}
-	return s.Tags.Get(uint32(uid))
+	return s.tags.Get(uint32(uid))
 }
 
 func (s *server) resolveNameOrAddress(str string) (swarm.Address, error) {
-	log := s.Logger
+	log := s.logger
 
 	// Try and parse the name as a bzz address.
 	addr, err := swarm.ParseHexAddress(str)
@@ -167,13 +167,13 @@ func (s *server) resolveNameOrAddress(str string) (swarm.Address, error) {
 	}
 
 	// If no resolver is not available, return an error.
-	if s.Resolver == nil {
+	if s.resolver == nil {
 		return swarm.ZeroAddress, errNoResolver
 	}
 
 	// Try and resolve the name using the provided resolver.
 	log.Debugf("name resolve: attempting to resolve %s to bzz address", str)
-	addr, err = s.Resolver.Resolve(str)
+	addr, err = s.resolver.Resolve(str)
 	if err == nil {
 		log.Tracef("name resolve: resolved name %s to %s", str, addr)
 		return addr, nil
@@ -197,18 +197,18 @@ func requestEncrypt(r *http.Request) bool {
 func (s *server) newTracingHandler(spanName string) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, err := s.Tracer.WithContextFromHTTPHeaders(r.Context(), r.Header)
+			ctx, err := s.tracer.WithContextFromHTTPHeaders(r.Context(), r.Header)
 			if err != nil && !errors.Is(err, tracing.ErrContextNotFound) {
-				s.Logger.Debugf("span '%s': extract tracing context: %v", spanName, err)
+				s.logger.Debugf("span '%s': extract tracing context: %v", spanName, err)
 				// ignore
 			}
 
-			span, _, ctx := s.Tracer.StartSpanFromContext(ctx, spanName, s.Logger)
+			span, _, ctx := s.tracer.StartSpanFromContext(ctx, spanName, s.logger)
 			defer span.Finish()
 
-			err = s.Tracer.AddContextHTTPHeader(ctx, r.Header)
+			err = s.tracer.AddContextHTTPHeader(ctx, r.Header)
 			if err != nil {
-				s.Logger.Debugf("span '%s': inject tracing context: %v", spanName, err)
+				s.logger.Debugf("span '%s': inject tracing context: %v", spanName, err)
 				// ignore
 			}
 

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -23,7 +23,7 @@ type bytesPostResponse struct {
 
 // bytesUploadHandler handles upload of raw binary data of arbitrary length.
 func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
 
 	tag, created, err := s.getOrCreateTag(r.Header.Get(SwarmTagHeader))
 	if err != nil {
@@ -38,8 +38,8 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 		if estimatedTotalChunks := requestCalculateNumberOfChunks(r); estimatedTotalChunks > 0 {
 			err = tag.IncN(tags.TotalChunks, estimatedTotalChunks)
 			if err != nil {
-				s.Logger.Debugf("bytes upload: increment tag: %v", err)
-				s.Logger.Error("bytes upload: increment tag")
+				s.logger.Debugf("bytes upload: increment tag: %v", err)
+				s.logger.Error("bytes upload: increment tag")
 				jsonhttp.InternalServerError(w, "increment tag")
 				return
 			}
@@ -49,7 +49,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
 
-	pipe := builder.NewPipelineBuilder(ctx, s.Storer, requestModePut(r), requestEncrypt(r))
+	pipe := builder.NewPipelineBuilder(ctx, s.storer, requestModePut(r), requestEncrypt(r))
 	address, err := builder.FeedPipeline(ctx, pipe, r.Body, r.ContentLength)
 	if err != nil {
 		logger.Debugf("bytes upload: split write all: %v", err)
@@ -75,7 +75,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 // bytesGetHandler handles retrieval of raw binary data of arbitrary length.
 func (s *server) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger).Logger
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger).Logger
 	nameOrHex := mux.Vars(r)["address"]
 
 	address, err := s.resolveNameOrAddress(nameOrHex)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -34,8 +34,8 @@ import (
 )
 
 func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
-	ls := loadsave.New(s.Storer, storage.ModePutRequest, false)
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
+	ls := loadsave.New(s.storer, storage.ModePutRequest, false)
 	feedDereferenced := false
 
 	targets := r.URL.Query().Get("targets")
@@ -62,7 +62,7 @@ func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 
 FETCH:
 	// read manifest entry
-	j, _, err := joiner.New(ctx, s.Storer, address)
+	j, _, err := joiner.New(ctx, s.storer, address)
 	if err != nil {
 		logger.Debugf("bzz download: joiner manifest entry %s: %v", address, err)
 		logger.Errorf("bzz download: joiner %s", address)
@@ -104,8 +104,8 @@ FETCH:
 			feedDereferenced = true
 			curBytes, err := cur.MarshalBinary()
 			if err != nil {
-				s.Logger.Debugf("bzz download: marshal feed index: %v", err)
-				s.Logger.Error("bzz download: marshal index")
+				s.logger.Debugf("bzz download: marshal feed index: %v", err)
+				s.logger.Error("bzz download: marshal index")
 				jsonhttp.InternalServerError(w, "marshal index")
 				return
 			}
@@ -129,7 +129,7 @@ FETCH:
 	}
 
 	// read metadata
-	j, _, err = joiner.New(ctx, s.Storer, e.Metadata())
+	j, _, err = joiner.New(ctx, s.storer, e.Metadata())
 	if err != nil {
 		logger.Debugf("bzz download: joiner metadata %s: %v", address, err)
 		logger.Errorf("bzz download: joiner %s", address)
@@ -251,13 +251,13 @@ FETCH:
 
 func (s *server) serveManifestEntry(w http.ResponseWriter, r *http.Request, address, manifestEntryAddress swarm.Address, etag bool) {
 	var (
-		logger = tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
+		logger = tracing.NewLoggerWithTraceID(r.Context(), s.logger)
 		ctx    = r.Context()
 		buf    = bytes.NewBuffer(nil)
 	)
 
 	// read file entry
-	j, _, err := joiner.New(ctx, s.Storer, manifestEntryAddress)
+	j, _, err := joiner.New(ctx, s.storer, manifestEntryAddress)
 	if err != nil {
 		logger.Debugf("bzz download: joiner read file entry %s: %v", address, err)
 		logger.Errorf("bzz download: joiner read file entry %s", address)
@@ -282,7 +282,7 @@ func (s *server) serveManifestEntry(w http.ResponseWriter, r *http.Request, addr
 	}
 
 	// read file metadata
-	j, _, err = joiner.New(ctx, s.Storer, fe.Metadata())
+	j, _, err = joiner.New(ctx, s.storer, fe.Metadata())
 	if err != nil {
 		logger.Debugf("bzz download: joiner read file entry %s: %v", address, err)
 		logger.Errorf("bzz download: joiner read file entry %s", address)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -43,7 +43,7 @@ const (
 
 // dirUploadHandler uploads a directory supplied as a tar in an HTTP request
 func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.Logger)
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
 	err := validateRequest(r)
 	if err != nil {
 		logger.Errorf("dir upload, validate request")
@@ -62,10 +62,10 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Add the tag to the context
 	ctx := sctx.SetTag(r.Context(), tag)
-	p := requestPipelineFn(s.Storer, r)
+	p := requestPipelineFn(s.storer, r)
 	encrypt := requestEncrypt(r)
-	l := loadsave.New(s.Storer, requestModePut(r), encrypt)
-	reference, err := storeDir(ctx, encrypt, r.Body, s.Logger, p, l, r.Header.Get(SwarmIndexDocumentHeader), r.Header.Get(SwarmErrorDocumentHeader), tag, created)
+	l := loadsave.New(s.storer, requestModePut(r), encrypt)
+	reference, err := storeDir(ctx, encrypt, r.Body, s.logger, p, l, r.Header.Get(SwarmIndexDocumentHeader), r.Header.Get(SwarmErrorDocumentHeader), tag, created)
 	if err != nil {
 		logger.Debugf("dir upload: store dir err: %v", err)
 		logger.Errorf("dir upload: store dir")

--- a/pkg/api/pin_bytes.go
+++ b/pkg/api/pin_bytes.go
@@ -19,25 +19,25 @@ import (
 func (s *server) pinBytes(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin bytes: parse address: %v", err)
-		s.Logger.Error("pin bytes: parse address")
+		s.logger.Debugf("pin bytes: parse address: %v", err)
+		s.logger.Error("pin bytes: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin bytes: localstore has: %v", err)
-		s.Logger.Error("pin bytes: store")
+		s.logger.Debugf("pin bytes: localstore has: %v", err)
+		s.logger.Error("pin bytes: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
 
 	if !has {
-		_, err := s.Storer.Get(r.Context(), storage.ModeGetRequest, addr)
+		_, err := s.storer.Get(r.Context(), storage.ModeGetRequest, addr)
 		if err != nil {
-			s.Logger.Debugf("pin chunk: netstore get: %v", err)
-			s.Logger.Error("pin chunk: netstore")
+			s.logger.Debugf("pin chunk: netstore get: %v", err)
+			s.logger.Error("pin chunk: netstore")
 
 			jsonhttp.NotFound(w, nil)
 			return
@@ -48,17 +48,17 @@ func (s *server) pinBytes(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.pinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseBytesAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseBytesAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin bytes: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin bytes: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin bytes: invalid type")
+			s.logger.Error("pin bytes: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin bytes: cannot pin")
+		s.logger.Error("pin bytes: cannot pin")
 		jsonhttp.InternalServerError(w, "cannot pin")
 		return
 	}
@@ -70,16 +70,16 @@ func (s *server) pinBytes(w http.ResponseWriter, r *http.Request) {
 func (s *server) unpinBytes(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin bytes: parse address: %v", err)
-		s.Logger.Error("pin bytes: parse address")
+		s.logger.Debugf("pin bytes: parse address: %v", err)
+		s.logger.Error("pin bytes: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin bytes: localstore has: %v", err)
-		s.Logger.Error("pin bytes: store")
+		s.logger.Debugf("pin bytes: localstore has: %v", err)
+		s.logger.Error("pin bytes: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -93,17 +93,17 @@ func (s *server) unpinBytes(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.unpinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseBytesAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseBytesAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin bytes: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin bytes: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin bytes: invalid type")
+			s.logger.Error("pin bytes: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin bytes: cannot unpin")
+		s.logger.Error("pin bytes: cannot unpin")
 		jsonhttp.InternalServerError(w, "cannot unpin")
 		return
 	}

--- a/pkg/api/pin_bzz.go
+++ b/pkg/api/pin_bzz.go
@@ -19,25 +19,25 @@ import (
 func (s *server) pinBzz(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin bzz: parse address: %v", err)
-		s.Logger.Error("pin bzz: parse address")
+		s.logger.Debugf("pin bzz: parse address: %v", err)
+		s.logger.Error("pin bzz: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin bzz: localstore has: %v", err)
-		s.Logger.Error("pin bzz: store")
+		s.logger.Debugf("pin bzz: localstore has: %v", err)
+		s.logger.Error("pin bzz: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
 
 	if !has {
-		_, err := s.Storer.Get(r.Context(), storage.ModeGetRequest, addr)
+		_, err := s.storer.Get(r.Context(), storage.ModeGetRequest, addr)
 		if err != nil {
-			s.Logger.Debugf("pin chunk: netstore get: %v", err)
-			s.Logger.Error("pin chunk: netstore")
+			s.logger.Debugf("pin chunk: netstore get: %v", err)
+			s.logger.Error("pin chunk: netstore")
 
 			jsonhttp.NotFound(w, nil)
 			return
@@ -48,17 +48,17 @@ func (s *server) pinBzz(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.pinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseManifestAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseManifestAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin bzz: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin bzz: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin bzz: invalid type")
+			s.logger.Error("pin bzz: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin bzz: cannot pin")
+		s.logger.Error("pin bzz: cannot pin")
 		jsonhttp.InternalServerError(w, "cannot pin")
 		return
 	}
@@ -70,16 +70,16 @@ func (s *server) pinBzz(w http.ResponseWriter, r *http.Request) {
 func (s *server) unpinBzz(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin bzz: parse address: %v", err)
-		s.Logger.Error("pin bzz: parse address")
+		s.logger.Debugf("pin bzz: parse address: %v", err)
+		s.logger.Error("pin bzz: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin bzz: localstore has: %v", err)
-		s.Logger.Error("pin bzz: store")
+		s.logger.Debugf("pin bzz: localstore has: %v", err)
+		s.logger.Error("pin bzz: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -93,17 +93,17 @@ func (s *server) unpinBzz(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.unpinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseManifestAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseManifestAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin bzz: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin bzz: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin bzz: invalid type")
+			s.logger.Error("pin bzz: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin bzz: cannot unpin")
+		s.logger.Error("pin bzz: cannot unpin")
 		jsonhttp.InternalServerError(w, "cannot unpin")
 		return
 	}

--- a/pkg/api/pin_chunks.go
+++ b/pkg/api/pin_chunks.go
@@ -26,35 +26,35 @@ import (
 func (s *server) pinChunk(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin chunk: parse chunk address: %v", err)
-		s.Logger.Error("pin chunk: parse address")
+		s.logger.Debugf("pin chunk: parse chunk address: %v", err)
+		s.logger.Error("pin chunk: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	err = s.Storer.Set(r.Context(), storage.ModeSetPin, addr)
+	err = s.storer.Set(r.Context(), storage.ModeSetPin, addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			ch, err := s.Storer.Get(r.Context(), storage.ModeGetRequest, addr)
+			ch, err := s.storer.Get(r.Context(), storage.ModeGetRequest, addr)
 			if err != nil {
-				s.Logger.Debugf("pin chunk: netstore get: %v", err)
-				s.Logger.Error("pin chunk: netstore")
+				s.logger.Debugf("pin chunk: netstore get: %v", err)
+				s.logger.Error("pin chunk: netstore")
 
 				jsonhttp.NotFound(w, nil)
 				return
 			}
 
-			_, err = s.Storer.Put(r.Context(), storage.ModePutRequestPin, ch)
+			_, err = s.storer.Put(r.Context(), storage.ModePutRequestPin, ch)
 			if err != nil {
-				s.Logger.Debugf("pin chunk: storer put pin: %v", err)
-				s.Logger.Error("pin chunk: storer put pin")
+				s.logger.Debugf("pin chunk: storer put pin: %v", err)
+				s.logger.Error("pin chunk: storer put pin")
 
 				jsonhttp.InternalServerError(w, err)
 				return
 			}
 		} else {
-			s.Logger.Debugf("pin chunk: pinning error: %v, addr %s", err, addr)
-			s.Logger.Error("pin chunk: cannot pin chunk")
+			s.logger.Debugf("pin chunk: pinning error: %v, addr %s", err, addr)
+			s.logger.Error("pin chunk: cannot pin chunk")
 
 			jsonhttp.InternalServerError(w, "cannot pin chunk")
 			return
@@ -69,16 +69,16 @@ func (s *server) pinChunk(w http.ResponseWriter, r *http.Request) {
 func (s *server) unpinChunk(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin chunk: parse chunk address: %v", err)
-		s.Logger.Error("pin chunk: parse address")
+		s.logger.Debugf("pin chunk: parse chunk address: %v", err)
+		s.logger.Error("pin chunk: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin chunk: localstore has: %v", err)
-		s.Logger.Error("pin chunk: store")
+		s.logger.Debugf("pin chunk: localstore has: %v", err)
+		s.logger.Error("pin chunk: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -88,18 +88,18 @@ func (s *server) unpinChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = s.Storer.PinCounter(addr)
+	_, err = s.storer.PinCounter(addr)
 	if err != nil {
-		s.Logger.Debugf("pin chunk: not pinned: %v", err)
-		s.Logger.Error("pin chunk: pin counter")
+		s.logger.Debugf("pin chunk: not pinned: %v", err)
+		s.logger.Error("pin chunk: pin counter")
 		jsonhttp.BadRequest(w, "chunk is not yet pinned")
 		return
 	}
 
-	err = s.Storer.Set(r.Context(), storage.ModeSetUnpin, addr)
+	err = s.storer.Set(r.Context(), storage.ModeSetUnpin, addr)
 	if err != nil {
-		s.Logger.Debugf("pin chunk: unpinning error: %v, addr %s", err, addr)
-		s.Logger.Error("pin chunk: unpin")
+		s.logger.Debugf("pin chunk: unpinning error: %v, addr %s", err, addr)
+		s.logger.Error("pin chunk: unpin")
 		jsonhttp.InternalServerError(w, "cannot unpin chunk")
 		return
 	}
@@ -125,24 +125,24 @@ func (s *server) listPinnedChunks(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("offset"); v != "" {
 		offset, err = strconv.Atoi(v)
 		if err != nil {
-			s.Logger.Debugf("list pins: parse offset: %v", err)
-			s.Logger.Errorf("list pins: bad offset")
+			s.logger.Debugf("list pins: parse offset: %v", err)
+			s.logger.Errorf("list pins: bad offset")
 			jsonhttp.BadRequest(w, "bad offset")
 		}
 	}
 	if v := r.URL.Query().Get("limit"); v != "" {
 		limit, err = strconv.Atoi(v)
 		if err != nil {
-			s.Logger.Debugf("list pins: parse limit: %v", err)
-			s.Logger.Errorf("list pins: bad limit")
+			s.logger.Debugf("list pins: parse limit: %v", err)
+			s.logger.Errorf("list pins: bad limit")
 			jsonhttp.BadRequest(w, "bad limit")
 		}
 	}
 
-	pinnedChunks, err := s.Storer.PinnedChunks(r.Context(), offset, limit)
+	pinnedChunks, err := s.storer.PinnedChunks(r.Context(), offset, limit)
 	if err != nil {
-		s.Logger.Debugf("list pins: list pinned: %v", err)
-		s.Logger.Errorf("list pins: list pinned")
+		s.logger.Debugf("list pins: list pinned: %v", err)
+		s.logger.Errorf("list pins: list pinned")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -160,16 +160,16 @@ func (s *server) listPinnedChunks(w http.ResponseWriter, r *http.Request) {
 func (s *server) getPinnedChunk(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin counter: parse chunk ddress: %v", err)
-		s.Logger.Errorf("pin counter: parse address")
+		s.logger.Debugf("pin counter: parse chunk ddress: %v", err)
+		s.logger.Errorf("pin counter: parse address")
 		jsonhttp.NotFound(w, nil)
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin counter: localstore has: %v", err)
-		s.Logger.Errorf("pin counter: store")
+		s.logger.Debugf("pin counter: localstore has: %v", err)
+		s.logger.Errorf("pin counter: store")
 		jsonhttp.NotFound(w, nil)
 		return
 	}
@@ -179,14 +179,14 @@ func (s *server) getPinnedChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pinCounter, err := s.Storer.PinCounter(addr)
+	pinCounter, err := s.storer.PinCounter(addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			jsonhttp.NotFound(w, nil)
 			return
 		}
-		s.Logger.Debugf("pin counter: get pin counter: %v", err)
-		s.Logger.Errorf("pin counter: get pin counter")
+		s.logger.Debugf("pin counter: get pin counter: %v", err)
+		s.logger.Errorf("pin counter: get pin counter")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -204,16 +204,16 @@ type updatePinCounter struct {
 func (s *server) updatePinnedChunkPinCounter(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("update pin counter: parse chunk ddress: %v", err)
-		s.Logger.Errorf("update pin counter: parse address")
+		s.logger.Debugf("update pin counter: parse chunk ddress: %v", err)
+		s.logger.Errorf("update pin counter: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("update pin counter: localstore has: %v", err)
-		s.Logger.Errorf("update pin counter: store")
+		s.logger.Debugf("update pin counter: localstore has: %v", err)
+		s.logger.Errorf("update pin counter: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -223,14 +223,14 @@ func (s *server) updatePinnedChunkPinCounter(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	pinCounter, err := s.Storer.PinCounter(addr)
+	pinCounter, err := s.storer.PinCounter(addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			jsonhttp.NotFound(w, nil)
 			return
 		}
-		s.Logger.Debugf("pin counter: get pin counter: %v", err)
-		s.Logger.Errorf("pin counter: get pin counter")
+		s.logger.Debugf("pin counter: get pin counter: %v", err)
+		s.logger.Errorf("pin counter: get pin counter")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -240,8 +240,8 @@ func (s *server) updatePinnedChunkPinCounter(w http.ResponseWriter, r *http.Requ
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
 		}
-		s.Logger.Debugf("update pin counter: read request body error: %v", err)
-		s.Logger.Error("update pin counter: read request body error")
+		s.logger.Debugf("update pin counter: read request body error: %v", err)
+		s.logger.Error("update pin counter: read request body error")
 		jsonhttp.InternalServerError(w, "cannot read request")
 		return
 	}
@@ -250,15 +250,15 @@ func (s *server) updatePinnedChunkPinCounter(w http.ResponseWriter, r *http.Requ
 	if len(body) > 0 {
 		err = json.Unmarshal(body, &newPinCount)
 		if err != nil {
-			s.Logger.Debugf("update pin counter: unmarshal pin counter error: %v", err)
-			s.Logger.Errorf("update pin counter: unmarshal pin counter error")
+			s.logger.Debugf("update pin counter: unmarshal pin counter error: %v", err)
+			s.logger.Errorf("update pin counter: unmarshal pin counter error")
 			jsonhttp.InternalServerError(w, "error unmarshaling pin counter")
 			return
 		}
 	}
 
 	if newPinCount.PinCounter > math.MaxInt32 {
-		s.Logger.Errorf("update pin counter: invalid pin counter %d", newPinCount.PinCounter)
+		s.logger.Errorf("update pin counter: invalid pin counter %d", newPinCount.PinCounter)
 		jsonhttp.BadRequest(w, "invalid pin counter")
 		return
 	}
@@ -267,19 +267,19 @@ func (s *server) updatePinnedChunkPinCounter(w http.ResponseWriter, r *http.Requ
 
 	err = s.updatePinCount(r.Context(), addr, int(diff))
 	if err != nil {
-		s.Logger.Debugf("update pin counter: update error: %v, addr %s", err, addr)
-		s.Logger.Error("update pin counter: update")
+		s.logger.Debugf("update pin counter: update error: %v, addr %s", err, addr)
+		s.logger.Error("update pin counter: update")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
 
-	pinCounter, err = s.Storer.PinCounter(addr)
+	pinCounter, err = s.storer.PinCounter(addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			pinCounter = 0
 		} else {
-			s.Logger.Debugf("update pin counter: get pin counter: %v", err)
-			s.Logger.Errorf("update pin counter: get pin counter")
+			s.logger.Debugf("update pin counter: get pin counter: %v", err)
+			s.logger.Errorf("update pin counter: get pin counter")
 			jsonhttp.InternalServerError(w, err)
 			return
 		}
@@ -310,7 +310,7 @@ func (s *server) updatePinCount(ctx context.Context, reference swarm.Address, de
 		default:
 		}
 
-		err := s.Storer.Set(ctx, mode, reference)
+		err := s.storer.Set(ctx, mode, reference)
 		if err != nil {
 			return err
 		}
@@ -323,26 +323,26 @@ func (s *server) pinChunkAddressFn(ctx context.Context, reference swarm.Address)
 	return func(address swarm.Address) error {
 		// NOTE: stop pinning on first error
 
-		err := s.Storer.Set(ctx, storage.ModeSetPin, address)
+		err := s.storer.Set(ctx, storage.ModeSetPin, address)
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
 				// chunk not found locally, try to get from netstore
-				ch, err := s.Storer.Get(ctx, storage.ModeGetRequest, address)
+				ch, err := s.storer.Get(ctx, storage.ModeGetRequest, address)
 				if err != nil {
-					s.Logger.Debugf("pin traversal: storer get: for reference %s, address %s: %w", reference, address, err)
+					s.logger.Debugf("pin traversal: storer get: for reference %s, address %s: %w", reference, address, err)
 					return err
 				}
 
-				_, err = s.Storer.Put(ctx, storage.ModePutRequestPin, ch)
+				_, err = s.storer.Put(ctx, storage.ModePutRequestPin, ch)
 				if err != nil {
-					s.Logger.Debugf("pin traversal: storer put pin: for reference %s, address %s: %w", reference, address, err)
+					s.logger.Debugf("pin traversal: storer put pin: for reference %s, address %s: %w", reference, address, err)
 					return err
 				}
 
 				return nil
 			}
 
-			s.Logger.Debugf("pin traversal: storer set pin: for reference %s, address %s: %w", reference, address, err)
+			s.logger.Debugf("pin traversal: storer set pin: for reference %s, address %s: %w", reference, address, err)
 			return err
 		}
 
@@ -352,14 +352,14 @@ func (s *server) pinChunkAddressFn(ctx context.Context, reference swarm.Address)
 
 func (s *server) unpinChunkAddressFn(ctx context.Context, reference swarm.Address) func(address swarm.Address) error {
 	return func(address swarm.Address) error {
-		_, err := s.Storer.PinCounter(address)
+		_, err := s.storer.PinCounter(address)
 		if err != nil {
 			return err
 		}
 
-		err = s.Storer.Set(ctx, storage.ModeSetUnpin, address)
+		err = s.storer.Set(ctx, storage.ModeSetUnpin, address)
 		if err != nil {
-			s.Logger.Debugf("unpin traversal: for reference %s, address %s: %w", reference, address, err)
+			s.logger.Debugf("unpin traversal: for reference %s, address %s: %w", reference, address, err)
 			// continue un-pinning all chunks
 		}
 

--- a/pkg/api/pin_files.go
+++ b/pkg/api/pin_files.go
@@ -19,25 +19,25 @@ import (
 func (s *server) pinFile(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin files: parse address: %v", err)
-		s.Logger.Error("pin files: parse address")
+		s.logger.Debugf("pin files: parse address: %v", err)
+		s.logger.Error("pin files: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin files: localstore has: %v", err)
-		s.Logger.Error("pin files: store")
+		s.logger.Debugf("pin files: localstore has: %v", err)
+		s.logger.Error("pin files: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
 
 	if !has {
-		_, err := s.Storer.Get(r.Context(), storage.ModeGetRequest, addr)
+		_, err := s.storer.Get(r.Context(), storage.ModeGetRequest, addr)
 		if err != nil {
-			s.Logger.Debugf("pin chunk: netstore get: %v", err)
-			s.Logger.Error("pin chunk: netstore")
+			s.logger.Debugf("pin chunk: netstore get: %v", err)
+			s.logger.Error("pin chunk: netstore")
 
 			jsonhttp.NotFound(w, nil)
 			return
@@ -48,17 +48,17 @@ func (s *server) pinFile(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.pinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseFileAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseFileAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin files: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin files: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin files: invalid type")
+			s.logger.Error("pin files: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin files: cannot pin")
+		s.logger.Error("pin files: cannot pin")
 		jsonhttp.InternalServerError(w, "cannot pin")
 		return
 	}
@@ -70,16 +70,16 @@ func (s *server) pinFile(w http.ResponseWriter, r *http.Request) {
 func (s *server) unpinFile(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("pin files: parse address: %v", err)
-		s.Logger.Error("pin files: parse address")
+		s.logger.Debugf("pin files: parse address: %v", err)
+		s.logger.Error("pin files: parse address")
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("pin files: localstore has: %v", err)
-		s.Logger.Error("pin files: store")
+		s.logger.Debugf("pin files: localstore has: %v", err)
+		s.logger.Error("pin files: store")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}
@@ -93,17 +93,17 @@ func (s *server) unpinFile(w http.ResponseWriter, r *http.Request) {
 
 	chunkAddressFn := s.unpinChunkAddressFn(ctx, addr)
 
-	err = s.Traversal.TraverseFileAddresses(ctx, addr, chunkAddressFn)
+	err = s.traversal.TraverseFileAddresses(ctx, addr, chunkAddressFn)
 	if err != nil {
-		s.Logger.Debugf("pin files: traverse chunks: %v, addr %s", err, addr)
+		s.logger.Debugf("pin files: traverse chunks: %v, addr %s", err, addr)
 
 		if errors.Is(err, traversal.ErrInvalidType) {
-			s.Logger.Error("pin files: invalid type")
+			s.logger.Error("pin files: invalid type")
 			jsonhttp.BadRequest(w, "invalid type")
 			return
 		}
 
-		s.Logger.Error("pin files: cannot unpin")
+		s.logger.Error("pin files: cannot unpin")
 		jsonhttp.InternalServerError(w, "cannot unpin")
 		return
 	}

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -37,8 +37,8 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 	for _, v := range tgts {
 		target, err := hex.DecodeString(v)
 		if err != nil || len(target) > targetMaxLength {
-			s.Logger.Debugf("pss send: bad targets: %v", err)
-			s.Logger.Error("pss send: bad targets")
+			s.logger.Debugf("pss send: bad targets: %v", err)
+			s.logger.Error("pss send: bad targets")
 			jsonhttp.BadRequest(w, nil)
 			return
 		}
@@ -55,8 +55,8 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		var err error
 		recipient, err = pss.ParseRecipient(recipientQueryString)
 		if err != nil {
-			s.Logger.Debugf("pss recipient: %v", err)
-			s.Logger.Error("pss recipient")
+			s.logger.Debugf("pss recipient: %v", err)
+			s.logger.Error("pss recipient")
 			jsonhttp.BadRequest(w, nil)
 			return
 		}
@@ -64,16 +64,16 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		s.Logger.Debugf("pss read payload: %v", err)
-		s.Logger.Error("pss read payload")
+		s.logger.Debugf("pss read payload: %v", err)
+		s.logger.Error("pss read payload")
 		jsonhttp.InternalServerError(w, nil)
 		return
 	}
 
-	err = s.Pss.Send(r.Context(), topic, payload, recipient, targets)
+	err = s.pss.Send(r.Context(), topic, payload, recipient, targets)
 	if err != nil {
-		s.Logger.Debugf("pss send payload: %v. topic: %s", err, topicVar)
-		s.Logger.Error("pss send payload")
+		s.logger.Debugf("pss send payload: %v. topic: %s", err, topicVar)
+		s.logger.Error("pss send payload")
 		jsonhttp.InternalServerError(w, nil)
 		return
 	}
@@ -91,8 +91,8 @@ func (s *server) pssWsHandler(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		s.Logger.Debugf("pss ws: upgrade: %v", err)
-		s.Logger.Error("pss ws: cannot upgrade")
+		s.logger.Debugf("pss ws: upgrade: %v", err)
+		s.logger.Error("pss ws: cannot upgrade")
 		jsonhttp.InternalServerError(w, nil)
 		return
 	}
@@ -116,14 +116,14 @@ func (s *server) pumpWs(conn *websocket.Conn, t string) {
 		ticker.Stop()
 		_ = conn.Close()
 	}()
-	cleanup := s.Pss.Register(topic, func(_ context.Context, m []byte) {
+	cleanup := s.pss.Register(topic, func(_ context.Context, m []byte) {
 		dataC <- m
 	})
 
 	defer cleanup()
 
 	conn.SetCloseHandler(func(code int, text string) error {
-		s.Logger.Debugf("pss handler: client gone. code %d message %s", code, text)
+		s.logger.Debugf("pss handler: client gone. code %d message %s", code, text)
 		close(gone)
 		return nil
 	})
@@ -133,13 +133,13 @@ func (s *server) pumpWs(conn *websocket.Conn, t string) {
 		case b := <-dataC:
 			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 			if err != nil {
-				s.Logger.Debugf("pss set write deadline: %v", err)
+				s.logger.Debugf("pss set write deadline: %v", err)
 				return
 			}
 
 			err = conn.WriteMessage(websocket.BinaryMessage, b)
 			if err != nil {
-				s.Logger.Debugf("pss write to websocket: %v", err)
+				s.logger.Debugf("pss write to websocket: %v", err)
 				return
 			}
 
@@ -147,12 +147,12 @@ func (s *server) pumpWs(conn *websocket.Conn, t string) {
 			// shutdown
 			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 			if err != nil {
-				s.Logger.Debugf("pss set write deadline: %v", err)
+				s.logger.Debugf("pss set write deadline: %v", err)
 				return
 			}
 			err = conn.WriteMessage(websocket.CloseMessage, []byte{})
 			if err != nil {
-				s.Logger.Debugf("pss write close message: %v", err)
+				s.logger.Debugf("pss write close message: %v", err)
 			}
 			return
 		case <-gone:
@@ -161,7 +161,7 @@ func (s *server) pumpWs(conn *websocket.Conn, t string) {
 		case <-ticker.C:
 			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 			if err != nil {
-				s.Logger.Debugf("pss set write deadline: %v", err)
+				s.logger.Debugf("pss set write deadline: %v", err)
 				return
 			}
 			if err = conn.WriteMessage(websocket.PingMessage, nil); err != nil {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -190,7 +190,7 @@ func (s *server) setupRouting() {
 	)
 
 	s.Handler = web.ChainHandlers(
-		httpaccess.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, s.Tracer, "api access"),
+		httpaccess.NewHTTPAccessLogHandler(s.logger, logrus.InfoLevel, s.tracer, "api access"),
 		handlers.CompressHandler,
 		// todo: add recovery handler
 		s.pageviewMetricsHandler,
@@ -214,7 +214,7 @@ func (s *server) setupRouting() {
 func (s *server) gatewayModeForbidEndpointHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.GatewayMode {
-			s.Logger.Tracef("gateway mode: forbidden %s", r.URL.String())
+			s.logger.Tracef("gateway mode: forbidden %s", r.URL.String())
 			jsonhttp.Forbidden(w, nil)
 			return
 		}
@@ -226,12 +226,12 @@ func (s *server) gatewayModeForbidHeadersHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.GatewayMode {
 			if strings.ToLower(r.Header.Get(SwarmPinHeader)) == "true" {
-				s.Logger.Tracef("gateway mode: forbidden pinning %s", r.URL.String())
+				s.logger.Tracef("gateway mode: forbidden pinning %s", r.URL.String())
 				jsonhttp.Forbidden(w, "pinning is disabled")
 				return
 			}
 			if strings.ToLower(r.Header.Get(SwarmEncryptHeader)) == "true" {
-				s.Logger.Tracef("gateway mode: forbidden encryption %s", r.URL.String())
+				s.logger.Tracef("gateway mode: forbidden encryption %s", r.URL.String())
 				jsonhttp.Forbidden(w, "encryption is disabled")
 				return
 			}

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -50,8 +50,8 @@ func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
 		}
-		s.Logger.Debugf("create tag: read request body error: %v", err)
-		s.Logger.Error("create tag: read request body error")
+		s.logger.Debugf("create tag: read request body error: %v", err)
+		s.logger.Error("create tag: read request body error")
 		jsonhttp.InternalServerError(w, "cannot read request")
 		return
 	}
@@ -60,17 +60,17 @@ func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
 	if len(body) > 0 {
 		err = json.Unmarshal(body, &tagr)
 		if err != nil {
-			s.Logger.Debugf("create tag: unmarshal tag name error: %v", err)
-			s.Logger.Errorf("create tag: unmarshal tag name error")
+			s.logger.Debugf("create tag: unmarshal tag name error: %v", err)
+			s.logger.Errorf("create tag: unmarshal tag name error")
 			jsonhttp.InternalServerError(w, "error unmarshaling metadata")
 			return
 		}
 	}
 
-	tag, err := s.Tags.Create(0)
+	tag, err := s.tags.Create(0)
 	if err != nil {
-		s.Logger.Debugf("create tag: tag create error: %v", err)
-		s.Logger.Error("create tag: tag create error")
+		s.logger.Debugf("create tag: tag create error: %v", err)
+		s.logger.Error("create tag: tag create error")
 		jsonhttp.InternalServerError(w, "cannot create tag")
 		return
 	}
@@ -83,22 +83,22 @@ func (s *server) getTagHandler(w http.ResponseWriter, r *http.Request) {
 
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		s.Logger.Debugf("get tag: parse id  %s: %v", idStr, err)
-		s.Logger.Error("get tag: parse id")
+		s.logger.Debugf("get tag: parse id  %s: %v", idStr, err)
+		s.logger.Error("get tag: parse id")
 		jsonhttp.BadRequest(w, "invalid id")
 		return
 	}
 
-	tag, err := s.Tags.Get(uint32(id))
+	tag, err := s.tags.Get(uint32(id))
 	if err != nil {
 		if errors.Is(err, tags.ErrNotFound) {
-			s.Logger.Debugf("get tag: tag not present: %v, id %s", err, idStr)
-			s.Logger.Error("get tag: tag not present")
+			s.logger.Debugf("get tag: tag not present: %v, id %s", err, idStr)
+			s.logger.Error("get tag: tag not present")
 			jsonhttp.NotFound(w, "tag not present")
 			return
 		}
-		s.Logger.Debugf("get tag: tag %v: %v", idStr, err)
-		s.Logger.Errorf("get tag: %v", idStr)
+		s.logger.Debugf("get tag: tag %v: %v", idStr, err)
+		s.logger.Errorf("get tag: %v", idStr)
 		jsonhttp.InternalServerError(w, "cannot get tag")
 		return
 	}
@@ -112,27 +112,27 @@ func (s *server) deleteTagHandler(w http.ResponseWriter, r *http.Request) {
 
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		s.Logger.Debugf("delete tag: parse id  %s: %v", idStr, err)
-		s.Logger.Error("delete tag: parse id")
+		s.logger.Debugf("delete tag: parse id  %s: %v", idStr, err)
+		s.logger.Error("delete tag: parse id")
 		jsonhttp.BadRequest(w, "invalid id")
 		return
 	}
 
-	tag, err := s.Tags.Get(uint32(id))
+	tag, err := s.tags.Get(uint32(id))
 	if err != nil {
 		if errors.Is(err, tags.ErrNotFound) {
-			s.Logger.Debugf("delete tag: tag not present: %v, id %s", err, idStr)
-			s.Logger.Error("delete tag: tag not present")
+			s.logger.Debugf("delete tag: tag not present: %v, id %s", err, idStr)
+			s.logger.Error("delete tag: tag not present")
 			jsonhttp.NotFound(w, "tag not present")
 			return
 		}
-		s.Logger.Debugf("delete tag: tag %v: %v", idStr, err)
-		s.Logger.Errorf("delete tag: %v", idStr)
+		s.logger.Debugf("delete tag: tag %v: %v", idStr, err)
+		s.logger.Errorf("delete tag: %v", idStr)
 		jsonhttp.InternalServerError(w, "cannot get tag")
 		return
 	}
 
-	s.Tags.Delete(tag.Uid)
+	s.tags.Delete(tag.Uid)
 	jsonhttp.NoContent(w)
 }
 
@@ -141,8 +141,8 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		s.Logger.Debugf("done split tag: parse id  %s: %v", idStr, err)
-		s.Logger.Error("done split tag: parse id")
+		s.logger.Debugf("done split tag: parse id  %s: %v", idStr, err)
+		s.logger.Error("done split tag: parse id")
 		jsonhttp.BadRequest(w, "invalid id")
 		return
 	}
@@ -152,8 +152,8 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
 		}
-		s.Logger.Debugf("done split tag: read request body error: %v", err)
-		s.Logger.Error("done split tag: read request body error")
+		s.logger.Debugf("done split tag: read request body error: %v", err)
+		s.logger.Error("done split tag: read request body error")
 		jsonhttp.InternalServerError(w, "cannot read request")
 		return
 	}
@@ -162,31 +162,31 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 	if len(body) > 0 {
 		err = json.Unmarshal(body, &tagr)
 		if err != nil {
-			s.Logger.Debugf("done split tag: unmarshal tag name error: %v", err)
-			s.Logger.Errorf("done split tag: unmarshal tag name error")
+			s.logger.Debugf("done split tag: unmarshal tag name error: %v", err)
+			s.logger.Errorf("done split tag: unmarshal tag name error")
 			jsonhttp.InternalServerError(w, "error unmarshaling metadata")
 			return
 		}
 	}
 
-	tag, err := s.Tags.Get(uint32(id))
+	tag, err := s.tags.Get(uint32(id))
 	if err != nil {
 		if errors.Is(err, tags.ErrNotFound) {
-			s.Logger.Debugf("done split: tag not present: %v, id %s", err, idStr)
-			s.Logger.Error("done split: tag not present")
+			s.logger.Debugf("done split: tag not present: %v, id %s", err, idStr)
+			s.logger.Error("done split: tag not present")
 			jsonhttp.NotFound(w, "tag not present")
 			return
 		}
-		s.Logger.Debugf("done split: tag %v: %v", idStr, err)
-		s.Logger.Errorf("done split: %v", idStr)
+		s.logger.Debugf("done split: tag %v: %v", idStr, err)
+		s.logger.Errorf("done split: %v", idStr)
 		jsonhttp.InternalServerError(w, "cannot get tag")
 		return
 	}
 
 	_, err = tag.DoneSplit(tagr.Address)
 	if err != nil {
-		s.Logger.Debugf("done split: failed for address %v", tagr.Address)
-		s.Logger.Errorf("done split: failed for address %v", tagr.Address)
+		s.logger.Debugf("done split: failed for address %v", tagr.Address)
+		s.logger.Errorf("done split: failed for address %v", tagr.Address)
 		jsonhttp.InternalServerError(w, nil)
 		return
 	}
@@ -202,24 +202,24 @@ func (s *server) listTagsHandler(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("offset"); v != "" {
 		offset, err = strconv.Atoi(v)
 		if err != nil {
-			s.Logger.Debugf("list tags: parse offset: %v", err)
-			s.Logger.Errorf("list tags: bad offset")
+			s.logger.Debugf("list tags: parse offset: %v", err)
+			s.logger.Errorf("list tags: bad offset")
 			jsonhttp.BadRequest(w, "bad offset")
 		}
 	}
 	if v := r.URL.Query().Get("limit"); v != "" {
 		limit, err = strconv.Atoi(v)
 		if err != nil {
-			s.Logger.Debugf("list tags: parse limit: %v", err)
-			s.Logger.Errorf("list tags: bad limit")
+			s.logger.Debugf("list tags: parse limit: %v", err)
+			s.logger.Errorf("list tags: bad limit")
 			jsonhttp.BadRequest(w, "bad limit")
 		}
 	}
 
-	tagList, err := s.Tags.ListAll(r.Context(), offset, limit)
+	tagList, err := s.tags.ListAll(r.Context(), offset, limit)
 	if err != nil {
-		s.Logger.Debugf("list tags: listing: %v", err)
-		s.Logger.Errorf("list tags: listing")
+		s.logger.Debugf("list tags: listing: %v", err)
+		s.logger.Errorf("list tags: listing")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}


### PR DESCRIPTION
The fields on the HTTP API are exported for no particular reason, and are therefore unexported in this PR.