### PR TITLE
localstore: increase gc batch size

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -36,8 +36,8 @@ var (
 	// garbage collection runs.
 	gcTargetRatio = 0.9
 	// gcBatchSize limits the number of chunks in a single
-	// badger transaction on garbage collection.
-	gcBatchSize uint64 = 200
+	// transaction on garbage collection.
+	gcBatchSize uint64 = 2000
 )
 
 // collectGarbageWorker is a long running function that waits for

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -119,7 +119,7 @@ type DB struct {
 	collectGarbageWorkerDone chan struct{}
 
 	// wait for all subscriptions to finish before closing
-	// underlaying BadgerDB to prevent possible panics from
+	// underlaying leveldb to prevent possible panics from
 	// iterators
 	subscritionsWG sync.WaitGroup
 


### PR DESCRIPTION
Users are reporting that we are spending a lot of time in GC, causing goroutines to pile up waiting for the lock.