### PR TITLE
localstore: simplify updategc logic, put to pullsync index when stamp valid

### DIFF
--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -221,6 +221,15 @@ func (db *DB) putRequest(batch *leveldb.Batch, binIDs map[uint8]uint64, item she
 		return false, 0, err
 	}
 
+	if !forceCache {
+		// if we are here it means the chunk has a valid stamp
+		// therefore we'd like to be able to pullsync it
+		err = db.pullIndex.PutInBatch(batch, item)
+		if err != nil {
+			return false, 0, err
+		}
+	}
+
 	return false, gcSizeChange, nil
 }
 

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -64,6 +64,7 @@ func TestModePutRequest(t *testing.T) {
 				}
 
 				newItemsCountTest(db.gcIndex, tc.count)(t)
+				newItemsCountTest(db.pullIndex, tc.count)(t)
 				newIndexGCSizeTest(db)(t)
 			})
 
@@ -83,6 +84,7 @@ func TestModePutRequest(t *testing.T) {
 				}
 
 				newItemsCountTest(db.gcIndex, tc.count)(t)
+				newItemsCountTest(db.pullIndex, tc.count)(t)
 				newIndexGCSizeTest(db)(t)
 			})
 		})

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -380,8 +380,9 @@ func TestModePutUpload_parallel(t *testing.T) {
 }
 
 // TestModePut_sameChunk puts the same chunk multiple times
-// and validates that all relevant indexes have only one item
-// in them.
+// and validates that all relevant indexes have the correct counts.
+// The test assumes that chunk fall into the reserve part of
+// the store.
 func TestModePut_sameChunk(t *testing.T) {
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -396,6 +397,18 @@ func TestModePut_sameChunk(t *testing.T) {
 				{
 					name:      "ModePutRequest",
 					mode:      storage.ModePutRequest,
+					pullIndex: true,
+					pushIndex: false,
+				},
+				{
+					name:      "ModePutRequestPin",
+					mode:      storage.ModePutRequest,
+					pullIndex: true,
+					pushIndex: false,
+				},
+				{
+					name:      "ModePutRequestCache",
+					mode:      storage.ModePutRequestCache,
 					pullIndex: false,
 					pushIndex: false,
 				},

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -191,7 +191,6 @@ func TestPinIndexesSync(t *testing.T) {
 		t.Fatal(err)
 	}
 	runCountsTest(t, "setUnPin", db, 1, 1, 0, 1, 0, 1)
-
 }
 
 func runCountsTest(t *testing.T, name string, db *DB, r, a, push, pull, pin, gc int) {


### PR DESCRIPTION
This PR adds the chunk to the pullIndex when the stamp is valid and received from a retrieve request. It also simplifies the logic in the updateGC method.