### PR TITLE
streamtest: add option to add a correct base address

### DIFF
--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -30,6 +30,7 @@ var (
 )
 
 type Recorder struct {
+	base        swarm.Address
 	records     map[string][]*Record
 	recordsMu   sync.Mutex
 	protocols   []p2p.ProtocolSpec
@@ -45,6 +46,12 @@ func WithProtocols(protocols ...p2p.ProtocolSpec) Option {
 func WithMiddlewares(middlewares ...p2p.HandlerMiddleware) Option {
 	return optionFunc(func(r *Recorder) {
 		r.middlewares = append(r.middlewares, middlewares...)
+	})
+}
+
+func WithBaseAddr(a swarm.Address) Option {
+	return optionFunc(func(r *Recorder) {
+		r.base = a
 	})
 }
 
@@ -98,7 +105,7 @@ func (r *Recorder) NewStream(ctx context.Context, addr swarm.Address, h p2p.Head
 
 		// pass a new context to handler,
 		// do not cancel it with the client stream context
-		err := handler(context.Background(), p2p.Peer{Address: addr}, streamIn)
+		err := handler(context.Background(), p2p.Peer{Address: r.base}, streamIn)
 		if err != nil && err != io.EOF {
 			record.setErr(err)
 		}

--- a/pkg/pricing/pricing_test.go
+++ b/pkg/pricing/pricing_test.go
@@ -40,13 +40,15 @@ func TestAnnouncePaymentThreshold(t *testing.T) {
 	recipient := pricing.New(nil, logger, testThreshold)
 	recipient.SetPaymentThresholdObserver(observer)
 
+	peerID := swarm.MustParseHexAddress("9ee7add7")
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(recipient.Protocol()),
+		streamtest.WithBaseAddr(peerID),
 	)
 
 	payer := pricing.New(recorder, logger, testThreshold)
 
-	peerID := swarm.MustParseHexAddress("9ee7add7")
 	paymentThreshold := big.NewInt(10000)
 
 	err := payer.AnnouncePaymentThreshold(context.Background(), peerID, paymentThreshold)

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -357,8 +357,6 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("unexpected balance on trigger. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	// we need to check here for pivotPeer instead of triggerPeer because during
-	// streamtest the peer in the handler is actually the receiver
 	balance, err = pivotAccounting.Balance(triggerPeer)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -48,7 +48,7 @@ func TestSendChunkAndReceiveReceipt(t *testing.T) {
 	psPeer, storerPeer, _, peerAccounting := createPushSyncNode(t, closestPeer, nil, nil, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer.Close()
 
-	recorder := streamtest.New(streamtest.WithProtocols(psPeer.Protocol()))
+	recorder := streamtest.New(streamtest.WithProtocols(psPeer.Protocol()), streamtest.WithBaseAddr(pivotNode))
 
 	// pivot node needs the streamer since the chunk is intercepted by
 	// the chunk worker, then gets sent by opening a new stream
@@ -70,7 +70,6 @@ func TestSendChunkAndReceiveReceipt(t *testing.T) {
 
 	// this intercepts the incoming receipt message
 	waitOnRecordAndTest(t, closestPeer, recorder, chunk.Address(), nil)
-
 	balance, err := pivotAccounting.Balance(closestPeer)
 	if err != nil {
 		t.Fatal(err)
@@ -80,11 +79,10 @@ func TestSendChunkAndReceiveReceipt(t *testing.T) {
 		t.Fatalf("unexpected balance on pivot. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	balance, err = peerAccounting.Balance(closestPeer)
+	balance, err = peerAccounting.Balance(pivotNode)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if balance.Int64() != int64(fixedPrice) {
 		t.Fatalf("unexpected balance on peer. want %d got %d", int64(fixedPrice), balance)
 	}
@@ -104,7 +102,7 @@ func TestPushChunkToClosest(t *testing.T) {
 	psPeer, storerPeer, _, peerAccounting := createPushSyncNode(t, closestPeer, nil, chanFunc(callbackC), mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer.Close()
 
-	recorder := streamtest.New(streamtest.WithProtocols(psPeer.Protocol()))
+	recorder := streamtest.New(streamtest.WithProtocols(psPeer.Protocol()), streamtest.WithBaseAddr(pivotNode))
 
 	// pivot node needs the streamer since the chunk is intercepted by
 	// the chunk worker, then gets sent by opening a new stream
@@ -159,7 +157,7 @@ func TestPushChunkToClosest(t *testing.T) {
 		t.Fatalf("unexpected balance on pivot. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	balance, err = peerAccounting.Balance(closestPeer)
+	balance, err = peerAccounting.Balance(pivotNode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,6 +218,7 @@ func TestPushChunkToNextClosest(t *testing.T) {
 				}
 			},
 		),
+		streamtest.WithBaseAddr(pivotNode),
 	)
 
 	// pivot node needs the streamer since the chunk is intercepted by
@@ -277,7 +276,7 @@ func TestPushChunkToNextClosest(t *testing.T) {
 		t.Fatalf("unexpected balance on pivot. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	balance2, err := peerAccounting2.Balance(peer2)
+	balance2, err := peerAccounting2.Balance(pivotNode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,13 +314,13 @@ func TestHandler(t *testing.T) {
 	psClosestPeer, closestStorerPeerDB, _, closestAccounting := createPushSyncNode(t, closestPeer, nil, nil, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer closestStorerPeerDB.Close()
 
-	closestRecorder := streamtest.New(streamtest.WithProtocols(psClosestPeer.Protocol()))
+	closestRecorder := streamtest.New(streamtest.WithProtocols(psClosestPeer.Protocol()), streamtest.WithBaseAddr(pivotPeer))
 
 	// creating the pivot peer
 	psPivot, storerPivotDB, _, pivotAccounting := createPushSyncNode(t, pivotPeer, closestRecorder, nil, mock.WithClosestPeer(closestPeer))
 	defer storerPivotDB.Close()
 
-	pivotRecorder := streamtest.New(streamtest.WithProtocols(psPivot.Protocol()))
+	pivotRecorder := streamtest.New(streamtest.WithProtocols(psPivot.Protocol()), streamtest.WithBaseAddr(triggerPeer))
 
 	// Creating the trigger peer
 	psTriggerPeer, triggerStorerDB, _, triggerAccounting := createPushSyncNode(t, triggerPeer, pivotRecorder, nil, mock.WithClosestPeer(pivotPeer))
@@ -358,8 +357,9 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("unexpected balance on trigger. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	// we need to check here for pivotPeer instead of triggerPeer because during streamtest the peer in the handler is actually the receiver
-	balance, err = pivotAccounting.Balance(pivotPeer)
+	// we need to check here for pivotPeer instead of triggerPeer because during
+	// streamtest the peer in the handler is actually the receiver
+	balance, err = pivotAccounting.Balance(triggerPeer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +377,7 @@ func TestHandler(t *testing.T) {
 		t.Fatalf("unexpected balance on pivot. want %d got %d", -int64(fixedPrice), balance)
 	}
 
-	balance, err = closestAccounting.Balance(closestPeer)
+	balance, err = closestAccounting.Balance(pivotPeer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -50,8 +50,11 @@ func TestPayment(t *testing.T) {
 	recipient := pseudosettle.New(nil, logger, storeRecipient)
 	recipient.SetNotifyPaymentFunc(observer.NotifyPayment)
 
+	peerID := swarm.MustParseHexAddress("9ee7add7")
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(recipient.Protocol()),
+		streamtest.WithBaseAddr(peerID),
 	)
 
 	storePayer := mock.NewStateStore()
@@ -59,7 +62,6 @@ func TestPayment(t *testing.T) {
 
 	payer := pseudosettle.New(recorder, logger, storePayer)
 
-	peerID := swarm.MustParseHexAddress("9ee7add7")
 	amount := big.NewInt(10000)
 
 	err := payer.Pay(context.Background(), peerID, amount)


### PR DESCRIPTION
This rectifies the mistake we had in the recorder, where the `p2p.Peer` that we called the handler call with was the wrong address, carrying over the destination address, instead of the origin address of the message.

There is still one todo here, and that is to rewrite the preemptive retry test to use mocked server responses instead of the current behavior which is injected through a middleware if statement. Since this change is a blocker for @esadakar's PR, I'd rather have it in so he can rebase, then we can mend the skipped test.