### PR TITLE
localstore: dont acquire batchMu for a single chunk that already exists

### DIFF
--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -58,7 +58,7 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 	if len(chs) == 1 {
 		has, err := db.retrievalDataIndex.Has(chunkToItem(chs[0]))
 		if err != nil {
-			return []bool{false}, err
+			return nil, err
 		}
 		if has {
 			return []bool{true}, nil

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -55,7 +55,7 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 	// this is an optimization that tries to optimize on already existing chunks
 	// not needing to acquire batchMu. This is in order to reduce lock contention
 	// when chunks are retried across the network for whatever reason.
-	if len(chs) == 1 {
+	if len(chs) == 1 && mode != storage.ModePutRequestPin && mode != storage.ModePutUploadPin {
 		has, err := db.retrievalDataIndex.Has(chunkToItem(chs[0]))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR optimizes the way we acquire the `batchMu` in localstore for a single chunk.

In `pushsync`, chunks may be resent over the network. However, if a chunk already exists, the lock must not be acquired. This should improve lock contention on chunks which are retried, but as well leave the current situation in which two copies of the same chunk which are competing over the same lock will not be aware of each other. In order to solve this edge case, some sort of detection of inflight writes would be necessary, with result propagation to potentially multiple writers.