### PR TITLE
Correct metrics to use Set instead of Put

### DIFF
--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -33,11 +33,11 @@ import (
 // Set is required to implement chunk.Store
 // interface.
 func (db *DB) Set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Address) (err error) {
-	db.metrics.ModePut.Inc()
+	db.metrics.ModeSet.Inc()
 	defer totalTimeMetric(db.metrics.TotalTimeSet, time.Now())
 	err = db.set(mode, addrs...)
 	if err != nil {
-		db.metrics.ModePutFailure.Inc()
+		db.metrics.ModeSetFailure.Inc()
 	}
 	return err
 }


### PR DESCRIPTION
This fixes issue #1409 by changing the Put metric references to already defined Set metrics.