### PR TITLE
transaction: add extra gas everywhere

### DIFF
--- a/pkg/settlement/swap/transaction/transaction.go
+++ b/pkg/settlement/swap/transaction/transaction.go
@@ -166,6 +166,9 @@ func prepareTransaction(ctx context.Context, request *TxRequest, from common.Add
 		if err != nil {
 			return nil, err
 		}
+
+		gasLimit += gasLimit / 5 // add 20% on top
+
 	} else {
 		gasLimit = request.GasLimit
 	}


### PR DESCRIPTION
add an extra 20% gas to all transactions if the estimator is used.

deployment transactions can also run out of gas if multiple chequebooks are deployed in the same block. 