### PR TITLE
fix: expose content-disposition HTTP header for CORS requests

### DIFF
--- a/pkg/api/file.go
+++ b/pkg/api/file.go
@@ -382,6 +382,7 @@ func (s *server) downloadHandler(w http.ResponseWriter, r *http.Request, referen
 	}
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", l))
 	w.Header().Set("Decompressed-Content-Length", fmt.Sprintf("%d", l))
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 	if targets != "" {
 		w.Header().Set(TargetsRecoveryHeader, targets)
 	}


### PR DESCRIPTION
This PR adds the `Content-Disposition` header to the exposed headers for CORS request.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers

Fixes https://github.com/ethersphere/bee-js/issues/86

The original problem is that filename is sent in the `Content-Disposition` header when a file is downloaded from the `/files` endpoint, but in the case of a cross-origin request by default it is not exposed (e.g. Javascript applications in the browser such as anything built with bee-js has no access to that value). This PR fixes that by exposing the `Content-Disposition` header, therefore making it available. From a security perspective we can say that it's safe to expose the filename because the requester has already access to the full file data.