### PR TITLE
tags: delete persisted tag

### DIFF
--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -210,4 +210,21 @@ func TestPersistence(t *testing.T) {
 	if ta.Synced != rcvd2.Synced {
 		t.Fatalf("invalid synced: expected %d got %d", ta.Synced, rcvd2.Synced)
 	}
+
+	// regression test case: make sure that a persisted tag
+	// is flushed from statestore on Delete
+	ts.Delete(ta.Uid)
+
+	// simulate node closing down and booting up
+	err = ts.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts = NewTags(mockStatestore, logger)
+
+	// get the tag after the node boot up
+	_, err = ts.Get(ta.Uid)
+	if err == nil {
+		t.Fatal("expected error but got none")
+	}
 }

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -18,6 +18,7 @@ package tags
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"sort"
 	"testing"
@@ -224,7 +225,7 @@ func TestPersistence(t *testing.T) {
 
 	// get the tag after the node boot up
 	_, err = ts.Get(ta.Uid)
-	if err == nil {
-		t.Fatal("expected error but got none")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Persisted tags were never removed from statestore on `Delete`, which has resulted in deleted tags to be reloaded on node restart.

addresses https://github.com/ethersphere/bee/issues/1252