### PR TITLE
add sleep for sync check

### DIFF
--- a/pkg/settlement/swap/transaction/backend.go
+++ b/pkg/settlement/swap/transaction/backend.go
@@ -57,5 +57,11 @@ func WaitSynced(ctx context.Context, backend Backend, maxDelay time.Duration) er
 		if synced {
 			return nil
 		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
 	}
 }


### PR DESCRIPTION
sleep was missing for sync check. therefore we bombarded unsynced backends with maximum througput.