### PR TITLE
Receipts in Neighborhood sync

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -144,7 +144,9 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	// if the peer is closer to the chunk, we were selected for replication. Return early.
 	if dcmp, _ := swarm.DistanceCmp(chunk.Address().Bytes(), p.Address.Bytes(), ps.address.Bytes()); dcmp == 1 {
 		if ps.topologyDriver.IsWithinDepth(chunk.Address()) {
-			_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
+			ctxd, _ := context.WithTimeout(context.Background(), timeToWaitForPushsyncToNeighbor)
+
+			_, err = ps.storer.Put(ctxd, storage.ModePutSync, chunk)
 			if err != nil {
 				ps.logger.Errorf("pushsync: chunk store: %v", err)
 			}
@@ -155,7 +157,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 			// return back receipt
 			receipt := pb.Receipt{Address: chunk.Address().Bytes(), Signature: signature}
-			if err := w.WriteMsgWithContext(ctx, &receipt); err != nil {
+			if err := w.WriteMsgWithContext(ctxd, &receipt); err != nil {
 				return fmt.Errorf("send receipt to peer %s: %w", p.Address.String(), err)
 			}
 
@@ -229,7 +231,15 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 						err = fmt.Errorf("new stream for peer %s: %w", peer.String(), err)
 						return
 					}
-					defer streamer.Close()
+
+					defer func() {
+						if err != nil {
+							ps.metrics.TotalErrors.Inc()
+							_ = streamer.Reset()
+						} else {
+							_ = streamer.FullClose()
+						}
+					}()
 
 					w := protobuf.NewWriter(streamer)
 					ctx, cancel = context.WithTimeout(ctx, timeToWaitForPushsyncToNeighbor)
@@ -244,13 +254,11 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 						Stamp:   stamp,
 					})
 					if err != nil {
-						_ = streamer.Reset()
 						return
 					}
 
 					var receipt pb.Receipt
-					if err := r.ReadMsgWithContext(ctx, &receipt); err != nil {
-						_ = streamer.Reset()
+					if err = r.ReadMsgWithContext(ctx, &receipt); err != nil {
 						return
 					}
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -151,13 +151,9 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			if err != nil {
 				ps.logger.Errorf("pushsync: chunk store: %v", err)
 			}
-			signature, err := ps.signer.Sign(ch.Address)
-			if err != nil {
-				return fmt.Errorf("receipt signature: %w", err)
-			}
 
 			// return back receipt
-			receipt := pb.Receipt{Address: chunk.Address().Bytes(), Signature: signature}
+			receipt := pb.Receipt{Address: chunk.Address().Bytes()}
 			if err := w.WriteMsgWithContext(ctxd, &receipt); err != nil {
 				return fmt.Errorf("send receipt to peer %s: %w", p.Address.String(), err)
 			}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -144,23 +144,27 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	// if the peer is closer to the chunk, we were selected for replication. Return early.
 	if dcmp, _ := swarm.DistanceCmp(chunk.Address().Bytes(), p.Address.Bytes(), ps.address.Bytes()); dcmp == 1 {
 		if ps.topologyDriver.IsWithinDepth(chunk.Address()) {
-			ctxd, _ := context.WithTimeout(context.Background(), timeToWaitForPushsyncToNeighbor)
+			ctxd, canceld := context.WithTimeout(context.Background(), timeToWaitForPushsyncToNeighbor)
+			defer canceld()
 
 			_, err = ps.storer.Put(ctxd, storage.ModePutSync, chunk)
 			if err != nil {
+				fmt.Println("I")
 				ps.logger.Errorf("pushsync: chunk store: %v", err)
 			}
 			signature, err := ps.signer.Sign(ch.Address)
 			if err != nil {
+				fmt.Println("II")
 				return fmt.Errorf("receipt signature: %w", err)
 			}
 
 			// return back receipt
 			receipt := pb.Receipt{Address: chunk.Address().Bytes(), Signature: signature}
 			if err := w.WriteMsgWithContext(ctxd, &receipt); err != nil {
+				fmt.Println("III")
 				return fmt.Errorf("send receipt to peer %s: %w", p.Address.String(), err)
 			}
-
+			fmt.Println("IV")
 			return ps.accounting.Debit(p.Address, price)
 		}
 
@@ -259,11 +263,16 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 					var receipt pb.Receipt
 					if err = r.ReadMsgWithContext(ctx, &receipt); err != nil {
+						fmt.Println("VI")
+						fmt.Println(err)
 						return
 					}
 
 					if !chunk.Address().Equal(swarm.NewAddress(receipt.Address)) {
 						// if the receipt is invalid, give up
+						fmt.Println("VII")
+						fmt.Println(chunk.Address())
+						fmt.Println(receipt.Address)
 						return
 					}
 


### PR DESCRIPTION
Let the closest peer know whether those he pushed towards in-neighborhood accepted the chunk by sending a receipt.
This circumvents accounting imbalances arised from refused out-of-neigbhborhood depth content (that might be caused by asymmetric neighborhood concepts)