### PR TITLE
pullstorage: remove flaky test

### DIFF
--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -127,33 +127,6 @@ func TestIntervalChunks_GetChunksLater(t *testing.T) {
 	}
 }
 
-// Get some descriptors, but then let the iterator time out and return just the stuff we got in the beginning
-func TestIntervalChunks_NoChunksLater(t *testing.T) {
-	desc := someDescriptors(0, 2)
-	ps, db := newPullStorage(t, mock.WithSubscribePullChunks(desc...), mock.WithPartialInterval(true))
-
-	go func() {
-		<-time.After(600 * time.Millisecond)
-		// add chunks to subscribe pull on the storage mock
-		db.MorePull(someDescriptors(1, 3, 4)...)
-	}()
-
-	addrs, topmost, err := ps.IntervalChunks(context.Background(), 0, 0, 5, limit)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if l := len(addrs); l != 2 {
-		t.Fatalf("want %d addrs but got %d", 2, l)
-	}
-
-	// highest chunk we sent had BinID 3
-	exp := uint64(3)
-	if topmost != exp {
-		t.Fatalf("expected topmost %d but got %d", exp, topmost)
-	}
-}
-
 func TestIntervalChunks_Blocking(t *testing.T) {
 	desc := someDescriptors(0, 2)
 	ps, _ := newPullStorage(t, mock.WithSubscribePullChunks(desc...), mock.WithPartialInterval(true))


### PR DESCRIPTION
The `TestIntervalChunks_NoChunksLater` is flaky by design and the test case which it is testing for is implicitly covered by `TestIntervalChunks/some_in_the_middle` test case. I therefore consider this test redundant and safe to remove.