### PR TITLE
remove go-log.v1 yet again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect
-	gopkg.in/src-d/go-log.v1 v1.0.1
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect


### PR DESCRIPTION
this was introduced by accident in #1314, then removed in #1357, then reintroduced by accident in #1345 which changed the same file