### PR TITLE
libp2p: always close streams

### DIFF
--- a/pkg/p2p/libp2p/stream.go
+++ b/pkg/p2p/libp2p/stream.go
@@ -36,6 +36,9 @@ func (s *stream) Headers() p2p.Headers {
 }
 
 func (s *stream) FullClose() error {
+	// close the stream to make sure it is gc'd
+	defer s.Close()
+
 	if err := s.CloseWrite(); err != nil {
 		_ = s.Reset()
 		return err
@@ -60,5 +63,4 @@ func (s *stream) FullClose() error {
 		return err
 	}
 	return nil
-
 }


### PR DESCRIPTION
Using our `FullClose` helper method might not always result in streams being garbage collected. This PR adds a defer call to close the stream in any case when the method returns