### PR TITLE
libp2p: wait for readyness before accepting incoming connections

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -244,6 +244,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		return nil, fmt.Errorf("p2p service: %w", err)
 	}
 	b.p2pService = p2ps
+	defer p2ps.Ready()
 
 	if !o.Standalone {
 		if natManager := p2ps.NATManager(); natManager != nil {
@@ -502,8 +503,6 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	if err := kad.Start(p2pCtx); err != nil {
 		return nil, err
 	}
-
-	p2ps.Ready()
 
 	return b, nil
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -503,6 +503,8 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		return nil, err
 	}
 
+	p2ps.Ready()
+
 	return b, nil
 }
 

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -69,6 +69,7 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 	if err != nil {
 		t.Fatal(err)
 	}
+	s.Ready()
 
 	t.Cleanup(func() {
 		cancel()


### PR DESCRIPTION
Since the libp2p instance is created before the entire node goes online, some nodes might already be able to dial into the node, causing the handshake to pass, but to subsequent protocol bootstrapping to fail. This change adds a `Ready` call to libp2p abstraction which will be called once the node constructor finishes. It will block incoming connections before the node bootstrapping is done, preventing inconsistent state on other nodes in the meanwhile.