### PR TITLE
chequebook: remove erc20 bindings

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -135,7 +135,6 @@ func InitChequebookService(
 		overlayEthAddress,
 		chequeSigner,
 		chequebook.NewSimpleSwapBindings,
-		chequebook.NewERC20Bindings,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("chequebook init: %w", err)

--- a/pkg/settlement/swap/chequebook/bindings.go
+++ b/pkg/settlement/swap/chequebook/bindings.go
@@ -26,15 +26,3 @@ type SimpleSwapBindingFunc = func(common.Address, bind.ContractBackend) (SimpleS
 func NewSimpleSwapBindings(address common.Address, backend bind.ContractBackend) (SimpleSwapBinding, error) {
 	return simpleswapfactory.NewERC20SimpleSwap(address, backend)
 }
-
-// ERC20Binding is the interface for the generated go bindings for ERC20
-type ERC20Binding interface {
-	BalanceOf(*bind.CallOpts, common.Address) (*big.Int, error)
-}
-
-type ERC20BindingFunc = func(common.Address, bind.ContractBackend) (ERC20Binding, error)
-
-// NewERC20Bindings generates the default go bindings
-func NewERC20Bindings(address common.Address, backend bind.ContractBackend) (ERC20Binding, error) {
-	return simpleswapfactory.NewERC20(address, backend)
-}

--- a/pkg/settlement/swap/chequebook/common_test.go
+++ b/pkg/settlement/swap/chequebook/common_test.go
@@ -36,14 +36,6 @@ func (m *simpleSwapBindingMock) PaidOut(o *bind.CallOpts, c common.Address) (*bi
 	return m.paidOut(o, c)
 }
 
-type erc20BindingMock struct {
-	balanceOf func(*bind.CallOpts, common.Address) (*big.Int, error)
-}
-
-func (m *erc20BindingMock) BalanceOf(o *bind.CallOpts, a common.Address) (*big.Int, error) {
-	return m.balanceOf(o, a)
-}
-
 type chequeSignerMock struct {
 	sign func(cheque *chequebook.Cheque) ([]byte, error)
 }

--- a/pkg/settlement/swap/erc20/erc20.go
+++ b/pkg/settlement/swap/erc20/erc20.go
@@ -1,0 +1,92 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package erc20
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction"
+	"github.com/ethersphere/sw3-bindings/v3/simpleswapfactory"
+)
+
+var (
+	erc20ABI     = transaction.ParseABIUnchecked(simpleswapfactory.ERC20ABI)
+	errDecodeABI = errors.New("could not decode abi data")
+)
+
+type Service interface {
+	BalanceOf(ctx context.Context, address common.Address) (*big.Int, error)
+	Transfer(ctx context.Context, address common.Address, value *big.Int) (common.Hash, error)
+}
+
+type erc20Service struct {
+	backend            transaction.Backend
+	transactionService transaction.Service
+	address            common.Address
+}
+
+func New(backend transaction.Backend, transactionService transaction.Service, address common.Address) Service {
+	return &erc20Service{
+		backend:            backend,
+		transactionService: transactionService,
+		address:            address,
+	}
+}
+
+func (c *erc20Service) BalanceOf(ctx context.Context, address common.Address) (*big.Int, error) {
+	callData, err := erc20ABI.Pack("balanceOf", address)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := c.transactionService.Call(ctx, &transaction.TxRequest{
+		To:   &c.address,
+		Data: callData,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := erc20ABI.Unpack("balanceOf", output)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(results) != 1 {
+		return nil, errDecodeABI
+	}
+
+	balance, ok := abi.ConvertType(results[0], new(big.Int)).(*big.Int)
+	if !ok || balance == nil {
+		return nil, errDecodeABI
+	}
+	return balance, nil
+}
+
+func (c *erc20Service) Transfer(ctx context.Context, address common.Address, value *big.Int) (common.Hash, error) {
+	callData, err := erc20ABI.Pack("transfer", address, value)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	request := &transaction.TxRequest{
+		To:       &c.address,
+		Data:     callData,
+		GasPrice: nil,
+		GasLimit: 0,
+		Value:    big.NewInt(0),
+	}
+
+	txHash, err := c.transactionService.Send(ctx, request)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return txHash, nil
+}

--- a/pkg/settlement/swap/erc20/erc20_test.go
+++ b/pkg/settlement/swap/erc20/erc20_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package erc20_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/pkg/settlement/swap/erc20"
+	"github.com/ethersphere/bee/pkg/settlement/swap/transaction"
+	backendmock "github.com/ethersphere/bee/pkg/settlement/swap/transaction/backendmock"
+	transactionmock "github.com/ethersphere/bee/pkg/settlement/swap/transaction/mock"
+	"github.com/ethersphere/sw3-bindings/v3/simpleswapfactory"
+)
+
+var (
+	erc20ABI = transaction.ParseABIUnchecked(simpleswapfactory.ERC20ABI)
+)
+
+func TestBalanceOf(t *testing.T) {
+	erc20Address := common.HexToAddress("00")
+	account := common.HexToAddress("01")
+	expectedBalance := big.NewInt(100)
+
+	erc20 := erc20.New(
+		backendmock.New(),
+		transactionmock.New(
+			transactionmock.WithABICall(
+				&erc20ABI,
+				expectedBalance.FillBytes(make([]byte, 32)),
+				"balanceOf",
+				account,
+			),
+		),
+		erc20Address,
+	)
+
+	balance, err := erc20.BalanceOf(context.Background(), account)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expectedBalance.Cmp(balance) != 0 {
+		t.Fatalf("got wrong balance. wanted %d, got %d", expectedBalance, balance)
+	}
+}
+
+func TestTransfer(t *testing.T) {
+	address := common.HexToAddress("0xabcd")
+	account := common.HexToAddress("01")
+	value := big.NewInt(20)
+	txHash := common.HexToHash("0xdddd")
+
+	erc20 := erc20.New(
+		backendmock.New(),
+		transactionmock.New(
+			transactionmock.WithABISend(&erc20ABI, txHash, address, big.NewInt(0), "transfer", account, value),
+		),
+		address,
+	)
+
+	returnedTxHash, err := erc20.Transfer(context.Background(), account, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txHash != returnedTxHash {
+		t.Fatalf("returned wrong transaction hash. wanted %v, got %v", txHash, returnedTxHash)
+	}
+}

--- a/pkg/settlement/swap/erc20/mock/erc20.go
+++ b/pkg/settlement/swap/erc20/mock/erc20.go
@@ -1,0 +1,62 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/pkg/settlement/swap/erc20"
+)
+
+type Service struct {
+	balanceOfFunc func(ctx context.Context, address common.Address) (*big.Int, error)
+	transferFunc  func(ctx context.Context, address common.Address, value *big.Int) (common.Hash, error)
+}
+
+func WithBalanceOfFunc(f func(ctx context.Context, address common.Address) (*big.Int, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.balanceOfFunc = f
+	})
+}
+
+func WithTransferFunc(f func(ctx context.Context, address common.Address, value *big.Int) (common.Hash, error)) Option {
+	return optionFunc(func(s *Service) {
+		s.transferFunc = f
+	})
+}
+
+func New(opts ...Option) erc20.Service {
+	mock := new(Service)
+	for _, o := range opts {
+		o.apply(mock)
+	}
+	return mock
+}
+
+func (s *Service) BalanceOf(ctx context.Context, address common.Address) (*big.Int, error) {
+	if s.balanceOfFunc != nil {
+		return s.balanceOfFunc(ctx, address)
+	}
+	return big.NewInt(0), errors.New("Error")
+}
+
+func (s *Service) Transfer(ctx context.Context, address common.Address, value *big.Int) (common.Hash, error) {
+	if s.transferFunc != nil {
+		return s.transferFunc(ctx, address, value)
+	}
+	return common.Hash{}, errors.New("Error")
+}
+
+// Option is the option passed to the mock Chequebook service
+type Option interface {
+	apply(*Service)
+}
+
+type optionFunc func(*Service)
+
+func (f optionFunc) apply(r *Service) { f(r) }


### PR DESCRIPTION
this is the third in a series of PRs which remove the use of abigen-generated bindings in favour of just using the few things we need directly building on top of #1361.

This PR
* removes use of bindings for erc20
* introduces an erc20 service instead which uses go-ethereum abi directly (this has been extracted as some of its functions are also needed in `storage-incentives` where some code is currently duplicated)