### PR TITLE
transaction: add simple nonce tracking

### DIFF
--- a/pkg/crypto/mock/signer.go
+++ b/pkg/crypto/mock/signer.go
@@ -14,11 +14,15 @@ import (
 )
 
 type signerMock struct {
-	signTx        func(transaction *types.Transaction) (*types.Transaction, error)
-	signTypedData func(*eip712.TypedData) ([]byte, error)
+	signTx          func(transaction *types.Transaction) (*types.Transaction, error)
+	signTypedData   func(*eip712.TypedData) ([]byte, error)
+	ethereumAddress func() (common.Address, error)
 }
 
-func (*signerMock) EthereumAddress() (common.Address, error) {
+func (m *signerMock) EthereumAddress() (common.Address, error) {
+	if m.ethereumAddress != nil {
+		return m.ethereumAddress()
+	}
 	return common.Address{}, nil
 }
 
@@ -64,5 +68,11 @@ func WithSignTxFunc(f func(transaction *types.Transaction) (*types.Transaction, 
 func WithSignTypedDataFunc(f func(*eip712.TypedData) ([]byte, error)) Option {
 	return optionFunc(func(s *signerMock) {
 		s.signTypedData = f
+	})
+}
+
+func WithEthereumAddressFunc(f func() (common.Address, error)) Option {
+	return optionFunc(func(s *signerMock) {
+		s.ethereumAddress = f
 	})
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -153,7 +153,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		if err != nil {
 			return nil, err
 		}
-		transactionService, err := transaction.NewService(logger, swapBackend, signer)
+		transactionService, err := transaction.NewService(logger, swapBackend, signer, stateStore)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/settlement/swap/transaction/backend.go
+++ b/pkg/settlement/swap/transaction/backend.go
@@ -24,6 +24,10 @@ type Backend interface {
 	BalanceAt(ctx context.Context, address common.Address, block *big.Int) (*big.Int, error)
 }
 
+// IsSynced will check if we are synced with the given blockchain backend. This
+// is true if the current wall clock is after the block time of last block
+// with the given maxDelay as the maximum duration we can be behind the block
+// time.
 func IsSynced(ctx context.Context, backend Backend, maxDelay time.Duration) (bool, error) {
 	number, err := backend.BlockNumber(ctx)
 	if err != nil {
@@ -40,6 +44,9 @@ func IsSynced(ctx context.Context, backend Backend, maxDelay time.Duration) (boo
 	return blockTime.After(time.Now().UTC().Add(-maxDelay)), nil
 }
 
+// WaitSynced will wait until we are synced with the given blockchain backend,
+// with the given maxDelay duration as the maximum time we can be behind the
+// last block.
 func WaitSynced(ctx context.Context, backend Backend, maxDelay time.Duration) error {
 	for {
 		synced, err := IsSynced(ctx, backend, maxDelay)

--- a/pkg/settlement/swap/transaction/transaction.go
+++ b/pkg/settlement/swap/transaction/transaction.go
@@ -6,7 +6,9 @@ package transaction
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -14,7 +16,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/storage"
 	"golang.org/x/net/context"
+)
+
+const (
+	noncePrefix = "transaction_nonce_"
 )
 
 var (
@@ -39,14 +46,17 @@ type Service interface {
 }
 
 type transactionService struct {
+	lock sync.Mutex
+
 	logger  logging.Logger
 	backend Backend
 	signer  crypto.Signer
 	sender  common.Address
+	store   storage.StateStorer
 }
 
 // NewService creates a new transaction service.
-func NewService(logger logging.Logger, backend Backend, signer crypto.Signer) (Service, error) {
+func NewService(logger logging.Logger, backend Backend, signer crypto.Signer, store storage.StateStorer) (Service, error) {
 	senderAddress, err := signer.EthereumAddress()
 	if err != nil {
 		return nil, err
@@ -56,12 +66,21 @@ func NewService(logger logging.Logger, backend Backend, signer crypto.Signer) (S
 		backend: backend,
 		signer:  signer,
 		sender:  senderAddress,
+		store:   store,
 	}, nil
 }
 
 // Send creates and signs a transaction based on the request and sends it.
 func (t *transactionService) Send(ctx context.Context, request *TxRequest) (txHash common.Hash, err error) {
-	tx, err := prepareTransaction(ctx, request, t.sender, t.backend)
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	nonce, err := t.nextNonce(ctx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	tx, err := prepareTransaction(ctx, request, t.sender, t.backend, nonce)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -72,6 +91,11 @@ func (t *transactionService) Send(ctx context.Context, request *TxRequest) (txHa
 	}
 
 	err = t.backend.SendTransaction(ctx, signedTx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	err = t.putNonce(nonce + 1)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -102,7 +126,7 @@ func (t *transactionService) WaitForReceipt(ctx context.Context, txHash common.H
 }
 
 // prepareTransaction creates a signable transaction based on a request.
-func prepareTransaction(ctx context.Context, request *TxRequest, from common.Address, backend Backend) (tx *types.Transaction, err error) {
+func prepareTransaction(ctx context.Context, request *TxRequest, from common.Address, backend Backend, nonce uint64) (tx *types.Transaction, err error) {
 	var gasLimit uint64
 	if request.GasLimit == 0 {
 		gasLimit, err = backend.EstimateGas(ctx, ethereum.CallMsg{
@@ -127,11 +151,6 @@ func prepareTransaction(ctx context.Context, request *TxRequest, from common.Add
 		gasPrice = request.GasPrice
 	}
 
-	nonce, err := backend.PendingNonceAt(ctx, from)
-	if err != nil {
-		return nil, err
-	}
-
 	if request.To != nil {
 		return types.NewTransaction(
 			nonce,
@@ -150,4 +169,35 @@ func prepareTransaction(ctx context.Context, request *TxRequest, from common.Add
 			request.Data,
 		), nil
 	}
+}
+
+func (t *transactionService) nonceKey() string {
+	return fmt.Sprintf("%s%x", noncePrefix, t.sender)
+}
+
+func (t *transactionService) nextNonce(ctx context.Context) (uint64, error) {
+	onchainNonce, err := t.backend.PendingNonceAt(ctx, t.sender)
+	if err != nil {
+		return 0, err
+	}
+
+	var nonce uint64
+	err = t.store.Get(t.nonceKey(), &nonce)
+	if err != nil {
+		// if no nonce was found locally used whatever we get from the backend
+		if errors.Is(err, storage.ErrNotFound) {
+			return onchainNonce, nil
+		}
+		return 0, err
+	}
+
+	// if the nonce onchain is larger than what we have there were external transactions and we need to update our nonce
+	if onchainNonce > nonce {
+		return onchainNonce, nil
+	}
+	return nonce, nil
+}
+
+func (t *transactionService) putNonce(nonce uint64) error {
+	return t.store.Put(t.nonceKey(), nonce)
 }

--- a/pkg/settlement/swap/transaction/transaction_test.go
+++ b/pkg/settlement/swap/transaction/transaction_test.go
@@ -7,6 +7,7 @@ package transaction_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"testing"
@@ -14,168 +15,299 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/crypto"
 	signermock "github.com/ethersphere/bee/pkg/crypto/mock"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/settlement/swap/transaction"
 	"github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
+	storemock "github.com/ethersphere/bee/pkg/statestore/mock"
 )
 
-func TestTransactionSend(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
-	recipient := common.HexToAddress("0xabcd")
-	signedTx := types.NewTransaction(0, recipient, big.NewInt(0), 0, nil, nil)
-	txData := common.Hex2Bytes("0xabcdee")
-	value := big.NewInt(1)
-	suggestedGasPrice := big.NewInt(2)
-	estimatedGasLimit := uint64(3)
-	nonce := uint64(2)
-
-	request := &transaction.TxRequest{
-		To:    &recipient,
-		Data:  txData,
-		Value: value,
-	}
-
-	transactionService, err := transaction.NewService(logger,
-		backendmock.New(
-			backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
-				if tx != signedTx {
-					t.Fatal("not sending signed transaction")
-				}
-				return nil
-			}),
-			backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-				if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
-					t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
-				}
-				if !bytes.Equal(call.Data, txData) {
-					t.Fatal("estimating with wrong data")
-				}
-				return estimatedGasLimit, nil
-			}),
-			backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
-				return suggestedGasPrice, nil
-			}),
-			backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
-				return nonce, nil
-			}),
-		),
-		signermock.New(
-			signermock.WithSignTxFunc(func(transaction *types.Transaction) (*types.Transaction, error) {
-				if !bytes.Equal(transaction.To().Bytes(), recipient.Bytes()) {
-					t.Fatalf("signing transaction with wrong recipient. wanted %x, got %x", recipient, transaction.To())
-				}
-				if !bytes.Equal(transaction.Data(), txData) {
-					t.Fatalf("signing transaction with wrong data. wanted %x, got %x", txData, transaction.Data())
-				}
-				if transaction.Value().Cmp(value) != 0 {
-					t.Fatalf("signing transaction with wrong value. wanted %d, got %d", value, transaction.Value())
-				}
-				if transaction.Gas() != estimatedGasLimit {
-					t.Fatalf("signing transaction with wrong gas. wanted %d, got %d", estimatedGasLimit, transaction.Gas())
-				}
-				if transaction.GasPrice().Cmp(suggestedGasPrice) != 0 {
-					t.Fatalf("signing transaction with wrong gasprice. wanted %d, got %d", suggestedGasPrice, transaction.GasPrice())
-				}
-
-				if transaction.Nonce() != nonce {
-					t.Fatalf("signing transaction with wrong nonce. wanted %d, got %d", nonce, transaction.Nonce())
-				}
-
-				return signedTx, nil
-			}),
-		),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	txHash, err := transactionService.Send(context.Background(), request)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
-		t.Fatal("returning wrong transaction hash")
-	}
+func nonceKey(sender common.Address) string {
+	return fmt.Sprintf("transaction_nonce_%x", sender)
 }
 
-func TestTransactionDeploy(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
-	signedTx := types.NewContractCreation(0, big.NewInt(0), 0, nil, nil)
-	txData := common.Hex2Bytes("0xabcdee")
-	value := big.NewInt(1)
-	suggestedGasPrice := big.NewInt(2)
-	estimatedGasLimit := uint64(3)
-	nonce := uint64(2)
-
-	request := &transaction.TxRequest{
-		To:    nil,
-		Data:  txData,
-		Value: value,
-	}
-
-	transactionService, err := transaction.NewService(logger,
-		backendmock.New(
-			backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
-				if tx != signedTx {
-					t.Fatal("not sending signed transaction")
-				}
-				return nil
-			}),
-			backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-				if call.To != nil {
-					t.Fatalf("estimating with recipient. wanted nil, got %x", call.To)
-				}
-				if !bytes.Equal(call.Data, txData) {
-					t.Fatal("estimating with wrong data")
-				}
-				return estimatedGasLimit, nil
-			}),
-			backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
-				return suggestedGasPrice, nil
-			}),
-			backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
-				return nonce, nil
-			}),
-		),
-		signermock.New(
-			signermock.WithSignTxFunc(func(transaction *types.Transaction) (*types.Transaction, error) {
+func signerMockForTransaction(signedTx *types.Transaction, sender common.Address, t *testing.T) crypto.Signer {
+	return signermock.New(
+		signermock.WithSignTxFunc(func(transaction *types.Transaction) (*types.Transaction, error) {
+			if signedTx.To() == nil {
 				if transaction.To() != nil {
 					t.Fatalf("signing transaction with recipient. wanted nil, got %x", transaction.To())
 				}
-				if !bytes.Equal(transaction.Data(), txData) {
-					t.Fatalf("signing transaction with wrong data. wanted %x, got %x", txData, transaction.Data())
+			} else {
+				if transaction.To() == nil || *transaction.To() != *signedTx.To() {
+					t.Fatalf("signing transactiono with wrong recipient. wanted %x, got %x", signedTx.To(), transaction.To())
 				}
-				if transaction.Value().Cmp(value) != 0 {
-					t.Fatalf("signing transaction with wrong value. wanted %d, got %d", value, transaction.Value())
-				}
-				if transaction.Gas() != estimatedGasLimit {
-					t.Fatalf("signing transaction with wrong gas. wanted %d, got %d", estimatedGasLimit, transaction.Gas())
-				}
-				if transaction.GasPrice().Cmp(suggestedGasPrice) != 0 {
-					t.Fatalf("signing transaction with wrong gasprice. wanted %d, got %d", suggestedGasPrice, transaction.GasPrice())
-				}
-				if transaction.Nonce() != nonce {
-					t.Fatalf("signing transaction with wrong nonce. wanted %d, got %d", nonce, transaction.Nonce())
-				}
+			}
+			if !bytes.Equal(transaction.Data(), signedTx.Data()) {
+				t.Fatalf("signing transaction with wrong data. wanted %x, got %x", signedTx.Data(), transaction.Data())
+			}
+			if transaction.Value().Cmp(signedTx.Value()) != 0 {
+				t.Fatalf("signing transaction with wrong value. wanted %d, got %d", signedTx.Value(), transaction.Value())
+			}
+			if transaction.Gas() != signedTx.Gas() {
+				t.Fatalf("signing transaction with wrong gas. wanted %d, got %d", signedTx.Gas(), transaction.Gas())
+			}
+			if transaction.GasPrice().Cmp(signedTx.GasPrice()) != 0 {
+				t.Fatalf("signing transaction with wrong gasprice. wanted %d, got %d", signedTx.GasPrice(), transaction.GasPrice())
+			}
 
-				return signedTx, nil
-			}),
-		),
+			if transaction.Nonce() != signedTx.Nonce() {
+				t.Fatalf("signing transaction with wrong nonce. wanted %d, got %d", signedTx.Nonce(), transaction.Nonce())
+			}
+
+			return signedTx, nil
+		}),
+		signermock.WithEthereumAddressFunc(func() (common.Address, error) {
+			return sender, nil
+		}),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+}
 
-	txHash, err := transactionService.Send(context.Background(), request)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestTransactionSend(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+	sender := common.HexToAddress("0xddff")
+	recipient := common.HexToAddress("0xabcd")
+	txData := common.Hex2Bytes("0xabcdee")
+	value := big.NewInt(1)
+	suggestedGasPrice := big.NewInt(2)
+	estimatedGasLimit := uint64(3)
+	nonce := uint64(2)
 
-	if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
-		t.Fatal("returning wrong transaction hash")
-	}
+	t.Run("send", func(t *testing.T) {
+		signedTx := types.NewTransaction(nonce, recipient, value, estimatedGasLimit, suggestedGasPrice, txData)
+		request := &transaction.TxRequest{
+			To:    &recipient,
+			Data:  txData,
+			Value: value,
+		}
+		store := storemock.NewStateStore()
+		err := store.Put(nonceKey(sender), nonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		transactionService, err := transaction.NewService(logger,
+			backendmock.New(
+				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
+					if tx != signedTx {
+						t.Fatal("not sending signed transaction")
+					}
+					return nil
+				}),
+				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+					}
+					if !bytes.Equal(call.Data, txData) {
+						t.Fatal("estimating with wrong data")
+					}
+					return estimatedGasLimit, nil
+				}),
+				backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
+					return suggestedGasPrice, nil
+				}),
+				backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
+					return nonce - 1, nil
+				}),
+			),
+			signerMockForTransaction(signedTx, sender, t),
+			store,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		txHash, err := transactionService.Send(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
+			t.Fatal("returning wrong transaction hash")
+		}
+
+		var storedNonce uint64
+		err = store.Get(nonceKey(sender), &storedNonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if storedNonce != nonce+1 {
+			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nonce+1, storedNonce)
+		}
+	})
+
+	t.Run("send_no_nonce", func(t *testing.T) {
+		signedTx := types.NewTransaction(nonce, recipient, value, estimatedGasLimit, suggestedGasPrice, txData)
+		request := &transaction.TxRequest{
+			To:    &recipient,
+			Data:  txData,
+			Value: value,
+		}
+		store := storemock.NewStateStore()
+
+		transactionService, err := transaction.NewService(logger,
+			backendmock.New(
+				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
+					if tx != signedTx {
+						t.Fatal("not sending signed transaction")
+					}
+					return nil
+				}),
+				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+					}
+					if !bytes.Equal(call.Data, txData) {
+						t.Fatal("estimating with wrong data")
+					}
+					return estimatedGasLimit, nil
+				}),
+				backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
+					return suggestedGasPrice, nil
+				}),
+				backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
+					return nonce, nil
+				}),
+			),
+			signerMockForTransaction(signedTx, sender, t),
+			store,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		txHash, err := transactionService.Send(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
+			t.Fatal("returning wrong transaction hash")
+		}
+
+		var storedNonce uint64
+		err = store.Get(nonceKey(sender), &storedNonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if storedNonce != nonce+1 {
+			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nonce+1, storedNonce)
+		}
+	})
+
+	t.Run("send_skipped_nonce", func(t *testing.T) {
+		nextNonce := nonce + 5
+		signedTx := types.NewTransaction(nextNonce, recipient, value, estimatedGasLimit, suggestedGasPrice, txData)
+		request := &transaction.TxRequest{
+			To:    &recipient,
+			Data:  txData,
+			Value: value,
+		}
+		store := storemock.NewStateStore()
+		err := store.Put(nonceKey(sender), nonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		transactionService, err := transaction.NewService(logger,
+			backendmock.New(
+				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
+					if tx != signedTx {
+						t.Fatal("not sending signed transaction")
+					}
+					return nil
+				}),
+				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+					}
+					if !bytes.Equal(call.Data, txData) {
+						t.Fatal("estimating with wrong data")
+					}
+					return estimatedGasLimit, nil
+				}),
+				backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
+					return suggestedGasPrice, nil
+				}),
+				backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
+					return nextNonce, nil
+				}),
+			),
+			signerMockForTransaction(signedTx, sender, t),
+			store,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		txHash, err := transactionService.Send(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
+			t.Fatal("returning wrong transaction hash")
+		}
+
+		var storedNonce uint64
+		err = store.Get(nonceKey(sender), &storedNonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if storedNonce != nextNonce+1 {
+			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nextNonce+1, storedNonce)
+		}
+	})
+
+	t.Run("deploy", func(t *testing.T) {
+		signedTx := types.NewContractCreation(nonce, value, estimatedGasLimit, suggestedGasPrice, txData)
+		request := &transaction.TxRequest{
+			To:    nil,
+			Data:  txData,
+			Value: value,
+		}
+
+		transactionService, err := transaction.NewService(logger,
+			backendmock.New(
+				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
+					if tx != signedTx {
+						t.Fatal("not sending signed transaction")
+					}
+					return nil
+				}),
+				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+					if call.To != nil {
+						t.Fatalf("estimating with recipient. wanted nil, got %x", call.To)
+					}
+					if !bytes.Equal(call.Data, txData) {
+						t.Fatal("estimating with wrong data")
+					}
+					return estimatedGasLimit, nil
+				}),
+				backendmock.WithSuggestGasPriceFunc(func(ctx context.Context) (*big.Int, error) {
+					return suggestedGasPrice, nil
+				}),
+				backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
+					return nonce, nil
+				}),
+			),
+			signerMockForTransaction(signedTx, sender, t),
+			storemock.NewStateStore(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		txHash, err := transactionService.Send(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
+			t.Fatal("returning wrong transaction hash")
+		}
+	})
 }
 
 func TestTransactionWaitForReceipt(t *testing.T) {
@@ -191,6 +323,7 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 			}),
 		),
 		signermock.New(),
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/settlement/swap/transaction/transaction_test.go
+++ b/pkg/settlement/swap/transaction/transaction_test.go
@@ -133,7 +133,7 @@ func TestTransactionSend(t *testing.T) {
 			t.Fatal(err)
 		}
 		if storedNonce != nonce+1 {
-			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nonce+1, storedNonce)
+			t.Fatalf("nonce not stored correctly: want %d, got %d", nonce+1, storedNonce)
 		}
 	})
 


### PR DESCRIPTION
adds simple nonce tracking. this does not capture all edge cases but should work better than what we have currently when trying to send multiple transactions concurrently. further PRs will refine this mechanism later.

The logic is as follows:
* next nonce to be used is stored locally in state store
* if there is already a higher nonce response from the backend we skip forward to that (to prevent the node from getting stuck if the private key is used outside bee)
* if there is no nonce stored yet, we use the value returned from the backend

Note: this was tested with 100 concurrent deposit transactions with a local geth and goerli infura.