### PR TITLE
Soc refactor

### DIFF
--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -217,7 +217,7 @@ func TestFeedIndirection(t *testing.T) {
 	// called from the bzz endpoint. then call the bzz endpoint with
 	// the pregenerated feed root manifest hash
 
-	feedUpdate := toChunk(121212, resp.Reference.Bytes())
+	feedUpdate := toChunk(t, 121212, resp.Reference.Bytes())
 
 	var (
 		feedChunkAddr       = swarm.MustParseHexAddress("891a1d1c8436c792d02fc2e8883fef7ab387eaeaacd25aa9f518be7be7856d54")

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -84,7 +84,6 @@ func TestBzz(t *testing.T) {
 		}
 
 		fileMetadataReference, err := pipeWriteAll(bytes.NewReader(fileMetadataBytes), int64(len(fileMetadataBytes)))
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -171,7 +170,6 @@ func TestBzz(t *testing.T) {
 			}),
 		)
 	})
-
 }
 
 func TestFeedIndirection(t *testing.T) {
@@ -219,7 +217,7 @@ func TestFeedIndirection(t *testing.T) {
 	// called from the bzz endpoint. then call the bzz endpoint with
 	// the pregenerated feed root manifest hash
 
-	feedUpdate, _ := toChunk(121212, resp.Reference.Bytes())
+	feedUpdate := toChunk(121212, resp.Reference.Bytes())
 
 	var (
 		feedChunkAddr       = swarm.MustParseHexAddress("891a1d1c8436c792d02fc2e8883fef7ab387eaeaacd25aa9f518be7be7856d54")

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -29,9 +29,7 @@ const (
 	feedMetadataEntryType  = "swarm-feed-type"
 )
 
-var (
-	errInvalidFeedUpdate = errors.New("invalid feed update")
-)
+var errInvalidFeedUpdate = errors.New("invalid feed update")
 
 type feedReferenceResponse struct {
 	Reference swarm.Address `json:"reference"`
@@ -176,12 +174,12 @@ func (s *server) feedPostHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func parseFeedUpdate(ch swarm.Chunk) (swarm.Address, int64, error) {
-	sch, err := soc.FromChunk(ch)
+	s, err := soc.FromChunk(ch)
 	if err != nil {
 		return swarm.ZeroAddress, 0, fmt.Errorf("soc unmarshal: %w", err)
 	}
 
-	update := sch.Chunk.Data()
+	update := s.WrappedChunk().Data()
 	// split the timestamp and reference
 	// possible values right now:
 	// unencrypted ref: span+timestamp+ref => 8+8+32=48

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -82,7 +82,7 @@ func TestFeed_Get(t *testing.T) {
 	t.Run("with at", func(t *testing.T) {
 		var (
 			timestamp    = int64(12121212)
-			ch           = toChunk(uint64(timestamp), expReference.Bytes())
+			ch           = toChunk(t, uint64(timestamp), expReference.Bytes())
 			look         = newMockLookup(12, 0, ch, nil, &id{}, &id{})
 			factory      = newMockFactory(look)
 			idBytes, _   = (&id{}).MarshalBinary()
@@ -113,7 +113,7 @@ func TestFeed_Get(t *testing.T) {
 	t.Run("latest", func(t *testing.T) {
 		var (
 			timestamp  = int64(12121212)
-			ch         = toChunk(uint64(timestamp), expReference.Bytes())
+			ch         = toChunk(t, uint64(timestamp), expReference.Bytes())
 			look       = newMockLookup(-1, 2, ch, nil, &id{}, &id{})
 			factory    = newMockFactory(look)
 			idBytes, _ = (&id{}).MarshalBinary()
@@ -235,12 +235,12 @@ func (l *mockLookup) At(_ context.Context, at, after int64) (swarm.Chunk, feeds.
 	return nil, nil, nil, errors.New("no feed update found")
 }
 
-func toChunk(at uint64, payload []byte) swarm.Chunk {
+func toChunk(t *testing.T, at uint64, payload []byte) swarm.Chunk {
 	ts := make([]byte, 8)
 	binary.BigEndian.PutUint64(ts, at)
 	content := append(ts, payload...)
 
-	s := testingsoc.GenerateMockSoc(content)
+	s := testingsoc.GenerateMockSoc(t, content)
 	return s.Chunk()
 }
 

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -240,7 +240,7 @@ func toChunk(t *testing.T, at uint64, payload []byte) swarm.Chunk {
 	binary.BigEndian.PutUint64(ts, at)
 	content := append(ts, payload...)
 
-	s := testingsoc.GenerateMockSoc(t, content)
+	s := testingsoc.GenerateMockSOC(t, content)
 	return s.Chunk()
 }
 

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -253,20 +253,15 @@ func toChunk(at uint64, payload []byte) (swarm.Chunk, error) {
 	}
 	signer := crypto.NewDefaultSigner(privKey)
 
-	sch := soc.New(id, ch)
-	if err != nil {
-		return nil, err
-	}
-	err = sch.AddSigner(signer)
+	s, err := soc.NewSoc(id, ch, signer)
 	if err != nil {
 		return nil, err
 	}
 
-	return sch.ToChunk()
+	return s.Sign()
 }
 
-type id struct {
-}
+type id struct{}
 
 func (i *id) MarshalBinary() ([]byte, error) {
 	return []byte("accd"), nil

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -252,13 +252,9 @@ func toChunk(at uint64, payload []byte) (swarm.Chunk, error) {
 		return nil, err
 	}
 	signer := crypto.NewDefaultSigner(privKey)
+	s := soc.New(id, ch)
 
-	s, err := soc.NewSoc(id, ch, signer)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.Sign()
+	return s.Sign(signer)
 }
 
 type id struct{}

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/api"
-	"github.com/ethersphere/bee/pkg/cac"
-	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/file/loadsave"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -25,6 +23,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/manifest"
 	"github.com/ethersphere/bee/pkg/soc"
+	testingsoc "github.com/ethersphere/bee/pkg/soc/testing"
 	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
@@ -241,20 +240,13 @@ func toChunk(at uint64, payload []byte) (swarm.Chunk, error) {
 	ts := make([]byte, 8)
 	binary.BigEndian.PutUint64(ts, at)
 	content := append(ts, payload...)
-	ch, err := cac.New(content)
+
+	s := testingsoc.GenerateMockSoc(content)
+	ss, err := soc.NewSigned(s.ID, s.Chunk, s.Owner, s.Signature)
 	if err != nil {
 		return nil, err
 	}
-
-	id := make([]byte, soc.IdSize)
-	privKey, err := crypto.GenerateSecp256k1Key()
-	if err != nil {
-		return nil, err
-	}
-	signer := crypto.NewDefaultSigner(privKey)
-	s := soc.New(id, ch)
-
-	return s.Sign(signer)
+	return ss.Chunk()
 }
 
 type id struct{}

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/manifest"
-	"github.com/ethersphere/bee/pkg/soc"
 	testingsoc "github.com/ethersphere/bee/pkg/soc/testing"
 	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -83,7 +82,7 @@ func TestFeed_Get(t *testing.T) {
 	t.Run("with at", func(t *testing.T) {
 		var (
 			timestamp    = int64(12121212)
-			ch, _        = toChunk(uint64(timestamp), expReference.Bytes())
+			ch           = toChunk(uint64(timestamp), expReference.Bytes())
 			look         = newMockLookup(12, 0, ch, nil, &id{}, &id{})
 			factory      = newMockFactory(look)
 			idBytes, _   = (&id{}).MarshalBinary()
@@ -114,7 +113,7 @@ func TestFeed_Get(t *testing.T) {
 	t.Run("latest", func(t *testing.T) {
 		var (
 			timestamp  = int64(12121212)
-			ch, _      = toChunk(uint64(timestamp), expReference.Bytes())
+			ch         = toChunk(uint64(timestamp), expReference.Bytes())
 			look       = newMockLookup(-1, 2, ch, nil, &id{}, &id{})
 			factory    = newMockFactory(look)
 			idBytes, _ = (&id{}).MarshalBinary()
@@ -236,17 +235,13 @@ func (l *mockLookup) At(_ context.Context, at, after int64) (swarm.Chunk, feeds.
 	return nil, nil, nil, errors.New("no feed update found")
 }
 
-func toChunk(at uint64, payload []byte) (swarm.Chunk, error) {
+func toChunk(at uint64, payload []byte) swarm.Chunk {
 	ts := make([]byte, 8)
 	binary.BigEndian.PutUint64(ts, at)
 	content := append(ts, payload...)
 
 	s := testingsoc.GenerateMockSoc(content)
-	ss, err := soc.NewSigned(s.ID, s.Chunk, s.Owner, s.Signature)
-	if err != nil {
-		return nil, err
-	}
-	return ss.Chunk()
+	return s.Chunk()
 }
 
 type id struct{}

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -90,9 +90,9 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	ss, err := soc.NewSignedSoc(id, ch, owner, sig)
 	if err != nil {
-		s.logger.Debugf("soc upload: soc error: %v", err)
-		s.logger.Error("soc upload: soc error")
-		jsonhttp.InternalServerError(w, "cannot create soc from data")
+		s.logger.Debugf("soc upload: signed soc error: %v", err)
+		s.logger.Error("soc upload: signed soc error")
+		jsonhttp.Unauthorized(w, "invalid signature")
 		return
 	}
 

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -88,7 +88,15 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chunk, err := soc.NewSignedChunk(id, ch, owner, sig)
+	ss, err := soc.NewSignedSoc(id, ch, owner, sig)
+	if err != nil {
+		s.logger.Debugf("soc upload: soc error: %v", err)
+		s.logger.Error("soc upload: soc error")
+		jsonhttp.InternalServerError(w, "cannot create soc from data")
+		return
+	}
+
+	chunk, err := ss.Chunk()
 	if err != nil {
 		s.logger.Debugf("soc upload: read chunk data error: %v", err)
 		s.logger.Error("soc upload: read chunk data error")

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -88,15 +88,15 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ss, err := soc.NewSignedSoc(id, ch, owner, sig)
+	ss, err := soc.NewSigned(id, ch, owner, sig)
 	if err != nil {
-		s.logger.Debugf("soc upload: signed soc error: %v", err)
-		s.logger.Error("soc upload: signed soc error")
-		jsonhttp.Unauthorized(w, "invalid signature")
+		s.logger.Debugf("soc upload: address soc error: %v", err)
+		s.logger.Error("soc upload: address soc error")
+		jsonhttp.Unauthorized(w, "invalid address")
 		return
 	}
 
-	chunk, err := ss.Chunk()
+	sch, err := ss.Chunk()
 	if err != nil {
 		s.logger.Debugf("soc upload: read chunk data error: %v", err)
 		s.logger.Error("soc upload: read chunk data error")
@@ -104,7 +104,7 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !soc.Valid(chunk) {
+	if !soc.Valid(sch) {
 		s.logger.Debugf("soc upload: invalid chunk: %v", err)
 		s.logger.Error("soc upload: invalid chunk")
 		jsonhttp.Unauthorized(w, "invalid chunk")
@@ -114,7 +114,7 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	has, err := s.storer.Has(ctx, chunk.Address())
+	has, err := s.storer.Has(ctx, sch.Address())
 	if err != nil {
 		s.logger.Debugf("soc upload: store has: %v", err)
 		s.logger.Error("soc upload: store has")
@@ -127,7 +127,7 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = s.storer.Put(ctx, requestModePut(r), chunk)
+	_, err = s.storer.Put(ctx, requestModePut(r), sch)
 	if err != nil {
 		s.logger.Debugf("soc upload: chunk write error: %v", err)
 		s.logger.Error("soc upload: chunk write error")
@@ -135,5 +135,5 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonhttp.Created(w, chunkAddressResponse{Reference: chunk.Address()})
+	jsonhttp.Created(w, chunkAddressResponse{Reference: sch.Address()})
 }

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethersphere/bee/pkg/tags"
 )
 
-func TestSoc(t *testing.T) {
+func TestSOC(t *testing.T) {
 	var (
 		testData       = []byte("foo")
 		socResource    = func(owner, id, sig string) string { return fmt.Sprintf("/soc/%s/%s?sig=%s", owner, id, sig) }
@@ -73,7 +73,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("signature invalid", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(t, testData)
+		s := testingsoc.GenerateMockSOC(t, testData)
 
 		// modify the sign
 		sig := make([]byte, soc.SignatureSize)
@@ -91,7 +91,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(t, testData)
+		s := testingsoc.GenerateMockSOC(t, testData)
 
 		jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(s.Owner), hex.EncodeToString(s.ID), hex.EncodeToString(s.Signature)), http.StatusCreated,
 			jsonhttptest.WithRequestBody(bytes.NewReader(s.WrappedChunk.Data())),
@@ -114,7 +114,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("already exists", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(t, testData)
+		s := testingsoc.GenerateMockSOC(t, testData)
 
 		jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(s.Owner), hex.EncodeToString(s.ID), hex.EncodeToString(s.Signature)), http.StatusCreated,
 			jsonhttptest.WithRequestBody(bytes.NewReader(s.WrappedChunk.Data())),

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -73,7 +73,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("signature invalid", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(testData)
+		s := testingsoc.GenerateMockSoc(t, testData)
 
 		// modify the sign
 		sig := make([]byte, soc.SignatureSize)
@@ -91,7 +91,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(testData)
+		s := testingsoc.GenerateMockSoc(t, testData)
 
 		jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(s.Owner), hex.EncodeToString(s.ID), hex.EncodeToString(s.Signature)), http.StatusCreated,
 			jsonhttptest.WithRequestBody(bytes.NewReader(s.WrappedChunk.Data())),
@@ -114,7 +114,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("already exists", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(testData)
+		s := testingsoc.GenerateMockSoc(t, testData)
 
 		jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(s.Owner), hex.EncodeToString(s.ID), hex.EncodeToString(s.Signature)), http.StatusCreated,
 			jsonhttptest.WithRequestBody(bytes.NewReader(s.WrappedChunk.Data())),

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestSoc(t *testing.T) {
 	var (
+		testData       = []byte("foo")
 		socResource    = func(owner, id, sig string) string { return fmt.Sprintf("/soc/%s/%s?sig=%s", owner, id, sig) }
 		mockStatestore = statestore.NewStateStore()
 		logger         = logging.New(ioutil.Discard, 0)
@@ -34,8 +35,6 @@ func TestSoc(t *testing.T) {
 			Storer: mockStorer,
 			Tags:   tag,
 		})
-		testData   = []byte("foo")
-		hexPrivKey = "634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd"
 	)
 	t.Run("cmpty data", func(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodPost, socResource("8d3766440f0d7b949a5e32995d09619a7f86e632", "bb", "cc"), http.StatusBadRequest,
@@ -74,7 +73,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("signature invalid", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(hexPrivKey, testData)
+		s := testingsoc.GenerateMockSoc(testData)
 
 		// modify the sign
 		sig := make([]byte, soc.SignatureSize)
@@ -92,7 +91,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(hexPrivKey, testData)
+		s := testingsoc.GenerateMockSoc(testData)
 		ss, err := soc.NewSigned(s.ID, s.Chunk, s.Owner, s.Signature)
 		if err != nil {
 			t.Fatal(err)
@@ -127,7 +126,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("already exists", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(hexPrivKey, nil)
+		s := testingsoc.GenerateMockSoc(nil)
 		ss, err := soc.NewSigned(s.ID, s.Chunk, s.Owner, s.Signature)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -126,7 +126,7 @@ func TestSoc(t *testing.T) {
 	})
 
 	t.Run("already exists", func(t *testing.T) {
-		s := testingsoc.GenerateMockSoc(nil)
+		s := testingsoc.GenerateMockSoc(testData)
 		ss, err := soc.NewSigned(s.ID, s.Chunk, s.Owner, s.Signature)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -115,7 +115,7 @@ func TestSoc(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ch, err := s.ToChunk()
+		ch, err := s.Sign()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -149,7 +149,6 @@ func TestSoc(t *testing.T) {
 				}),
 		)
 	})
-
 }
 
 // returns a valid, mocked SOC
@@ -171,16 +170,11 @@ func mockSoc(t *testing.T) (*soc.Soc, []byte, []byte) {
 	copy(fooBytes[8:], foo)
 	ch := swarm.NewChunk(address, fooBytes)
 
-	sch := soc.New(id, ch)
+	sch, err := soc.NewSoc(id, ch, signer)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = sch.AddSigner(signer)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, _ = sch.ToChunk()
+	_, _ = sch.Sign()
 
 	return sch, sch.OwnerAddress(), ch.Data()
 }

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -86,7 +86,7 @@ func TestSoc(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(owner), hex.EncodeToString(id), hex.EncodeToString(sig)), http.StatusUnauthorized,
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-				Message: "invalid chunk",
+				Message: "invalid signature",
 				Code:    http.StatusUnauthorized,
 			}),
 		)

--- a/pkg/feeds/feed.go
+++ b/pkg/feeds/feed.go
@@ -150,9 +150,5 @@ func (u *Update) Address() (swarm.Address, error) {
 	if err != nil {
 		return addr, err
 	}
-	owner, err := soc.NewOwner(u.Owner[:])
-	if err != nil {
-		return addr, err
-	}
-	return soc.CreateAddress(i, owner)
+	return soc.CreateAddress(i, u.Owner[:])
 }

--- a/pkg/feeds/feed.go
+++ b/pkg/feeds/feed.go
@@ -112,10 +112,16 @@ func NewUpdate(f *Feed, idx Index, timestamp int64, payload []byte, sig []byte) 
 		return nil, fmt.Errorf("toChunk: %w", err)
 	}
 
-	ch, err := soc.NewSignedChunk(id, cac, f.Owner.Bytes(), sig)
+	ss, err := soc.NewSignedSoc(id, cac, f.Owner.Bytes(), sig)
+	if err != nil {
+		return nil, fmt.Errorf("new signed soc: %w", err)
+	}
+
+	ch, err := ss.Chunk()
 	if err != nil {
 		return nil, fmt.Errorf("new chunk: %w", err)
 	}
+
 	if !soc.Valid(ch) {
 		return nil, storage.ErrInvalidChunk
 	}
@@ -135,7 +141,6 @@ func Id(topic []byte, index Index) ([]byte, error) {
 	}
 	i := &id{topic, indexBytes}
 	return i.MarshalBinary()
-
 }
 
 // Address calculates the soc address of a feed update

--- a/pkg/feeds/feed.go
+++ b/pkg/feeds/feed.go
@@ -112,7 +112,7 @@ func NewUpdate(f *Feed, idx Index, timestamp int64, payload []byte, sig []byte) 
 		return nil, fmt.Errorf("toChunk: %w", err)
 	}
 
-	ss, err := soc.NewSignedSoc(id, cac, f.Owner.Bytes(), sig)
+	ss, err := soc.NewSigned(id, cac, f.Owner.Bytes(), sig)
 	if err != nil {
 		return nil, fmt.Errorf("new signed soc: %w", err)
 	}

--- a/pkg/feeds/getter.go
+++ b/pkg/feeds/getter.go
@@ -55,7 +55,7 @@ func FromChunk(ch swarm.Chunk) (uint64, []byte, error) {
 	if err != nil {
 		return 0, nil, err
 	}
-	cac := s.Chunk
+	cac := s.WrappedChunk()
 	if len(cac.Data()) < 16 {
 		return 0, nil, fmt.Errorf("feed update payload too short")
 	}

--- a/pkg/feeds/putter.go
+++ b/pkg/feeds/putter.go
@@ -48,11 +48,8 @@ func (u *Putter) Put(ctx context.Context, i Index, at int64, payload []byte) err
 	if err != nil {
 		return err
 	}
-	s, err := soc.NewSoc(id, cac, u.signer)
-	if err != nil {
-		return err
-	}
-	ch, err := s.Sign()
+	s := soc.New(id, cac)
+	ch, err := s.Sign(u.signer)
 	if err != nil {
 		return err
 	}

--- a/pkg/feeds/putter.go
+++ b/pkg/feeds/putter.go
@@ -48,7 +48,11 @@ func (u *Putter) Put(ctx context.Context, i Index, at int64, payload []byte) err
 	if err != nil {
 		return err
 	}
-	ch, err := soc.NewChunk(id, cac, u.signer)
+	s, err := soc.NewSoc(id, cac, u.signer)
+	if err != nil {
+		return err
+	}
+	ch, err := s.Sign()
 	if err != nil {
 		return err
 	}

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -5,9 +5,9 @@
 package soc
 
 var (
-	ErrNoOwner     = errNoOwner
-	Hash           = hash
-	RecoverAddress = recoverAddress
+	ErrInvalidAddress = errInvalidAddress
+	Hash              = hash
+	RecoverAddress    = recoverAddress
 )
 
 // Signature returns the soc signature.

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -10,17 +10,17 @@ var (
 	RecoverAddress    = recoverAddress
 )
 
-// Signature returns the soc signature.
-func (s *Soc) Signature() []byte {
+// Signature returns the SOC signature.
+func (s *SOC) Signature() []byte {
 	return s.signature
 }
 
-// OwnerAddress returns the ethereum address of the signer of the Chunk.
-func (s *Soc) OwnerAddress() []byte {
+// OwnerAddress returns the ethereum address of the SOC owner.
+func (s *SOC) OwnerAddress() []byte {
 	return s.owner
 }
 
-// Id returns the soc id.
-func (s *Soc) ID() []byte {
+// ID returns the SOC id.
+func (s *SOC) ID() []byte {
 	return s.id
 }

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -9,3 +9,18 @@ var (
 	ToSignDigest   = toSignDigest
 	RecoverAddress = recoverAddress
 )
+
+// Signature returns the soc signature.
+func (s *Soc) Signature() []byte {
+	return s.signature
+}
+
+// OwnerAddress returns the ethereum address of the signer of the Chunk.
+func (s *Soc) OwnerAddress() []byte {
+	return s.owner
+}
+
+// Id returns the soc id.
+func (s *Soc) ID() []byte {
+	return s.id
+}

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -5,6 +5,7 @@
 package soc
 
 var (
+	ErrNoOwner     = errNoOwner
 	Hash           = hash
 	RecoverAddress = recoverAddress
 )

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -5,6 +5,7 @@
 package soc
 
 var (
+	Hash           = hash
 	ToSignDigest   = toSignDigest
 	RecoverAddress = recoverAddress
 )

--- a/pkg/soc/export_test.go
+++ b/pkg/soc/export_test.go
@@ -6,7 +6,6 @@ package soc
 
 var (
 	Hash           = hash
-	ToSignDigest   = toSignDigest
 	RecoverAddress = recoverAddress
 )
 

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -183,7 +183,7 @@ func hash(values ...[]byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// recoverAddress returns the ethereum address of the owner of an soc.
+// recoverAddress returns the ethereum address of the owner of a soc.
 func recoverAddress(signature, digest []byte) ([]byte, error) {
 	recoveredPublicKey, err := crypto.Recover(signature, digest)
 	if err != nil {

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package soc provides the single-owner chunk implemention
+// Package soc provides the single-owner chunk implementation
 // and validator.
 package soc
 

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -29,7 +29,7 @@ var (
 // ID is a soc identifier
 type ID []byte
 
-// Soc wraps a single-owner chunk.
+// Soc wraps a content-addressed chunk.
 type Soc struct {
 	id        ID
 	owner     []byte // Owner is the address in bytes of soc owner.

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -22,6 +22,11 @@ const (
 	minChunkSize  = IdSize + SignatureSize + swarm.SpanSize
 )
 
+var (
+	errNoOwner        = errors.New("soc: owner not set")
+	errWrongChunkSize = errors.New("soc: chunk length is less than minimum")
+)
+
 // ID is a soc identifier
 type ID []byte
 
@@ -67,8 +72,8 @@ func NewSigned(id ID, ch swarm.Chunk, owner, sig []byte) (*Soc, error) {
 
 // address returns the soc chunk address.
 func (s *Soc) address() (swarm.Address, error) {
-	if len(s.owner) == 0 {
-		return swarm.ZeroAddress, errors.New("soc: owner not set")
+	if len(s.owner) != crypto.AddressSize {
+		return swarm.ZeroAddress, errNoOwner
 	}
 	return CreateAddress(s.id, s.owner)
 }
@@ -134,7 +139,7 @@ func (s *Soc) Sign(signer crypto.Signer) (swarm.Chunk, error) {
 func FromChunk(sch swarm.Chunk) (*Soc, error) {
 	chunkData := sch.Data()
 	if len(chunkData) < minChunkSize {
-		return nil, errors.New("soc: chunk length is less than minimum")
+		return nil, errWrongChunkSize
 	}
 
 	// add all the data fields

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -115,7 +115,7 @@ func (s *Soc) Sign(signer crypto.Signer) (swarm.Chunk, error) {
 	s.owner = ownerAddress
 
 	// generate the data to sign
-	toSignBytes, err := toSignDigest(s.id, s.chunk.Address().Bytes())
+	toSignBytes, err := hash(s.id, s.chunk.Address().Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func FromChunk(sch swarm.Chunk) (*Soc, error) {
 		return nil, err
 	}
 
-	toSignBytes, err := toSignDigest(s.id, ch.Address().Bytes())
+	toSignBytes, err := hash(s.id, ch.Address().Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -179,11 +179,6 @@ func CreateAddress(id ID, owner Owner) (swarm.Address, error) {
 		return swarm.ZeroAddress, err
 	}
 	return swarm.NewAddress(sum), nil
-}
-
-// toSignDigest creates a digest suitable for signing to represent the soc.
-func toSignDigest(id ID, sum []byte) ([]byte, error) {
-	return hash(id, sum)
 }
 
 // hash hashes the given values in order.

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -28,7 +28,7 @@ type ID []byte
 // Owner is the address in bytes of soc owner.
 type Owner []byte
 
-// NewOwner creates a new Owner ensuring a valid length address of soc owner.
+// NewOwner ensures a valid length address of soc owner.
 func NewOwner(address []byte) (Owner, error) {
 	if len(address) != crypto.AddressSize {
 		return nil, fmt.Errorf("soc: invalid address %x", address)
@@ -65,8 +65,8 @@ func NewSigned(id ID, ch swarm.Chunk, owner, sig []byte) (*Soc, error) {
 	return s, nil
 }
 
-// Address returns the soc chunk address.
-func (s *Soc) Address() (swarm.Address, error) {
+// address returns the soc chunk address.
+func (s *Soc) address() (swarm.Address, error) {
 	if len(s.owner) == 0 {
 		return swarm.ZeroAddress, errors.New("soc: owner not set")
 	}
@@ -80,7 +80,7 @@ func (s *Soc) WrappedChunk() swarm.Chunk {
 
 // Chunk returns the soc chunk.
 func (s *Soc) Chunk() (swarm.Chunk, error) {
-	socAddress, err := s.Address()
+	socAddress, err := s.address()
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func FromChunk(sch swarm.Chunk) (*Soc, error) {
 	return s, nil
 }
 
-// createAddress creates a new soc address from the soc id and the ethereum address of the signer.
+// CreateAddress creates a new soc address from the soc id and the ethereum address of the signer.
 func CreateAddress(id ID, owner Owner) (swarm.Address, error) {
 	sum, err := hash(id, owner)
 	if err != nil {

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Swarm Authos. All rights reserved.
+// Copyright 2020 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/soc/soc.go
+++ b/pkg/soc/soc.go
@@ -144,7 +144,7 @@ func FromChunk(sch swarm.Chunk) (*Soc, error) {
 	s.id = chunkData[cursor:IdSize]
 	cursor += IdSize
 
-	signature := chunkData[cursor : cursor+SignatureSize]
+	s.signature = chunkData[cursor : cursor+SignatureSize]
 	cursor += SignatureSize
 
 	ch, err := cac.NewWithDataSpan(chunkData[cursor:])
@@ -158,7 +158,7 @@ func FromChunk(sch swarm.Chunk) (*Soc, error) {
 	}
 
 	// recover owner information
-	recoveredEthereumAddress, err := recoverAddress(signature, toSignBytes)
+	recoveredEthereumAddress, err := recoverAddress(s.signature, toSignBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -166,8 +166,8 @@ func TestChunkErrorWithoutOwner(t *testing.T) {
 	s := soc.New(id, ch)
 
 	_, err = s.Chunk()
-	if !errors.Is(err, soc.ErrNoOwner) {
-		t.Fatalf("expect error. got `%v` want `%v`", err, soc.ErrNoOwner)
+	if !errors.Is(err, soc.ErrInvalidAddress) {
+		t.Fatalf("expect error. got `%v` want `%v`", err, soc.ErrInvalidAddress)
 	}
 }
 

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-func TestNewSoc(t *testing.T) {
+func TestNew(t *testing.T) {
 	payload := []byte("foo")
 	ch, err := cac.New(payload)
 	if err != nil {
@@ -28,7 +28,7 @@ func TestNewSoc(t *testing.T) {
 	id := make([]byte, soc.IdSize)
 	s := soc.New(id, ch)
 
-	// check soc fields
+	// check SOC fields
 	if !bytes.Equal(s.ID(), id) {
 		t.Fatalf("id mismatch. got %x want %x", s.ID(), id)
 	}
@@ -45,9 +45,9 @@ func TestNewSoc(t *testing.T) {
 	}
 }
 
-func TestNewSignedSoc(t *testing.T) {
+func TestNewSigned(t *testing.T) {
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
-	// signature of h(id + chunk address of foo)
+	// signature of hash(id + chunk address of foo)
 	sig, err := hex.DecodeString("5acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a053deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c1348311b")
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +65,7 @@ func TestNewSignedSoc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// check signed soc fields
+	// check signed SOC fields
 	if !bytes.Equal(s.ID(), id) {
 		t.Fatalf("id mismatch. got %x want %x", s.ID(), id)
 	}
@@ -90,8 +90,8 @@ func TestNewSignedSoc(t *testing.T) {
 	}
 }
 
-// TestChunk verifies that the chunk created from the Soc object
-// corresponds to the soc spec.
+// TestChunk verifies that the chunk created from the SOC object
+// corresponds to the SOC spec.
 func TestChunk(t *testing.T) {
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
 	sig, err := hex.DecodeString("5acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a053deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c1348311b")
@@ -106,7 +106,7 @@ func TestChunk(t *testing.T) {
 	}
 
 	id := make([]byte, soc.IdSize)
-	// creates a new signed soc
+	// creates a new signed SOC
 	s, err := soc.NewSigned(id, ch, owner.Bytes(), sig)
 	if err != nil {
 		t.Fatal(err)
@@ -116,20 +116,20 @@ func TestChunk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedSocAddress := swarm.NewAddress(sum)
+	expectedSOCAddress := swarm.NewAddress(sum)
 
-	// creates soc chunk
+	// creates SOC chunk
 	sch, err := s.Chunk()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(sch.Address().Bytes(), expectedSocAddress.Bytes()) {
-		t.Fatalf("soc address mismatch. got %x want %x", sch.Address().Bytes(), expectedSocAddress.Bytes())
+	if !bytes.Equal(sch.Address().Bytes(), expectedSOCAddress.Bytes()) {
+		t.Fatalf("soc address mismatch. got %x want %x", sch.Address().Bytes(), expectedSOCAddress.Bytes())
 	}
 
 	chunkData := sch.Data()
-	// verifies that id, signature, payload is in place in the soc chunk
+	// verifies that id, signature, payload is in place in the SOC chunk
 	cursor := 0
 	if !bytes.Equal(chunkData[cursor:soc.IdSize], id) {
 		t.Fatalf("id mismatch. got %x want %x", chunkData[cursor:soc.IdSize], id)
@@ -258,27 +258,27 @@ func TestFromChunk(t *testing.T) {
 	}
 
 	// attempt to recover soc from signed chunk
-	recoveredSoc, err := soc.FromChunk(sch)
+	recoveredSOC, err := soc.FromChunk(sch)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// owner matching means the address was successfully recovered from
 	// payload and signature
-	if !bytes.Equal(recoveredSoc.OwnerAddress(), ownerAddress) {
-		t.Fatalf("owner address mismatch. got %x want %x", recoveredSoc.OwnerAddress(), ownerAddress)
+	if !bytes.Equal(recoveredSOC.OwnerAddress(), ownerAddress) {
+		t.Fatalf("owner address mismatch. got %x want %x", recoveredSOC.OwnerAddress(), ownerAddress)
 	}
 
-	if !bytes.Equal(recoveredSoc.ID(), id) {
-		t.Fatalf("id mismatch. got %x want %x", recoveredSoc.ID(), id)
+	if !bytes.Equal(recoveredSOC.ID(), id) {
+		t.Fatalf("id mismatch. got %x want %x", recoveredSOC.ID(), id)
 	}
 
-	if !bytes.Equal(recoveredSoc.Signature(), sig) {
-		t.Fatalf("signature mismatch. got %x want %x", recoveredSoc.Signature(), sig)
+	if !bytes.Equal(recoveredSOC.Signature(), sig) {
+		t.Fatalf("signature mismatch. got %x want %x", recoveredSOC.Signature(), sig)
 	}
 
-	if !ch.Equal(recoveredSoc.WrappedChunk()) {
-		t.Fatalf("wrapped chunk mismatch. got %s want %s", recoveredSoc.WrappedChunk().Address(), ch.Address())
+	if !ch.Equal(recoveredSOC.WrappedChunk()) {
+		t.Fatalf("wrapped chunk mismatch. got %s want %s", recoveredSOC.WrappedChunk().Address(), ch.Address())
 	}
 }
 

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -238,14 +238,6 @@ func TestFromChunk(t *testing.T) {
 	// owner: 0x8d3766440f0d7b949a5e32995d09619a7f86e632
 	sch := swarm.NewChunk(socAddress, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 205, 56, 79, 235, 193, 51, 183, 178, 69, 229, 221, 198, 45, 130, 210, 205, 237, 145, 130, 210, 113, 97, 38, 205, 136, 68, 80, 154, 246, 90, 5, 61, 235, 65, 130, 8, 2, 127, 84, 142, 62, 136, 52, 58, 246, 248, 74, 135, 114, 251, 60, 235, 192, 161, 131, 58, 14, 167, 236, 12, 19, 72, 49, 27, 3, 0, 0, 0, 0, 0, 0, 0, 102, 111, 111})
 
-	// recover soc from signed chunk
-	recoveredSoc, err := soc.FromChunk(sch)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// owner matching means the address was successfully recovered from
-	// payload and signature
 	cursor := soc.IdSize + soc.SignatureSize
 	data := sch.Data()
 	id := data[:soc.IdSize]
@@ -254,6 +246,7 @@ func TestFromChunk(t *testing.T) {
 
 	chunkAddress := swarm.MustParseHexAddress("2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48")
 	ch := swarm.NewChunk(chunkAddress, chunkData)
+
 	signedDigest, err := soc.Hash(id, ch.Address().Bytes())
 	if err != nil {
 		t.Fatal(err)
@@ -264,6 +257,14 @@ func TestFromChunk(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// attempt to recover soc from signed chunk
+	recoveredSoc, err := soc.FromChunk(sch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// owner matching means the address was successfully recovered from
+	// payload and signature
 	if !bytes.Equal(recoveredSoc.OwnerAddress(), ownerAddress) {
 		t.Fatalf("owner address mismatch. got %x want %x", recoveredSoc.OwnerAddress(), ownerAddress)
 	}
@@ -309,6 +310,7 @@ func TestRecoverAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// attempt to recover address from signature
 	addr, err := soc.RecoverAddress(sig, signedDigest)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -165,7 +166,7 @@ func TestChunkErrorWithoutOwner(t *testing.T) {
 	s := soc.New(id, ch)
 
 	_, err = s.Chunk()
-	if err == nil {
+	if !errors.Is(err, soc.ErrNoOwner) {
 		t.Fatalf("expect error. got `%v` want `%v`", err, soc.ErrNoOwner)
 	}
 }

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -153,6 +153,23 @@ func TestChunk(t *testing.T) {
 	}
 }
 
+func TestChunkErrorWithoutOwner(t *testing.T) {
+	payload := []byte("foo")
+	ch, err := cac.New(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := make([]byte, soc.IdSize)
+
+	// creates a new soc
+	s := soc.New(id, ch)
+
+	_, err = s.Chunk()
+	if err == nil {
+		t.Fatalf("expect error. got `%v` want `%v`", err, soc.ErrNoOwner)
+	}
+}
+
 // TestSign tests whether a soc is correctly signed.
 func TestSign(t *testing.T) {
 	privKey, err := crypto.GenerateSecp256k1Key()

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -31,7 +31,11 @@ func TestToChunk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sch, err := soc.NewChunk(id, ch, signer)
+	s, err := soc.NewSoc(id, ch, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sch, err := s.Sign()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,11 +102,14 @@ func TestFromChunk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sch, err := soc.NewChunk(id, ch, signer)
+	s, err := soc.NewSoc(id, ch, signer)
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	sch, err := s.Sign()
+	if err != nil {
+		t.Fatal(err)
+	}
 	u2, err := soc.FromChunk(sch)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -13,28 +13,27 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// MockSoc defines a mocked soc with exported fields for easy testing.
-type MockSoc struct {
+// MockSOC defines a mocked SOC with exported fields for easy testing.
+type MockSOC struct {
 	ID           soc.ID
 	Owner        []byte
 	Signature    []byte
 	WrappedChunk swarm.Chunk
 }
 
-// Address returns the soc address of the mocked soc.
-func (ms MockSoc) Address() swarm.Address {
+// Address returns the SOC address of the mocked SOC.
+func (ms MockSOC) Address() swarm.Address {
 	addr, _ := soc.CreateAddress(ms.ID, ms.Owner)
 	return addr
 }
 
-// Chunk returns the soc chunk of the mocked soc.
-func (ms MockSoc) Chunk() swarm.Chunk {
+// Chunk returns the SOC chunk of the mocked SOC.
+func (ms MockSOC) Chunk() swarm.Chunk {
 	return swarm.NewChunk(ms.Address(), append(ms.ID, append(ms.Signature, ms.WrappedChunk.Data()...)...))
 }
 
-// GenerateMockSoc generates a valid mocked soc from given data.
-// If data is nil it generates random data.
-func GenerateMockSoc(t *testing.T, data []byte) *MockSoc {
+// GenerateMockSOC generates a valid mocked SOC from given data.
+func GenerateMockSOC(t *testing.T, data []byte) *MockSOC {
 	t.Helper()
 
 	privKey, err := crypto.GenerateSecp256k1Key()
@@ -64,7 +63,7 @@ func GenerateMockSoc(t *testing.T, data []byte) *MockSoc {
 		t.Fatal(err)
 	}
 
-	return &MockSoc{
+	return &MockSOC{
 		ID:           id,
 		Owner:        owner.Bytes(),
 		Signature:    signature,

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -5,19 +5,13 @@
 package testing
 
 import (
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/ethersphere/bee/pkg/cac"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/soc"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // MockSoc defines a mocked soc with exported fields for easy testing.
 type MockSoc struct {
@@ -53,13 +47,6 @@ func GenerateMockSoc(t *testing.T, data []byte) *MockSoc {
 		t.Fatal(err)
 	}
 
-	if data == nil {
-		data = make([]byte, swarm.ChunkSize)
-		_, err = rand.Read(data)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
 	ch, err := cac.New(data)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -42,7 +42,11 @@ func (ms MockSoc) Chunk() swarm.Chunk {
 // If data is nil it generates random data.
 func GenerateMockSoc(t *testing.T, data []byte) *MockSoc {
 	t.Helper()
-	privKey, _ := crypto.GenerateSecp256k1Key()
+
+	privKey, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
 	signer := crypto.NewDefaultSigner(privKey)
 	owner, err := signer.EthereumAddress()
 	if err != nil {
@@ -68,7 +72,11 @@ func GenerateMockSoc(t *testing.T, data []byte) *MockSoc {
 		t.Fatal(err)
 	}
 
-	signature, _ := signer.Sign(hasher.Sum(nil))
+	signature, err := signer.Sign(hasher.Sum(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return &MockSoc{
 		ID:           id,
 		Owner:        owner.Bytes(),

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -5,8 +5,6 @@
 package testing
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"math/rand"
 	"time"
 
@@ -28,12 +26,10 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// GenerateMockSoc generates a valid mock soc from given private key
-// (in hexdecimal format) and data.
+// GenerateMockSoc generates a valid mock soc from given data.
 // If data is nil it generates random data.
-func GenerateMockSoc(hexPrivKey string, data []byte) *MockSoc {
-	keyBytes, _ := hex.DecodeString(hexPrivKey)
-	privKey, _ := crypto.DecodeSecp256k1PrivateKey(keyBytes)
+func GenerateMockSoc(data []byte) *MockSoc {
+	privKey, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(privKey)
 	owner, _ := signer.EthereumAddress()
 
@@ -44,8 +40,6 @@ func GenerateMockSoc(hexPrivKey string, data []byte) *MockSoc {
 	ch, _ := cac.New(data)
 
 	id := make([]byte, 32)
-	binary.LittleEndian.PutUint32(id, rand.Uint32())
-
 	hasher := swarm.NewHasher()
 	_, _ = hasher.Write(append(id, ch.Address().Bytes()...))
 	signature, _ := signer.Sign(hasher.Sum(nil))

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -14,19 +14,30 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// MockSoc defines exported soc fields for easy testing.
-type MockSoc struct {
-	ID        soc.ID
-	Owner     soc.Owner
-	Signature []byte
-	Chunk     swarm.Chunk // wrapped chunk
-}
-
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// GenerateMockSoc generates a valid mock soc from given data.
+// MockSoc defines a mocked soc with exported fields for easy testing.
+type MockSoc struct {
+	ID           soc.ID
+	Owner        soc.Owner
+	Signature    []byte
+	WrappedChunk swarm.Chunk
+}
+
+// Address returns the soc address of the mocked soc.
+func (ms MockSoc) Address() swarm.Address {
+	addr, _ := soc.CreateAddress(ms.ID, ms.Owner)
+	return addr
+}
+
+// Chunk returns the soc chunk of the mocked soc.
+func (ms MockSoc) Chunk() swarm.Chunk {
+	return swarm.NewChunk(ms.Address(), append(ms.ID, append(ms.Signature, ms.WrappedChunk.Data()...)...))
+}
+
+// GenerateMockSoc generates a valid mocked soc from given data.
 // If data is nil it generates random data.
 func GenerateMockSoc(data []byte) *MockSoc {
 	privKey, _ := crypto.GenerateSecp256k1Key()
@@ -44,9 +55,9 @@ func GenerateMockSoc(data []byte) *MockSoc {
 	_, _ = hasher.Write(append(id, ch.Address().Bytes()...))
 	signature, _ := signer.Sign(hasher.Sum(nil))
 	return &MockSoc{
-		ID:        id,
-		Owner:     owner.Bytes(),
-		Signature: signature,
-		Chunk:     ch,
+		ID:           id,
+		Owner:        owner.Bytes(),
+		Signature:    signature,
+		WrappedChunk: ch,
 	}
 }

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -50,7 +50,7 @@ func GenerateMockSoc(data []byte) *MockSoc {
 	}
 	ch, _ := cac.New(data)
 
-	id := make([]byte, 32)
+	id := make([]byte, soc.IdSize)
 	hasher := swarm.NewHasher()
 	_, _ = hasher.Write(append(id, ch.Address().Bytes()...))
 	signature, _ := signer.Sign(hasher.Sum(nil))

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"math/rand"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/cac"
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/ethersphere/bee/pkg/soc"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// MockSoc defines exported soc fields for easy testing.
+type MockSoc struct {
+	ID        soc.ID
+	Owner     soc.Owner
+	Signature []byte
+	Chunk     swarm.Chunk // wrapped chunk
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// GenerateMockSoc generates a valid mock soc from given private key
+// (in hexdecimal format) and data.
+// If data is nil it generates random data.
+func GenerateMockSoc(hexPrivKey string, data []byte) *MockSoc {
+	keyBytes, _ := hex.DecodeString(hexPrivKey)
+	privKey, _ := crypto.DecodeSecp256k1PrivateKey(keyBytes)
+	signer := crypto.NewDefaultSigner(privKey)
+	owner, _ := signer.EthereumAddress()
+
+	if data == nil {
+		data = make([]byte, swarm.ChunkSize)
+		_, _ = rand.Read(data)
+	}
+	ch, _ := cac.New(data)
+
+	id := make([]byte, 32)
+	binary.LittleEndian.PutUint32(id, rand.Uint32())
+
+	hasher := swarm.NewHasher()
+	_, _ = hasher.Write(append(id, ch.Address().Bytes()...))
+	signature, _ := signer.Sign(hasher.Sum(nil))
+	return &MockSoc{
+		ID:        id,
+		Owner:     owner.Bytes(),
+		Signature: signature,
+		Chunk:     ch,
+	}
+}

--- a/pkg/soc/validator.go
+++ b/pkg/soc/validator.go
@@ -15,7 +15,7 @@ func Valid(ch swarm.Chunk) bool {
 		return false
 	}
 
-	address, err := s.Address()
+	address, err := s.address()
 	if err != nil {
 		return false
 	}

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -5,59 +5,110 @@
 package soc_test
 
 import (
-	"encoding/binary"
+	"strings"
 	"testing"
 
-	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/soc"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// TestValidator verifies that the validator can detect both
-// valid soc chunks, as well as chunks with invalid data and invalid
-// address.
-func TestValidator(t *testing.T) {
-	id := make([]byte, soc.IdSize)
-	privKey, err := crypto.GenerateSecp256k1Key()
-	if err != nil {
-		t.Fatal(err)
-	}
-	signer := crypto.NewDefaultSigner(privKey)
+// TestValid verifies that the validator can detect
+// valid soc chunks.
+func TestValid(t *testing.T) {
+	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
-	bmtHashOfFoo := "2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48"
-	address := swarm.MustParseHexAddress(bmtHashOfFoo)
-	foo := "foo"
-	fooLength := len(foo)
-	fooBytes := make([]byte, 8+fooLength)
-	binary.LittleEndian.PutUint64(fooBytes, uint64(fooLength))
-	copy(fooBytes[8:], foo)
-	ch := swarm.NewChunk(address, fooBytes)
-
-	s := soc.New(id, ch)
-
-	sch, err := s.Sign(signer)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// signed soc chunk of:
+	// id: 0
+	// wrapped chunk of: `foo`
+	// owner: 0x8d3766440f0d7b949a5e32995d09619a7f86e632
+	sch := swarm.NewChunk(socAddress, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 205, 56, 79, 235, 193, 51, 183, 178, 69, 229, 221, 198, 45, 130, 210, 205, 237, 145, 130, 210, 113, 97, 38, 205, 136, 68, 80, 154, 246, 90, 5, 61, 235, 65, 130, 8, 2, 127, 84, 142, 62, 136, 52, 58, 246, 248, 74, 135, 114, 251, 60, 235, 192, 161, 131, 58, 14, 167, 236, 12, 19, 72, 49, 27, 3, 0, 0, 0, 0, 0, 0, 0, 102, 111, 111})
 
 	// check valid chunk
 	if !soc.Valid(sch) {
 		t.Fatal("valid chunk evaluates to invalid")
 	}
+}
 
-	// check invalid data
-	sch.Data()[0] = 0x01
-	if soc.Valid(sch) {
-		t.Fatal("chunk with invalid data evaluates to valid")
-	}
+// TestInvalid verifies that the validator can detect chunks
+// with invalid data and invalid address.
+func TestInvalid(t *testing.T) {
+	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
-	// check invalid address
-	sch.Data()[0] = 0x00
-	wrongAddressBytes := sch.Address().Bytes()
-	wrongAddressBytes[0] = 255 - wrongAddressBytes[0]
-	wrongAddress := swarm.NewAddress(wrongAddressBytes)
-	sch = swarm.NewChunk(wrongAddress, sch.Data())
-	if soc.Valid(sch) {
-		t.Fatal("chunk with invalid address evaluates to valid")
+	// signed soc chunk of:
+	// id: 0
+	// wrapped chunk of: `foo`
+	// owner: 0x8d3766440f0d7b949a5e32995d09619a7f86e632
+	sch := swarm.NewChunk(socAddress, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 205, 56, 79, 235, 193, 51, 183, 178, 69, 229, 221, 198, 45, 130, 210, 205, 237, 145, 130, 210, 113, 97, 38, 205, 136, 68, 80, 154, 246, 90, 5, 61, 235, 65, 130, 8, 2, 127, 84, 142, 62, 136, 52, 58, 246, 248, 74, 135, 114, 251, 60, 235, 192, 161, 131, 58, 14, 167, 236, 12, 19, 72, 49, 27, 3, 0, 0, 0, 0, 0, 0, 0, 102, 111, 111})
+
+	for _, c := range []struct {
+		name  string
+		chunk func() swarm.Chunk
+	}{
+		{
+			name: "wrong soc address",
+			chunk: func() swarm.Chunk {
+				wrongAddressBytes := sch.Address().Bytes()
+				wrongAddressBytes[0] = 255 - wrongAddressBytes[0]
+				wrongAddress := swarm.NewAddress(wrongAddressBytes)
+				return swarm.NewChunk(wrongAddress, sch.Data())
+			},
+		},
+		{
+			name: "invalid data",
+			chunk: func() swarm.Chunk {
+				data := make([]byte, len(sch.Data()))
+				copy(data, sch.Data())
+				cursor := soc.IdSize + soc.SignatureSize
+				chunkData := data[cursor:]
+				chunkData[0] = 0x01
+				return swarm.NewChunk(socAddress, data)
+			},
+		},
+		{
+			name: "invalid id",
+			chunk: func() swarm.Chunk {
+				data := make([]byte, len(sch.Data()))
+				copy(data, sch.Data())
+				id := data[:soc.IdSize]
+				id[0] = 0x01
+				return swarm.NewChunk(socAddress, data)
+			},
+		},
+		{
+			name: "invalid signature",
+			chunk: func() swarm.Chunk {
+				data := make([]byte, len(sch.Data()))
+				copy(data, sch.Data())
+				// modify signature
+				cursor := soc.IdSize + soc.SignatureSize
+				sig := data[soc.IdSize:cursor]
+				sig[0] = 0x01
+				return swarm.NewChunk(socAddress, data)
+			},
+		},
+		{
+			name: "nil data",
+			chunk: func() swarm.Chunk {
+				return swarm.NewChunk(socAddress, nil)
+			},
+		},
+		{
+			name: "small data",
+			chunk: func() swarm.Chunk {
+				return swarm.NewChunk(socAddress, []byte("small"))
+			},
+		},
+		{
+			name: "large data",
+			chunk: func() swarm.Chunk {
+				return swarm.NewChunk(socAddress, []byte(strings.Repeat("a", swarm.ChunkSize+swarm.SpanSize+1)))
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if soc.Valid(c.chunk()) {
+				t.Fatal("chunk with invalid data evaluates to valid")
+			}
+		})
 	}
 }

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -33,7 +33,12 @@ func TestValidator(t *testing.T) {
 	copy(fooBytes[8:], foo)
 	ch := swarm.NewChunk(address, fooBytes)
 
-	sch, err := soc.NewChunk(id, ch, signer)
+	s, err := soc.NewSoc(id, ch, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sch, err := s.Sign()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -33,12 +33,9 @@ func TestValidator(t *testing.T) {
 	copy(fooBytes[8:], foo)
 	ch := swarm.NewChunk(address, fooBytes)
 
-	s, err := soc.NewSoc(id, ch, signer)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := soc.New(id, ch)
 
-	sch, err := s.Sign()
+	sch, err := s.Sign(signer)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR attempt to refactor the soc API to a more idiomatic and clean API.

The new API exposes the following:
```go
func New(id ID, ch swarm.Chunk) *Soc
func NewSigned(id ID, ch swarm.Chunk, owner, sig []byte) (*Soc, error)

func (s *Soc) Sign(signer crypto.Signer) (swarm.Chunk, error)
func (s *Soc) Chunk() (swarm.Chunk, error)
func (s *Soc) WrappedChunk() swarm.Chunk

func FromChunk(sch swarm.Chunk) (*Soc, error)
func CreateAddress(id ID, owner Owner) (swarm.Address, error) 
func Valid(ch swarm.Chunk) bool
```