### PR TITLE
batchstore: fix panic

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -291,7 +291,11 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	validStamp := postage.ValidStamp(batchStore)
 	post := postage.NewService(stateStore, chainID)
 
-	var postageContractService postagecontract.Interface
+	var (
+		postageContractService postagecontract.Interface
+		batchSvc               postage.EventUpdater
+	)
+
 	if !o.Standalone {
 		postageContractAddress, priceOracleAddress, found := listener.DiscoverAddresses(chainID)
 		if o.PostageContractAddress != "" {
@@ -313,7 +317,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		eventListener := listener.New(logger, swapBackend, postageContractAddress, priceOracleAddress)
 		b.listenerCloser = eventListener
 
-		_ = batchservice.New(batchStore, logger, eventListener)
+		batchSvc = batchservice.New(batchStore, logger, eventListener)
 
 		erc20Address, err := postagecontract.LookupERC20Address(p2pCtx, transactionService, postageContractAddress)
 		if err != nil {
@@ -394,6 +398,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.SetPickyNotifier(kad)
 	batchStore.SetRadiusSetter(kad)
+	batchSvc.Start()
 
 	paymentThreshold, ok := new(big.Int).SetString(o.PaymentThreshold, 10)
 	if !ok {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -25,10 +25,7 @@ type Interface interface {
 
 // New will create a new BatchService.
 func New(storer postage.Storer, logger logging.Logger, listener postage.Listener) Interface {
-	svc := &batchService{storer, logger, listener}
-	cs := svc.storer.GetChainState()
-	svc.listener.Listen(cs.Block+1, svc)
-	return svc
+	return &batchService{storer, logger, listener}
 }
 
 // Create will create a new batch with the given ID, owner value and depth and
@@ -109,4 +106,9 @@ func (svc *batchService) UpdateBlockNumber(blockNumber uint64) error {
 
 	svc.logger.Debugf("batch service: updated block height to %d", blockNumber)
 	return nil
+}
+
+func (svc *batchService) Start() {
+	cs := svc.storer.GetChainState()
+	svc.listener.Listen(cs.Block+1, svc)
 }

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -30,7 +30,6 @@ type store struct {
 	metrics       metrics             // metrics
 
 	radiusSetter postage.RadiusSetter // setter for radius notifications
-	//radiusSetterMu sync.Mutex
 }
 
 // New constructs a new postage batch store.
@@ -110,8 +109,10 @@ func (s *store) Put(b *postage.Batch, value *big.Int, depth uint8) error {
 	if err != nil {
 		return err
 	}
-	s.radiusSetter.SetRadius(s.rs.Radius)
 
+	if s.radiusSetter != nil {
+		s.radiusSetter.SetRadius(s.rs.Radius)
+	}
 	return s.store.Put(batchKey(b.ID), b)
 }
 
@@ -143,7 +144,11 @@ func (s *store) PutChainState(cs *postage.ChainState) error {
 	if err != nil {
 		return err
 	}
-	s.radiusSetter.SetRadius(s.rs.Radius)
+	// this needs to be improved, since we can miss some calls on
+	// startup. the same goes for the other call to radiusSetter
+	if s.radiusSetter != nil {
+		s.radiusSetter.SetRadius(s.rs.Radius)
+	}
 
 	return s.store.Put(chainStateKey, cs)
 }
@@ -155,9 +160,7 @@ func (s *store) GetChainState() *postage.ChainState {
 }
 
 func (s *store) SetRadiusSetter(r postage.RadiusSetter) {
-	//s.radiusSetterMu.Lock()
 	s.radiusSetter = r
-	//s.radiusSetterMu.Unlock()
 }
 
 // batchKey returns the index key for the batch ID used in the by-ID batch index.

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -17,6 +17,7 @@ type EventUpdater interface {
 	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int) error
 	UpdatePrice(price *big.Int) error
 	UpdateBlockNumber(blockNumber uint64) error
+	Start()
 }
 
 // Storer represents the persistence layer for batches on the current (highest

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -275,6 +275,8 @@ func (u *updater) UpdateBlockNumber(blockNumber uint64) error {
 	return nil
 }
 
+func (u *updater) Start() {}
+
 type mockFilterer struct {
 	filterLogEvents    []types.Log
 	subscriptionEvents []types.Log


### PR DESCRIPTION
fixes a panic that occurs on startup before kademlia instance is set to the batchstore. this is a bit problematic since we might miss some calls on startup. a sleep might be needed on the listener before it starts listening @ralph-pichler WDYT?