### PR TITLE
pipeline: add special case for empty file

### DIFF
--- a/pkg/file/pipeline/builder/builder_test.go
+++ b/pkg/file/pipeline/builder/builder_test.go
@@ -56,6 +56,27 @@ func TestHelloWorld(t *testing.T) {
 	}
 }
 
+// TestEmpty tests that a hash is generated for an empty file.
+func TestEmpty(t *testing.T) {
+	m := mock.NewStorer()
+	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+
+	data := []byte{}
+	_, err := p.Write(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum, err := p.Sum()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := swarm.MustParseHexAddress("ffd70157e48063fc33c97a050f7f640233bf646cc98d9524c6b92bcf3ab56f83")
+	if !bytes.Equal(exp.Bytes(), sum) {
+		t.Fatalf("expected %s got %s", exp.String(), hex.EncodeToString(sum))
+	}
+}
+
 func TestAllVectors(t *testing.T) {
 	for i := 1; i <= 20; i++ {
 		data, expect := test.GetVector(t, i)

--- a/pkg/file/pipeline/feeder/feeder.go
+++ b/pkg/file/pipeline/feeder/feeder.go
@@ -18,6 +18,7 @@ type chunkFeeder struct {
 	next      pipeline.ChainWriter
 	buffer    []byte
 	bufferIdx int
+	wrote     int64
 }
 
 // newChunkFeederWriter creates a new chunkFeeder that allows for partial
@@ -83,6 +84,7 @@ func (f *chunkFeeder) Write(b []byte) (int, error) {
 		w += sp
 		sp = 0
 	}
+	f.wrote += int64(w)
 	return w, nil
 }
 
@@ -100,6 +102,19 @@ func (f *chunkFeeder) Sum() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		f.wrote += int64(len(d))
+	}
+
+	if f.wrote == 0 {
+		// this is an empty file, we should write the span of
+		// an empty file (0).
+		d := make([]byte, span)
+		args := &pipeline.PipeWriteArgs{Data: d, Span: d}
+		err := f.next.ChainWrite(args)
+		if err != nil {
+			return nil, err
+		}
+		f.wrote += int64(len(d))
 	}
 
 	return f.next.Sum()

--- a/pkg/file/pipeline/feeder/feeder_test.go
+++ b/pkg/file/pipeline/feeder/feeder_test.go
@@ -129,9 +129,9 @@ func TestFeederFlush(t *testing.T) {
 		span      uint64 // expected span of written data
 	}{
 		{
-			name:      "empty write",
+			name:      "empty file",
 			dataSize:  []int{0},
-			expWrites: 0,
+			expWrites: 1,
 		},
 		{
 			name:      "less than chunk, one write",


### PR DESCRIPTION
fixes a regression caused by #1267, which in turn caused #1332 