### PR TITLE
add metrics to track number of cheques

### DIFF
--- a/pkg/settlement/swap/metrics.go
+++ b/pkg/settlement/swap/metrics.go
@@ -38,13 +38,13 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "cheques_received",
-			Help:      "Amount of cheques received from peers",
+			Help:      "Number of cheques received from peers",
 		}),
 		ChequesSent: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "cheques_sent",
-			Help:      "Amount of cheques sent to peer",
+			Help:      "Number of cheques sent to peers",
 		}),
 		ChequesRejected: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/settlement/swap/metrics.go
+++ b/pkg/settlement/swap/metrics.go
@@ -12,6 +12,8 @@ import (
 type metrics struct {
 	TotalReceived    prometheus.Counter
 	TotalSent        prometheus.Counter
+	ChequesReceived  prometheus.Counter
+	ChequesSent      prometheus.Counter
 	ChequesRejected  prometheus.Counter
 	AvailableBalance prometheus.Gauge
 }
@@ -31,6 +33,18 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "total_sent",
 			Help:      "Amount of tokens sent to peers (costs paid by the node)",
+		}),
+		ChequesReceived: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "cheques_received",
+			Help:      "Amount of cheques received from peers",
+		}),
+		ChequesSent: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "cheques_sent",
+			Help:      "Amount of cheques sent to peer",
 		}),
 		ChequesRejected: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/settlement/swap/swap.go
+++ b/pkg/settlement/swap/swap.go
@@ -101,6 +101,7 @@ func (s *Service) ReceiveCheque(ctx context.Context, peer swarm.Address, cheque 
 	}
 
 	s.metrics.TotalReceived.Add(float64(amount.Uint64()))
+	s.metrics.ChequesReceived.Inc()
 
 	return s.notifyPaymentFunc(peer, amount)
 }
@@ -129,6 +130,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int) 
 	s.metrics.AvailableBalance.Set(bal)
 	amountFloat, _ := big.NewFloat(0).SetInt(amount).Float64()
 	s.metrics.TotalSent.Add(amountFloat)
+	s.metrics.ChequesSent.Inc()
 	return nil
 }
 


### PR DESCRIPTION
adds more metrics so we can easily tell how much cheque traffic is actually happening. hopefully this can give some insight on why there are so many `eth_Call` operations.