### PR TITLE
chequebook: better event parsing

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -157,7 +157,7 @@ func initChequeStoreCashout(
 	chainID int64,
 	overlayEthAddress common.Address,
 	transactionService transaction.Service,
-) (chequebook.ChequeStore, chequebook.CashoutService, error) {
+) (chequebook.ChequeStore, chequebook.CashoutService) {
 	chequeStore := chequebook.NewChequeStore(
 		stateStore,
 		swapBackend,
@@ -168,18 +168,14 @@ func initChequeStoreCashout(
 		chequebook.RecoverCheque,
 	)
 
-	cashout, err := chequebook.NewCashoutService(
+	cashout := chequebook.NewCashoutService(
 		stateStore,
-		chequebook.NewSimpleSwapBindings,
 		swapBackend,
 		transactionService,
 		chequeStore,
 	)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return chequeStore, cashout, nil
+	return chequeStore, cashout
 }
 
 // InitSwap will initialize and register the swap service.

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -189,7 +189,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 			return nil, err
 		}
 
-		chequeStore, cashoutService, err = initChequeStoreCashout(
+		chequeStore, cashoutService = initChequeStoreCashout(
 			stateStore,
 			swapBackend,
 			chequebookFactory,
@@ -197,9 +197,6 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 			overlayEthAddress,
 			transactionService,
 		)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	p2ps, err := libp2p.New(p2pCtx, signer, networkID, swarmAddress, addr, addressbook, stateStore, logger, tracer, libp2p.Options{

--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/sw3-bindings/v3/simpleswapfactory"
 )
 
@@ -19,8 +18,6 @@ type SimpleSwapBinding interface {
 	Issuer(*bind.CallOpts) (common.Address, error)
 	TotalPaidOut(*bind.CallOpts) (*big.Int, error)
 	PaidOut(*bind.CallOpts, common.Address) (*big.Int, error)
-	ParseChequeCashed(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error)
-	ParseChequeBounced(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error)
 }
 
 type SimpleSwapBindingFunc = func(common.Address, bind.ContractBackend) (SimpleSwapBinding, error)
@@ -44,7 +41,6 @@ func NewERC20Bindings(address common.Address, backend bind.ContractBackend) (ERC
 
 // SimpleSwapFactoryBinding is the interface for the generated go bindings for SimpleSwapFactory
 type SimpleSwapFactoryBinding interface {
-	ParseSimpleSwapDeployed(types.Log) (*simpleswapfactory.SimpleSwapFactorySimpleSwapDeployed, error)
 	DeployedContracts(*bind.CallOpts, common.Address) (bool, error)
 	ERC20Address(*bind.CallOpts) (common.Address, error)
 }

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -10,19 +10,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
-	"github.com/ethersphere/sw3-bindings/v3/simpleswapfactory"
 )
 
 type simpleSwapFactoryBindingMock struct {
-	erc20Address            func(*bind.CallOpts) (common.Address, error)
-	deployedContracts       func(*bind.CallOpts, common.Address) (bool, error)
-	parseSimpleSwapDeployed func(types.Log) (*simpleswapfactory.SimpleSwapFactorySimpleSwapDeployed, error)
-}
-
-func (m *simpleSwapFactoryBindingMock) ParseSimpleSwapDeployed(l types.Log) (*simpleswapfactory.SimpleSwapFactorySimpleSwapDeployed, error) {
-	return m.parseSimpleSwapDeployed(l)
+	erc20Address      func(*bind.CallOpts) (common.Address, error)
+	deployedContracts func(*bind.CallOpts, common.Address) (bool, error)
 }
 
 func (m *simpleSwapFactoryBindingMock) DeployedContracts(o *bind.CallOpts, a common.Address) (bool, error) {
@@ -33,12 +26,10 @@ func (m *simpleSwapFactoryBindingMock) ERC20Address(o *bind.CallOpts) (common.Ad
 }
 
 type simpleSwapBindingMock struct {
-	balance            func(*bind.CallOpts) (*big.Int, error)
-	issuer             func(*bind.CallOpts) (common.Address, error)
-	totalPaidOut       func(o *bind.CallOpts) (*big.Int, error)
-	paidOut            func(*bind.CallOpts, common.Address) (*big.Int, error)
-	parseChequeCashed  func(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error)
-	parseChequeBounced func(types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error)
+	balance      func(*bind.CallOpts) (*big.Int, error)
+	issuer       func(*bind.CallOpts) (common.Address, error)
+	totalPaidOut func(o *bind.CallOpts) (*big.Int, error)
+	paidOut      func(*bind.CallOpts, common.Address) (*big.Int, error)
 }
 
 func (m *simpleSwapBindingMock) Balance(o *bind.CallOpts) (*big.Int, error) {
@@ -51,14 +42,6 @@ func (m *simpleSwapBindingMock) Issuer(o *bind.CallOpts) (common.Address, error)
 
 func (m *simpleSwapBindingMock) TotalPaidOut(o *bind.CallOpts) (*big.Int, error) {
 	return m.totalPaidOut(o)
-}
-
-func (m *simpleSwapBindingMock) ParseChequeCashed(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeCashed, error) {
-	return m.parseChequeCashed(l)
-}
-
-func (m *simpleSwapBindingMock) ParseChequeBounced(l types.Log) (*simpleswapfactory.ERC20SimpleSwapChequeBounced, error) {
-	return m.parseChequeBounced(l)
 }
 
 func (m *simpleSwapBindingMock) PaidOut(o *bind.CallOpts, c common.Address) (*big.Int, error) {

--- a/pkg/settlement/swap/transaction/backend.go
+++ b/pkg/settlement/swap/transaction/backend.go
@@ -6,9 +6,12 @@ package transaction
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -64,4 +67,13 @@ func WaitSynced(ctx context.Context, backend Backend, maxDelay time.Duration) er
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+// ParseABIUnchecked will parse a valid json abi. Only use this with string constants known to be correct.
+func ParseABIUnchecked(json string) abi.ABI {
+	cabi, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("error creating ABI for contract: %v", err))
+	}
+	return cabi
 }

--- a/pkg/settlement/swap/transaction/event.go
+++ b/pkg/settlement/swap/transaction/event.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package transaction
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	ErrEventNotFound = errors.New("event not found")
+	ErrNoTopic       = errors.New("no topic")
+)
+
+// ParseEvent will parse the specified abi event from the given log
+func ParseEvent(a *abi.ABI, eventName string, c interface{}, e types.Log) error {
+	if len(e.Topics) == 0 {
+		return ErrNoTopic
+	}
+	if len(e.Data) > 0 {
+		if err := a.UnpackIntoInterface(c, eventName, e.Data); err != nil {
+			return err
+		}
+	}
+	var indexed abi.Arguments
+	for _, arg := range a.Events[eventName].Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	return abi.ParseTopics(c, indexed, e.Topics[1:])
+}
+
+// FindSingleEvent will find the first event of the given kind.
+func FindSingleEvent(abi *abi.ABI, receipt *types.Receipt, contractAddress common.Address, event abi.Event, out interface{}) error {
+	if receipt.Status != 1 {
+		return ErrTransactionReverted
+	}
+	for _, log := range receipt.Logs {
+		if log.Address != contractAddress {
+			continue
+		}
+		if len(log.Topics) == 0 {
+			continue
+		}
+		if log.Topics[0] != event.ID {
+			continue
+		}
+
+		return ParseEvent(abi, event.Name, out, *log)
+	}
+	return ErrEventNotFound
+}

--- a/pkg/settlement/swap/transaction/event_test.go
+++ b/pkg/settlement/swap/transaction/event_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package transaction_test
 
 import (

--- a/pkg/settlement/swap/transaction/event_test.go
+++ b/pkg/settlement/swap/transaction/event_test.go
@@ -1,0 +1,144 @@
+package transaction_test
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction"
+	"github.com/ethersphere/sw3-bindings/v3/simpleswapfactory"
+)
+
+var (
+	erc20ABI = transaction.ParseABIUnchecked(simpleswapfactory.ERC20ABI)
+)
+
+type transferEvent struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+}
+
+func newTransferLog(address common.Address, from common.Address, to common.Address, value *big.Int) *types.Log {
+	return &types.Log{
+		Topics: []common.Hash{
+			erc20ABI.Events["Transfer"].ID,
+			from.Hash(),
+			to.Hash(),
+		},
+		Data:    value.FillBytes(make([]byte, 32)),
+		Address: address,
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	from := common.HexToAddress("00")
+	to := common.HexToAddress("01")
+	value := big.NewInt(0)
+
+	t.Run("ok", func(t *testing.T) {
+		var event transferEvent
+		err := transaction.ParseEvent(&erc20ABI, "Transfer", &event, *newTransferLog(common.Address{}, from, to, value))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if event.From != from {
+			t.Fatalf("parsed wrong from. wanted %x, got %x", from, event.From)
+		}
+
+		if event.To != to {
+			t.Fatalf("parsed wrong to. wanted %x, got %x", to, event.To)
+		}
+
+		if value.Cmp(event.Value) != 0 {
+			t.Fatalf("parsed wrong value. wanted %d, got %d", value, event.Value)
+		}
+	})
+
+	t.Run("no topic", func(t *testing.T) {
+		var event transferEvent
+		err := transaction.ParseEvent(&erc20ABI, "Transfer", &event, types.Log{
+			Topics: []common.Hash{},
+		})
+		if !errors.Is(err, transaction.ErrNoTopic) {
+			t.Fatalf("expected error %v, got %v", transaction.ErrNoTopic, err)
+		}
+	})
+}
+
+func TestFindSingleEvent(t *testing.T) {
+	contractAddress := common.HexToAddress("abcd")
+	from := common.HexToAddress("00")
+	to := common.HexToAddress("01")
+	value := big.NewInt(0)
+
+	t.Run("ok", func(t *testing.T) {
+		var event transferEvent
+		err := transaction.FindSingleEvent(
+			&erc20ABI,
+			&types.Receipt{
+				Logs: []*types.Log{
+					newTransferLog(from, to, from, value),                 // event from different contract
+					{Topics: []common.Hash{{}}, Address: contractAddress}, // different event from same contract
+					newTransferLog(contractAddress, from, to, value),
+				},
+				Status: 1,
+			},
+			contractAddress,
+			erc20ABI.Events["Transfer"],
+			&event,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if event.From != from {
+			t.Fatalf("parsed wrong from. wanted %x, got %x", from, event.From)
+		}
+
+		if event.To != to {
+			t.Fatalf("parsed wrong to. wanted %x, got %x", to, event.To)
+		}
+
+		if value.Cmp(event.Value) != 0 {
+			t.Fatalf("parsed wrong value. wanted %d, got %d", value, event.Value)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		var event transferEvent
+		err := transaction.FindSingleEvent(
+			&erc20ABI,
+			&types.Receipt{
+				Logs: []*types.Log{
+					newTransferLog(from, to, from, value),                 // event from different contract
+					{Topics: []common.Hash{{}}, Address: contractAddress}, // different event from same contract
+				},
+				Status: 1,
+			},
+			contractAddress,
+			erc20ABI.Events["Transfer"],
+			&event,
+		)
+		if !errors.Is(err, transaction.ErrEventNotFound) {
+			t.Fatalf("wanted error %v, got %v", transaction.ErrEventNotFound, err)
+		}
+	})
+
+	t.Run("Reverted", func(t *testing.T) {
+		var event transferEvent
+		err := transaction.FindSingleEvent(
+			&erc20ABI,
+			&types.Receipt{Status: 0},
+			contractAddress,
+			erc20ABI.Events["Transfer"],
+			&event,
+		)
+		if !errors.Is(err, transaction.ErrTransactionReverted) {
+			t.Fatalf("wanted error %v, got %v", transaction.ErrTransactionReverted, err)
+		}
+	})
+}


### PR DESCRIPTION
this is the first in a series of PRs which remove the use of `abigen`-generated bindings in favour of just using the few things we need directly. the reason behind this move is that generating correct abigen bindings for the correct go-ethereum version can be tricky (e.g. bindings for `>1.9.23` can only be generated with `master`, not with `1.9.23` or `1.9.25`), we can't really use them for all the things we need (we already bypass them for transaction sending and our event parsing was a bit of a hack which cannot differentiate between errors properly) and its 95% unused boilerplate code. the idea is to instead just have the abi json and the bytecode hex in our generated go library for the contracts.

This PR
* parses ABIs into package package level vars and panic if that fails (as is done also on the `storage-incentives` branch). all abi json strings we use are hardcoded as part of the binary anyway, and therefore `abi.JSON()` cannot actually fail. This allows to get rid of a lot of impossible errors in constructors.
* event parsing is no longer done through the abigen bindings but custom helper functions in the `transaction` package (similar to how we do event parsing in `storage-incentives` branch).
* unit tests now test with real valid log data