### PR TITLE
pushsync: reduce logging

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -241,9 +241,6 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk) (rr *pb.R
 			return nil, fmt.Errorf("push price headers: read returned: %w", err)
 		}
 
-		ps.logger.Debugf("push price headers: returned target %v with price as %v, from peer %s", returnedTarget, returnedPrice, peer)
-		ps.logger.Debugf("push price headers: original target %v with price as %v, from peer %s", ch.Address(), receiptPrice, peer)
-
 		// check if returned price matches presumed price, if not, update price
 		if returnedPrice != receiptPrice {
 			err = ps.pricer.NotifyPeerPrice(peer, returnedPrice, returnedIndex) // save priceHeaders["price"] corresponding row for peer

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -236,7 +236,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk) (rr *pb.R
 		deferFuncs = append(deferFuncs, func() { go streamer.FullClose() })
 
 		returnedHeaders := streamer.Headers()
-		returnedTarget, returnedPrice, returnedIndex, err := headerutils.ParsePricingResponseHeaders(returnedHeaders)
+		_, returnedPrice, returnedIndex, err := headerutils.ParsePricingResponseHeaders(returnedHeaders)
 		if err != nil {
 			return nil, fmt.Errorf("push price headers: read returned: %w", err)
 		}


### PR DESCRIPTION
This invokes 2 lines of logging for every chunk we process and makes the console unusable. Reducing this for now