### PR TITLE
fix cors preflight headers bug

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -162,7 +162,7 @@ func (s *server) setupRouting() {
 				if o := r.Header.Get("Origin"); o != "" && s.checkOrigin(r) {
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
 					w.Header().Set("Access-Control-Allow-Origin", o)
-					w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method")
+					w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method, Swarm-Tag, Swarm-Pin, Swarm-Encrypt, Swarm-Index-Document, Swarm-Error-Document, Swarm-Collection")
 					w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS, POST, PUT, DELETE")
 					w.Header().Set("Access-Control-Max-Age", "3600")
 				}

--- a/pkg/debugapi/cors.go
+++ b/pkg/debugapi/cors.go
@@ -15,7 +15,7 @@ func (s *Service) corsHandler(h http.Handler) http.Handler {
 		if o := r.Header.Get("Origin"); o != "" && checkOrigin(r, s.corsAllowedOrigins) {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Origin", o)
-			w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method")
+			w.Header().Set("Access-Control-Allow-Headers", "Origin, Accept, Authorization, Content-Type, X-Requested-With, Access-Control-Request-Headers, Access-Control-Request-Method, Gas-Price, Gas-Limit")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS, POST, PUT, DELETE")
 			w.Header().Set("Access-Control-Max-Age", "3600")
 		}


### PR DESCRIPTION
Closes #1376.

It is not a completely clean solution, as currently, it returns all Bee's custom headers across all endpoints, while a better solution would be to return only those that the endpoint indeed supports. But that would require quite a more complex support structure in the code that I was not really keen to introduce. I think this will make the work done, but it will require having it in mind when new headers are added to propagate them in here as well.