### PR TITLE
localstore: fix data race in test

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -162,9 +162,6 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 	for _, item := range candidates {
 		if swarm.NewAddress(item.Address).MemberOf(db.dirtyAddresses) {
 			collectedCount--
-			if gcSize-collectedCount > target {
-				done = false
-			}
 			continue
 		}
 
@@ -189,6 +186,10 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 			return 0, false, err
 		}
 	}
+	if gcSize-collectedCount > target {
+		done = false
+	}
+
 	db.metrics.GCCommittedCounter.Add(float64(collectedCount))
 	db.gcSize.PutInBatch(batch, gcSize-collectedCount)
 

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -131,9 +131,9 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 
 		collectedCount++
 		if collectedCount >= gcBatchSize {
-			// batch size limit reached,
-			// another gc run is needed
-			done = false
+			// batch size limit reached, however we don't
+			// know whether another gc run is needed until
+			// we weed out the dirty entries below
 			return true, nil
 		}
 		return false, nil

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -732,14 +732,13 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	db := newTestDB(t, &Options{
 		Capacity: 10,
 	})
-
-	closed := db.close
+	defer db.Close()
 
 	testHookCollectGarbageChan := make(chan uint64)
 	t.Cleanup(setTestHookCollectGarbage(func(collectedCount uint64) {
 		select {
 		case testHookCollectGarbageChan <- collectedCount:
-		case <-closed:
+		case <-db.close:
 		}
 	}))
 

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -727,12 +727,11 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	defer func(s uint64) { gcBatchSize = s }(gcBatchSize)
 	gcBatchSize = 2
 
-	chunkCount := 15
+	chunkCount := 10
 
 	db := newTestDB(t, &Options{
 		Capacity: 10,
 	})
-	defer db.Close()
 
 	testHookCollectGarbageChan := make(chan uint64)
 	t.Cleanup(setTestHookCollectGarbage(func(collectedCount uint64) {
@@ -748,6 +747,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 		incomingChan <- struct{}{}
 		<-dirtyChan
 	}))
+	defer close(incomingChan)
 	addrs := make([]swarm.Address, 0)
 	mtx := new(sync.Mutex)
 	online := make(chan struct{})

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -725,7 +725,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 	// lower the maximal number of chunks in a single
 	// gc batch to ensure multiple batches.
 	defer func(s uint64) { gcBatchSize = s }(gcBatchSize)
-	gcBatchSize = 2
+	gcBatchSize = 1
 
 	chunkCount := 10
 
@@ -735,6 +735,13 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	testHookCollectGarbageChan := make(chan uint64)
 	t.Cleanup(setTestHookCollectGarbage(func(collectedCount uint64) {
+		// don't trigger if we haven't collected anything - this may
+		// result in a race condition when we inspect the gcsize below,
+		// causing the database to shut down while the cleanup to happen
+		// before the correct signal has been communicated here.
+		if collectedCount == 0 {
+			return
+		}
 		select {
 		case testHookCollectGarbageChan <- collectedCount:
 		case <-db.close:
@@ -772,7 +779,6 @@ func TestGC_NoEvictDirty(t *testing.T) {
 			}
 			dirtyChan <- struct{}{}
 		}
-
 	}()
 	<-online
 	// upload random chunks


### PR DESCRIPTION
seen in a different PR:
```
=== RUN   TestGC_NoEvictDirty/get_most_recent_synced_chunk
==================
WARNING: DATA RACE
Write at 0x000005415c48 by goroutine 85:
  github.com/ethersphere/bee/pkg/localstore.setTestHookCollectGarbage.func1()
      /Users/runner/work/bee/bee/pkg/localstore/gc_test.go:481 +0x4d
  testing.(*common).Cleanup.func1()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:880 +0x103
  testing.(*common).Cleanup.func1.1()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:874 +0x91
  testing.(*common).Cleanup.func1()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:881 +0x104
  testing.(*common).runCleanup()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:957 +0xca
  testing.tRunner.func2()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1117 +0x74
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1127 +0x22a

Previous read at 0x000005415c48 by goroutine 94:
  github.com/ethersphere/bee/pkg/localstore.(*DB).collectGarbageWorker()
      /Users/runner/work/bee/bee/pkg/localstore/gc.go:66 +0x20d

Goroutine 85 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1168 +0x5bb
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1439 +0xa6
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1123 +0x202
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1437 +0x612
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1345 +0x3b3
  main.main()
      _testmain.go:153 +0x236

Goroutine 94 (running) created at:
  github.com/ethersphere/bee/pkg/localstore.New()
      /Users/runner/work/bee/bee/pkg/localstore/localstore.go:419 +0x20f3
  github.com/ethersphere/bee/pkg/localstore.newTestDB()
      /Users/runner/work/bee/bee/pkg/localstore/localstore_test.go:160 +0x168
  github.com/ethersphere/bee/pkg/localstore.TestGC_NoEvictDirty()
      /Users/runner/work/bee/bee/pkg/localstore/gc_test.go:732 +0x10e
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1123 +0x202
==================
=== CONT  TestGC_NoEvictDirty
    testing.go:1038: race detected during execution of test
```

This was happening since the trigger was emitted with a `0` collected count when the dirty chunks have been detected, however the test would still detect the right numbers in the `gcSize`, triggering the cleanup too early while the last GC was still running, causing the race detector to flag this as a data race, as the cleanup would try to set the empty value back to the hook.

The other cause here is that we might be setting `done=false` in the initial candidates round, causing the gc to run another time unnecessarily. It should only be set after weeding out the dirty candidates from the list, I therefore removed the assignment in the initial round and moved it after the cleanup phase.