### PR TITLE
api: endpoints for stamp issuers

### DIFF
--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -21,6 +21,8 @@ type (
 	ListPinnedChunksResponse = listPinnedChunksResponse
 	UpdatePinCounter         = updatePinCounter
 	PostageCreateResponse    = postageCreateResponse
+	PostageStampResponse     = postageStampResponse
+	PostageStampsResponse    = postageStampsResponse
 )
 
 var (

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -91,6 +91,7 @@ func (s *server) postageGetStampsHandler(w http.ResponseWriter, r *http.Request)
 	}
 	jsonhttp.OK(w, resp)
 }
+
 func (s *server) postageGetStampHandler(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 	if idStr == "" || len(idStr) != 64 {

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -139,7 +139,7 @@ func TestPostageGetStamps(t *testing.T) {
 	jsonhttptest.Request(t, client, http.MethodGet, "/stamps", http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{
 			Stamps: []api.PostageStampResponse{
-				api.PostageStampResponse{
+				{
 					BatchID:     batchID,
 					Utilization: 0,
 				},

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -189,6 +189,20 @@ func (s *server) setupRouting() {
 		})),
 	)
 
+	handle(router, "/stamps", web.ChainHandlers(
+		s.gatewayModeForbidEndpointHandler,
+		web.FinalHandler(jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.postageGetStampsHandler),
+		})),
+	)
+
+	handle(router, "/stamps/{id}", web.ChainHandlers(
+		s.gatewayModeForbidEndpointHandler,
+		web.FinalHandler(jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.postageGetStampHandler),
+		})),
+	)
+
 	handle(router, "/stamps/{amount}/{depth}", web.ChainHandlers(
 		s.gatewayModeForbidEndpointHandler,
 		web.FinalHandler(jsonhttp.MethodHandler{

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -47,7 +47,7 @@ func (m *mockPostage) Add(s *postage.StampIssuer) {
 }
 
 func (m *mockPostage) StampIssuers() []*postage.StampIssuer {
-	panic("not implemented") // TODO: Implement
+	return []*postage.StampIssuer{m.i}
 }
 
 func (m *mockPostage) GetStampIssuer(_ []byte) (*postage.StampIssuer, error) {

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -112,7 +112,10 @@ func toString(buf []byte) string {
 }
 
 func (st *StampIssuer) Utilization() uint32 {
-	return 0
+	top := 0
+
+	//TODO return top bucket value for now
+	return top
 }
 
 func (s *StampIssuer) ID() []byte {

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -112,7 +112,8 @@ func toString(buf []byte) string {
 }
 
 // Utilization returns the batch utilization in the form of
-// an integer between 0 and 4294967295.
+// an integer between 0 and 4294967295. Batch fullness can be
+// calculated with: max_bucket_value / 2 ^ (batch_depth - bucket_depth)
 func (st *StampIssuer) Utilization() uint32 {
 	top := uint32(0)
 

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -111,13 +111,21 @@ func toString(buf []byte) string {
 	return string(buf[i:])
 }
 
+// Utilization returns the batch utilization in the form of
+// an integer between 0 and 4294967295.
 func (st *StampIssuer) Utilization() uint32 {
-	top := 0
+	top := uint32(0)
 
-	//TODO return top bucket value for now
+	for _, v := range st.buckets {
+		if v > top {
+			top = v
+		}
+	}
+
 	return top
 }
 
+// ID returns the BatchID for this batch.
 func (s *StampIssuer) ID() []byte {
 	id := make([]byte, len(s.batchID))
 	copy(id, s.batchID)

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -110,3 +110,13 @@ func toString(buf []byte) string {
 	}
 	return string(buf[i:])
 }
+
+func (st *StampIssuer) Utilization() uint32 {
+	return 0
+}
+
+func (s *StampIssuer) ID() []byte {
+	id := make([]byte, len(s.batchID))
+	copy(id, s.batchID)
+	return id
+}


### PR DESCRIPTION
This PR adds two API endpoints as discussed with the JS team cc @agazso. These return either all available batches or the information about a specific batch and can be used to further build upon.
I did not add the OpenAPI spec and realised that it also doesn't exist for the other API endpoint (POST). And considering the amount of changes of the openapi spec on `master` I would suggest to postpone this in a few days, so that we can first rebase the storage incentives branch over `master, then deal with this, if there's no objection.