### PR TITLE
publish docker image to quay.io as well

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -140,8 +140,11 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event.action != 'beekeeper' && success()
         run: |
           docker tag registry.localhost:5000/ethersphere/bee:latest ethersphere/bee:latest
+          docker tag registry.localhost:5000/ethersphere/bee:latest quay.io/ethersphere/bee:latest
           printf ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          printf ${{ secrets.QUAY_PASSWORD }} | docker login --username ${{QUAY_USERNAME}} quay.io --password-stdin
           docker push ethersphere/bee:latest
+          docker push quay.io/ethersphere/bee:latest
           echo RUN_TYPE="MERGE RUN" >> $GITHUB_ENV
       - name: Set IMAGE_DIGEST variable
         if: github.ref == 'refs/heads/master' && github.event.action != 'beekeeper' && success()

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -142,7 +142,7 @@ jobs:
           docker tag registry.localhost:5000/ethersphere/bee:latest ethersphere/bee:latest
           docker tag registry.localhost:5000/ethersphere/bee:latest quay.io/ethersphere/bee:latest
           printf ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-          printf ${{ secrets.QUAY_PASSWORD }} | docker login --username ${{QUAY_USERNAME}} quay.io --password-stdin
+          printf ${{ secrets.QUAY_PASSWORD }} | docker login --username ${{ secrets.QUAY_USERNAME }} quay.io --password-stdin
           docker push ethersphere/bee:latest
           docker push quay.io/ethersphere/bee:latest
           echo RUN_TYPE="MERGE RUN" >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,12 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Quay Login
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          echo "${QUAY_PASSWORD}" | docker login --username "${QUAY_USERNAME}" quay.io --password-stdin
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -230,6 +230,7 @@ brews:
 dockers:
 - image_templates:
   - "ethersphere/bee:{{ .Version }}-amd64"
+  - "quay.io/ethersphere/bee:{{ .Version }}-amd64"
   use_buildx: true
   ids:
     - linux
@@ -244,6 +245,7 @@ dockers:
   - "--label=org.opencontainers.image.version={{.Version}}"
 - image_templates:
   - "ethersphere/bee:{{ .Version }}-armv7"
+  - "quay.io/ethersphere/bee:{{ .Version }}-armv7"
   use_buildx: true
   ids:
     - linux
@@ -259,6 +261,7 @@ dockers:
   - "--label=org.opencontainers.image.version={{.Version}}"
 - image_templates:
   - "ethersphere/bee:{{ .Version }}-arm64v8"
+  - "quay.io/ethersphere/bee:{{ .Version }}-arm64v8"
   use_buildx: true
   ids:
     - linux
@@ -297,3 +300,28 @@ docker_manifests:
   - ethersphere/bee:{{ .Version }}-amd64
   - ethersphere/bee:{{ .Version }}-armv7
   - ethersphere/bee:{{ .Version }}-arm64v8
+- name_template: quay.io/ethersphere/bee:{{ .Major }}
+  image_templates:
+  - quay.io/ethersphere/bee:{{ .Version }}-amd64
+  - quay.io/ethersphere/bee:{{ .Version }}-armv7
+  - quay.io/ethersphere/bee:{{ .Version }}-arm64v8
+- name_template: quay.io/ethersphere/bee:{{ .Major }}.{{ .Minor }}
+  image_templates:
+  - quay.io/ethersphere/bee:{{ .Version }}-amd64
+  - quay.io/ethersphere/bee:{{ .Version }}-armv7
+  - quay.io/ethersphere/bee:{{ .Version }}-arm64v8
+- name_template: quay.io/ethersphere/bee:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+  image_templates:
+  - quay.io/ethersphere/bee:{{ .Version }}-amd64
+  - quay.io/ethersphere/bee:{{ .Version }}-armv7
+  - quay.io/ethersphere/bee:{{ .Version }}-arm64v8
+- name_template: quay.io/ethersphere/bee:latest
+  image_templates:
+  - quay.io/ethersphere/bee:{{ .Version }}-amd64
+  - quay.io/ethersphere/bee:{{ .Version }}-armv7
+  - quay.io/ethersphere/bee:{{ .Version }}-arm64v8
+- name_template: quay.io/ethersphere/bee:beta
+  image_templates:
+  - quay.io/ethersphere/bee:{{ .Version }}-amd64
+  - quay.io/ethersphere/bee:{{ .Version }}-armv7
+  - quay.io/ethersphere/bee:{{ .Version }}-arm64v8


### PR DESCRIPTION
With docker introducing pull requests limits projects publish images to multiple registries just to provide users options if you hit limit on one registry, quay is one of the alternatives