### PR TITLE
set swap-endpoint to slock.it goerli for deb, rpm and brew package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -125,7 +125,7 @@ brews:
         Logs:   #{var}/log/swarm-bee/bee.log
         Config: #{etc}/swarm-bee/bee.yaml
 
-        Bee has SWAP enabled by default and it needs ethereum endpoint to operate.
+        Bee has SWAP enabled and by default is using slock.it goerli ethereum endpoint.
         It is recommended to use external signer with bee.
         Check documentation for more info:
         - SWAP https://docs.ethswarm.org/docs/installation/manual#swap-bandwidth-incentives

--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -51,7 +51,7 @@ password-file: /var/lib/bee/password
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "http://localhost:8545")
-# swap-endpoint: http://localhost:8545
+swap-endpoint: https://rpc.slock.it/goerli
 ## swap factory address
 # swap-factory-address: ""
 ## initial deposit if deploying a new chequebook (default 100000000)

--- a/packaging/homebrew/bee.yaml
+++ b/packaging/homebrew/bee.yaml
@@ -51,7 +51,7 @@ password-file: /usr/local/var/lib/swarm-bee/password
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "http://localhost:8545")
-# swap-endpoint: http://localhost:8545
+swap-endpoint: https://rpc.slock.it/goerli
 ## swap factory address
 # swap-factory-address: ""
 ## initial deposit if deploying a new chequebook (default 100000000)

--- a/packaging/rpm/post
+++ b/packaging/rpm/post
@@ -10,7 +10,7 @@ if [ $1 -eq 1 ] ; then
 Logs:   journalctl -f -u bee.service
 Config: /etc/bee/bee.yaml
 
-Bee has SWAP enabled by default and it needs ethereum endpoint to operate.
+Bee has SWAP enabled and by default is using slock.it goerli ethereum endpoint.
 It is recommended to use external signer with bee.
 Check documentation for more info:
 - SWAP https://docs.ethswarm.org/docs/installation/manual#swap-bandwidth-incentives


### PR DESCRIPTION
Set `https://rpc.slock.it/goerli` as a `swap-endpoint` for deb, rpm and brew packages
@Eknir should I set that as a default for docker-compose?