### PR TITLE
Missing defers

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -193,8 +193,6 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 	db.metrics.GCCommittedCounter.Add(float64(collectedCount))
 	db.gcSize.PutInBatch(batch, gcSize-collectedCount)
 
-	db.metrics.GCSize.Set(float64(gcSize-collectedCount))
-	db.gcSize.PutInBatch(batch, gcSize-collectedCount)
 	err = db.shed.WriteBatch(batch)
 	if err != nil {
 		db.metrics.GCErrorCounter.Inc()

--- a/pkg/localstore/subscription_pull.go
+++ b/pkg/localstore/subscription_pull.go
@@ -65,7 +65,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 	go func() {
 		defer clean()
 		defer db.subscritionsWG.Done()
-		db.metrics.SubscribePullStop.Inc()
+		defer db.metrics.SubscribePullStop.Inc()
 		// close the returned store.Descriptor channel at the end to
 		// signal that the subscription is done
 		defer close(chunkDescriptors)

--- a/pkg/localstore/subscription_push.go
+++ b/pkg/localstore/subscription_push.go
@@ -50,7 +50,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan swarm.Chunk, stop fun
 	go func() {
 		defer clean()
 		defer db.subscritionsWG.Done()
-		db.metrics.SubscribePushIterationDone.Inc()
+		defer db.metrics.SubscribePushIterationDone.Inc()
 		// close the returned chunkInfo channel at the end to
 		// signal that the subscription is done
 		defer close(chunks)


### PR DESCRIPTION
While looking at the various metrics around pull and push sync, I noticed that there was never any outstanding subscriptions.  Checking the code showed that the increment of the completion metric was occurring at the start of the goroutine instead of being deferred to the end.  This PR corrects that misteak (sic).