### PR TITLE
batchstore, kademlia: add radius as depth upper bound

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -392,6 +392,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	b.topologyCloser = kad
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.SetPickyNotifier(kad)
+	batchStore.SetRadiusSetter(kad)
 
 	paymentThreshold, ok := new(big.Int).SetString(o.PaymentThreshold, 10)
 	if !ok {

--- a/pkg/postage/batchstore/mock/store.go
+++ b/pkg/postage/batchstore/mock/store.go
@@ -123,3 +123,7 @@ func (bs *BatchStore) PutChainState(cs *postage.ChainState) error {
 func (bs *BatchStore) GetReserveState() *postage.Reservestate {
 	return bs.rs
 }
+
+func (bs *BatchStore) SetRadiusSetter(r postage.RadiusSetter) {
+	panic("not implemented")
+}

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -57,6 +57,7 @@ func TestBatchStoreUnreserveEvents(t *testing.T) {
 	batchstore.Capacity = batchstore.Exp2(16)
 
 	bStore, unreserved := setupBatchStore(t)
+	bStore.SetRadiusSetter(noopRadiusSetter{})
 	batches := make(map[string]*postage.Batch)
 
 	t.Run("new batches only", func(t *testing.T) {
@@ -139,6 +140,7 @@ func TestBatchStoreUnreserveAll(t *testing.T) {
 	batchstore.Capacity = batchstore.Exp2(16)
 
 	bStore, unreserved := setupBatchStore(t)
+	bStore.SetRadiusSetter(noopRadiusSetter{})
 	var batches [][]byte
 	// iterate starting from batchstore.DefaultDepth to maxPO
 	_, depth := batchstore.GetReserve(bStore)
@@ -211,6 +213,7 @@ func setupBatchStore(t *testing.T) (postage.Storer, map[string]uint8) {
 		return nil
 	}
 	bStore, _ := batchstore.New(stateStore, unreserveFunc)
+	bStore.SetRadiusSetter(noopRadiusSetter{})
 
 	// initialise chainstate
 	err = bStore.PutChainState(&postage.ChainState{
@@ -535,6 +538,7 @@ func TestBatchStore_Unreserve(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			store, unreserved := setupBatchStore(t)
+			store.SetRadiusSetter(noopRadiusSetter{})
 			batches := addBatch(t, store,
 				depthValue(initBatchDepth, 3),
 				depthValue(initBatchDepth, 4),
@@ -651,6 +655,7 @@ func TestBatchStore_Topup(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			store, unreserved := setupBatchStore(t)
+			store.SetRadiusSetter(noopRadiusSetter{})
 			batches := addBatch(t, store,
 				depthValue(initBatchDepth, 2),
 				depthValue(initBatchDepth, 3),
@@ -771,6 +776,7 @@ func TestBatchStore_Dilution(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			store, unreserved := setupBatchStore(t)
+			store.SetRadiusSetter(noopRadiusSetter{})
 			batches := addBatch(t, store,
 				depthValue(initBatchDepth, 2),
 				depthValue(initBatchDepth, 3),
@@ -799,6 +805,7 @@ func TestBatchStore_EvictExpired(t *testing.T) {
 	initBatchDepth := uint8(8)
 
 	store, unreserved := setupBatchStore(t)
+	store.SetRadiusSetter(noopRadiusSetter{})
 	batches := addBatch(t, store,
 		depthValue(initBatchDepth, 2),
 		depthValue(initBatchDepth, 3),

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -33,7 +33,7 @@ func TestBatchStorePut(t *testing.T) {
 
 	stateStore := mock.NewStateStore()
 	batchStore, _ := batchstore.New(stateStore, unreserve)
-
+	batchStore.SetRadiusSetter(noopRadiusSetter{})
 	batchStorePutBatch(t, batchStore, testBatch)
 
 	var got postage.Batch
@@ -46,6 +46,7 @@ func TestBatchStoreGetChainState(t *testing.T) {
 
 	stateStore := mock.NewStateStore()
 	batchStore, _ := batchstore.New(stateStore, nil)
+	batchStore.SetRadiusSetter(noopRadiusSetter{})
 
 	err := batchStore.PutChainState(testChainState)
 	if err != nil {
@@ -60,6 +61,7 @@ func TestBatchStorePutChainState(t *testing.T) {
 
 	stateStore := mock.NewStateStore()
 	batchStore, _ := batchstore.New(stateStore, nil)
+	batchStore.SetRadiusSetter(noopRadiusSetter{})
 
 	batchStorePutChainState(t, batchStore, testChainState)
 	var got postage.ChainState
@@ -101,3 +103,7 @@ func batchStorePutChainState(t *testing.T, st postage.Storer, cs *postage.ChainS
 		t.Fatalf("postage storer put chain state: %v", err)
 	}
 }
+
+type noopRadiusSetter struct{}
+
+func (_ noopRadiusSetter) SetRadius(_ uint8) {}

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -27,6 +27,11 @@ type Storer interface {
 	PutChainState(*ChainState) error
 	GetChainState() *ChainState
 	GetReserveState() *Reservestate
+	SetRadiusSetter(RadiusSetter)
+}
+
+type RadiusSetter interface {
+	SetRadius(uint8)
 }
 
 // Listener provides a blockchain event iterator.


### PR DESCRIPTION
This PR wires in the postage radius of responsibility into kademlia as an upper bound of the neighborhood depth, paving the way for agreement between connected neighborhoods and data persistence responsibility.