### PR TITLE
chequebook: remove use of bindings for factory

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -95,17 +95,11 @@ func InitChequebookFactory(
 		logger.Infof("using custom factory address: %x", addr)
 	}
 
-	chequebookFactory, err := chequebook.NewFactory(
+	return chequebook.NewFactory(
 		backend,
 		transactionService,
 		addr,
-		chequebook.NewSimpleSwapFactoryBindingFunc,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("new factory: %w", err)
-	}
-
-	return chequebookFactory, nil
+	), nil
 }
 
 // InitChequebookService will initialize the chequebook service with the given

--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -38,16 +38,3 @@ type ERC20BindingFunc = func(common.Address, bind.ContractBackend) (ERC20Binding
 func NewERC20Bindings(address common.Address, backend bind.ContractBackend) (ERC20Binding, error) {
 	return simpleswapfactory.NewERC20(address, backend)
 }
-
-// SimpleSwapFactoryBinding is the interface for the generated go bindings for SimpleSwapFactory
-type SimpleSwapFactoryBinding interface {
-	DeployedContracts(*bind.CallOpts, common.Address) (bool, error)
-	ERC20Address(*bind.CallOpts) (common.Address, error)
-}
-
-type SimpleSwapFactoryBindingFunc = func(common.Address, bind.ContractBackend) (SimpleSwapFactoryBinding, error)
-
-// NewSimpleSwapFactoryBindingFunc generates the default go bindings
-func NewSimpleSwapFactoryBindingFunc(address common.Address, backend bind.ContractBackend) (SimpleSwapFactoryBinding, error) {
-	return simpleswapfactory.NewSimpleSwapFactory(address, backend)
-}

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -13,18 +13,6 @@ import (
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 )
 
-type simpleSwapFactoryBindingMock struct {
-	erc20Address      func(*bind.CallOpts) (common.Address, error)
-	deployedContracts func(*bind.CallOpts, common.Address) (bool, error)
-}
-
-func (m *simpleSwapFactoryBindingMock) DeployedContracts(o *bind.CallOpts, a common.Address) (bool, error) {
-	return m.deployedContracts(o, a)
-}
-func (m *simpleSwapFactoryBindingMock) ERC20Address(o *bind.CallOpts) (common.Address, error) {
-	return m.erc20Address(o)
-}
-
 type simpleSwapBindingMock struct {
 	balance      func(*bind.CallOpts) (*big.Int, error)
 	issuer       func(*bind.CallOpts) (common.Address, error)

--- a/pkg/settlement/swap/transaction/transaction.go
+++ b/pkg/settlement/swap/transaction/transaction.go
@@ -44,6 +44,8 @@ type TxRequest struct {
 type Service interface {
 	// Send creates a transaction based on the request and sends it.
 	Send(ctx context.Context, request *TxRequest) (txHash common.Hash, err error)
+	// Call simulate a transaction based on the request.
+	Call(ctx context.Context, request *TxRequest) (result []byte, err error)
 	// WaitForReceipt waits until either the transaction with the given hash has been mined or the context is cancelled.
 	WaitForReceipt(ctx context.Context, txHash common.Hash) (receipt *types.Receipt, err error)
 }
@@ -107,6 +109,24 @@ func (t *transactionService) Send(ctx context.Context, request *TxRequest) (txHa
 	}
 
 	return signedTx.Hash(), nil
+}
+
+func (t *transactionService) Call(ctx context.Context, request *TxRequest) ([]byte, error) {
+	msg := ethereum.CallMsg{
+		From:     t.sender,
+		To:       request.To,
+		Data:     request.Data,
+		GasPrice: request.GasPrice,
+		Gas:      request.GasLimit,
+		Value:    request.Value,
+	}
+
+	data, err := t.backend.CallContract(ctx, msg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }
 
 // WaitForReceipt waits until either the transaction with the given hash has


### PR DESCRIPTION
this is the second in a series of PRs which remove the use of abigen-generated bindings in favour of just using the few things we need directly building on top of #1360.

This PR
* removes the use of bindings in `factory.go` instead doing the call via the transaction service (`Call` was copied from `storage-incentives`)
* adds abi-aware helpers to the `transaction` mock for more ergonomic checking of wether the `TxRequest`s are correct.
* adds the `transactionmock.WithABICallSequence` helper which is not used directly in this PR but in follow-ups where functions with more than one call need to be tested.