### PR TITLE
Slack/api metrics

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -44,7 +44,7 @@ func newMetrics() metrics {
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
-				Name:      "http_error_responses",
+				Name:      "reponse_error_codes",
 				Help:      "How many 5XX HTTP errors were returned",
 			},
 			[]string{"code", "method"},
@@ -68,8 +68,8 @@ func (s *server) pageviewMetricsHandler(h http.Handler) http.Handler {
 func (s *server) errorPageviewMetricsHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wrapper := NewErrorResponseWriter(w)
-		h.ServeHTTP(w, r)
-		if wrapper.statusCode >= 500 {
+		h.ServeHTTP(wrapper, r)
+		if wrapper.statusCode >= 400 {
 			s.metrics.ErrorPageViews.WithLabelValues(
 				fmt.Sprintf("%d", wrapper.statusCode),
 				r.Method,

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -44,7 +44,7 @@ func newMetrics() metrics {
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
-				Name:      "reponse_code_count",
+				Name:      "response_code_count",
 				Help:      "Response count grouped by status code",
 			},
 			[]string{"code", "method"},

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -5,9 +5,7 @@
 package api
 
 import (
-	// "bufio"
 	"fmt"
-	// "net"
 	"net/http"
 	"time"
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -19,6 +20,7 @@ type metrics struct {
 	RequestCount     prometheus.Counter
 	ResponseDuration prometheus.Histogram
 	PingRequestCount prometheus.Counter
+	ErrorPageViews   *prometheus.CounterVec
 }
 
 func newMetrics() metrics {
@@ -38,6 +40,15 @@ func newMetrics() metrics {
 			Help:      "Histogram of API response durations.",
 			Buckets:   []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}),
+		ErrorPageViews: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "http_error_responses",
+				Help:      "How many 5XX HTTP errors were returned",
+			},
+			[]string{"code", "method"},
+		),
 	}
 }
 
@@ -52,4 +63,32 @@ func (s *server) pageviewMetricsHandler(h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 		s.metrics.ResponseDuration.Observe(time.Since(start).Seconds())
 	})
+}
+
+func (s *server) errorPageviewMetricsHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapper := NewErrorResponseWriter(w)
+		h.ServeHTTP(w, r)
+		if wrapper.statusCode >= 500 {
+			s.metrics.ErrorPageViews.WithLabelValues(
+				fmt.Sprintf("%d", wrapper.statusCode),
+				r.Method,
+			).Inc()
+		}
+	})
+}
+
+type errResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func NewErrorResponseWriter(w http.ResponseWriter) *errResponseWriter {
+	// StatusOK is called by default if nothing else is called
+	return &errResponseWriter{w, http.StatusOK}
+}
+
+func (erw *errResponseWriter) WriteHeader(code int) {
+	erw.statusCode = code
+	erw.ResponseWriter.WriteHeader(code)
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -84,7 +84,9 @@ type UpgradedResponseWriter interface {
 	http.Pusher
 	http.Hijacker
 	http.Flusher
-	http.CloseNotifier
+	// staticcheck SA1019 CloseNotifier interface is required by gorilla compress handler
+	// nolint:staticcheck
+	http.CloseNotifier // skipcq: SCC-SA1019
 }
 
 type responseWriter struct {
@@ -110,5 +112,4 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.UpgradedResponseWriter.WriteHeader(code)
 	rw.wroteHeader = true
-	return
 }

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -178,7 +178,7 @@ func (s *server) setupRouting() {
 		handlers.CompressHandler,
 		// todo: add recovery handler
 		s.pageviewMetricsHandler,
-		s.errorPageviewMetricsHandler,
+		s.responseCodeMetricsHandler,
 		func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if o := r.Header.Get("Origin"); o != "" && s.checkOrigin(r) {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -177,8 +177,8 @@ func (s *server) setupRouting() {
 		httpaccess.NewHTTPAccessLogHandler(s.logger, logrus.InfoLevel, s.tracer, "api access"),
 		handlers.CompressHandler,
 		// todo: add recovery handler
-		s.pageviewMetricsHandler,
 		s.responseCodeMetricsHandler,
+		s.pageviewMetricsHandler,
 		func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if o := r.Header.Get("Origin"); o != "" && s.checkOrigin(r) {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -178,6 +178,7 @@ func (s *server) setupRouting() {
 		handlers.CompressHandler,
 		// todo: add recovery handler
 		s.pageviewMetricsHandler,
+		s.errorPageviewMetricsHandler,
 		func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if o := r.Header.Get("Origin"); o != "" && s.checkOrigin(r) {


### PR DESCRIPTION
Adding counter for error codes that are returned eg:
```
# TYPE bee_api_reponse_error_codes counter
bee_api_reponse_error_codes{code="404",method="GET"} 3
```