### PR TITLE
chequebook: change cashout api to include uncashed amount

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -351,16 +351,14 @@ components:
       properties:
         peer:
           $ref: "#/components/schemas/SwarmAddress"
-        chequebook:
-          $ref: "#/components/schemas/EthereumAddress"
-        cumulativePayout:
-          type: integer
-        beneficiary:
-          $ref: "#/components/schemas/EthereumAddress"
+        lastCashedCheque:
+          $ref: "#/components/schemas/Cheque"
         transactionHash:
           $ref: "#/components/schemas/TransactionHash"
         result:
           $ref: "#/components/schemas/SwapCashoutResult"
+        uncashedAmount:
+          type: integer
 
     TagName:
       type: string

--- a/pkg/settlement/swap/chequebook/cashout.go
+++ b/pkg/settlement/swap/chequebook/cashout.go
@@ -176,7 +176,7 @@ func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress co
 		return nil, err
 	}
 
-	var action *cashoutAction
+	var action cashoutAction
 	err = s.store.Get(cashoutActionKey(chequebookAddress), &action)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/settlement/swap/chequebook/cashout.go
+++ b/pkg/settlement/swap/chequebook/cashout.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/sctx"
@@ -38,12 +39,18 @@ type cashoutService struct {
 	chequeStore        ChequeStore
 }
 
-// CashoutStatus is the action plus its result
-type CashoutStatus struct {
+// LastCashout contains information about the last cashout
+type LastCashout struct {
 	TxHash   common.Hash
 	Cheque   SignedCheque // the cheque that was used to cashout which may be different from the latest cheque
 	Result   *CashChequeResult
 	Reverted bool
+}
+
+// CashoutStatus is information about the last cashout and uncashed amounts
+type CashoutStatus struct {
+	Last           *LastCashout // last cashout for a chequebook
+	UncashedAmount *big.Int     // amount not yet cashed out
 }
 
 // CashChequeResult summarizes the result of a CashCheque or CashChequeBeneficiary call
@@ -91,6 +98,37 @@ func cashoutActionKey(chequebook common.Address) string {
 	return fmt.Sprintf("swap_cashout_%x", chequebook)
 }
 
+func (s *cashoutService) paidOut(ctx context.Context, chequebook, beneficiary common.Address) (*big.Int, error) {
+	callData, err := chequebookABI.Pack("paidOut", beneficiary)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := s.transactionService.Call(ctx, &transaction.TxRequest{
+		To:   &chequebook,
+		Data: callData,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := chequebookABI.Unpack("paidOut", output)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(results) != 1 {
+		return nil, errDecodeABI
+	}
+
+	paidOut, ok := abi.ConvertType(results[0], new(big.Int)).(*big.Int)
+	if !ok || paidOut == nil {
+		return nil, errDecodeABI
+	}
+
+	return paidOut, nil
+}
+
 // CashCheque sends a cashout transaction for the last cheque of the chequebook
 func (s *cashoutService) CashCheque(ctx context.Context, chequebook, recipient common.Address) (common.Hash, error) {
 	cheque, err := s.chequeStore.LastCheque(chequebook)
@@ -133,11 +171,19 @@ func (s *cashoutService) CashCheque(ctx context.Context, chequebook, recipient c
 
 // CashoutStatus gets the status of the latest cashout transaction for the chequebook
 func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress common.Address) (*CashoutStatus, error) {
+	cheque, err := s.chequeStore.LastCheque(chequebookAddress)
+	if err != nil {
+		return nil, err
+	}
+
 	var action *cashoutAction
-	err := s.store.Get(cashoutActionKey(chequebookAddress), &action)
+	err = s.store.Get(cashoutActionKey(chequebookAddress), &action)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, ErrNoCashout
+			return &CashoutStatus{
+				Last:           nil,
+				UncashedAmount: cheque.CumulativePayout, // if we never cashed out, assume everything is uncashed
+			}, nil
 		}
 		return nil, err
 	}
@@ -153,10 +199,14 @@ func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress co
 
 	if pending {
 		return &CashoutStatus{
-			TxHash:   action.TxHash,
-			Cheque:   action.Cheque,
-			Result:   nil,
-			Reverted: false,
+			Last: &LastCashout{
+				TxHash:   action.TxHash,
+				Cheque:   action.Cheque,
+				Result:   nil,
+				Reverted: false,
+			},
+			// uncashed is the difference since the last sent cashout. we assume that the entire cheque will clear in the pending transaction.
+			UncashedAmount: new(big.Int).Sub(cheque.CumulativePayout, action.Cheque.CumulativePayout),
 		}, nil
 	}
 
@@ -166,11 +216,21 @@ func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress co
 	}
 
 	if receipt.Status == types.ReceiptStatusFailed {
+		// if a tx failed (should be almost impossible in practice) we no longer have the necessary information to compute uncashed locally
+		// assume there are no pending transactions and that the on-chain paidOut is the last cashout action
+		paidOut, err := s.paidOut(ctx, chequebookAddress, cheque.Beneficiary)
+		if err != nil {
+			return nil, err
+		}
+
 		return &CashoutStatus{
-			TxHash:   action.TxHash,
-			Cheque:   action.Cheque,
-			Result:   nil,
-			Reverted: true,
+			Last: &LastCashout{
+				TxHash:   action.TxHash,
+				Cheque:   action.Cheque,
+				Result:   nil,
+				Reverted: true,
+			},
+			UncashedAmount: new(big.Int).Sub(cheque.CumulativePayout, paidOut),
 		}, nil
 	}
 
@@ -180,10 +240,14 @@ func (s *cashoutService) CashoutStatus(ctx context.Context, chequebookAddress co
 	}
 
 	return &CashoutStatus{
-		TxHash:   action.TxHash,
-		Cheque:   action.Cheque,
-		Result:   result,
-		Reverted: false,
+		Last: &LastCashout{
+			TxHash:   action.TxHash,
+			Cheque:   action.Cheque,
+			Result:   result,
+			Reverted: false,
+		},
+		// uncashed is the difference since the last sent (and confirmed) cashout.
+		UncashedAmount: new(big.Int).Sub(cheque.CumulativePayout, result.CumulativePayout),
 	}, nil
 }
 


### PR DESCRIPTION
changes the GET cashout endpoint to include uncashed amount. it always returns uncashed amount even if no cashout has taken place so far (as long as we have in fact at least one cheque from the peer).

The main advantage of putting this into cashout endpoint are easier cashout scripts as we can all relevant values in one call and better handling of currently pending or cancelled transactions (in the calculation of uncashed amount).

This is an API-breaking change as in addition to the new `uncashedAmount`, several values moved into `lastCashedCheque` (which may be `null`).