### PR TITLE
localstore: reduce critical section size on gc

### DIFF
--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -754,23 +754,21 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	go func() {
 		close(online) // make sure this is scheduled, otherwise test might flake
 		i := 0
-		for {
-			select {
-			case <-incomingChan:
-				// set a chunk to be updated in gc, resulting
-				// in a removal from the gc round. but don't do this
-				// for all chunks!
-				if i < 2 {
-					_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[i])
-					if err != nil {
-						t.Fatal(err)
-					}
-					i++
-					time.Sleep(100 * time.Millisecond)
+		for range incomingChan {
+			// set a chunk to be updated in gc, resulting
+			// in a removal from the gc round. but don't do this
+			// for all chunks!
+			if i < 2 {
+				_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[i])
+				if err != nil {
+					t.Error(err)
 				}
-				dirtyChan <- struct{}{}
+				i++
+				time.Sleep(100 * time.Millisecond)
 			}
+			dirtyChan <- struct{}{}
 		}
+
 	}()
 	<-online
 	// upload random chunks

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -811,10 +811,18 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	t.Run("gc size", newIndexGCSizeTest(db))
 
 	// the first synced chunk should be removed
-	t.Run("get the first synced chunk", func(t *testing.T) {
+	t.Run("get the first two chunks, third is gone", func(t *testing.T) {
 		_, err := db.Get(context.Background(), storage.ModeGetRequest, addrs[0])
-		if errors.Is(err, storage.ErrNotFound) {
+		if err != nil {
 			t.Error("got error but expected none")
+		}
+		_, err = db.Get(context.Background(), storage.ModeGetRequest, addrs[1])
+		if err != nil {
+			t.Error("got error but expected none")
+		}
+		_, err = db.Get(context.Background(), storage.ModeGetRequest, addrs[2])
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Errorf("expected err not found but got %v", err)
 		}
 	})
 

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -109,6 +109,15 @@ type DB struct {
 
 	batchMu sync.Mutex
 
+	// gcRunning is true while GC is running. it is
+	// used to avoid touching dirty gc index entries
+	// while garbage collecting.
+	gcRunning bool
+
+	// dirtyAddresses are marked while gc is running
+	// in order to avoid the removal of dirty entries.
+	dirtyAddresses []swarm.Address
+
 	// this channel is closed when close function is called
 	// to terminate other goroutines
 	close chan struct{}

--- a/pkg/localstore/metrics.go
+++ b/pkg/localstore/metrics.go
@@ -10,6 +10,7 @@ import (
 )
 
 type metrics struct {
+	TotalTimeGCLock                 prometheus.Counter
 	TotalTimeGCFirstItem            prometheus.Counter
 	TotalTimeCollectGarbage         prometheus.Counter
 	TotalTimeGCExclude              prometheus.Counter
@@ -26,6 +27,7 @@ type metrics struct {
 	GCCounter                prometheus.Counter
 	GCErrorCounter           prometheus.Counter
 	GCCollectedCounter       prometheus.Counter
+	GCCommittedCounter       prometheus.Counter
 	GCExcludeCounter         prometheus.Counter
 	GCExcludeError           prometheus.Counter
 	GCExcludeWriteBatchError prometheus.Counter
@@ -63,6 +65,12 @@ func newMetrics() metrics {
 	subsystem := "localstore"
 
 	return metrics{
+		TotalTimeGCLock: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "gc_lock_time",
+			Help:      "Total time under lock in gc.",
+		}),
 		TotalTimeGCFirstItem: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
@@ -152,6 +160,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "gc_collected_count",
 			Help:      "Number of times the GC_COLLECTED operation is done.",
+		}),
+		GCCommittedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "gc_committed_count",
+			Help:      "Number of gc items to commit.",
 		}),
 		GCExcludeCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/localstore/mode_get.go
+++ b/pkg/localstore/mode_get.go
@@ -125,6 +125,9 @@ func (db *DB) updateGCItems(items ...shed.Item) {
 func (db *DB) updateGC(item shed.Item) (err error) {
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
+	if db.gcRunning {
+		db.dirtyAddresses = append(db.dirtyAddresses, swarm.NewAddress(item.Address))
+	}
 
 	batch := new(leveldb.Batch)
 

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -55,6 +55,11 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 	// protect parallel updates
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
+	if db.gcRunning {
+		for _, ch := range chs {
+			db.dirtyAddresses = append(db.dirtyAddresses, ch.Address())
+		}
+	}
 
 	batch := new(leveldb.Batch)
 

--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -50,6 +50,9 @@ func (db *DB) set(mode storage.ModeSet, addrs ...swarm.Address) (err error) {
 	// protect parallel updates
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
+	if db.gcRunning {
+		db.dirtyAddresses = append(db.dirtyAddresses, addrs...)
+	}
 
 	batch := new(leveldb.Batch)
 

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -77,6 +77,17 @@ func (a Address) Equal(b Address) bool {
 	return bytes.Equal(a.b, b.b)
 }
 
+// MemberOf returns true if the address is a member of the
+// provided set.
+func (a Address) MemberOf(addrs []Address) bool {
+	for _, v := range addrs {
+		if v.Equal(a) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsZero returns true if the Address is not set to any value.
 func (a Address) IsZero() bool {
 	return a.Equal(ZeroAddress)

--- a/pkg/swarm/swarm_test.go
+++ b/pkg/swarm/swarm_test.go
@@ -81,3 +81,21 @@ func TestAddress_jsonMarshalling(t *testing.T) {
 		t.Error("unmarshalled address is not equal to the original")
 	}
 }
+
+func TestAddress_MemberOf(t *testing.T) {
+	a1 := swarm.MustParseHexAddress("24798dd5a470e927fa")
+	a2 := swarm.MustParseHexAddress("24798dd5a470e927fa")
+	a3 := swarm.MustParseHexAddress("24798dd5a470e927fb")
+	a4 := swarm.MustParseHexAddress("24798dd5a470e927fc")
+
+	set1 := []swarm.Address{a2, a3}
+	if !a1.MemberOf(set1) {
+		t.Fatal("expected addr as member")
+	}
+
+	set2 := []swarm.Address{a3, a4}
+	if a1.MemberOf(set2) {
+		t.Fatal("expected addr not member")
+	}
+
+}


### PR DESCRIPTION
This PR changes the way we do the GC in localstore. Previous approach was locking the database for quite a long time, causing other protocols to slow down for a significant amount of time. This changeset introduces a flag that indicates whether gc is running, and when it does - chunk addresses that are changed in the database are logged to a slice. Once the gc collects enough candidates, it checks the slice for possible dirty candidates, leaving the dirty ones outside the GC round, then commits the result to leveldb.

Tested on our staging cluster and shows an order of magnitude improvement in the time we spend under lock while garbage collection is running.

The slice of dirty addresses can later be optimized to be a cuckoo or a bloom filter.