### PR TITLE
kademlia, cmd, node: add bootnode-mode flag

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -42,6 +42,7 @@ const (
 	optionNamePaymentTolerance          = "payment-tolerance"
 	optionNamePaymentEarly              = "payment-early"
 	optionNameResolverEndpoints         = "resolver-options"
+	optionNameBootnodeMode              = "bootnode-mode"
 	optionNameGatewayMode               = "gateway-mode"
 	optionNameClefSignerEnable          = "clef-signer-enable"
 	optionNameClefSignerEndpoint        = "clef-signer-endpoint"
@@ -203,6 +204,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNamePaymentEarly, "1000000000000", "amount in BZZ below the peers payment threshold when we initiate settlement")
 	cmd.Flags().StringSlice(optionNameResolverEndpoints, []string{}, "ENS compatible API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url")
 	cmd.Flags().Bool(optionNameGatewayMode, false, "disable a set of sensitive features in the api")
+	cmd.Flags().Bool(optionNameBootnodeMode, false, "cause the node to always accept incoming connections")
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
 	cmd.Flags().String(optionNameClefSignerEthereumAddress, "", "ethereum address to use from clef signer")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -143,6 +143,7 @@ Welcome to the Swarm.... Bzzz Bzzzz Bzzzz
 				PaymentEarly:           c.config.GetString(optionNamePaymentEarly),
 				ResolverConnectionCfgs: resolverCfgs,
 				GatewayMode:            c.config.GetBool(optionNameGatewayMode),
+				BootnodeMode:           c.config.GetBool(optionNameBootnodeMode),
 				SwapEndpoint:           c.config.GetString(optionNameSwapEndpoint),
 				SwapFactoryAddress:     c.config.GetString(optionNameSwapFactoryAddress),
 				SwapInitialDeposit:     c.config.GetString(optionNameSwapInitialDeposit),

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -104,6 +104,7 @@ type Options struct {
 	PaymentEarly           string
 	ResolverConnectionCfgs []multiresolver.ConnectionConfig
 	GatewayMode            bool
+	BootnodeMode           bool
 	SwapEndpoint           string
 	SwapFactoryAddress     string
 	SwapInitialDeposit     string
@@ -361,7 +362,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	settlement.SetNotifyPaymentFunc(acc.AsyncNotifyPayment)
 	pricing.SetPaymentThresholdObserver(acc)
 
-	kad := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger, kademlia.Options{Bootnodes: bootnodes, Standalone: o.Standalone})
+	kad := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger, kademlia.Options{Bootnodes: bootnodes, StandaloneMode: o.Standalone, BootnodeMode: o.BootnodeMode})
 	b.topologyCloser = kad
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.SetPickyNotifier(kad)


### PR DESCRIPTION
As a result of #1352, nodes will limit the amount of incoming connections from other peers.
This is an undesirable for our bootnodes, which should be accepting more incoming connections so that new peers can get informed about the rest of the network.

In the future we should improve this by accepting new nodes in bootnode mode and either give them a list of peers to connect to, or just kick away old nodes that have been connected for a while (oldest, perhaps), so that we rotate the network that the bootnode sees, without prioritizing or preferring certain nodes over others.