### PR TITLE
shed: improve leveldb configuration

### DIFF
--- a/pkg/shed/db.go
+++ b/pkg/shed/db.go
@@ -32,7 +32,9 @@ import (
 )
 
 var (
-	openFileLimit = 128 // The limit for LevelDB OpenFilesCacheCapacity.
+	openFileLimit      = 128 // The limit for LevelDB OpenFilesCacheCapacity.
+	blockCacheCapacity = 32 * 1024 * 1024
+	writeBuffer        = 32 * 1024 * 1024
 )
 
 // DB provides abstractions over LevelDB in order to
@@ -55,6 +57,9 @@ func NewDB(path string) (db *DB, err error) {
 	} else {
 		ldb, err = leveldb.OpenFile(path, &opt.Options{
 			OpenFilesCacheCapacity: openFileLimit,
+			BlockCacheCapacity:     blockCacheCapacity,
+			DisableSeeksCompaction: true,
+			WriteBuffer:            writeBuffer,
 		})
 	}
 


### PR DESCRIPTION
Users are experiencing a lot of I/O coming from bee. This PR attempts to tweak some of the leveldb parameters in order to improve the situation.
