### PR TITLE
node: wait till synced with postage contract before starting node

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -392,7 +392,16 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.SetPickyNotifier(kad)
 	batchStore.SetRadiusSetter(kad)
-	batchSvc.Start()
+	syncedChan := batchSvc.Start()
+
+	// wait for the postage contract listener to sync
+	logger.Info("waiting to sync postage contract data, this may take a while... more info available in Debug loglevel")
+
+	// arguably this is not a very nice solution since we dont support
+	// interrupts at this stage of the application lifecycle. some changes
+	// would be needed on the cmd level to support context cancellation at
+	// this stage
+	<-syncedChan
 
 	paymentThreshold, ok := new(big.Int).SetString(o.PaymentThreshold, 10)
 	if !ok {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -108,7 +108,7 @@ func (svc *batchService) UpdateBlockNumber(blockNumber uint64) error {
 	return nil
 }
 
-func (svc *batchService) Start() {
+func (svc *batchService) Start() <-chan struct{} {
 	cs := svc.storer.GetChainState()
-	svc.listener.Listen(cs.Block+1, svc)
+	return svc.listener.Listen(cs.Block+1, svc)
 }

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -26,8 +26,8 @@ var (
 type mockListener struct {
 }
 
-func (*mockListener) Listen(from uint64, updater postage.EventUpdater) {}
-func (*mockListener) Close() error                                     { return nil }
+func (*mockListener) Listen(from uint64, updater postage.EventUpdater) <-chan struct{} { return nil }
+func (*mockListener) Close() error                                                     { return nil }
 
 func newMockListener() *mockListener {
 	return &mockListener{}

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -17,7 +17,7 @@ type EventUpdater interface {
 	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int) error
 	UpdatePrice(price *big.Int) error
 	UpdateBlockNumber(blockNumber uint64) error
-	Start()
+	Start() <-chan struct{}
 }
 
 // Storer represents the persistence layer for batches on the current (highest
@@ -38,5 +38,5 @@ type RadiusSetter interface {
 // Listener provides a blockchain event iterator.
 type Listener interface {
 	io.Closer
-	Listen(from uint64, updater EventUpdater)
+	Listen(from uint64, updater EventUpdater) <-chan struct{}
 }

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -279,7 +279,7 @@ func (u *updater) UpdateBlockNumber(blockNumber uint64) error {
 	return nil
 }
 
-func (u *updater) Start() {}
+func (u *updater) Start() <-chan struct{} { return nil }
 
 type mockFilterer struct {
 	filterLogEvents    []types.Log


### PR DESCRIPTION
this adds a small improvement of waiting till the contract listener stops paging at the application startup. this might lead to a slight unnecessary delay at startup but would guarantee syncing with the contract data so that nodes dont start receiving chunks before syncing with the chain, resulting in some chunks being dropped since the batch are not yet found, since the node is not synced.