### PR TITLE
Price based routing

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -409,7 +409,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	}
 	b.localstoreCloser = storer
 
-	retrieve := retrieval.New(swarmAddress, storer, p2ps, kad, logger, acc, pricer, tracer)
+	retrieve := retrieval.New(swarmAddress, storer, p2ps, logger, acc, pricer, tracer)
 	tagService := tags.NewTags(stateStore, logger)
 	b.tagsCloser = tagService
 

--- a/pkg/pricer/pricer.go
+++ b/pkg/pricer/pricer.go
@@ -5,7 +5,6 @@
 package pricer
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -18,6 +17,8 @@ import (
 )
 
 var _ Interface = (*Pricer)(nil)
+
+var gPoPrice uint64
 
 // Pricer returns pricing information for chunk hashes and proximity orders
 type Interface interface {
@@ -37,12 +38,9 @@ type Interface interface {
 	CheapestPeer(addr swarm.Address, skipPeers []swarm.Address, allowUpstream bool) (swarm.Address, error)
 }
 
-var (
-	ErrPersistingBalancePeer = errors.New("failed to persist pricetable for peer")
-)
-
 type pricingPeer struct {
 	lock       sync.Mutex
+	address    swarm.Address
 	priceTable []uint64
 }
 
@@ -50,6 +48,7 @@ type Pricer struct {
 	pricingPeersMu sync.Mutex
 	pricingPeers   map[string]*pricingPeer
 	peerSuggester  topology.EachPeerer
+	lock           sync.Mutex
 	logger         logging.Logger
 	store          storage.StateStorer
 	overlay        swarm.Address
@@ -59,6 +58,7 @@ type Pricer struct {
 }
 
 func New(logger logging.Logger, store storage.StateStorer, overlay swarm.Address, poPrice uint64) *Pricer {
+	gPoPrice = poPrice
 	return &Pricer{
 		logger:       logger,
 		pricingPeers: make(map[string]*pricingPeer),
@@ -71,25 +71,13 @@ func New(logger logging.Logger, store storage.StateStorer, overlay swarm.Address
 // PriceTable returns the pricetable stored for the node
 // If not available, the default pricetable is provided
 func (s *Pricer) PriceTable() (priceTable []uint64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	if len(s.priceTable) > 0 {
-		return s.priceTable
+		prt := make([]uint64, len(s.priceTable))
+		copy(prt, s.priceTable)
+		return prt
 	}
-	return s.defaultPriceTable()
-}
-
-// peerPriceTable returns the price table stored for the given peer.
-// If we can't get price table from store, we return the default price table
-func (s *Pricer) peerPriceTable(peer swarm.Address) (priceTable []uint64) {
-	pricingPeer, err := s.getPricingPeer(peer)
-	// this never happens as getPricingPeer has no error branch currently
-	if err != nil {
-		return s.defaultPriceTable()
-	}
-
-	if len(pricingPeer.priceTable) > 0 {
-		return pricingPeer.priceTable
-	}
-
 	return s.defaultPriceTable()
 }
 
@@ -121,86 +109,118 @@ func (s *Pricer) PriceForPeer(peer, chunk swarm.Address) uint64 {
 func (s *Pricer) priceWithIndexForPeer(peer, chunk swarm.Address) (price uint64, index uint8) {
 	proximity := swarm.Proximity(s.overlay.Bytes(), chunk.Bytes())
 	neighborhoodDepth := s.neighborhoodDepth()
+	peerproximity := swarm.Proximity(peer.Bytes(), chunk.Bytes())
 
-	priceTable := s.PriceTable()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	if int(proximity) >= len(priceTable) {
-		proximity = uint8(len(priceTable) - 1)
+	if len(s.priceTable) == 0 {
+		if proximity >= neighborhoodDepth {
+			proximity = neighborhoodDepth
+			if peerproximity >= neighborhoodDepth {
+				return 0, proximity
+			}
+		}
+		return s.defaultPrice(proximity), proximity
+	}
+
+	if int(proximity) >= len(s.priceTable) {
+		proximity = uint8(len(s.priceTable) - 1)
 	}
 
 	if proximity >= neighborhoodDepth {
 		proximity = neighborhoodDepth
-		peerproximity := swarm.Proximity(peer.Bytes(), chunk.Bytes())
 		if peerproximity >= neighborhoodDepth {
 			return 0, proximity
 		}
 	}
 
-	return priceTable[proximity], proximity
+	return s.priceTable[proximity], proximity
 }
 
 // pricePO returns the price for a PO from the table stored for the node.
 func (s *Pricer) pricePO(po uint8) (uint64, error) {
-	priceTable := s.PriceTable()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	proximity := po
-	if int(po) >= len(priceTable) {
-		proximity = uint8(len(priceTable) - 1)
+	if len(s.priceTable) == 0 {
+		return s.defaultPrice(po), nil
 	}
 
-	return priceTable[proximity], nil
+	proximity := po
+	if int(po) >= len(s.priceTable) {
+		proximity = uint8(len(s.priceTable) - 1)
+	}
+
+	return s.priceTable[proximity], nil
 }
 
 // PeerPrice returns the price for the PO of a chunk from the table stored for the given peer.
 // Taking into consideration that the peer might be an in-neighborhood peer,
 // if the chunk is at least neighborhood depth proximate to both the node and the peer, the price is 0
 func (s *Pricer) PeerPrice(peer, chunk swarm.Address) uint64 {
-	proximity := swarm.Proximity(peer.Bytes(), chunk.Bytes())
+
+	neighborhoodDepth := s.neighborhoodDepth()
+	proximity := swarm.Proximity(s.overlay.Bytes(), chunk.Bytes())
+	peerproximity := swarm.Proximity(peer.Bytes(), chunk.Bytes())
+
+	pricingPeer, err := s.getPricingPeer(peer)
+	if err != nil {
+		if peerproximity >= neighborhoodDepth {
+			peerproximity = neighborhoodDepth
+			if proximity >= neighborhoodDepth {
+				return 0
+			}
+		}
+		return s.defaultPrice(peerproximity)
+	}
+
+	pricingPeer.lock.Lock()
+	defer pricingPeer.lock.Unlock()
+
+	if len(pricingPeer.priceTable) == 0 {
+		if peerproximity >= neighborhoodDepth {
+			peerproximity = neighborhoodDepth
+			if proximity >= neighborhoodDepth {
+				return 0
+			}
+		}
+		return s.defaultPrice(peerproximity)
+	}
 
 	// Determine neighborhood depth presumed by peer based on pricetable rows
-	priceTable := s.peerPriceTable(peer)
-	peerNeighborhoodDepth := uint8(len(priceTable) - 1)
+	peerNeighborhoodDepth := uint8(len(pricingPeer.priceTable) - 1)
 
 	// determine whether the chunk is within presumed neighborhood depth of peer
-	if proximity >= peerNeighborhoodDepth {
+	if peerproximity >= peerNeighborhoodDepth {
+		peerproximity = peerNeighborhoodDepth
 		// determine if the chunk is within presumed neighborhood depth of peer to us
-		selfproximity := swarm.Proximity(s.overlay.Bytes(), chunk.Bytes())
-		if selfproximity >= peerNeighborhoodDepth {
+		if proximity >= peerNeighborhoodDepth {
 			return 0
 		}
 	}
 
-	price, err := s.peerPricePO(peer, proximity)
-
-	if err != nil {
-		price = s.defaultPrice(proximity)
-	}
+	price := pricingPeer.priceTable[peerproximity]
 
 	return price
 }
 
-// peerPricePO returns the price for a PO from the table stored for the given peer.
 func (s *Pricer) peerPricePO(peer swarm.Address, po uint8) (uint64, error) {
-	priceTable := s.peerPriceTable(peer)
-
-	proximity := po
-	if int(po) >= len(priceTable) {
-		proximity = uint8(len(priceTable) - 1)
+	pricingPeer, err := s.getPricingPeer(peer)
+	if err != nil {
+		return s.defaultPrice(po), nil
 	}
 
-	return priceTable[proximity], nil
+	pricingPeer.lock.Lock()
+	defer pricingPeer.lock.Unlock()
+
+	if int(po) >= len(pricingPeer.priceTable) {
+		po = uint8(len(pricingPeer.priceTable) - 1)
+	}
+
+	return pricingPeer.priceTable[po], nil
 
 }
-
-// peerPriceTableKey returns the price table storage key for the given peer.
-// func peerPriceTableKey(peer swarm.Address) string {
-// 	return fmt.Sprintf("%s%s", priceTablePrefix, peer.String())
-// }
-//
-// // priceTableKey returns the price table storage key for own price table
-// func priceTableKey() string {
-// 	return fmt.Sprintf("%s%s", priceTablePrefix, "self")
-// }
 
 func (s *Pricer) getPricingPeer(peer swarm.Address) (*pricingPeer, error) {
 	s.pricingPeersMu.Lock()
@@ -208,16 +228,11 @@ func (s *Pricer) getPricingPeer(peer swarm.Address) (*pricingPeer, error) {
 
 	peerData, ok := s.pricingPeers[peer.String()]
 	if !ok {
-		peerData = &pricingPeer{}
+		peerData = &pricingPeer{address: peer}
 		s.pricingPeers[peer.String()] = peerData
 	}
 
 	return peerData, nil
-}
-
-func (s *Pricer) storePriceTable(pricingPeer *pricingPeer, priceTable []uint64) error {
-	pricingPeer.priceTable = priceTable
-	return nil
 }
 
 // NotifyPriceTable should be called to notify pricer of changes in the peers pricetable
@@ -227,10 +242,7 @@ func (s *Pricer) NotifyPriceTable(peer swarm.Address, priceTable []uint64) error
 		return err
 	}
 
-	pricingPeer.lock.Lock()
-	defer pricingPeer.lock.Unlock()
-
-	return s.storePriceTable(pricingPeer, priceTable)
+	return pricingPeer.setPriceTable(priceTable)
 }
 
 func (s *Pricer) NotifyPeerPrice(peer swarm.Address, price uint64, index uint8) error {
@@ -244,44 +256,7 @@ func (s *Pricer) NotifyPeerPrice(peer swarm.Address, price uint64, index uint8) 
 		return err
 	}
 
-	var priceTable []uint64
-
-	// lock pricingPeer until update is done so that no other changes are discarded
-	pricingPeer.lock.Lock()
-	defer pricingPeer.lock.Unlock()
-
-	if len(pricingPeer.priceTable) > 0 {
-		priceTable = pricingPeer.priceTable
-	}
-
-	currentIndexDepth := uint8(len(priceTable)) - 1
-
-	// Simple case, already have index depth, single value change
-	if index <= currentIndexDepth {
-		// if value not updated, return
-		if priceTable[index] == price {
-			return nil
-		}
-		priceTable[index] = price
-		return s.storePriceTable(pricingPeer, priceTable)
-	}
-
-	// Complicated case, index is larger than depth of already known table
-	newPriceTable := make([]uint64, index+1)
-
-	// Copy previous content
-	_ = copy(newPriceTable, priceTable)
-
-	// Check how many rows are missing
-	numberOfMissingRows := index - currentIndexDepth
-
-	// make descending values for the missing rows, ending with newly learned value
-	for i := uint8(0); i < numberOfMissingRows; i++ {
-		currentrow := index - i
-		newPriceTable[currentrow] = price + uint64(i)*s.poPrice
-	}
-
-	return s.storePriceTable(pricingPeer, newPriceTable)
+	return pricingPeer.setPrice(index, price)
 }
 
 func (s *Pricer) defaultPriceTable() []uint64 {
@@ -415,4 +390,54 @@ func (s *Pricer) CheapestPeer(addr swarm.Address, skipPeers []swarm.Address, all
 func (s *Pricer) SetTopology(top topology.Driver) {
 	s.topology = top
 	s.peerSuggester = top
+}
+
+func (p *pricingPeer) setPrice(index uint8, price uint64) error {
+
+	var priceTable []uint64
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if len(p.priceTable) > 0 {
+		priceTable = p.priceTable
+	}
+
+	currentIndexDepth := uint8(len(priceTable)) - 1
+
+	// Simple case, already have index depth, single value change
+	if index <= currentIndexDepth {
+		// if value not updated, return
+		if priceTable[index] == price {
+			return nil
+		}
+		priceTable[index] = price
+		p.priceTable = priceTable
+		return nil
+	}
+
+	// Complicated case, index is larger than depth of already known table
+	newPriceTable := make([]uint64, index+1)
+
+	// Copy previous content
+	_ = copy(newPriceTable, priceTable)
+
+	// Check how many rows are missing
+	numberOfMissingRows := index - currentIndexDepth
+
+	// make descending values for the missing rows, ending with newly learned value
+	for i := uint8(0); i < numberOfMissingRows; i++ {
+		currentrow := index - i
+		newPriceTable[currentrow] = price + uint64(i)*gPoPrice
+	}
+
+	p.priceTable = newPriceTable
+	return nil
+}
+
+func (p *pricingPeer) setPriceTable(priceTable []uint64) error {
+	p.lock.Lock()
+	p.priceTable = priceTable
+	p.lock.Unlock()
+	return nil
 }

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -319,10 +319,10 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk) (rr *pb.R
 
 		defersFn()
 
-		// find the next closest peer
-		peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), skipPeers...)
+		// find the next cheapest peer
+		peer, err := ps.pricer.CheapestPeer(ch.Address(), skipPeers, false)
 		if err != nil {
-			// ClosestPeer can return ErrNotFound in case we are not connected to any peers
+			// CheapestPeer can return ErrNotFound in case we are not connected to any peers
 			// in which case we should return immediately.
 			// if ErrWantSelf is returned, it means we are the closest peer.
 			return nil, fmt.Errorf("closest peer: %w", err)

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -28,7 +28,6 @@ import (
 	storemock "github.com/ethersphere/bee/pkg/storage/mock"
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/topology"
 )
 
 // TestCallback tests that a  callback can be created and called.
@@ -221,29 +220,14 @@ func newTestNetStore(t *testing.T, recoveryFunc recovery.Callback) storage.Store
 	serverMockAccounting := accountingmock.NewAccounting()
 
 	pricerMock := pricermock.NewMockService()
-	peerID := swarm.MustParseHexAddress("deadbeef")
-	ps := mockPeerSuggester{eachPeerRevFunc: func(f topology.EachPeerFunc) error {
-		_, _, _ = f(peerID, 0)
-		return nil
-	}}
-	server := retrieval.New(swarm.ZeroAddress, mockStorer, nil, ps, logger, serverMockAccounting, pricerMock, nil)
+
+	server := retrieval.New(swarm.ZeroAddress, mockStorer, nil, logger, serverMockAccounting, pricerMock, nil)
 	recorder := streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
 	)
-	retrieve := retrieval.New(swarm.ZeroAddress, mockStorer, recorder, ps, logger, serverMockAccounting, pricerMock, nil)
+	retrieve := retrieval.New(swarm.ZeroAddress, mockStorer, recorder, logger, serverMockAccounting, pricerMock, nil)
 	ns := netstore.New(storer, recoveryFunc, retrieve, logger)
 	return ns
-}
-
-type mockPeerSuggester struct {
-	eachPeerRevFunc func(f topology.EachPeerFunc) error
-}
-
-func (s mockPeerSuggester) EachPeer(topology.EachPeerFunc) error {
-	return errors.New("not implemented")
-}
-func (s mockPeerSuggester) EachPeerRev(f topology.EachPeerFunc) error {
-	return s.eachPeerRevFunc(f)
 }
 
 type mockPssSender struct {


### PR DESCRIPTION
Pricer pkg: add CheapestPeer function
Retrieval, push sync: replace closestPeer calls with calls of CheapestPeer using AllowUpstream false to enable price based routing and circumvent requests floating around staying distant from destination
