### PR TITLE
run beekeeper tests on every push to pr

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -4,7 +4,8 @@ on:
   repository_dispatch:
     types: [trigger-beekeeper, beekeeper]
   pull_request:
-    types: [ready_for_review]
+    branches:
+      - '**'
 
 jobs:
   beekeeper:


### PR DESCRIPTION
Apparently there is not enough visibility for devs when infra tests fail after they are merged into master, with this PR infra tests will be executed with every push into PR and thus merge into master will be blocked until infra tests pass.