### PR TITLE
clef: allow specifying account

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -17,39 +17,39 @@ import (
 )
 
 const (
-	optionNameDataDir              = "data-dir"
-	optionNameDBCapacity           = "db-capacity"
-	optionNamePassword             = "password"
-	optionNamePasswordFile         = "password-file"
-	optionNameAPIAddr              = "api-addr"
-	optionNameP2PAddr              = "p2p-addr"
-	optionNameNATAddr              = "nat-addr"
-	optionNameP2PWSEnable          = "p2p-ws-enable"
-	optionNameP2PQUICEnable        = "p2p-quic-enable"
-	optionNameDebugAPIEnable       = "debug-api-enable"
-	optionNameDebugAPIAddr         = "debug-api-addr"
-	optionNameBootnodes            = "bootnode"
-	optionNameNetworkID            = "network-id"
-	optionWelcomeMessage           = "welcome-message"
-	optionCORSAllowedOrigins       = "cors-allowed-origins"
-	optionNameStandalone           = "standalone"
-	optionNameTracingEnabled       = "tracing-enable"
-	optionNameTracingEndpoint      = "tracing-endpoint"
-	optionNameTracingServiceName   = "tracing-service-name"
-	optionNameVerbosity            = "verbosity"
-	optionNameGlobalPinningEnabled = "global-pinning-enable"
-	optionNamePaymentThreshold     = "payment-threshold"
-	optionNamePaymentTolerance     = "payment-tolerance"
-	optionNamePaymentEarly         = "payment-early"
-	optionNameResolverEndpoints    = "resolver-options"
-	optionNameGatewayMode          = "gateway-mode"
-	optionNameClefSignerEnable     = "clef-signer-enable"
-	optionNameClefSignerEndpoint   = "clef-signer-endpoint"
-	optionNameClefSignerAddress    = "clef-signer-address"
-	optionNameSwapEndpoint         = "swap-endpoint"
-	optionNameSwapFactoryAddress   = "swap-factory-address"
-	optionNameSwapInitialDeposit   = "swap-initial-deposit"
-	optionNameSwapEnable           = "swap-enable"
+	optionNameDataDir                   = "data-dir"
+	optionNameDBCapacity                = "db-capacity"
+	optionNamePassword                  = "password"
+	optionNamePasswordFile              = "password-file"
+	optionNameAPIAddr                   = "api-addr"
+	optionNameP2PAddr                   = "p2p-addr"
+	optionNameNATAddr                   = "nat-addr"
+	optionNameP2PWSEnable               = "p2p-ws-enable"
+	optionNameP2PQUICEnable             = "p2p-quic-enable"
+	optionNameDebugAPIEnable            = "debug-api-enable"
+	optionNameDebugAPIAddr              = "debug-api-addr"
+	optionNameBootnodes                 = "bootnode"
+	optionNameNetworkID                 = "network-id"
+	optionWelcomeMessage                = "welcome-message"
+	optionCORSAllowedOrigins            = "cors-allowed-origins"
+	optionNameStandalone                = "standalone"
+	optionNameTracingEnabled            = "tracing-enable"
+	optionNameTracingEndpoint           = "tracing-endpoint"
+	optionNameTracingServiceName        = "tracing-service-name"
+	optionNameVerbosity                 = "verbosity"
+	optionNameGlobalPinningEnabled      = "global-pinning-enable"
+	optionNamePaymentThreshold          = "payment-threshold"
+	optionNamePaymentTolerance          = "payment-tolerance"
+	optionNamePaymentEarly              = "payment-early"
+	optionNameResolverEndpoints         = "resolver-options"
+	optionNameGatewayMode               = "gateway-mode"
+	optionNameClefSignerEnable          = "clef-signer-enable"
+	optionNameClefSignerEndpoint        = "clef-signer-endpoint"
+	optionNameClefSignerEthereumAddress = "clef-signer-ethereum-address"
+	optionNameSwapEndpoint              = "swap-endpoint"
+	optionNameSwapFactoryAddress        = "swap-factory-address"
+	optionNameSwapInitialDeposit        = "swap-initial-deposit"
+	optionNameSwapEnable                = "swap-enable"
 )
 
 func init() {
@@ -205,7 +205,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameGatewayMode, false, "disable a set of sensitive features in the api")
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
-	cmd.Flags().String(optionNameClefSignerAddress, "", "ethereum address to usee from clef signer")
+	cmd.Flags().String(optionNameClefSignerEthereumAddress, "", "ethereum address to use from clef signer")
 	cmd.Flags().String(optionNameSwapEndpoint, "http://localhost:8545", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory address")
 	cmd.Flags().String(optionNameSwapInitialDeposit, "100000000000000000", "initial deposit if deploying a new chequebook")

--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -45,6 +45,7 @@ const (
 	optionNameGatewayMode          = "gateway-mode"
 	optionNameClefSignerEnable     = "clef-signer-enable"
 	optionNameClefSignerEndpoint   = "clef-signer-endpoint"
+	optionNameClefSignerAddress    = "clef-signer-address"
 	optionNameSwapEndpoint         = "swap-endpoint"
 	optionNameSwapFactoryAddress   = "swap-factory-address"
 	optionNameSwapInitialDeposit   = "swap-initial-deposit"
@@ -204,6 +205,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameGatewayMode, false, "disable a set of sensitive features in the api")
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
+	cmd.Flags().String(optionNameClefSignerAddress, "", "ethereum address to usee from clef signer")
 	cmd.Flags().String(optionNameSwapEndpoint, "http://localhost:8545", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory address")
 	cmd.Flags().String(optionNameSwapInitialDeposit, "100000000000000000", "initial deposit if deploying a new chequebook")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/external"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/bee"
 	"github.com/ethersphere/bee/pkg/crypto"
@@ -320,7 +321,14 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 			return nil, err
 		}
 
-		signer, err = clef.NewSigner(externalSigner, clefRPC, crypto.Recover)
+		wantedAddress := c.config.GetString(optionNameClefSignerAddress)
+		var overlayEthAddress *common.Address = nil
+		if wantedAddress != "" {
+			ethAddress := common.HexToAddress(wantedAddress)
+			overlayEthAddress = &ethAddress
+		}
+
+		signer, err = clef.NewSigner(externalSigner, clefRPC, crypto.Recover, overlayEthAddress)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -323,6 +323,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 
 		wantedAddress := c.config.GetString(optionNameClefSignerEthereumAddress)
 		var overlayEthAddress *common.Address = nil
+		// if wantedAddress was specified use that, otherwise clef account 0 will be selected.
 		if wantedAddress != "" {
 			ethAddress := common.HexToAddress(wantedAddress)
 			overlayEthAddress = &ethAddress

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -321,7 +321,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 			return nil, err
 		}
 
-		wantedAddress := c.config.GetString(optionNameClefSignerAddress)
+		wantedAddress := c.config.GetString(optionNameClefSignerEthereumAddress)
 		var overlayEthAddress *common.Address = nil
 		if wantedAddress != "" {
 			ethAddress := common.HexToAddress(wantedAddress)

--- a/pkg/crypto/clef/clef.go
+++ b/pkg/crypto/clef/clef.go
@@ -88,14 +88,9 @@ func selectAccount(clef ExternalSignerInterface, ethAddress *common.Address) (ac
 }
 
 // NewSigner creates a new connection to the signer at endpoint.
+// If ethAddress is nil the account with index 0 will be selected. Otherwise it will verify the requested account actually exists.
 // As clef does not expose public keys it signs a test message to recover the public key.
 func NewSigner(clef ExternalSignerInterface, client Client, recoverFunc crypto.RecoverFunc, ethAddress *common.Address) (signer crypto.Signer, err error) {
-	// get the list of available ethereum accounts
-	clefAccounts := clef.Accounts()
-	if len(clefAccounts) == 0 {
-		return nil, ErrNoAccounts
-	}
-
 	account, err := selectAccount(clef, ethAddress)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
add a flag to enable specifying which clef account to use. It's important that if this is specified it also needs to be specified on any further run of that bee node. in a future pr the used overlay should be stored and checked.

this helps against the following problems:
* new keys are added to clef and the original is no longer at index 0
* multiple bees using the same clef