### PR TITLE
set bee image to beta and adjust README

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -35,6 +35,11 @@ From logs find URL line with `on goerli you can get both goerli eth and goerli b
 docker-compose logs -f bee-1
 ```
 
+Update services with
+```
+docker-compose pull && docker-compose up -d
+```
+
 ## Running multiple Bee nodes
 It is easy to run multiple bee nodes with docker compose by adding more services to `docker-compose.yaml`
 To do so, open `docker-compose.yaml`, copy lines 3-58 and past this after line 58.

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     command: full
 
   bee-1:
-    image: ethersphere/bee:0.5.3
+    image: ethersphere/bee:beta
     restart: unless-stopped
     environment:
       - BEE_API_ADDR


### PR DESCRIPTION
Not to have to update this file with every release we could go with something like this? Set image tag to `beta` every release is tagged with it and define upgrade/update as `docker-compose pull` (this will pull the latest image) `&& docker-compose up -d` (this will update running image