### PR TITLE
packaging/docker: remove quotes from compose .env file

### DIFF
--- a/packaging/docker/env
+++ b/packaging/docker/env
@@ -7,23 +7,23 @@
 
 ### BEE
 
-## HTTP API listen address (default ":1633")
+## HTTP API listen address (default :1633)
 # BEE_API_ADDR=:1633
 ## initial nodes to connect to (default [/dnsaddr/bootnode.ethswarm.org])
 # BEE_BOOTNODE=[/dnsaddr/bootnode.ethswarm.org]
 ## enable clef signer
 # BEE_CLEF_SIGNER_ENABLE=false
 ## clef signer endpoint
-# BEE_CLEF_SIGNER_ENDPOINT=""
+# BEE_CLEF_SIGNER_ENDPOINT=
 ## config file (default is /home/<user>/.bee.yaml)
 # BEE_CONFIG=/home/bee/.bee.yaml
 ## origins with CORS headers enabled
 # BEE_CORS_ALLOWED_ORIGINS=[]
-## data directory (default "/home/<user>/.bee")
+## data directory (default /home/<user>/.bee)
 # BEE_DATA_DIR=/home/bee/.bee
 ## db capacity in chunks, multiply by 4096 to get approximate capacity in bytes
 # BEE_DB_CAPACITY=5000000
-## debug HTTP API listen address (default ":1635")
+## debug HTTP API listen address (default :1635)
 # BEE_DEBUG_API_ADDR=:1635
 ## enable debug HTTP API
 # BEE_DEBUG_API_ENABLE=false
@@ -32,19 +32,19 @@
 ## enable global pinning
 # BEE_GLOBAL_PINNING_ENABLE=false
 ## NAT exposed address
-# BEE_NAT_ADDR=""
+# BEE_NAT_ADDR=
 ## ID of the Swarm network (default 1)
 # BEE_NETWORK_ID=1
-## P2P listen address (default ":1634")
+## P2P listen address (default :1634)
 # BEE_P2P_ADDR=:1634
 ## enable P2P QUIC protocol
 # BEE_P2P_QUIC_ENABLE=false
 ## enable P2P WebSocket transport
 # BEE_P2P_WS_ENABLE=false
 ## password for decrypting keys
-# BEE_PASSWORD=""
+# BEE_PASSWORD=
 ## path to a file that contains password for decrypting keys
-# BEE_PASSWORD_FILE=""
+# BEE_PASSWORD_FILE=
 ## amount in BZZ below the peers payment threshold when we initiate settlement (default 10000)
 # BEE_PAYMENT_EARLY=10000
 ## threshold in BZZ where you expect to get paid from your peers (default 100000)
@@ -57,19 +57,19 @@
 # BEE_STANDALONE=false
 ## enable swap (default true)
 # BEE_SWAP_ENABLE=true
-## swap ethereum blockchain endpoint (default "http://localhost:8545")
+## swap ethereum blockchain endpoint (default http://localhost:8545)
 # BEE_SWAP_ENDPOINT=http://localhost:8545
 ## swap factory address
-# BEE_SWAP_FACTORY_ADDRESS=""
+# BEE_SWAP_FACTORY_ADDRESS=
 ## initial deposit if deploying a new chequebook (default 100000000)
 # BEE_SWAP_INITIAL_DEPOSIT=100000000
 ## enable tracing
 # BEE_TRACING_ENABLE=false
-## endpoint to send tracing data (default "127.0.0.1:6831")
+## endpoint to send tracing data (default 127.0.0.1:6831)
 # BEE_TRACING_ENDPOINT=127.0.0.1:6831
-## service name identifier for tracing (default "bee")
+## service name identifier for tracing (default bee)
 # BEE_TRACING_SERVICE_NAME=bee
-## log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace (default "info")
+## log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace (default info)
 # BEE_VERBOSITY=info
 ## send a welcome message string during handshakes
-# BEE_WELCOME_MESSAGE=""
+# BEE_WELCOME_MESSAGE=


### PR DESCRIPTION
Related to https://github.com/ethersphere/docs.github.io/pull/133

The values inside the docker-compose .env file should not contain quotes. Otherwise these will be included in the values and we start seeing errors i ike :

```
Error: parse "\"https://rpc.slock.it/goerli\"": first path segment in URL cannot contain colon
```