### PR TITLE
accounting: copy big numbers in various places

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -448,7 +448,7 @@ func (a *Accounting) getAccountingPeer(peer swarm.Address) (*accountingPeer, err
 		peerData = &accountingPeer{
 			reservedBalance: big.NewInt(0),
 			// initially assume the peer has the same threshold as us
-			paymentThreshold: a.paymentThreshold,
+			paymentThreshold: new(big.Int).Set(a.paymentThreshold),
 		}
 		a.accountingPeers[peer.String()] = peerData
 	}

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -105,9 +105,9 @@ func NewAccounting(
 ) (*Accounting, error) {
 	return &Accounting{
 		accountingPeers:  make(map[string]*accountingPeer),
-		paymentThreshold: PaymentThreshold,
-		paymentTolerance: PaymentTolerance,
-		earlyPayment:     EarlyPayment,
+		paymentThreshold: new(big.Int).Set(PaymentThreshold),
+		paymentTolerance: new(big.Int).Set(PaymentTolerance),
+		earlyPayment:     new(big.Int).Set(EarlyPayment),
 		logger:           Logger,
 		store:            Store,
 		settlement:       Settlement,


### PR DESCRIPTION
the payment threshold field was set as a reference instead of a copy. therefore receiving a payment threshold update actually updated our own payment threshold as well.

I added copying to the numbers that are passed to accounting as well to avoid further unexpected surprises (e.g. many tests pass the same paymentThreshold parameter which could cause cross test effects if it were to be mutated).