### PR TITLE
kademlia: check peer sanctioned when connecting on balanced loop

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -244,11 +244,10 @@ func (k *Kad) manage() {
 			// attempt balanced connection first
 			err := func() error {
 				// for each bin
-				k.waitNextMu.Lock()
-				wnCopy := k.waitNext
-				k.waitNextMu.Unlock()
 				spf := func(peer swarm.Address) bool {
-					if next, ok := wnCopy[peer.String()]; ok && time.Now().Before(next.tryAfter) {
+					k.waitNextMu.Lock()
+					defer k.waitNextMu.Unlock()
+					if next, ok := k.waitNext[peer.String()]; ok && time.Now().Before(next.tryAfter) {
 						return true
 					}
 					return false


### PR DESCRIPTION
the balanced kademlia part does not check the fact that a peer might be sanctioned. i am adding a check to the `closestPeer` function, which should improve the situation. symptom is that peers just constantly try to connect to each other. this is still visible on staging