### PR TITLE
localstore: communicate schema incompatibility

### DIFF
--- a/pkg/localstore/migration.go
+++ b/pkg/localstore/migration.go
@@ -32,7 +32,10 @@ type migration struct {
 // schemaMigrations contains an ordered list of the database schemes, that is
 // in order to run data migrations in the correct sequence
 var schemaMigrations = []migration{
-	{name: DbSchemaCode, fn: func(db *DB) error { return nil }},
+	{name: DbSchemaCode, fn: func(_ *DB) error { return nil }},
+	{name: DbSchemaYuj, fn: func(_ *DB) error {
+		return errors.New("db schema incompatible. you must migrate your data manually. see the release notes for more info")
+	}},
 }
 
 func (db *DB) migrate(schemaName string) error {

--- a/pkg/localstore/schema.go
+++ b/pkg/localstore/schema.go
@@ -18,10 +18,14 @@ package localstore
 
 // The DB schema we want to use. The actual/current DB schema might differ
 // until migrations are run.
-var DbSchemaCurrent = DbSchemaCode
+var DbSchemaCurrent = DbSchemaYuj
 
 // There was a time when we had no schema at all.
 const DbSchemaNone = ""
 
 // DbSchemaCode is the first bee schema identifier
 const DbSchemaCode = "code"
+
+// DbSchemaYuj is the bee schema indentifier for storage incentives
+// initial iteration.
+const DbSchemaYuj = "yuj"


### PR DESCRIPTION
The DB schema changed with storage incentives. This needs to be communicated to the user which tries to update the binary unknowingly. We do this in a form of a data migration that always returns an error. Further details should be communicated in the release notes on how to migrate the nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1610)
<!-- Reviewable:end -->
