### PR TITLE
fix unconfigured cors origin

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -29,17 +29,18 @@ import (
 )
 
 type testServerOptions struct {
-	Storer          storage.Storer
-	Resolver        resolver.Interface
-	Pss             pss.Interface
-	Traversal       traversal.Service
-	WsPath          string
-	Tags            *tags.Tags
-	GatewayMode     bool
-	WsPingPeriod    time.Duration
-	Logger          logging.Logger
-	PreventRedirect bool
-	Feeds           feeds.Factory
+	Storer             storage.Storer
+	Resolver           resolver.Interface
+	Pss                pss.Interface
+	Traversal          traversal.Service
+	WsPath             string
+	Tags               *tags.Tags
+	GatewayMode        bool
+	WsPingPeriod       time.Duration
+	Logger             logging.Logger
+	PreventRedirect    bool
+	Feeds              feeds.Factory
+	CORSAllowedOrigins []string
 }
 
 func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.Conn, string) {
@@ -53,8 +54,9 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		o.WsPingPeriod = 60 * time.Second
 	}
 	s := api.New(o.Tags, o.Storer, o.Resolver, o.Pss, o.Traversal, o.Feeds, o.Logger, nil, api.Options{
-		GatewayMode:  o.GatewayMode,
-		WsPingPeriod: o.WsPingPeriod,
+		CORSAllowedOrigins: o.CORSAllowedOrigins,
+		GatewayMode:        o.GatewayMode,
+		WsPingPeriod:       o.WsPingPeriod,
 	})
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)

--- a/pkg/api/cors_test.go
+++ b/pkg/api/cors_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package debugapi_test
+package api_test
 
 import (
 	"net/http"
@@ -74,7 +74,7 @@ func TestCORSHeaders(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			testServer := newTestServer(t, testServerOptions{
+			client, _, _ := newTestServer(t, testServerOptions{
 				CORSAllowedOrigins: tc.allowedOrigins,
 			})
 
@@ -86,7 +86,7 @@ func TestCORSHeaders(t *testing.T) {
 				req.Header.Set("Origin", tc.origin)
 			}
 
-			r, err := testServer.Client.Do(req)
+			r, err := client.Do(req)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -196,7 +196,7 @@ func (s *server) setupRouting() {
 		s.pageviewMetricsHandler,
 		func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if o := r.Header.Get("Origin"); o != "" && (len(s.CORSAllowedOrigins) == 0 || s.checkOrigin(r)) {
+				if o := r.Header.Get("Origin"); o != "" && s.checkOrigin(r) {
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
 					w.Header().Set("Access-Control-Allow-Origin", o)
 					w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method")

--- a/pkg/debugapi/cors.go
+++ b/pkg/debugapi/cors.go
@@ -12,7 +12,7 @@ import (
 // corsHandler sets CORS headers to HTTP response if allowed origins are configured.
 func (s *Service) corsHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if o := r.Header.Get("Origin"); o != "" && (len(s.corsAllowedOrigins) == 0 || checkOrigin(r, s.corsAllowedOrigins)) {
+		if o := r.Header.Get("Origin"); o != "" && checkOrigin(r, s.corsAllowedOrigins) {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Origin", o)
 			w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method")


### PR DESCRIPTION
This PR solves a serious bug with serving CORS headers if no allowed origins are configured and an origin header is present in an HTTP request. If CORS headers are configured, the functionality is correct.

This PR adds two test cases in already existing debugapi test and adds the same test for the api package.