### PR TITLE
Revert "kademlia: hotfix for peer list inconsistency (#1020)"

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -522,37 +522,18 @@ func (k *Kad) notifyPeerSig() {
 	}
 }
 
-func isIn(a swarm.Address, addresses []p2p.Peer) bool {
-	for _, v := range addresses {
-		if v.Address.Equal(a) {
-			return true
-		}
-	}
-	return false
-}
-
 // ClosestPeer returns the closest peer to a given address.
 func (k *Kad) ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (swarm.Address, error) {
 	if k.connectedPeers.Length() == 0 {
 		return swarm.Address{}, topology.ErrNotFound
 	}
 
-	peers := k.p2p.Peers()
-	var peersToDisconnect []swarm.Address
 	closest := k.base
-
 	err := k.connectedPeers.EachBinRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
 		for _, a := range skipPeers {
 			if a.Equal(peer) {
 				return false, false, nil
 			}
-		}
-
-		// kludge: hotfix for topology peer inconsistencies bug
-		if !isIn(peer, peers) {
-			a := swarm.NewAddress(peer.Bytes())
-			peersToDisconnect = append(peersToDisconnect, a)
-			return false, false, nil
 		}
 
 		dcmp, err := swarm.DistanceCmp(addr.Bytes(), closest.Bytes(), peer.Bytes())
@@ -573,10 +554,6 @@ func (k *Kad) ClosestPeer(addr swarm.Address, skipPeers ...swarm.Address) (swarm
 	})
 	if err != nil {
 		return swarm.Address{}, err
-	}
-
-	for _, v := range peersToDisconnect {
-		k.Disconnected(p2p.Peer{Address: v})
 	}
 
 	// check if self

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -265,7 +265,6 @@ func TestBinSaturation(t *testing.T) {
 // TestNotifierHooks tests that the Connected/Disconnected hooks
 // result in the correct behavior once called.
 func TestNotifierHooks(t *testing.T) {
-	t.Skip("disabled due to kademlia inconsistencies hotfix")
 	var (
 		base, kad, ab, _, signer = newTestKademlia(nil, nil, nil, nil)
 		peer                     = test.RandomAddressAt(base, 3)
@@ -462,9 +461,6 @@ func TestAddressBookPrune(t *testing.T) {
 
 // TestClosestPeer tests that ClosestPeer method returns closest connected peer to a given address.
 func TestClosestPeer(t *testing.T) {
-	_ = waitPeers
-	t.Skip("disabled due to kademlia inconsistencies hotfix")
-
 	logger := logging.New(ioutil.Discard, 0)
 	base := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 	connectedPeers := []p2p.Peer{


### PR DESCRIPTION
This reverts commit 8bca1737fee541f29837880bd55b42a58d7b6b7d.

Longstanding cleanup