### PR TITLE
bump clef version

### DIFF
--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   clef-1:
-    image: ethersphere/clef:0.4.8
+    image: ethersphere/clef:0.4.9
     restart: unless-stopped
     environment:
       - CLEF_CHAINID


### PR DESCRIPTION
new clef is released, bumping clef version inside docker-compose