### PR TITLE
pullsync: coalesce batch writes

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -236,8 +236,11 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 	}
 	if len(chunksToPut) > 0 {
 		s.metrics.DbOpsCounter.Inc()
-		if err = s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
-			return 0, ru.Ruid, fmt.Errorf("delivery put: %w", err)
+		if ierr := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); ierr != nil {
+			if err != nil {
+				ierr = fmt.Errorf(", sync err: %w", err)
+			}
+			return 0, ru.Ruid, fmt.Errorf("delivery put: %w", ierr)
 		}
 	}
 	// there might have been an error in the for loop above,

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -133,8 +133,8 @@ func TestIncoming_WantAll(t *testing.T) {
 
 	// should have all
 	haveChunks(t, clientDb, addrs...)
-	if p := clientDb.PutCalls(); p != 5 {
-		t.Fatalf("want %d puts but got %d", 5, p)
+	if p := clientDb.PutCalls(); p != 1 {
+		t.Fatalf("want %d puts but got %d", 1, p)
 	}
 }
 


### PR DESCRIPTION
This should also improve the CPU usage, since leveldb doesn't need to do individual writes. The downside is that because it might take longer to do the actual write, we might end up wanting the same chunk from multiple peers since this creates a possible data race (we want the chunk from one peer which is slow, and another peer which is fast, resulting in deliveries from both).

Open for discussion about this. Not entirely sure if it's needed if we get the other change which buffers the triggers to the subscriptions, which should solve the problem.