### PR TITLE
libp2p: disable flaky resolver test

### DIFF
--- a/pkg/p2p/libp2p/static_resolver_test.go
+++ b/pkg/p2p/libp2p/static_resolver_test.go
@@ -6,7 +6,6 @@ package libp2p_test
 
 import (
 	"net"
-	"runtime"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
@@ -15,9 +14,7 @@ import (
 )
 
 func TestStaticAddressResolver(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
-		t.Skipf("skipped all dns resolver tests on %v", runtime.GOOS)
-	}
+	t.Skipf("skipping flaky static address resolver tests")
 
 	for _, tc := range []struct {
 		name              string


### PR DESCRIPTION
The test is flaky due to some problems in infrastructure it seems. The library used to mock the dns queries is not able to bind correctly. I am not sure how to work around this. Any suggestions? @janos 
```
--- FAIL: TestStaticAddressResolver (0.00s)
    --- FAIL: TestStaticAddressResolver/replace_ip_v4_and_port_with_ip_v6 (0.00s)
        static_resolver_test.go:100: new mockdns: listen udp4 127.0.0.1:42209: bind: address already in use
FAIL
coverage: 78.0% of statements
FAIL	github.com/ethersphere/bee/pkg/p2p/libp2p	25.987s
```