### PR TITLE
statestore: try to recover leveldb on corrupted db

### DIFF
--- a/pkg/intervalstore/store_test.go
+++ b/pkg/intervalstore/store_test.go
@@ -39,7 +39,7 @@ func TestDBStore(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	store, err := leveldb.NewStateStore(dir)
+	store, err := leveldb.NewStateStore(dir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -136,7 +136,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		stateStore = mockinmem.NewStateStore()
 		logger.Warning("using in-mem state store. no node state will be persisted")
 	} else {
-		stateStore, err = leveldb.NewStateStore(filepath.Join(o.DataDir, "statestore"))
+		stateStore, err = leveldb.NewStateStore(filepath.Join(o.DataDir, "statestore"), logger)
 		if err != nil {
 			return nil, fmt.Errorf("statestore: %w", err)
 		}

--- a/pkg/statestore/leveldb/leveldb_test.go
+++ b/pkg/statestore/leveldb/leveldb_test.go
@@ -26,7 +26,7 @@ func TestPersistentStateStore(t *testing.T) {
 			}
 		})
 
-		store, err := leveldb.NewStateStore(dir)
+		store, err := leveldb.NewStateStore(dir, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +40,7 @@ func TestPersistentStateStore(t *testing.T) {
 	})
 
 	test.RunPersist(t, func(t *testing.T, dir string) storage.StateStorer {
-		store, err := leveldb.NewStateStore(dir)
+		store, err := leveldb.NewStateStore(dir, nil)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
It appears that the statestore might shut down in an unclean state, resulting in a corrupted db.
This PR adds an attempt to recover the statestore whenever a corrupt state is detected.

refers to a bug reported in https://github.com/ethersphere/bee/issues/1232

This is obviously controversial as it can yield some other strange states, I am open for suggestions or scratching this entirely.