### PR TITLE
add fetch-depth: 0 to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
           go-version: 1.15
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker Login
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Goreleaser now fails on shallow clones https://github.com/goreleaser/goreleaser/pull/2135