### PR TITLE
debug api as a concrete service

### DIFF
--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -31,12 +31,12 @@ type balancesResponse struct {
 	Balances []balanceResponse `json:"balances"`
 }
 
-func (s *server) balancesHandler(w http.ResponseWriter, r *http.Request) {
-	balances, err := s.Accounting.Balances()
+func (s *Service) balancesHandler(w http.ResponseWriter, r *http.Request) {
+	balances, err := s.accounting.Balances()
 	if err != nil {
 		jsonhttp.InternalServerError(w, errCantBalances)
-		s.Logger.Debugf("debug api: balances: %v", err)
-		s.Logger.Error("debug api: can not get balances")
+		s.logger.Debugf("debug api: balances: %v", err)
+		s.logger.Error("debug api: can not get balances")
 		return
 	}
 
@@ -53,24 +53,24 @@ func (s *server) balancesHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, balancesResponse{Balances: balResponses})
 }
 
-func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: balances peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: balances peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: balances peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: balances peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
-	balance, err := s.Accounting.Balance(peer)
+	balance, err := s.accounting.Balance(peer)
 	if err != nil {
 		if errors.Is(err, accounting.ErrPeerNoBalance) {
 			jsonhttp.NotFound(w, errNoBalance)
 			return
 		}
-		s.Logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)
-		s.Logger.Errorf("debug api: balances peer: can't get peer %s balance", peer.String())
+		s.logger.Debugf("debug api: balances peer: get peer %s balance: %v", peer.String(), err)
+		s.logger.Errorf("debug api: balances peer: can't get peer %s balance", peer.String())
 		jsonhttp.InternalServerError(w, errCantBalance)
 		return
 	}
@@ -81,12 +81,12 @@ func (s *server) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *server) compensatedBalancesHandler(w http.ResponseWriter, r *http.Request) {
-	balances, err := s.Accounting.CompensatedBalances()
+func (s *Service) compensatedBalancesHandler(w http.ResponseWriter, r *http.Request) {
+	balances, err := s.accounting.CompensatedBalances()
 	if err != nil {
 		jsonhttp.InternalServerError(w, errCantBalances)
-		s.Logger.Debugf("debug api: compensated balances: %v", err)
-		s.Logger.Error("debug api: can not get compensated balances")
+		s.logger.Debugf("debug api: compensated balances: %v", err)
+		s.logger.Error("debug api: can not get compensated balances")
 		return
 	}
 
@@ -103,24 +103,24 @@ func (s *server) compensatedBalancesHandler(w http.ResponseWriter, r *http.Reque
 	jsonhttp.OK(w, balancesResponse{Balances: balResponses})
 }
 
-func (s *server) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: compensated balances peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: compensated balances peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: compensated balances peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: compensated balances peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
-	balance, err := s.Accounting.CompensatedBalance(peer)
+	balance, err := s.accounting.CompensatedBalance(peer)
 	if err != nil {
 		if errors.Is(err, accounting.ErrPeerNoBalance) {
 			jsonhttp.NotFound(w, errNoBalance)
 			return
 		}
-		s.Logger.Debugf("debug api: compensated balances peer: get peer %s balance: %v", peer.String(), err)
-		s.Logger.Errorf("debug api: compensated balances peer: can't get peer %s balance", peer.String())
+		s.logger.Debugf("debug api: compensated balances peer: get peer %s balance: %v", peer.String(), err)
+		s.logger.Errorf("debug api: compensated balances peer: can't get peer %s balance", peer.String())
 		jsonhttp.InternalServerError(w, errCantBalance)
 		return
 	}

--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -56,46 +56,46 @@ type chequebookLastChequesResponse struct {
 	LastCheques []chequebookLastChequesPeerResponse `json:"lastcheques"`
 }
 
-func (s *server) chequebookBalanceHandler(w http.ResponseWriter, r *http.Request) {
-	balance, err := s.Chequebook.Balance(r.Context())
+func (s *Service) chequebookBalanceHandler(w http.ResponseWriter, r *http.Request) {
+	balance, err := s.chequebook.Balance(r.Context())
 	if err != nil {
 		jsonhttp.InternalServerError(w, errChequebookBalance)
-		s.Logger.Debugf("debug api: chequebook balance: %v", err)
-		s.Logger.Error("debug api: cannot get chequebook balance")
+		s.logger.Debugf("debug api: chequebook balance: %v", err)
+		s.logger.Error("debug api: cannot get chequebook balance")
 		return
 	}
 
-	availableBalance, err := s.Chequebook.AvailableBalance(r.Context())
+	availableBalance, err := s.chequebook.AvailableBalance(r.Context())
 	if err != nil {
 		jsonhttp.InternalServerError(w, errChequebookBalance)
-		s.Logger.Debugf("debug api: chequebook availableBalance: %v", err)
-		s.Logger.Error("debug api: cannot get chequebook availableBalance")
+		s.logger.Debugf("debug api: chequebook availableBalance: %v", err)
+		s.logger.Error("debug api: cannot get chequebook availableBalance")
 		return
 	}
 
 	jsonhttp.OK(w, chequebookBalanceResponse{TotalBalance: balance, AvailableBalance: availableBalance})
 }
 
-func (s *server) chequebookAddressHandler(w http.ResponseWriter, r *http.Request) {
-	address := s.Chequebook.Address()
+func (s *Service) chequebookAddressHandler(w http.ResponseWriter, r *http.Request) {
+	address := s.chequebook.Address()
 	jsonhttp.OK(w, chequebookAddressResponse{Address: address.String()})
 }
 
-func (s *server) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: chequebook cheque peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: chequebook cheque peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: chequebook cheque peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: chequebook cheque peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
 	var lastSentResponse *chequebookLastChequePeerResponse
-	lastSent, err := s.Swap.LastSentCheque(peer)
+	lastSent, err := s.swap.LastSentCheque(peer)
 	if err != nil && err != chequebook.ErrNoCheque {
-		s.Logger.Debugf("debug api: chequebook cheque peer: get peer %s last cheque: %v", peer.String(), err)
-		s.Logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
+		s.logger.Debugf("debug api: chequebook cheque peer: get peer %s last cheque: %v", peer.String(), err)
+		s.logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
 		jsonhttp.InternalServerError(w, errCantLastChequePeer)
 		return
 	}
@@ -108,10 +108,10 @@ func (s *server) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	var lastReceivedResponse *chequebookLastChequePeerResponse
-	lastReceived, err := s.Swap.LastReceivedCheque(peer)
+	lastReceived, err := s.swap.LastReceivedCheque(peer)
 	if err != nil && err != chequebook.ErrNoCheque {
-		s.Logger.Debugf("debug api: chequebook cheque peer: get peer %s last cheque: %v", peer.String(), err)
-		s.Logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
+		s.logger.Debugf("debug api: chequebook cheque peer: get peer %s last cheque: %v", peer.String(), err)
+		s.logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
 		jsonhttp.InternalServerError(w, errCantLastChequePeer)
 		return
 	}
@@ -130,18 +130,18 @@ func (s *server) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Reques
 	})
 }
 
-func (s *server) chequebookAllLastHandler(w http.ResponseWriter, r *http.Request) {
-	lastchequessent, err := s.Swap.LastSentCheques()
+func (s *Service) chequebookAllLastHandler(w http.ResponseWriter, r *http.Request) {
+	lastchequessent, err := s.swap.LastSentCheques()
 	if err != nil {
-		s.Logger.Debugf("debug api: chequebook cheque all: get all last cheques: %v", err)
-		s.Logger.Errorf("debug api: chequebook cheque all: can't get all last cheques")
+		s.logger.Debugf("debug api: chequebook cheque all: get all last cheques: %v", err)
+		s.logger.Errorf("debug api: chequebook cheque all: can't get all last cheques")
 		jsonhttp.InternalServerError(w, errCantLastCheque)
 		return
 	}
-	lastchequesreceived, err := s.Swap.LastReceivedCheques()
+	lastchequesreceived, err := s.swap.LastReceivedCheques()
 	if err != nil {
-		s.Logger.Debugf("debug api: chequebook cheque all: get all last cheques: %v", err)
-		s.Logger.Errorf("debug api: chequebook cheque all: can't get all last cheques")
+		s.logger.Debugf("debug api: chequebook cheque all: get all last cheques: %v", err)
+		s.logger.Errorf("debug api: chequebook cheque all: can't get all last cheques")
 		jsonhttp.InternalServerError(w, errCantLastCheque)
 		return
 	}
@@ -194,20 +194,20 @@ type swapCashoutResponse struct {
 	TransactionHash string `json:"transactionHash"`
 }
 
-func (s *server) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: cashout peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: cashout peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: cashout peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: cashout peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
-	txHash, err := s.Swap.CashCheque(r.Context(), peer)
+	txHash, err := s.swap.CashCheque(r.Context(), peer)
 	if err != nil {
-		s.Logger.Debugf("debug api: cashout peer: cannot cash %s: %v", addr, err)
-		s.Logger.Errorf("debug api: cashout peer: cannot cash %s", addr)
+		s.logger.Debugf("debug api: cashout peer: cannot cash %s: %v", addr, err)
+		s.logger.Errorf("debug api: cashout peer: cannot cash %s", addr)
 		jsonhttp.InternalServerError(w, errCannotCash)
 		return
 	}
@@ -230,32 +230,32 @@ type swapCashoutStatusResponse struct {
 	Result           *swapCashoutStatusResult `json:"result"`
 }
 
-func (s *server) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: cashout status peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: cashout status peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: cashout status peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: cashout status peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
-	status, err := s.Swap.CashoutStatus(r.Context(), peer)
+	status, err := s.swap.CashoutStatus(r.Context(), peer)
 	if err != nil {
 		if errors.Is(err, chequebook.ErrNoCheque) {
-			s.Logger.Debugf("debug api: cashout status peer: %v", addr, err)
-			s.Logger.Errorf("debug api: cashout status peer: %s", addr)
+			s.logger.Debugf("debug api: cashout status peer: %v", addr, err)
+			s.logger.Errorf("debug api: cashout status peer: %s", addr)
 			jsonhttp.NotFound(w, errNoCheque)
 			return
 		}
 		if errors.Is(err, chequebook.ErrNoCashout) {
-			s.Logger.Debugf("debug api: cashout status peer: %v", addr, err)
-			s.Logger.Errorf("debug api: cashout status peer: %s", addr)
+			s.logger.Debugf("debug api: cashout status peer: %v", addr, err)
+			s.logger.Errorf("debug api: cashout status peer: %s", addr)
 			jsonhttp.NotFound(w, errNoCashout)
 			return
 		}
-		s.Logger.Debugf("debug api: cashout status peer: cannot get status %s: %v", addr, err)
-		s.Logger.Errorf("debug api: cashout status peer: cannot get status %s", addr)
+		s.logger.Debugf("debug api: cashout status peer: cannot get status %s: %v", addr, err)
+		s.logger.Errorf("debug api: cashout status peer: cannot get status %s", addr)
 		jsonhttp.InternalServerError(w, errCannotCashStatus)
 		return
 	}
@@ -283,64 +283,64 @@ type chequebookTxResponse struct {
 	TransactionHash common.Hash `json:"transactionHash"`
 }
 
-func (s *server) chequebookWithdrawHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) chequebookWithdrawHandler(w http.ResponseWriter, r *http.Request) {
 	amountStr := r.URL.Query().Get("amount")
 	if amountStr == "" {
 		jsonhttp.BadRequest(w, errChequebookNoAmount)
-		s.Logger.Error("debug api: no withdraw amount")
+		s.logger.Error("debug api: no withdraw amount")
 		return
 	}
 
 	amount, ok := big.NewInt(0).SetString(amountStr, 10)
 	if !ok {
 		jsonhttp.BadRequest(w, errChequebookNoAmount)
-		s.Logger.Error("debug api: invalid withdraw amount")
+		s.logger.Error("debug api: invalid withdraw amount")
 		return
 	}
 
-	txHash, err := s.Chequebook.Withdraw(r.Context(), amount)
+	txHash, err := s.chequebook.Withdraw(r.Context(), amount)
 	if errors.Is(err, chequebook.ErrInsufficientFunds) {
 		jsonhttp.BadRequest(w, errChequebookInsufficientFunds)
-		s.Logger.Debugf("debug api: chequebook withdraw: %v", err)
-		s.Logger.Error("debug api: cannot withdraw from chequebook")
+		s.logger.Debugf("debug api: chequebook withdraw: %v", err)
+		s.logger.Error("debug api: cannot withdraw from chequebook")
 		return
 	}
 	if err != nil {
 		jsonhttp.InternalServerError(w, errChequebookNoWithdraw)
-		s.Logger.Debugf("debug api: chequebook withdraw: %v", err)
-		s.Logger.Error("debug api: cannot withdraw from chequebook")
+		s.logger.Debugf("debug api: chequebook withdraw: %v", err)
+		s.logger.Error("debug api: cannot withdraw from chequebook")
 		return
 	}
 
 	jsonhttp.OK(w, chequebookTxResponse{TransactionHash: txHash})
 }
 
-func (s *server) chequebookDepositHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) chequebookDepositHandler(w http.ResponseWriter, r *http.Request) {
 	amountStr := r.URL.Query().Get("amount")
 	if amountStr == "" {
 		jsonhttp.BadRequest(w, errChequebookNoAmount)
-		s.Logger.Error("debug api: no deposit amount")
+		s.logger.Error("debug api: no deposit amount")
 		return
 	}
 
 	amount, ok := big.NewInt(0).SetString(amountStr, 10)
 	if !ok {
 		jsonhttp.BadRequest(w, errChequebookNoAmount)
-		s.Logger.Error("debug api: invalid deposit amount")
+		s.logger.Error("debug api: invalid deposit amount")
 		return
 	}
 
-	txHash, err := s.Chequebook.Deposit(r.Context(), amount)
+	txHash, err := s.chequebook.Deposit(r.Context(), amount)
 	if errors.Is(err, chequebook.ErrInsufficientFunds) {
 		jsonhttp.BadRequest(w, errChequebookInsufficientFunds)
-		s.Logger.Debugf("debug api: chequebook deposit: %v", err)
-		s.Logger.Error("debug api: cannot deposit from chequebook")
+		s.logger.Debugf("debug api: chequebook deposit: %v", err)
+		s.logger.Error("debug api: cannot deposit from chequebook")
 		return
 	}
 	if err != nil {
 		jsonhttp.InternalServerError(w, errChequebookNoDeposit)
-		s.Logger.Debugf("debug api: chequebook deposit: %v", err)
-		s.Logger.Error("debug api: cannot deposit from chequebook")
+		s.logger.Debugf("debug api: chequebook deposit: %v", err)
+		s.logger.Error("debug api: cannot deposit from chequebook")
 		return
 	}
 

--- a/pkg/debugapi/chunk.go
+++ b/pkg/debugapi/chunk.go
@@ -13,17 +13,17 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *server) hasChunkHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) hasChunkHandler(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("debug api: parse chunk address: %v", err)
+		s.logger.Debugf("debug api: parse chunk address: %v", err)
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: localstore has: %v", err)
+		s.logger.Debugf("debug api: localstore has: %v", err)
 		jsonhttp.BadRequest(w, err)
 		return
 	}
@@ -35,17 +35,17 @@ func (s *server) hasChunkHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, nil)
 }
 
-func (s *server) removeChunk(w http.ResponseWriter, r *http.Request) {
+func (s *Service) removeChunk(w http.ResponseWriter, r *http.Request) {
 	addr, err := swarm.ParseHexAddress(mux.Vars(r)["address"])
 	if err != nil {
-		s.Logger.Debugf("debug api: parse chunk address: %v", err)
+		s.logger.Debugf("debug api: parse chunk address: %v", err)
 		jsonhttp.BadRequest(w, "bad address")
 		return
 	}
 
-	has, err := s.Storer.Has(r.Context(), addr)
+	has, err := s.storer.Has(r.Context(), addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: localstore remove: %v", err)
+		s.logger.Debugf("debug api: localstore remove: %v", err)
 		jsonhttp.BadRequest(w, err)
 		return
 	}
@@ -55,9 +55,9 @@ func (s *server) removeChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.Storer.Set(r.Context(), storage.ModeSetRemove, addr)
+	err = s.storer.Set(r.Context(), storage.ModeSetRemove, addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: localstore remove: %v", err)
+		s.logger.Debugf("debug api: localstore remove: %v", err)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}

--- a/pkg/debugapi/cors.go
+++ b/pkg/debugapi/cors.go
@@ -1,0 +1,68 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi
+
+import (
+	"net/http"
+	"unicode/utf8"
+)
+
+// corsHandler sets CORS headers to HTTP response if allowed origins are configured.
+func (s *Service) corsHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if o := r.Header.Get("Origin"); o != "" && (len(s.corsAllowedOrigins) == 0 || checkOrigin(r, s.corsAllowedOrigins)) {
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Origin", o)
+			w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS, POST, PUT, DELETE")
+			w.Header().Set("Access-Control-Max-Age", "3600")
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+// checkOrigin returns true if the origin header is not set or is equal to the request host.
+func checkOrigin(r *http.Request, allowed []string) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	hosts := append(allowed, scheme+"://"+r.Host)
+	for _, v := range hosts {
+		if equalASCIIFold(origin[0], v) || v == "*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// equalASCIIFold returns true if s is equal to t with ASCII case folding as
+// defined in RFC 4790.
+func equalASCIIFold(s, t string) bool {
+	for s != "" && t != "" {
+		sr, size := utf8.DecodeRuneInString(s)
+		s = s[size:]
+		tr, size := utf8.DecodeRuneInString(t)
+		t = t[size:]
+		if sr == tr {
+			continue
+		}
+		if 'A' <= sr && sr <= 'Z' {
+			sr = sr + 'a' - 'A'
+		}
+		if 'A' <= tr && tr <= 'Z' {
+			tr = tr + 'a' - 'A'
+		}
+		if sr != tr {
+			return false
+		}
+	}
+	return s == t
+}

--- a/pkg/debugapi/cors_test.go
+++ b/pkg/debugapi/cors_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package debugapi_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCORSHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		origin         string
+		allowedOrigins []string
+		wantCORS       bool
+	}{
+		{
+			name: "none",
+		},
+		{
+			name:           "no origin",
+			allowedOrigins: []string{"https://gateway.ethswarm.org"},
+			wantCORS:       false,
+		},
+		{
+			name:           "single explicit",
+			origin:         "https://gateway.ethswarm.org",
+			allowedOrigins: []string{"https://gateway.ethswarm.org"},
+			wantCORS:       true,
+		},
+		{
+			name:           "single explicit blocked",
+			origin:         "http://a-hacker.me",
+			allowedOrigins: []string{"https://gateway.ethswarm.org"},
+			wantCORS:       false,
+		},
+		{
+			name:           "multiple explicit",
+			origin:         "https://staging.gateway.ethswarm.org",
+			allowedOrigins: []string{"https://gateway.ethswarm.org", "https://staging.gateway.ethswarm.org"},
+			wantCORS:       true,
+		},
+		{
+			name:           "multiple explicit blocked",
+			origin:         "http://a-hacker.me",
+			allowedOrigins: []string{"https://gateway.ethswarm.org", "https://staging.gateway.ethswarm.org"},
+			wantCORS:       false,
+		},
+		{
+			name:           "wildcard",
+			origin:         "http://localhost:1234",
+			allowedOrigins: []string{"*"},
+			wantCORS:       true,
+		},
+		{
+			name:           "wildcard",
+			origin:         "https://gateway.ethswarm.org",
+			allowedOrigins: []string{"*"},
+			wantCORS:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testServer := newTestServer(t, testServerOptions{
+				CORSAllowedOrigins: tc.allowedOrigins,
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+
+			r, err := testServer.Client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := r.Header.Get("Access-Control-Allow-Origin")
+
+			if tc.wantCORS {
+				if got != tc.origin {
+					t.Errorf("got Access-Control-Allow-Origin %q, want %q", got, tc.origin)
+				}
+			} else {
+				if got != "" {
+					t.Errorf("got Access-Control-Allow-Origin %q, want none", got)
+				}
+			}
+		})
+	}
+
+}

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -11,7 +11,6 @@ import (
 	"crypto/ecdsa"
 	"net/http"
 	"sync"
-	"unicode/utf8"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -29,93 +28,44 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type Service interface {
-	http.Handler
-	Configure(p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service)
-	MustRegisterMetrics(cs ...prometheus.Collector)
-}
-
-type server struct {
-	Overlay            swarm.Address
-	PublicKey          ecdsa.PublicKey
-	PSSPublicKey       ecdsa.PublicKey
-	EthereumAddress    common.Address
-	P2P                p2p.DebugService
-	Pingpong           pingpong.Interface
-	TopologyDriver     topology.Driver
-	Storer             storage.Storer
-	Logger             logging.Logger
-	Tracer             *tracing.Tracer
-	Tags               *tags.Tags
-	Accounting         accounting.Interface
-	Settlement         settlement.Interface
-	ChequebookEnabled  bool
-	Chequebook         chequebook.Service
-	Swap               swap.ApiInterface
-	CORSAllowedOrigins []string
+// Service implements http.Handler interface to be used in HTTP server.
+type Service struct {
+	overlay            swarm.Address
+	publicKey          ecdsa.PublicKey
+	pssPublicKey       ecdsa.PublicKey
+	ethereumAddress    common.Address
+	p2p                p2p.DebugService
+	pingpong           pingpong.Interface
+	topologyDriver     topology.Driver
+	storer             storage.Storer
+	logger             logging.Logger
+	tracer             *tracing.Tracer
+	tags               *tags.Tags
+	accounting         accounting.Interface
+	settlement         settlement.Interface
+	chequebookEnabled  bool
+	chequebook         chequebook.Service
+	swap               swap.ApiInterface
+	corsAllowedOrigins []string
 	metricsRegistry    *prometheus.Registry
 	// handler is changed in the Configure method
 	handler   http.Handler
 	handlerMu sync.RWMutex
 }
 
-// checkOrigin returns true if the origin is not set or is equal to the request host.
-func (s *server) checkOrigin(r *http.Request) bool {
-	origin := r.Header["Origin"]
-	if len(origin) == 0 {
-		return true
-	}
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	hosts := append(s.CORSAllowedOrigins, scheme+"://"+r.Host)
-	for _, v := range hosts {
-		if equalASCIIFold(origin[0], v) || v == "*" {
-			return true
-		}
-	}
-
-	return false
-}
-
-// equalASCIIFold returns true if s is equal to t with ASCII case folding as
-// defined in RFC 4790.
-func equalASCIIFold(s, t string) bool {
-	for s != "" && t != "" {
-		sr, size := utf8.DecodeRuneInString(s)
-		s = s[size:]
-		tr, size := utf8.DecodeRuneInString(t)
-		t = t[size:]
-		if sr == tr {
-			continue
-		}
-		if 'A' <= sr && sr <= 'Z' {
-			sr = sr + 'a' - 'A'
-		}
-		if 'A' <= tr && tr <= 'Z' {
-			tr = tr + 'a' - 'A'
-		}
-		if sr != tr {
-			return false
-		}
-	}
-	return s == t
-}
-
 // New creates a new Debug API Service with only basic routers enabled in order
 // to expose /addresses, /health endpoints, Go metrics and pprof. It is useful to expose
 // these endpoints before all dependencies are configured and injected to have
 // access to basic debugging tools and /health endpoint.
-func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, logger logging.Logger, tracer *tracing.Tracer, corsAllowedOrigins []string) Service {
-	s := new(server)
-	s.Overlay = overlay
-	s.PublicKey = publicKey
-	s.PSSPublicKey = pssPublicKey
-	s.EthereumAddress = ethereumAddress
-	s.Logger = logger
-	s.Tracer = tracer
-	s.CORSAllowedOrigins = corsAllowedOrigins
+func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, logger logging.Logger, tracer *tracing.Tracer, corsAllowedOrigins []string) *Service {
+	s := new(Service)
+	s.overlay = overlay
+	s.publicKey = publicKey
+	s.pssPublicKey = pssPublicKey
+	s.ethereumAddress = ethereumAddress
+	s.logger = logger
+	s.tracer = tracer
+	s.corsAllowedOrigins = corsAllowedOrigins
 	s.metricsRegistry = newMetricsRegistry()
 
 	s.setRouter(s.newBasicRouter())
@@ -126,22 +76,23 @@ func New(overlay swarm.Address, publicKey, pssPublicKey ecdsa.PublicKey, ethereu
 // Configure injects required dependencies and configuration parameters and
 // constructs HTTP routes that depend on them. It is intended and safe to call
 // this method only once.
-func (s *server) Configure(p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) {
-	s.P2P = p2p
-	s.Pingpong = pingpong
-	s.TopologyDriver = topologyDriver
-	s.Storer = storer
-	s.Tags = tags
-	s.Accounting = accounting
-	s.Settlement = settlement
-	s.ChequebookEnabled = chequebookEnabled
-	s.Chequebook = chequebook
-	s.Swap = swap
+func (s *Service) Configure(p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, storer storage.Storer, tags *tags.Tags, accounting accounting.Interface, settlement settlement.Interface, chequebookEnabled bool, swap swap.ApiInterface, chequebook chequebook.Service) {
+	s.p2p = p2p
+	s.pingpong = pingpong
+	s.topologyDriver = topologyDriver
+	s.storer = storer
+	s.tags = tags
+	s.accounting = accounting
+	s.settlement = settlement
+	s.chequebookEnabled = chequebookEnabled
+	s.chequebook = chequebook
+	s.swap = swap
 
 	s.setRouter(s.newRouter())
 }
 
-func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// ServeHTTP implements http.Handler interface.
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// protect handler as it is changed by the Configure method
 	s.handlerMu.RLock()
 	h := s.handler

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -36,20 +36,21 @@ import (
 )
 
 type testServerOptions struct {
-	Overlay         swarm.Address
-	PublicKey       ecdsa.PublicKey
-	PSSPublicKey    ecdsa.PublicKey
-	EthereumAddress common.Address
-	P2P             *p2pmock.Service
-	Pingpong        pingpong.Interface
-	Storer          storage.Storer
-	Resolver        resolver.Interface
-	TopologyOpts    []topologymock.Option
-	Tags            *tags.Tags
-	AccountingOpts  []accountingmock.Option
-	SettlementOpts  []swapmock.Option
-	ChequebookOpts  []chequebookmock.Option
-	SwapOpts        []swapmock.Option
+	Overlay            swarm.Address
+	PublicKey          ecdsa.PublicKey
+	PSSPublicKey       ecdsa.PublicKey
+	EthereumAddress    common.Address
+	CORSAllowedOrigins []string
+	P2P                *p2pmock.Service
+	Pingpong           pingpong.Interface
+	Storer             storage.Storer
+	Resolver           resolver.Interface
+	TopologyOpts       []topologymock.Option
+	Tags               *tags.Tags
+	AccountingOpts     []accountingmock.Option
+	SettlementOpts     []swapmock.Option
+	ChequebookOpts     []chequebookmock.Option
+	SwapOpts           []swapmock.Option
 }
 
 type testServer struct {
@@ -63,7 +64,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	settlement := swapmock.New(o.SettlementOpts...)
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	swapserv := swapmock.NewApiInterface(o.SwapOpts...)
-	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(ioutil.Discard, 0), nil, nil)
+	s := debugapi.New(o.Overlay, o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(ioutil.Discard, 0), nil, o.CORSAllowedOrigins)
 	s.Configure(o.P2P, o.Pingpong, topologyDriver, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)

--- a/pkg/debugapi/metrics.go
+++ b/pkg/debugapi/metrics.go
@@ -32,6 +32,6 @@ func newMetricsRegistry() (r *prometheus.Registry) {
 	return r
 }
 
-func (s *server) MustRegisterMetrics(cs ...prometheus.Collector) {
+func (s *Service) MustRegisterMetrics(cs ...prometheus.Collector) {
 	s.metricsRegistry.MustRegister(cs...)
 }

--- a/pkg/debugapi/p2p.go
+++ b/pkg/debugapi/p2p.go
@@ -23,25 +23,25 @@ type addressesResponse struct {
 	PSSPublicKey string                `json:"pss_public_key"`
 }
 
-func (s *server) addressesHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) addressesHandler(w http.ResponseWriter, r *http.Request) {
 	// initialize variable to json encode as [] instead null if p2p is nil
 	underlay := make([]multiaddr.Multiaddr, 0)
 	// addresses endpoint is exposed before p2p service is configured
 	// to provide information about other addresses.
-	if s.P2P != nil {
-		u, err := s.P2P.Addresses()
+	if s.p2p != nil {
+		u, err := s.p2p.Addresses()
 		if err != nil {
-			s.Logger.Debugf("debug api: p2p addresses: %v", err)
+			s.logger.Debugf("debug api: p2p addresses: %v", err)
 			jsonhttp.InternalServerError(w, err)
 			return
 		}
 		underlay = u
 	}
 	jsonhttp.OK(w, addressesResponse{
-		Overlay:      s.Overlay,
+		Overlay:      s.overlay,
 		Underlay:     underlay,
-		Ethereum:     s.EthereumAddress,
-		PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PublicKey)),
-		PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.PSSPublicKey)),
+		Ethereum:     s.ethereumAddress,
+		PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.publicKey)),
+		PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.pssPublicKey)),
 	})
 }

--- a/pkg/debugapi/pingpong.go
+++ b/pkg/debugapi/pingpong.go
@@ -18,11 +18,11 @@ type pingpongResponse struct {
 	RTT string `json:"rtt"`
 }
 
-func (s *server) pingpongHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) pingpongHandler(w http.ResponseWriter, r *http.Request) {
 	peerID := mux.Vars(r)["peer-id"]
 	ctx := r.Context()
 
-	span, logger, ctx := s.Tracer.StartSpanFromContext(ctx, "pingpong-api", s.Logger)
+	span, logger, ctx := s.tracer.StartSpanFromContext(ctx, "pingpong-api", s.logger)
 	defer span.Finish()
 
 	address, err := swarm.ParseHexAddress(peerID)
@@ -32,7 +32,7 @@ func (s *server) pingpongHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rtt, err := s.Pingpong.Ping(ctx, address, "hey", "there", ",", "how are", "you", "?")
+	rtt, err := s.pingpong.Ping(ctx, address, "hey", "there", ",", "how are", "you", "?")
 	if err != nil {
 		logger.Debugf("pingpong: ping %s: %v", peerID, err)
 		if errors.Is(err, p2p.ErrPeerNotFound) {

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -32,20 +32,20 @@ type settlementsResponse struct {
 	Settlements             []settlementResponse `json:"settlements"`
 }
 
-func (s *server) settlementsHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) settlementsHandler(w http.ResponseWriter, r *http.Request) {
 
-	settlementsSent, err := s.Settlement.SettlementsSent()
+	settlementsSent, err := s.settlement.SettlementsSent()
 	if err != nil {
 		jsonhttp.InternalServerError(w, errCantSettlements)
-		s.Logger.Debugf("debug api: sent settlements: %v", err)
-		s.Logger.Error("debug api: can not get sent settlements")
+		s.logger.Debugf("debug api: sent settlements: %v", err)
+		s.logger.Error("debug api: can not get sent settlements")
 		return
 	}
-	settlementsReceived, err := s.Settlement.SettlementsReceived()
+	settlementsReceived, err := s.settlement.SettlementsReceived()
 	if err != nil {
 		jsonhttp.InternalServerError(w, errCantSettlements)
-		s.Logger.Debugf("debug api: received settlements: %v", err)
-		s.Logger.Error("debug api: can not get received settlements")
+		s.logger.Debugf("debug api: received settlements: %v", err)
+		s.logger.Error("debug api: can not get received settlements")
 		return
 	}
 
@@ -88,23 +88,23 @@ func (s *server) settlementsHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, settlementsResponse{TotalSettlementReceived: totalReceived, TotalSettlementSent: totalSent, Settlements: settlementResponsesArray})
 }
 
-func (s *server) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) {
 	addr := mux.Vars(r)["peer"]
 	peer, err := swarm.ParseHexAddress(addr)
 	if err != nil {
-		s.Logger.Debugf("debug api: settlements peer: invalid peer address %s: %v", addr, err)
-		s.Logger.Errorf("debug api: settlements peer: invalid peer address %s", addr)
+		s.logger.Debugf("debug api: settlements peer: invalid peer address %s: %v", addr, err)
+		s.logger.Errorf("debug api: settlements peer: invalid peer address %s", addr)
 		jsonhttp.NotFound(w, errInvaliAddress)
 		return
 	}
 
 	peerexists := false
 
-	received, err := s.Settlement.TotalReceived(peer)
+	received, err := s.settlement.TotalReceived(peer)
 	if err != nil {
 		if !errors.Is(err, settlement.ErrPeerNoSettlements) {
-			s.Logger.Debugf("debug api: settlements peer: get peer %s received settlement: %v", peer.String(), err)
-			s.Logger.Errorf("debug api: settlements peer: can't get peer %s received settlement", peer.String())
+			s.logger.Debugf("debug api: settlements peer: get peer %s received settlement: %v", peer.String(), err)
+			s.logger.Errorf("debug api: settlements peer: can't get peer %s received settlement", peer.String())
 			jsonhttp.InternalServerError(w, errCantSettlementsPeer)
 			return
 		} else {
@@ -116,11 +116,11 @@ func (s *server) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) 
 		peerexists = true
 	}
 
-	sent, err := s.Settlement.TotalSent(peer)
+	sent, err := s.settlement.TotalSent(peer)
 	if err != nil {
 		if !errors.Is(err, settlement.ErrPeerNoSettlements) {
-			s.Logger.Debugf("debug api: settlements peer: get peer %s sent settlement: %v", peer.String(), err)
-			s.Logger.Errorf("debug api: settlements peer: can't get peer %s sent settlement", peer.String())
+			s.logger.Debugf("debug api: settlements peer: get peer %s sent settlement: %v", peer.String(), err)
+			s.logger.Errorf("debug api: settlements peer: can't get peer %s sent settlement", peer.String())
 			jsonhttp.InternalServerError(w, errCantSettlementsPeer)
 			return
 		} else {

--- a/pkg/debugapi/tag.go
+++ b/pkg/debugapi/tag.go
@@ -42,27 +42,27 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 	}
 }
 
-func (s *server) getTagHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) getTagHandler(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		s.Logger.Debugf("get tag: parse id  %s: %v", idStr, err)
-		s.Logger.Error("get tag: parse id")
+		s.logger.Debugf("get tag: parse id  %s: %v", idStr, err)
+		s.logger.Error("get tag: parse id")
 		jsonhttp.BadRequest(w, "invalid id")
 		return
 	}
 
-	tag, err := s.Tags.Get(uint32(id))
+	tag, err := s.tags.Get(uint32(id))
 	if err != nil {
 		if errors.Is(err, tags.ErrNotFound) {
-			s.Logger.Debugf("get tag: tag not present: %v, id %s", err, idStr)
-			s.Logger.Error("get tag: tag not present")
+			s.logger.Debugf("get tag: tag not present: %v, id %s", err, idStr)
+			s.logger.Error("get tag: tag not present")
 			jsonhttp.NotFound(w, "tag not present")
 			return
 		}
-		s.Logger.Debugf("get tag: tag %v: %v", idStr, err)
-		s.Logger.Errorf("get tag: %v", idStr)
+		s.logger.Debugf("get tag: tag %v: %v", idStr, err)
+		s.logger.Errorf("get tag: %v", idStr)
 		jsonhttp.InternalServerError(w, "cannot get tag")
 		return
 	}

--- a/pkg/debugapi/topology.go
+++ b/pkg/debugapi/topology.go
@@ -13,17 +13,17 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
-func (s *server) topologyHandler(w http.ResponseWriter, r *http.Request) {
-	ms, ok := s.TopologyDriver.(json.Marshaler)
+func (s *Service) topologyHandler(w http.ResponseWriter, r *http.Request) {
+	ms, ok := s.topologyDriver.(json.Marshaler)
 	if !ok {
-		s.Logger.Error("topology driver cast to json marshaler")
+		s.logger.Error("topology driver cast to json marshaler")
 		jsonhttp.InternalServerError(w, "topology json marshal interface error")
 		return
 	}
 
 	b, err := ms.MarshalJSON()
 	if err != nil {
-		s.Logger.Errorf("topology marshal to json: %v", err)
+		s.logger.Errorf("topology marshal to json: %v", err)
 		jsonhttp.InternalServerError(w, err)
 		return
 	}

--- a/pkg/debugapi/welcome_message.go
+++ b/pkg/debugapi/welcome_message.go
@@ -21,25 +21,25 @@ type welcomeMessageResponse struct {
 	WelcomeMesssage string `json:"welcome_message"`
 }
 
-func (s *server) getWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
-	val := s.P2P.GetWelcomeMessage()
+func (s *Service) getWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
+	val := s.p2p.GetWelcomeMessage()
 	jsonhttp.OK(w, welcomeMessageResponse{
 		WelcomeMesssage: val,
 	})
 }
 
-func (s *server) setWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) setWelcomeMessageHandler(w http.ResponseWriter, r *http.Request) {
 	var data welcomeMessageRequest
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
-		s.Logger.Debugf("debugapi: welcome message: failed to read request: %v", err)
+		s.logger.Debugf("debugapi: welcome message: failed to read request: %v", err)
 		jsonhttp.BadRequest(w, err)
 		return
 	}
 
-	if err := s.P2P.SetWelcomeMessage(data.WelcomeMesssage); err != nil {
-		s.Logger.Debugf("debugapi: welcome message: failed to set: %v", err)
-		s.Logger.Errorf("Failed to set welcome message")
+	if err := s.p2p.SetWelcomeMessage(data.WelcomeMesssage); err != nil {
+		s.logger.Debugf("debugapi: welcome message: failed to set: %v", err)
+		s.logger.Errorf("Failed to set welcome message")
 		jsonhttp.InternalServerError(w, err)
 		return
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -128,7 +128,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		tracerCloser:   tracerCloser,
 	}
 
-	var debugAPIService debugapi.Service
+	var debugAPIService *debugapi.Service
 	if o.DebugAPIAddr != "" {
 		overlayEthAddress, err := signer.EthereumAddress()
 		if err != nil {


### PR DESCRIPTION
This PR is a followup on https://github.com/ethersphere/bee/pull/1358 comments on code improvements.

- interface is removed for simplification as its purpose is not justified with the complex method that it contains
- server struct is renamed to Service and all fields are unexported
- cors headers handling is contained into one file with a dedicated handler
- basic tests for cors headers are added