### PR TITLE
api: dont accept two soc's with the same address

### DIFF
--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -105,7 +105,21 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 
 	}
+
 	ctx := r.Context()
+
+	has, err := s.storer.Has(ctx, chunk.Address())
+	if err != nil {
+		s.logger.Debugf("soc upload: store has: %v", err)
+		s.logger.Error("soc upload: store has")
+		jsonhttp.InternalServerError(w, "storage error")
+		return
+	}
+	if has {
+		s.logger.Error("soc upload: chunk already exists")
+		jsonhttp.Conflict(w, "chunk already exists")
+		return
+	}
 
 	_, err = s.storer.Put(ctx, requestModePut(r), chunk)
 	if err != nil {


### PR DESCRIPTION
SOCs are not content addressed, therefore SOCs with different content addressed chunks in their payload can result in the same SOC address.
This PR adds a check in the API, to verify that a chunk with the same address does not exist in the localstore before inserting it.

addresses #1247 