### PR TITLE
libp2p: improve cleanup on shutdown and tests

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -361,11 +361,7 @@ func TestBlocklisting(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error during connection, got nil")
 	}
-	t.Logf("s1 connect threw error: %v", err)
 
-	// expectPeersEventually is needed since s1 will not know that s2 blocked it
-	// therefore it will add s2 to the peers list, but since s2 disconnects, it should
-	// eventually be removed from the peers list.
 	expectPeers(t, s1)
 	expectPeersEventually(t, s2)
 }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -703,6 +703,10 @@ func (s *Service) Close() error {
 	if err := s.libp2pPeerstore.Close(); err != nil {
 		return err
 	}
+	if err := s.natManager.Close(); err != nil {
+		return err
+	}
+
 	return s.host.Close()
 }
 

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"os"
+	"io/ioutil"
 	"sort"
 	"testing"
 	"time"
@@ -48,7 +48,7 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 	addr := ":0"
 
 	if o.Logger == nil {
-		o.Logger = logging.New(os.Stdout, 5)
+		o.Logger = logging.New(ioutil.Discard, 0)
 	}
 
 	statestore := mock.NewStateStore()

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -48,7 +48,7 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 	addr := ":0"
 
 	if o.Logger == nil {
-		o.Logger = logging.New(ioutil.Discard, 0)
+		o.Logger = logging.New(os.Stdout, 5)
 	}
 
 	statestore := mock.NewStateStore()


### PR DESCRIPTION
Adds a missing close to `natManager` and test cleanups.