### PR TITLE
libp2p: skip static resolver tests on windows completely

### DIFF
--- a/pkg/p2p/libp2p/static_resolver_test.go
+++ b/pkg/p2p/libp2p/static_resolver_test.go
@@ -7,7 +7,6 @@ package libp2p_test
 import (
 	"net"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
@@ -16,6 +15,10 @@ import (
 )
 
 func TestStaticAddressResolver(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skipf("skipped all dns resolver tests on %v", runtime.GOOS)
+	}
+
 	for _, tc := range []struct {
 		name              string
 		natAddr           string
@@ -83,14 +86,6 @@ func TestStaticAddressResolver(t *testing.T) {
 			want:              "/dns/ipv4and6.com/tcp/30777/p2p/16Uiu2HAkyyGKpjBiCkVqCKoJa6RzzZw9Nr7hGogsMPcdad1KyMmd",
 		},
 	} {
-		if strings.Contains(tc.name, "dns") {
-			// The windows and plan9 implementation of the resolver does not use
-			// the Dial function.
-			switch runtime.GOOS {
-			case "windows", "plan9":
-				t.Skipf("skipped all dns resolver tests on %v", runtime.GOOS)
-			}
-		}
 		t.Run(tc.name, func(t *testing.T) {
 			srv, err := mockdns.NewServer(map[string]mockdns.Zone{
 				"ipv4.com.": {


### PR DESCRIPTION
this is now FUBAR. following up with the mockdns package maintainer on this