### PR TITLE
Feature/keys command

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -100,6 +100,10 @@ func newCommand(opts ...option) (c *command, err error) {
 		return nil, err
 	}
 
+	if err := c.initKeysCmd(); err != nil {
+		return nil, err
+	}
+
 	c.initVersionCmd()
 
 	if err := c.initConfigurateOptionsCmd(); err != nil {

--- a/cmd/bee/cmd/keys.go
+++ b/cmd/bee/cmd/keys.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+)
+
+func (c *command) initKeysCmd() (err error) {
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "Keys management",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) > 0 {
+				return cmd.Help()
+			}
+
+			var logger logging.Logger
+			switch v := strings.ToLower(c.config.GetString(optionNameVerbosity)); v {
+			case "0", "silent":
+				logger = logging.New(ioutil.Discard, 0)
+			case "1", "error":
+				logger = logging.New(cmd.OutOrStdout(), logrus.ErrorLevel)
+			case "2", "warn":
+				logger = logging.New(cmd.OutOrStdout(), logrus.WarnLevel)
+			case "3", "info":
+				logger = logging.New(cmd.OutOrStdout(), logrus.InfoLevel)
+			case "4", "debug":
+				logger = logging.New(cmd.OutOrStdout(), logrus.DebugLevel)
+			case "5", "trace":
+				logger = logging.New(cmd.OutOrStdout(), logrus.TraceLevel)
+			default:
+				return fmt.Errorf("unknown verbosity level %q", v)
+			}
+
+			signerConfig, err := c.configureSigner(cmd, logger)
+			fmt.Printf("swarm public key: 0x%x\n", crypto.EncodeSecp256k1PublicKey(signerConfig.publicKey))
+			fmt.Printf("swarm private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.swarmPrivateKey))
+
+			return err
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.config.BindPFlags(cmd.Flags())
+		},
+	}
+
+	// c.setAllFlags(cmd)
+	c.root.AddCommand(cmd)
+	return nil
+}

--- a/cmd/bee/cmd/keys.go
+++ b/cmd/bee/cmd/keys.go
@@ -52,7 +52,7 @@ func (c *command) initKeysCmd() (err error) {
 			fmt.Printf("p2p public key: 0x%x\n", crypto.EncodeSecp256k1PublicKey(&signerConfig.libp2pPrivateKey.PublicKey))
 			fmt.Printf("p2p private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.libp2pPrivateKey))
 
-			var ethAddr,_ = signerConfig.signer.EthereumAddress()
+			var ethAddr, _ = signerConfig.signer.EthereumAddress()
 			fmt.Printf("eth address: 0x%x\n", ethAddr)
 			fmt.Printf("eth address private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.swarmPrivateKey))
 

--- a/cmd/bee/cmd/keys.go
+++ b/cmd/bee/cmd/keys.go
@@ -45,7 +45,16 @@ func (c *command) initKeysCmd() (err error) {
 
 			signerConfig, err := c.configureSigner(cmd, logger)
 			fmt.Printf("swarm public key: 0x%x\n", crypto.EncodeSecp256k1PublicKey(signerConfig.publicKey))
-			fmt.Printf("swarm private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.swarmPrivateKey))
+
+			fmt.Printf("pss public key: 0x%x\n", crypto.EncodeSecp256k1PublicKey(&signerConfig.pssPrivateKey.PublicKey))
+			fmt.Printf("pss private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.pssPrivateKey))
+
+			fmt.Printf("p2p public key: 0x%x\n", crypto.EncodeSecp256k1PublicKey(&signerConfig.libp2pPrivateKey.PublicKey))
+			fmt.Printf("p2p private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.libp2pPrivateKey))
+
+			var ethAddr,_ = signerConfig.signer.EthereumAddress()
+			fmt.Printf("eth address: 0x%x\n", ethAddr)
+			fmt.Printf("eth address private key: 0x%x\n", crypto.EncodeSecp256k1PrivateKey(signerConfig.swarmPrivateKey))
 
 			return err
 		},
@@ -54,7 +63,7 @@ func (c *command) initKeysCmd() (err error) {
 		},
 	}
 
-	// c.setAllFlags(cmd)
+	c.setAllFlags(cmd)
 	c.root.AddCommand(cmd)
 	return nil
 }


### PR DESCRIPTION
Add **keys** command to bee client to dump all keys (including Private Keys!)
This could be useful when not using clef (e.g. import Eth account into Wallet by private key, like Metamask)