### PR TITLE
debug api basic and full routing

### DIFF
--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -154,6 +154,7 @@ func TestServer_Configure(t *testing.T) {
 	jsonhttptest.Request(t, client, http.MethodGet, "/addresses", http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.AddressesResponse{
 			Overlay:      o.Overlay,
+			Underlay:     make([]multiaddr.Multiaddr, 0),
 			Ethereum:     o.EthereumAddress,
 			PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&o.PublicKey)),
 			PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&o.PSSPublicKey)),

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -13,8 +13,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee"
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/debugapi"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/pingpong"
@@ -57,7 +60,8 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	settlement := swapmock.New(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
-	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, logging.New(ioutil.Discard, 0), nil, o.Tags, acc, settlement, true, swapserv, chequebook, debugapi.Options{})
+	s := debugapi.New(logging.New(ioutil.Discard, 0), nil, nil)
+	s.Configure(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 
@@ -85,4 +89,71 @@ func mustMultiaddr(t *testing.T, s string) multiaddr.Multiaddr {
 		t.Fatal(err)
 	}
 	return a
+}
+
+// TestServer_Configure validates that http routes are correct when server is
+// constructed with only basic routes and after it is configured with
+// dependencies.
+func TestServer_Configure(t *testing.T) {
+	var o testServerOptions
+	topologyDriver := topologymock.NewTopologyDriver(o.TopologyOpts...)
+	acc := accountingmock.NewAccounting(o.AccountingOpts...)
+	settlement := swapmock.New(o.SettlementOpts...)
+	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
+	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
+	s := debugapi.New(logging.New(ioutil.Discard, 0), nil, nil)
+	ts := httptest.NewServer(s)
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		Transport: web.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			u, err := url.Parse(ts.URL + r.URL.String())
+			if err != nil {
+				return nil, err
+			}
+			r.URL = u
+			return ts.Client().Transport.RoundTrip(r)
+		}),
+	}
+
+	testBasicRouter(t, client)
+	jsonhttptest.Request(t, client, http.MethodGet, "/readiness", http.StatusNotFound,
+		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+			Message: http.StatusText(http.StatusNotFound),
+			Code:    http.StatusNotFound,
+		}),
+	)
+
+	s.Configure(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.P2P, o.Pingpong, topologyDriver, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook)
+
+	testBasicRouter(t, client)
+	jsonhttptest.Request(t, client, http.MethodGet, "/readiness", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
+			Status:  "ok",
+			Version: bee.Version,
+		}),
+	)
+}
+
+func testBasicRouter(t *testing.T, client *http.Client) {
+	t.Helper()
+
+	jsonhttptest.Request(t, client, http.MethodGet, "/health", http.StatusOK,
+		jsonhttptest.WithExpectedJSONResponse(debugapi.StatusResponse{
+			Status:  "ok",
+			Version: bee.Version,
+		}),
+	)
+
+	for _, path := range []string{
+		"/metrics",
+		"/debug/pprof",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile?seconds=1", // profile for only 1 second to check only the status code
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace",
+		"/debug/vars",
+	} {
+		jsonhttptest.Request(t, client, http.MethodGet, path, http.StatusOK)
+	}
 }

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -24,11 +24,18 @@ type addressesResponse struct {
 }
 
 func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
-	underlay, err := s.P2P.Addresses()
-	if err != nil {
-		s.Logger.Debugf("debug api: p2p addresses: %v", err)
-		jsonhttp.InternalServerError(w, err)
-		return
+	// initialize variable to json encode as [] instead null if p2p is nil
+	underlay := make([]multiaddr.Multiaddr, 0)
+	// addresses endpoint is exposed before p2p service is configured
+	// to provide information about other addresses.
+	if s.P2P != nil {
+		u, err := s.P2P.Addresses()
+		if err != nil {
+			s.Logger.Debugf("debug api: p2p addresses: %v", err)
+			jsonhttp.InternalServerError(w, err)
+			return
+		}
+		underlay = u
 	}
 	jsonhttp.OK(w, addressesResponse{
 		Overlay:      s.Overlay,

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -24,6 +24,7 @@ import (
 // - pprof
 // - vars
 // - metrics
+// - /addresses
 func (s *server) newBasicRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
@@ -54,6 +55,10 @@ func (s *server) newBasicRouter() *mux.Router {
 		web.FinalHandlerFunc(statusHandler),
 	))
 
+	router.Handle("/addresses", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.addressesHandler),
+	})
+
 	return router
 }
 
@@ -72,9 +77,6 @@ func (s *server) newRouter() *mux.Router {
 		"POST": http.HandlerFunc(s.pingpongHandler),
 	})
 
-	router.Handle("/addresses", jsonhttp.MethodHandler{
-		"GET": http.HandlerFunc(s.addressesHandler),
-	})
 	router.Handle("/connect/{multi-address:.+}", jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(s.peerConnectHandler),
 	})

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -19,19 +19,22 @@ import (
 	"github.com/ethersphere/bee/pkg/logging/httpaccess"
 )
 
-func (s *server) setupRouting() {
-	baseRouter := http.NewServeMux()
+// newBasicRouter constructs only the routes that do not depend on the injected dependencies:
+// - /health
+// - pprof
+// - vars
+// - metrics
+func (s *server) newBasicRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 
-	baseRouter.Handle("/metrics", web.ChainHandlers(
+	router.Path("/metrics").Handler(web.ChainHandlers(
 		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
 		web.FinalHandler(promhttp.InstrumentMetricHandler(
 			s.metricsRegistry,
 			promhttp.HandlerFor(s.metricsRegistry, promhttp.HandlerOpts{}),
 		)),
 	))
-
-	router := mux.NewRouter()
-	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 
 	router.Handle("/debug/pprof", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u := r.URL
@@ -48,11 +51,21 @@ func (s *server) setupRouting() {
 
 	router.Handle("/health", web.ChainHandlers(
 		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
-		web.FinalHandlerFunc(s.statusHandler),
+		web.FinalHandlerFunc(statusHandler),
 	))
+
+	return router
+}
+
+// newRouter construct the complete set of routes after all of the dependencies
+// are injected and exposes /readiness endpoint to provide information that
+// Debug API is fully active.
+func (s *server) newRouter() *mux.Router {
+	router := s.newBasicRouter()
+
 	router.Handle("/readiness", web.ChainHandlers(
 		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
-		web.FinalHandlerFunc(s.statusHandler),
+		web.FinalHandlerFunc(statusHandler),
 	))
 
 	router.Handle("/pingpong/{peer-id}", jsonhttp.MethodHandler{
@@ -149,7 +162,13 @@ func (s *server) setupRouting() {
 		"GET": http.HandlerFunc(s.getTagHandler),
 	})
 
-	baseRouter.Handle("/", web.ChainHandlers(
+	return router
+}
+
+// setRouter sets the base Debug API handler with common middlewares.
+func (s *server) setRouter(router http.Handler) {
+	h := http.NewServeMux()
+	h.Handle("/", web.ChainHandlers(
 		httpaccess.NewHTTPAccessLogHandler(s.Logger, logrus.InfoLevel, s.Tracer, "debug api access"),
 		handlers.CompressHandler,
 		func(h http.Handler) http.Handler {
@@ -164,10 +183,12 @@ func (s *server) setupRouting() {
 				h.ServeHTTP(w, r)
 			})
 		},
-		// todo: add recovery handler
 		web.NoCacheHeadersHandler,
 		web.FinalHandler(router),
 	))
 
-	s.Handler = baseRouter
+	s.handlerMu.Lock()
+	defer s.handlerMu.Unlock()
+
+	s.handler = h
 }

--- a/pkg/debugapi/status.go
+++ b/pkg/debugapi/status.go
@@ -16,7 +16,7 @@ type statusResponse struct {
 	Version string `json:"version"`
 }
 
-func (s *server) statusHandler(w http.ResponseWriter, r *http.Request) {
+func statusHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, statusResponse{
 		Status:  "ok",
 		Version: bee.Version,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -130,8 +130,12 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 
 	var debugAPIService debugapi.Service
 	if o.DebugAPIAddr != "" {
+		overlayEthAddress, err := signer.EthereumAddress()
+		if err != nil {
+			return nil, fmt.Errorf("eth address: %w", err)
+		}
 		// set up basic debug api endpoints for debugging and /health endpoint
-		debugAPIService = debugapi.New(logger, tracer, o.CORSAllowedOrigins)
+		debugAPIService = debugapi.New(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, logger, tracer, o.CORSAllowedOrigins)
 
 		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
 		if err != nil {
@@ -495,7 +499,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		}
 
 		// inject dependencies and configure full debug api http path routes
-		debugAPIService.Configure(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
+		debugAPIService.Configure(p2ps, pingPong, kad, storer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
 	}
 
 	if err := kad.Start(p2pCtx); err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -128,6 +128,35 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		tracerCloser:   tracerCloser,
 	}
 
+	var debugAPIService debugapi.Service
+	if o.DebugAPIAddr != "" {
+		// set up basic debug api endpoints for debugging and /health endpoint
+		debugAPIService = debugapi.New(logger, tracer, o.CORSAllowedOrigins)
+
+		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
+		if err != nil {
+			return nil, fmt.Errorf("debug api listener: %w", err)
+		}
+
+		debugAPIServer := &http.Server{
+			IdleTimeout:       30 * time.Second,
+			ReadHeaderTimeout: 3 * time.Second,
+			Handler:           debugAPIService,
+			ErrorLog:          log.New(b.errorLogWriter, "", 0),
+		}
+
+		go func() {
+			logger.Infof("debug api address: %s", debugAPIListener.Addr())
+
+			if err := debugAPIServer.Serve(debugAPIListener); err != nil && err != http.ErrServerClosed {
+				logger.Debugf("debug api server: %v", err)
+				logger.Error("unable to serve debug api")
+			}
+		}()
+
+		b.debugAPIServer = debugAPIServer
+	}
+
 	stateStore, err := InitStateStore(logger, o.DataDir)
 	if err != nil {
 		return nil, err
@@ -438,12 +467,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		b.apiCloser = apiService
 	}
 
-	if o.DebugAPIAddr != "" {
-		// Debug API server
-
-		debugAPIService := debugapi.New(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, logger, tracer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService, debugapi.Options{
-			CORSAllowedOrigins: o.CORSAllowedOrigins,
-		})
+	if debugAPIService != nil {
 		// register metrics from components
 		debugAPIService.MustRegisterMetrics(p2ps.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)
@@ -470,28 +494,8 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 			debugAPIService.MustRegisterMetrics(l.Metrics()...)
 		}
 
-		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
-		if err != nil {
-			return nil, fmt.Errorf("debug api listener: %w", err)
-		}
-
-		debugAPIServer := &http.Server{
-			IdleTimeout:       30 * time.Second,
-			ReadHeaderTimeout: 3 * time.Second,
-			Handler:           debugAPIService,
-			ErrorLog:          log.New(b.errorLogWriter, "", 0),
-		}
-
-		go func() {
-			logger.Infof("debug api address: %s", debugAPIListener.Addr())
-
-			if err := debugAPIServer.Serve(debugAPIListener); err != nil && err != http.ErrServerClosed {
-				logger.Debugf("debug api server: %v", err)
-				logger.Error("unable to serve debug api")
-			}
-		}()
-
-		b.debugAPIServer = debugAPIServer
+		// inject dependencies and configure full debug api http path routes
+		debugAPIService.Configure(swarmAddress, publicKey, pssPrivateKey.PublicKey, overlayEthAddress, p2ps, pingPong, kad, storer, tagService, acc, settlement, o.SwapEnable, swapService, chequebookService)
 	}
 
 	if err := kad.Start(p2pCtx); err != nil {


### PR DESCRIPTION
This PR introduces a two step Debug API router configuration.

Currently, debug api http listener is exposed at the end of the node starting process, when all of the services are constructed. This is a problem if there is a long running process, like localstore migration, and the /health endpoint is not exposed for a long time for kubernetes health check. This PR creates a debug api listener at the start of node initialization, exposing /health, /addresses and some other available debug endpoints, like metrics, pprof and vars. After all of the debug api dependencies are constructed, debug api service is configured with them and a full router is set.

This PR is with the minimal set of changes for this to be accomplished. A followup PR can be done to remove debugapi.Service interface and expose server in that package to avoid Configure method to be in the interface also. The interface is not needed. This change would require to unexport fields in the server struct which would raise the number of changed lines significantly here. I am avoiding that.