### PR TITLE
kademlia: balanced iterator erroneously exits but should continue

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -318,7 +318,7 @@ func (k *Kad) manage() {
 								k.waitNextMu.Unlock()
 
 								// continue to next
-								return nil
+								continue
 							}
 
 							k.waitNextMu.Lock()


### PR DESCRIPTION
The balanced kademlia erroneously exits upon an error connecting to a peer. The comment maintains that we should `// continue to next` but it instead just returns, invoking the normal kademlia connection iterator below.