### PR TITLE
prevent nodes from starting with a different overlay

### DIFF
--- a/cmd/bee/cmd/deploy.go
+++ b/cmd/bee/cmd/deploy.go
@@ -49,16 +49,21 @@ func (c *command) initDeployCmd() error {
 
 			stateStore, err := node.InitStateStore(logger, dataDir)
 			if err != nil {
-				return
+				return err
 			}
 
 			defer stateStore.Close()
 
 			signerConfig, err := c.configureSigner(cmd, logger)
 			if err != nil {
-				return
+				return err
 			}
 			signer := signerConfig.signer
+
+			err = node.CheckOverlayWithStore(signerConfig.address, stateStore)
+			if err != nil {
+				return err
+			}
 
 			ctx := cmd.Context()
 
@@ -70,7 +75,7 @@ func (c *command) initDeployCmd() error {
 				signer,
 			)
 			if err != nil {
-				return
+				return err
 			}
 			defer swapBackend.Close()
 
@@ -82,7 +87,7 @@ func (c *command) initDeployCmd() error {
 				factoryAddress,
 			)
 			if err != nil {
-				return
+				return err
 			}
 
 			_, err = node.InitChequebookService(
@@ -98,7 +103,7 @@ func (c *command) initDeployCmd() error {
 				swapInitialDeposit,
 			)
 
-			return
+			return err
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.config.BindPFlags(cmd.Flags())

--- a/cmd/bee/cmd/init.go
+++ b/cmd/bee/cmd/init.go
@@ -55,12 +55,7 @@ func (c *command) initInitCmd() (err error) {
 
 			defer stateStore.Close()
 
-			err = node.CheckOverlayWithStore(signerConfig.address, stateStore)
-			if err != nil {
-				return err
-			}
-
-			return err
+			return node.CheckOverlayWithStore(signerConfig.address, stateStore)
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.config.BindPFlags(cmd.Flags())

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -167,6 +167,11 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	}
 	b.stateStoreCloser = stateStore
 
+	err = CheckOverlayWithStore(swarmAddress, stateStore)
+	if err != nil {
+		return nil, err
+	}
+
 	addressbook := addressbook.New(stateStore)
 
 	var swapBackend *ethclient.Client

--- a/pkg/node/statestore.go
+++ b/pkg/node/statestore.go
@@ -6,6 +6,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -41,7 +42,7 @@ func CheckOverlayWithStore(overlay swarm.Address, storer storage.StateStorer) er
 	}
 
 	if !storedOverlay.Equal(overlay) {
-		return errors.New("overlay changed")
+		return fmt.Errorf("overlay address changed. was %s before but now is %s", storedOverlay, overlay)
 	}
 	return nil
 }

--- a/pkg/node/statestore.go
+++ b/pkg/node/statestore.go
@@ -5,12 +5,14 @@
 package node
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
 	"github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // InitStateStore will initialze the stateStore with the given path to the
@@ -23,4 +25,23 @@ func InitStateStore(log logging.Logger, dataDir string) (ret storage.StateStorer
 		return ret, nil
 	}
 	return leveldb.NewStateStore(filepath.Join(dataDir, "statestore"), log)
+}
+
+const overlayKey = "overlay"
+
+// CheckOverlayWithStore checks the overlay is the same as stored in the statestore
+func CheckOverlayWithStore(overlay swarm.Address, storer storage.StateStorer) error {
+	var storedOverlay swarm.Address
+	err := storer.Get(overlayKey, &storedOverlay)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			return err
+		}
+		return storer.Put(overlayKey, overlay)
+	}
+
+	if !storedOverlay.Equal(overlay) {
+		return errors.New("overlay changed")
+	}
+	return nil
 }


### PR DESCRIPTION
currently a bee node will happily start up with a different overlay key which breaks accounting, settlement and probably a ton of other stuff. this pr saves the expected overlay address on first boot and then checks it on every further startup. the check happens on `start`, `init` and `deploy` command.

this prevents user errors such as
* deleting swarm.key but not statestore
* changing key in clef but not deleting statestore
* adding key to clef which takes index 0 in the account list but not deleting statestore or specifying the account explicitly
* specifying another account with `clef-signer-ethereum-address` (from PR #1313) on a second run.