### PR TITLE
Apply CORS Options for Debug Api

### DIFF
--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -10,6 +10,7 @@ package debugapi
 import (
 	"crypto/ecdsa"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -50,10 +51,60 @@ type server struct {
 	Chequebook        chequebook.Service
 	Swap              swap.ApiInterface
 	metricsRegistry   *prometheus.Registry
+	Options
 	http.Handler
 }
 
-func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) Service {
+type Options struct {
+	CORSAllowedOrigins []string
+}
+
+// checkOrigin returns true if the origin is not set or is equal to the request host.
+func (s *server) checkOrigin(r *http.Request) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	hosts := append(s.CORSAllowedOrigins, scheme+"://"+r.Host)
+	for _, v := range hosts {
+		if equalASCIIFold(origin[0], v) || v == "*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// equalASCIIFold returns true if s is equal to t with ASCII case folding as
+// defined in RFC 4790.
+func equalASCIIFold(s, t string) bool {
+	for s != "" && t != "" {
+		sr, size := utf8.DecodeRuneInString(s)
+		s = s[size:]
+		tr, size := utf8.DecodeRuneInString(t)
+		t = t[size:]
+		if sr == tr {
+			continue
+		}
+		if 'A' <= sr && sr <= 'Z' {
+			sr = sr + 'a' - 'A'
+		}
+		if 'A' <= tr && tr <= 'Z' {
+			tr = tr + 'a' - 'A'
+		}
+		if sr != tr {
+			return false
+		}
+	}
+	return s == t
+}
+
+
+func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, logger logging.Logger, tracer *tracing.Tracer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service, o Options) Service {
 	s := &server{
 		Overlay:           overlay,
 		PublicKey:         publicKey,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -57,7 +57,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	settlement := swapmock.New(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
-	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook)
+	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook, api.Options{})
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -465,7 +465,9 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	if o.DebugAPIAddr != "" {
 		// Debug API server
 
-		debugAPIService := debugapi.New(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
+		debugAPIService := debugapi.New(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService, debugapi.Options{
+			CORSAllowedOrigins: o.CORSAllowedOrigins,
+		})
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)


### PR DESCRIPTION
This is a tentative PR to attempt to address #1280 

I think it makes sense that the same CORS settings are valid for the API are also valid for the Debug API on the basis that these settings are only supposed to apply for entities with privileged network access and without Gateway Mode enabled, pending implementing some sort of remote access.

Note I have duplicated code for `checkOrigin` and `equalASCIIFold` in `api.go` and `debugapi.go` and would appreciate guidance on how best to DRY this.

Otherwise it's pretty much a brutalistic copy paste job so please do feel free to close if it's not appropriate. 😀 
