### PR TITLE
kademlia: return ErrNotFound on skip peers

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -581,7 +581,16 @@ func (k *Kad) ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (swarm
 
 	// check if self
 	if closest.Equal(k.base) {
-		return swarm.Address{}, topology.ErrWantSelf
+		switch l := len(skipPeers); l {
+		case 0:
+			return swarm.Address{}, topology.ErrWantSelf
+		default:
+			// we skipped some peers and found that we are
+			// the closest one - return an ErrNotFound,
+			// since this means we are probably having poor
+			// connectivity.
+			return swarm.Address{}, topology.ErrNotFound
+		}
 	}
 
 	return closest, nil


### PR DESCRIPTION
As the change suggests, we might be returning `topology.ErrWantSelf` when we've already skipped some peers. This might suggest that we don't have very good connectivity, and the result is that we as a fallback are designated as the chunk storer, resulting in the chunk exiting the push sync index. This can specifically backfire if the node has very degraded connection, resulting in all chunks to be stored on the node, instead of being sent to others.