### PR TITLE
sign checksums.txt with gpg key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,18 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: GPG user IDs
+        run: |
+          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
+          echo "name:        ${{ steps.import_gpg.outputs.name }}"
+          echo "email:       ${{ steps.import_gpg.outputs.email }}"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,17 +36,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
-        with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      - name: GPG user IDs
         run: |
-          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
-          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
-          echo "name:        ${{ steps.import_gpg.outputs.name }}"
-          echo "email:       ${{ steps.import_gpg.outputs.email }}"
+          echo "$GPG_PRIVATE_KEY" | gpg --import --passphrase "$GPG_PASSPHRASE" --batch --allow-secret-key-import
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -56,3 +50,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
           SCOOP_PAT: ${{ secrets.SCOOP_PAT }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,13 @@ snapshot:
 
 signs:
   - artifacts: checksum
+    args: [
+    "--pinentry-mode", "loopback",
+    "--passphrase", "{{ .Env.GPG_PASSPHRASE }}",
+    "-u", "{{ .Env.GPG_FINGERPRINT }}",
+    "--output", "${signature}",
+    "--detach-sign", "${artifact}",
+  ]
 
 archives:
   -

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,9 @@ builds:
 snapshot:
   name_template: "{{.Tag}}-snapshot"
 
+signs:
+  - artifacts: checksum
+
 archives:
   -
     id: scoop


### PR DESCRIPTION
Releases are signed using the project GPG key with key-ID `65207E638F11F36B` and fingerprint `C07E 8D0F CC74 221F 2C24  1EEE 6520 7E63 8F11 F36B`. The key can be fetched from most keyservers.
```
gpg --recv-keys 65207E638F11F36B
```
Set trust for the key
```
$ gpg --edit-key 65207E638F11F36B
gpg> trust
pub  rsa4096/65207E638F11F36B
     created: 2021-04-19  expires: 2022-04-19  usage: C
     trust: ultimate      validity: ultimate
sub  rsa4096/60760BAEEDEFB3E6
     created: 2021-04-19  expires: 2022-04-19  usage: S
[ultimate] (1). ethersphere-bee (github.com/ethersphere/bee project key) <security@ethswarm.org>

Please decide how far you trust this user to correctly verify other users' keys
(by looking at passports, checking fingerprints from different sources, etc.)

  1 = I don't know or won't say
  2 = I do NOT trust
  3 = I trust marginally
  4 = I trust fully
  5 = I trust ultimately
  m = back to the main menu

Your decision? 5
Do you really want to set this key to ultimate trust? (y/N) y
gpg> quit
```
Download and verify the signature on the checksum file:
```
gpg --verify bee_v0.6.0_checksums.txt.sig bee_v0.6.0_checksums.txt
```
After verifying the checksum file signature use `shasum` to verify the checksums of the release artifacts:
```
shasum --check bee_v0.6.0_checksums.txt
```