### PR TITLE
kademlia: wait on peer before retrying after connect err

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -309,6 +309,11 @@ func (k *Kad) manage() {
 								}
 								k.logger.Debugf("peer not reachable from kademlia %s: %v", bzzAddr.String(), err)
 								k.logger.Warningf("peer not reachable when attempting to connect")
+
+								k.waitNextMu.Lock()
+								k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
+								k.waitNextMu.Unlock()
+
 								// continue to next
 								return nil
 							}
@@ -382,6 +387,11 @@ func (k *Kad) manage() {
 					}
 					k.logger.Debugf("peer not reachable from kademlia %s: %v", bzzAddr.String(), err)
 					k.logger.Warningf("peer not reachable when attempting to connect")
+
+					k.waitNextMu.Lock()
+					k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
+					k.waitNextMu.Unlock()
+
 					// continue to next
 					return false, false, nil
 				}

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -310,9 +310,11 @@ func (k *Kad) manage() {
 								k.logger.Debugf("peer not reachable from kademlia %s: %v", bzzAddr.String(), err)
 								k.logger.Warningf("peer not reachable when attempting to connect")
 
-								//k.waitNextMu.Lock()
-								//k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
-								//k.waitNextMu.Unlock()
+								k.waitNextMu.Lock()
+								if _, ok := k.waitNext[peer.String()]; !ok {
+									k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
+								}
+								k.waitNextMu.Unlock()
 
 								// continue to next
 								return nil
@@ -389,7 +391,9 @@ func (k *Kad) manage() {
 					k.logger.Warningf("peer not reachable when attempting to connect")
 
 					k.waitNextMu.Lock()
-					k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
+					if _, ok := k.waitNext[peer.String()]; !ok {
+						k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
+					}
 					k.waitNextMu.Unlock()
 
 					// continue to next

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -311,7 +311,7 @@ func (k *Kad) manage() {
 								k.logger.Warningf("peer not reachable when attempting to connect")
 
 								k.waitNextMu.Lock()
-								k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
+								k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
 								k.waitNextMu.Unlock()
 
 								// continue to next
@@ -389,7 +389,7 @@ func (k *Kad) manage() {
 					k.logger.Warningf("peer not reachable when attempting to connect")
 
 					k.waitNextMu.Lock()
-					k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(shortRetry)}
+					k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
 					k.waitNextMu.Unlock()
 
 					// continue to next

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -310,9 +310,9 @@ func (k *Kad) manage() {
 								k.logger.Debugf("peer not reachable from kademlia %s: %v", bzzAddr.String(), err)
 								k.logger.Warningf("peer not reachable when attempting to connect")
 
-								k.waitNextMu.Lock()
-								k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
-								k.waitNextMu.Unlock()
+								//k.waitNextMu.Lock()
+								//k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
+								//k.waitNextMu.Unlock()
 
 								// continue to next
 								return nil

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -312,6 +312,7 @@ func (k *Kad) manage() {
 
 								k.waitNextMu.Lock()
 								if _, ok := k.waitNext[peer.String()]; !ok {
+									// don't override existing data in the map
 									k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
 								}
 								k.waitNextMu.Unlock()
@@ -392,6 +393,7 @@ func (k *Kad) manage() {
 
 					k.waitNextMu.Lock()
 					if _, ok := k.waitNext[peer.String()]; !ok {
+						// don't override existing data in the map
 						k.waitNext[peer.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry)}
 					}
 					k.waitNextMu.Unlock()

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -44,6 +44,7 @@ var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cT
 // A more in depth testing of the functionality in `manage()` is explicitly
 // tested in TestManage below.
 func TestNeighborhoodDepth(t *testing.T) {
+	t.Skip("flaking")
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{})

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -578,7 +578,6 @@ func TestAddressBookPrune(t *testing.T) {
 	addr := test.RandomAddressAt(base, 1)
 	addr1 := test.RandomAddressAt(base, 1)
 	addr2 := test.RandomAddressAt(base, 1)
-	addr3 := test.RandomAddressAt(base, 1)
 
 	p, err := ab.Get(nonConnPeer.Overlay)
 	if err != nil {
@@ -621,16 +620,6 @@ func TestAddressBookPrune(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	// add one valid peer to initiate the retry, check connection and failed connection counters
-	addOne(t, signer, kad, ab, addr3)
-	waitCounter(t, &conns, 1)
-	waitCounter(t, &failedConns, 1)
-
-	_, err = ab.Get(nonConnPeer.Overlay)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	time.Sleep(50 * time.Millisecond)
 	addOne(t, signer, kad, ab, addr2)
 	waitCounter(t, &conns, 1)
 	waitCounter(t, &failedConns, 1)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -578,6 +578,7 @@ func TestAddressBookPrune(t *testing.T) {
 	addr := test.RandomAddressAt(base, 1)
 	addr1 := test.RandomAddressAt(base, 1)
 	addr2 := test.RandomAddressAt(base, 1)
+	addr3 := test.RandomAddressAt(base, 1)
 
 	p, err := ab.Get(nonConnPeer.Overlay)
 	if err != nil {
@@ -620,6 +621,14 @@ func TestAddressBookPrune(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	// add one valid peer to initiate the retry, check connection and failed connection counters
+	addOne(t, signer, kad, ab, addr3)
+	waitCounter(t, &conns, 1)
+	waitCounter(t, &failedConns, 1)
+
+	_, err = ab.Get(nonConnPeer.Overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
 	addOne(t, signer, kad, ab, addr2)
 	waitCounter(t, &conns, 1)
 	waitCounter(t, &failedConns, 1)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -44,7 +44,6 @@ var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cT
 // A more in depth testing of the functionality in `manage()` is explicitly
 // tested in TestManage below.
 func TestNeighborhoodDepth(t *testing.T) {
-	t.Skip("flaking")
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(&conns, nil, kademlia.Options{})

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -629,6 +629,8 @@ func TestAddressBookPrune(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(50 * time.Millisecond)
 	addOne(t, signer, kad, ab, addr2)
 	waitCounter(t, &conns, 1)
 	waitCounter(t, &failedConns, 1)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -496,6 +496,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 
 	if err := s.connectionBreaker.Execute(func() error { return s.host.Connect(ctx, *info) }); err != nil {
 		if errors.Is(err, breaker.ErrClosed) {
+			s.metrics.ConnectBreakerCount.Inc()
 			return nil, p2p.NewConnectionBackoffError(err, s.connectionBreaker.ClosedUntil())
 		}
 		return nil, err

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -20,6 +20,7 @@ type metrics struct {
 	BlocklistedPeerCount    prometheus.Counter
 	BlocklistedPeerErrCount prometheus.Counter
 	DisconnectCount         prometheus.Counter
+	ConnectBreakerCount     prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -67,6 +68,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "disconnect_count",
 			Help:      "Number of peers we've disconnected from (initiated locally).",
+		}),
+		ConnectBreakerCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "connect_breaker_count",
+			Help:      "Number of times we got a closed breaker while connecting to another peer.",
 		}),
 	}
 }


### PR DESCRIPTION
Adds a wait to wait before retrying a peer that we failed connecting to. Observed on staging.