### PR TITLE
flipflop: fix goroutine leak on subscription termination

### DIFF
--- a/pkg/flipflop/falling_edge.go
+++ b/pkg/flipflop/falling_edge.go
@@ -25,7 +25,7 @@ func NewFallingEdge(bufferTime, worstCase time.Duration) (in chan<- struct{}, ou
 		t:         bufferTime,
 		worstCase: worstCase,
 		buf:       make(chan struct{}, 1),
-		out:       make(chan struct{}),
+		out:       make(chan struct{}, 1),
 		quit:      make(chan struct{}),
 	}
 
@@ -48,11 +48,17 @@ func (d *detector) work() {
 				worstCase = time.After(d.worstCase)
 			}
 		case <-waitWrite:
-			d.out <- struct{}{}
+			select {
+			case d.out <- struct{}{}:
+			default:
+			}
 			worstCase = nil
 			waitWrite = nil
 		case <-worstCase:
-			d.out <- struct{}{}
+			select {
+			case d.out <- struct{}{}:
+			default:
+			}
 			worstCase = nil
 			waitWrite = nil
 		}

--- a/pkg/flipflop/falling_edge.go
+++ b/pkg/flipflop/falling_edge.go
@@ -25,7 +25,7 @@ func NewFallingEdge(bufferTime, worstCase time.Duration) (in chan<- struct{}, ou
 		t:         bufferTime,
 		worstCase: worstCase,
 		buf:       make(chan struct{}, 1),
-		out:       make(chan struct{}, 1),
+		out:       make(chan struct{}),
 		quit:      make(chan struct{}),
 	}
 
@@ -50,14 +50,16 @@ func (d *detector) work() {
 		case <-waitWrite:
 			select {
 			case d.out <- struct{}{}:
-			default:
+			case <-d.quit:
+				return
 			}
 			worstCase = nil
 			waitWrite = nil
 		case <-worstCase:
 			select {
 			case d.out <- struct{}{}:
-			default:
+			case <-d.quit:
+				return
 			}
 			worstCase = nil
 			waitWrite = nil


### PR DESCRIPTION
Embarrassing goroutine leak spotted by @ldeffenb.
On termination of a subscribe pull subscription, the detector might have a timer that is already pending, with the select case already selecting on the timer expiration, this results in an attempt to write to an unbuffered channel that is never read from, since the listening goroutine does not try to drain the channel. Also, draining the channel would be a bit ugly, since we'd have to potentially write one value to the `in` channel then wait for the incoming message after the buffer timeout expires. So I have instead added a buffer of one and a non-blocking trigger of the output.