### PR TITLE
Using the correct http response codes when creating a resource

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -375,7 +375,9 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/403"    
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -47,7 +47,7 @@ paths:
               type: string
               format: binary
       responses:
-        "200":
+        "201":
           description: Ok
           headers:
             "swarm-tag":
@@ -138,7 +138,7 @@ paths:
               type: string
               format: binary
       responses:
-        "200":
+        "201":
           description: Ok
           headers:
             "swarm-tag":
@@ -198,7 +198,7 @@ paths:
               type: string
               format: binary
       responses:
-        "200":
+        "201":
           description: Ok
           headers:
             "swarm-tag":
@@ -451,7 +451,7 @@ paths:
       tags:
         - Root hash pinning
       responses:
-        "200":
+        "201":
           description: Pinning root hash with address
           content:
             application/json:
@@ -546,7 +546,7 @@ paths:
           required: false
           description: Recipient publickey
       responses:
-        "200":
+        "201":
           description: Subscribed to topic
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
@@ -761,7 +761,7 @@ paths:
           required: false
           description: An optional label for this batch
       responses:
-        "200":
+        "201":
           description: Returns the newly created postage batch ID
           content:
             application/json:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -482,7 +482,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
@@ -553,7 +553,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: Transaction hash of the deposit transaction
           content:
             application/json:
@@ -579,7 +579,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: Transaction hash of the withdraw transaction
           content:
             application/json:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -236,7 +236,7 @@ paths:
           required: true
           description: Underlay address of peer
       responses:
-        "200":
+        "201":
           description: Returns overlay address of connected peer
           content:
             application/json:
@@ -318,7 +318,7 @@ paths:
           required: true
           description: Swarm address of peer
       responses:
-        "200":
+        "201":
           description: Returns round trip time for given peer
           content:
             application/json:
@@ -430,7 +430,7 @@ paths:
             schema:
               $ref: "SwarmCommon.yaml#/components/schemas/WelcomeMessage"
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
@@ -482,7 +482,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: OK
           content:
             application/json:
@@ -553,7 +553,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: Transaction hash of the deposit transaction
           content:
             application/json:
@@ -579,7 +579,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "200":
+        "201":
           description: Transaction hash of the withdraw transaction
           content:
             application/json:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -236,7 +236,7 @@ paths:
           required: true
           description: Underlay address of peer
       responses:
-        "201":
+        "200":
           description: Returns overlay address of connected peer
           content:
             application/json:
@@ -318,7 +318,7 @@ paths:
           required: true
           description: Swarm address of peer
       responses:
-        "201":
+        "200":
           description: Returns round trip time for given peer
           content:
             application/json:
@@ -430,7 +430,7 @@ paths:
             schema:
               $ref: "SwarmCommon.yaml#/components/schemas/WelcomeMessage"
       responses:
-        "201":
+        "200":
           description: OK
           content:
             application/json:
@@ -482,7 +482,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "201":
+        "200":
           description: OK
           content:
             application/json:
@@ -553,7 +553,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "201":
+        "200":
           description: Transaction hash of the deposit transaction
           content:
             application/json:
@@ -579,7 +579,7 @@ paths:
       tags:
         - Chequebook
       responses:
-        "201":
+        "200":
           description: Transaction hash of the withdraw transaction
           content:
             application/json:

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -290,7 +290,7 @@ func TestPostageHeaderError(t *testing.T) {
 		})
 		t.Run(endpoint+": ok batch", func(t *testing.T) {
 			hexbatch := hex.EncodeToString(batchOk)
-			expCode := http.StatusOK
+			expCode := http.StatusCreated
 			jsonhttptest.Request(t, client, http.MethodPost, "/"+endpoint, expCode,
 				jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
 				jsonhttptest.WithRequestHeader(api.ContentTypeHeader, "application/octet-stream"),

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -95,7 +95,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
-	jsonhttp.OK(w, bytesPostResponse{
+	jsonhttp.Created(w, bytesPostResponse{
 		Reference: address,
 	})
 }

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -54,7 +54,7 @@ func TestBytes(t *testing.T) {
 
 	t.Run("upload", func(t *testing.T) {
 		chunkAddr := swarm.MustParseHexAddress(expHash)
-		jsonhttptest.Request(t, client, http.MethodPost, resource, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, resource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(content)),
 			jsonhttptest.WithExpectedJSONResponse(api.BytesPostResponse{
@@ -77,7 +77,7 @@ func TestBytes(t *testing.T) {
 
 	t.Run("upload-with-pinning", func(t *testing.T) {
 		var res api.BytesPostResponse
-		jsonhttptest.Request(t, client, http.MethodPost, resource, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, resource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(content)),
 			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "true"),

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -254,7 +254,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request, store
 	w.Header().Set("ETag", fmt.Sprintf("%q", manifestReference.String()))
 	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
-	jsonhttp.OK(w, bzzUploadResponse{
+	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: manifestReference,
 	})
 }

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -91,7 +91,7 @@ func TestBzzFiles(t *testing.T) {
 			},
 		})
 		address := swarm.MustParseHexAddress("f30c0aa7e9e2a0ef4c9b1b750ebfeaeb7c7c24da700bb089da19a46e3677824b")
-		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(tr),
 			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
@@ -141,7 +141,7 @@ func TestBzzFiles(t *testing.T) {
 			},
 		})
 		address := swarm.MustParseHexAddress("f30c0aa7e9e2a0ef4c9b1b750ebfeaeb7c7c24da700bb089da19a46e3677824b")
-		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestHeader(api.SwarmPinHeader, "true"),
 			jsonhttptest.WithRequestBody(tr),
@@ -176,7 +176,7 @@ func TestBzzFiles(t *testing.T) {
 
 		var resp api.BzzUploadResponse
 		jsonhttptest.Request(t, client, http.MethodPost,
-			fileUploadResource+"?name="+fileName, http.StatusOK,
+			fileUploadResource+"?name="+fileName, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithRequestHeader(api.SwarmEncryptHeader, "True"),
@@ -207,7 +207,7 @@ func TestBzzFiles(t *testing.T) {
 		rootHash := "4f9146b3813ccbd7ce45a18be23763d7e436ab7a3982ef39961c6f3cd4da1dcf"
 
 		jsonhttptest.Request(t, client, http.MethodPost,
-			fileUploadResource+"?name="+fileName, http.StatusOK,
+			fileUploadResource+"?name="+fileName, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
@@ -248,7 +248,7 @@ func TestBzzFiles(t *testing.T) {
 		</html>`
 
 		rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost,
-			fileUploadResource+"?name="+fileName, http.StatusOK,
+			fileUploadResource+"?name="+fileName, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(strings.NewReader(sampleHtml)),
 			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
@@ -287,7 +287,7 @@ func TestBzzFiles(t *testing.T) {
 		rootHash := "65148cd89b58e91616773f5acea433f7b5a6274f2259e25f4893a332b74a7e28"
 
 		jsonhttptest.Request(t, client, http.MethodPost,
-			fileUploadResource+"?name="+fileName, http.StatusOK,
+			fileUploadResource+"?name="+fileName, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
@@ -416,7 +416,7 @@ func TestBzzFilesRangeRequests(t *testing.T) {
 				testOpts = append(testOpts, jsonhttptest.WithRequestHeader(api.SwarmCollectionHeader, "True"))
 			}
 
-			jsonhttptest.Request(t, client, http.MethodPost, upload.uploadEndpoint, http.StatusOK,
+			jsonhttptest.Request(t, client, http.MethodPost, upload.uploadEndpoint, http.StatusCreated,
 				testOpts...,
 			)
 
@@ -541,7 +541,7 @@ func TestFeedIndirection(t *testing.T) {
 	}
 
 	// verify directory tar upload response
-	jsonhttptest.Request(t, client, http.MethodPost, "/bzz", http.StatusOK, options...)
+	jsonhttptest.Request(t, client, http.MethodPost, "/bzz", http.StatusCreated, options...)
 
 	if resp.Reference.String() == "" {
 		t.Fatalf("expected file reference, did not got any")

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -138,7 +138,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
-	jsonhttp.OK(w, chunkAddressResponse{Reference: chunk.Address()})
+	jsonhttp.Created(w, chunkAddressResponse{Reference: chunk.Address()})
 }
 
 func (s *server) chunkGetHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -61,7 +61,7 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
@@ -80,7 +80,7 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 
 	t.Run("pin-invalid-value", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
@@ -93,7 +93,7 @@ func TestChunkUploadDownload(t *testing.T) {
 		}
 	})
 	t.Run("pin-header-missing", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
@@ -106,7 +106,7 @@ func TestChunkUploadDownload(t *testing.T) {
 	})
 	t.Run("pin-ok", func(t *testing.T) {
 		address := chunk.Address()
-		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksEndpoint, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: address}),

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -109,7 +109,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request, storer
 	}
 
 	w.Header().Set(SwarmTagHeader, fmt.Sprint(tag.Uid))
-	jsonhttp.OK(w, bzzUploadResponse{
+	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: reference,
 	})
 }

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -404,7 +404,7 @@ func TestDirs(t *testing.T) {
 				}
 
 				// verify directory tar upload response
-				jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusOK, options...)
+				jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusCreated, options...)
 
 				if resp.Reference.String() == "" {
 					t.Fatalf("expected file reference, did not got any")
@@ -437,7 +437,7 @@ func TestDirs(t *testing.T) {
 					}
 
 					// verify directory tar upload response
-					jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusOK, options...)
+					jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusCreated, options...)
 
 					if resp.Reference.String() == "" {
 						t.Fatalf("expected file reference, did not got any")

--- a/pkg/api/gatewaymode_test.go
+++ b/pkg/api/gatewaymode_test.go
@@ -67,14 +67,14 @@ func TestGatewayMode(t *testing.T) {
 		})
 
 		// should work without pinning
-		jsonhttptest.Request(t, client, http.MethodPost, "/chunks", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/chunks", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 		)
 
 		jsonhttptest.Request(t, client, http.MethodPost, "/chunks/0773a91efd6547c754fc1d95fb1c62c7d1b47f959c2caa685dfec8736da95c1c", http.StatusForbidden, forbiddenResponseOption, headerOption)
 
-		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 		) // should work without pinning
@@ -91,7 +91,7 @@ func TestGatewayMode(t *testing.T) {
 			Code:    http.StatusForbidden,
 		})
 
-		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 		) // should work without pinning

--- a/pkg/api/pin.go
+++ b/pkg/api/pin.go
@@ -44,7 +44,7 @@ func (s *server) pinRootHash(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonhttp.OK(w, nil)
+	jsonhttp.Created(w, nil)
 }
 
 // unpinRootHash unpin's an already pinned root hash. This method is idempotent.

--- a/pkg/api/pin_test.go
+++ b/pkg/api/pin_test.go
@@ -45,10 +45,10 @@ func checkPinHandlers(t *testing.T, client *http.Client, rootHash string) {
 		}),
 	)
 
-	jsonhttptest.Request(t, client, http.MethodPost, pinsAddressPath, http.StatusOK,
+	jsonhttptest.Request(t, client, http.MethodPost, pinsAddressPath, http.StatusCreated,
 		jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-			Message: http.StatusText(http.StatusOK),
-			Code:    http.StatusOK,
+			Message: http.StatusText(http.StatusCreated),
+			Code:    http.StatusCreated,
 		}),
 	)
 
@@ -93,7 +93,7 @@ func TestPinHandlers(t *testing.T) {
 
 	t.Run("bytes", func(t *testing.T) {
 		const rootHash = "838d0a193ecd1152d1bb1432d5ecc02398533b2494889e23b8bd5ace30ac2aeb"
-		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(strings.NewReader("this is a simple text")),
 			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
@@ -110,7 +110,7 @@ func TestPinHandlers(t *testing.T) {
 			dir:  "",
 		}})
 		rootHash := "9e178dbd1ed4b748379e25144e28dfb29c07a4b5114896ef454480115a56b237"
-		jsonhttptest.Request(t, client, http.MethodPost, "/bzz", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/bzz", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(tarReader),
 			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
@@ -122,7 +122,7 @@ func TestPinHandlers(t *testing.T) {
 		checkPinHandlers(t, client, rootHash)
 
 		rootHash = "dd13a5a6cc9db3ef514d645e6719178dbfb1a90b49b9262cafce35b0d27cf245"
-		jsonhttptest.Request(t, client, http.MethodPost, "/bzz?name=somefile.txt", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/bzz?name=somefile.txt", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestHeader("Content-Type", "text/plain"),
 			jsonhttptest.WithRequestBody(strings.NewReader("this is a simple text")),
@@ -138,7 +138,7 @@ func TestPinHandlers(t *testing.T) {
 			chunk    = testingc.GenerateTestRandomChunk()
 			rootHash = chunk.Address().String()
 		)
-		jsonhttptest.Request(t, client, http.MethodPost, "/chunks", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/chunks", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -68,7 +68,7 @@ func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonhttp.OK(w, &postageCreateResponse{
+	jsonhttp.Created(w, &postageCreateResponse{
 		BatchID: batchID,
 	})
 }

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -50,7 +50,7 @@ func TestPostageCreateStamp(t *testing.T) {
 			PostageContract: contract,
 		})
 
-		jsonhttptest.Request(t, client, http.MethodPost, createBatch(initialBalance, depth, label), http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, createBatch(initialBalance, depth, label), http.StatusCreated,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageCreateResponse{
 				BatchID: batchID,
 			}),

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -94,7 +94,7 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonhttp.OK(w, nil)
+	jsonhttp.Created(w, nil)
 }
 
 func (s *server) pssWsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -229,7 +229,7 @@ func TestPssSend(t *testing.T) {
 
 	t.Run("ok batch", func(t *testing.T) {
 		hexbatch := hex.EncodeToString(batchOk)
-		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/12", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/12", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
 		)
@@ -243,12 +243,12 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12?recipient="+recipient, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12?recipient="+recipient, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-				Message: "OK",
-				Code:    http.StatusOK,
+				Message: "Created",
+				Code:    http.StatusCreated,
 			}),
 		)
 		waitDone(t, &mtx, &done)
@@ -264,12 +264,12 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("without recipient", func(t *testing.T) {
-		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12", http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-				Message: "OK",
-				Code:    http.StatusOK,
+				Message: "Created",
+				Code:    http.StatusCreated,
 			}),
 		)
 		waitDone(t, &mtx, &done)

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -106,13 +106,13 @@ func TestTags(t *testing.T) {
 			jsonhttptest.WithUnmarshalJSONResponse(&tr),
 		)
 
-		_ = jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
+		_ = jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
 		)
 
-		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithExpectedJSONResponse(api.ChunkAddressResponse{Reference: chunk.Address()}),
@@ -232,7 +232,7 @@ func TestTags(t *testing.T) {
 		addr := test.RandomAddress()
 
 		// upload content with tag
-		jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusOK,
+		jsonhttptest.Request(t, client, http.MethodPost, chunksResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(chunk.Data())),
 			jsonhttptest.WithRequestHeader(api.SwarmTagHeader, fmt.Sprint(tagId)),
@@ -272,7 +272,7 @@ func TestTags(t *testing.T) {
 		expectedResponse := api.BzzUploadResponse{Reference: expectedHash}
 
 		respHeaders := jsonhttptest.Request(t, client, http.MethodPost,
-			bzzResource+"?name=somefile", http.StatusOK,
+			bzzResource+"?name=somefile", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader([]byte("some data"))),
 			jsonhttptest.WithExpectedJSONResponse(expectedResponse),
@@ -295,7 +295,7 @@ func TestTags(t *testing.T) {
 		expectedHash := swarm.MustParseHexAddress("42bc27c9137c93705ffbc2945fa1aab0e8e1826f1500b7f06f6e3f86f617213b")
 		expectedResponse := api.BzzUploadResponse{Reference: expectedHash}
 
-		respHeaders := jsonhttptest.Request(t, client, http.MethodPost, bzzResource, http.StatusOK,
+		respHeaders := jsonhttptest.Request(t, client, http.MethodPost, bzzResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(tarReader),
 			jsonhttptest.WithRequestHeader(api.SwarmCollectionHeader, "True"),
@@ -334,7 +334,7 @@ func TestTags(t *testing.T) {
 		copy(content[swarm.ChunkSize:], dataChunk)
 		copy(content[:swarm.ChunkSize], dataChunk)
 
-		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, bytesResource, http.StatusOK,
+		rcvdHeaders := jsonhttptest.Request(t, client, http.MethodPost, bytesResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(content)),
 			jsonhttptest.WithExpectedJSONResponse(fileUploadResponse{


### PR DESCRIPTION
As per #1084 we need to return http response code 201 every time we create a new resource.