### PR TITLE
fix correct bigint json marshalling

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -34,13 +34,18 @@ components:
         pssPublicKey:
           $ref: "#/components/schemas/PublicKey"
 
+    BigInt:
+      description: Numeric string that represents integer which might exceeds `Number.MAX_SAFE_INTEGER` limit (2^53-1)
+      type: string
+      example: "1000000000000000000"
+
     Balance:
       type: object
       properties:
         peer:
           $ref: "#/components/schemas/SwarmAddress"
         balance:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
 
     Balances:
       type: object
@@ -100,7 +105,7 @@ components:
         chequebook:
           $ref: "#/components/schemas/EthereumAddress"
         payout:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
 
     ChequeAllPeersResponse:
       type: object
@@ -124,9 +129,9 @@ components:
       type: object
       properties:
         totalBalance:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
         availableBalance:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
 
     ChequebookAddress:
       type: object
@@ -372,7 +377,7 @@ components:
         recipient:
           $ref: "#/components/schemas/EthereumAddress"
         lastPayout:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
         bounced:
           type: boolean
 
@@ -388,7 +393,7 @@ components:
         result:
           $ref: "#/components/schemas/SwapCashoutResult"
         uncashedAmount:
-          type: integer
+          $ref: "#/components/schemas/BigInt"
 
     TagName:
       type: string

--- a/pkg/bigint/bigint.go
+++ b/pkg/bigint/bigint.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bigint
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+)
+
+type BigInt struct {
+	*big.Int
+}
+
+func (i *BigInt) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, i.String())), nil
+}
+
+func (i *BigInt) UnmarshalJSON(b []byte) error {
+	var val string
+	err := json.Unmarshal(b, &val)
+	if err != nil {
+		return err
+	}
+
+	i.SetString(val, 10)
+
+	return nil
+}
+
+//Wrap wraps big.Int pointer into BigInt struct.
+func Wrap(i *big.Int) *BigInt {
+	return &BigInt{i}
+}

--- a/pkg/bigint/bigint.go
+++ b/pkg/bigint/bigint.go
@@ -25,6 +25,10 @@ func (i *BigInt) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	if i.Int == nil {
+		i.Int = new(big.Int)
+	}
+
 	i.SetString(val, 10)
 
 	return nil

--- a/pkg/bigint/bigint.go
+++ b/pkg/bigint/bigint.go
@@ -36,5 +36,5 @@ func (i *BigInt) UnmarshalJSON(b []byte) error {
 
 //Wrap wraps big.Int pointer into BigInt struct.
 func Wrap(i *big.Int) *BigInt {
-	return &BigInt{i}
+	return &BigInt{Int: i}
 }

--- a/pkg/bigint/bigint_test.go
+++ b/pkg/bigint/bigint_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bigint_test
+
+import (
+	"encoding/json"
+	"github.com/ethersphere/bee/pkg/bigint"
+	"math"
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func TestMarshaling(t *testing.T) {
+	mar, err := json.Marshal(struct {
+		Bg *bigint.BigInt
+	}{
+		Bg: bigint.Wrap(new(big.Int).Mul(big.NewInt(math.MaxInt64), big.NewInt(math.MaxInt64))),
+	})
+	if err != nil {
+		t.Errorf("Marshaling failed")
+	}
+	if !reflect.DeepEqual(mar, []byte("{\"Bg\":\"85070591730234615847396907784232501249\"}")) {
+		t.Errorf("Wrongly marshaled data")
+	}
+}

--- a/pkg/bigint/bigint_test.go
+++ b/pkg/bigint/bigint_test.go
@@ -20,7 +20,7 @@ func TestMarshaling(t *testing.T) {
 		Bg: bigint.Wrap(new(big.Int).Mul(big.NewInt(math.MaxInt64), big.NewInt(math.MaxInt64))),
 	})
 	if err != nil {
-		t.Errorf("Marshaling failed")
+		t.Errorf("Marshaling failed: %v", err)
 	}
 	if !reflect.DeepEqual(mar, []byte("{\"Bg\":\"85070591730234615847396907784232501249\"}")) {
 		t.Errorf("Wrongly marshaled data")

--- a/pkg/debugapi/balances.go
+++ b/pkg/debugapi/balances.go
@@ -6,10 +6,10 @@ package debugapi
 
 import (
 	"errors"
-	"math/big"
 	"net/http"
 
 	"github.com/ethersphere/bee/pkg/accounting"
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
@@ -23,8 +23,8 @@ var (
 )
 
 type balanceResponse struct {
-	Peer    string   `json:"peer"`
-	Balance *big.Int `json:"balance"`
+	Peer    string         `json:"peer"`
+	Balance *bigint.BigInt `json:"balance"`
 }
 
 type balancesResponse struct {
@@ -45,7 +45,7 @@ func (s *Service) balancesHandler(w http.ResponseWriter, r *http.Request) {
 	for k := range balances {
 		balResponses[i] = balanceResponse{
 			Peer:    k,
-			Balance: balances[k],
+			Balance: bigint.Wrap(balances[k]),
 		}
 		i++
 	}
@@ -77,7 +77,7 @@ func (s *Service) peerBalanceHandler(w http.ResponseWriter, r *http.Request) {
 
 	jsonhttp.OK(w, balanceResponse{
 		Peer:    peer.String(),
-		Balance: balance,
+		Balance: bigint.Wrap(balance),
 	})
 }
 
@@ -95,7 +95,7 @@ func (s *Service) compensatedBalancesHandler(w http.ResponseWriter, r *http.Requ
 	for k := range balances {
 		balResponses[i] = balanceResponse{
 			Peer:    k,
-			Balance: balances[k],
+			Balance: bigint.Wrap(balances[k]),
 		}
 		i++
 	}
@@ -127,6 +127,6 @@ func (s *Service) compensatedPeerBalanceHandler(w http.ResponseWriter, r *http.R
 
 	jsonhttp.OK(w, balanceResponse{
 		Peer:    peer.String(),
-		Balance: balance,
+		Balance: bigint.Wrap(balance),
 	})
 }

--- a/pkg/debugapi/balances_test.go
+++ b/pkg/debugapi/balances_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/accounting/mock"
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
@@ -35,15 +36,15 @@ func TestBalances(t *testing.T) {
 		[]debugapi.BalanceResponse{
 			{
 				Peer:    "DEAD",
-				Balance: big.NewInt(1000000000000000000),
+				Balance: bigint.Wrap(big.NewInt(1000000000000000000)),
 			},
 			{
 				Peer:    "BEEF",
-				Balance: big.NewInt(-100000000000000000),
+				Balance: bigint.Wrap(big.NewInt(-100000000000000000)),
 			},
 			{
 				Peer:    "PARTY",
-				Balance: big.NewInt(0),
+				Balance: bigint.Wrap(big.NewInt(0)),
 			},
 		},
 	}
@@ -89,7 +90,7 @@ func TestBalancesPeers(t *testing.T) {
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/balances/"+peer, http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.BalanceResponse{
 			Peer:    peer,
-			Balance: big.NewInt(100000000000000000),
+			Balance: bigint.Wrap(big.NewInt(100000000000000000)),
 		}),
 	)
 }
@@ -188,15 +189,15 @@ func TestConsumedBalances(t *testing.T) {
 		[]debugapi.BalanceResponse{
 			{
 				Peer:    "DEAD",
-				Balance: big.NewInt(1000000000000000000),
+				Balance: bigint.Wrap(big.NewInt(1000000000000000000)),
 			},
 			{
 				Peer:    "BEEF",
-				Balance: big.NewInt(-100000000000000000),
+				Balance: bigint.Wrap(big.NewInt(-100000000000000000)),
 			},
 			{
 				Peer:    "PARTY",
-				Balance: big.NewInt(0),
+				Balance: bigint.Wrap(big.NewInt(0)),
 			},
 		},
 	}
@@ -242,7 +243,7 @@ func TestConsumedPeers(t *testing.T) {
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/consumed/"+peer, http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.BalanceResponse{
 			Peer:    peer,
-			Balance: big.NewInt(1000000000000000000),
+			Balance: bigint.Wrap(big.NewInt(1000000000000000000)),
 		}),
 	)
 }

--- a/pkg/debugapi/chequebook_test.go
+++ b/pkg/debugapi/chequebook_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
@@ -44,8 +45,8 @@ func TestChequebookBalance(t *testing.T) {
 	})
 
 	expected := &debugapi.ChequebookBalanceResponse{
-		TotalBalance:     returnedBalance,
-		AvailableBalance: returnedAvailableBalance,
+		TotalBalance:     bigint.Wrap(returnedBalance),
+		AvailableBalance: bigint.Wrap(returnedAvailableBalance),
 	}
 
 	var got *debugapi.ChequebookBalanceResponse
@@ -278,12 +279,12 @@ func TestChequebookLastCheques(t *testing.T) {
 			LastReceived: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary.String(),
 				Chequebook:  chequebookAddress1.String(),
-				Payout:      cumulativePayout4,
+				Payout:      bigint.Wrap(cumulativePayout4),
 			},
 			LastSent: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary1.String(),
 				Chequebook:  chequebookAddress1.String(),
-				Payout:      cumulativePayout1,
+				Payout:      bigint.Wrap(cumulativePayout1),
 			},
 		},
 		{
@@ -292,7 +293,7 @@ func TestChequebookLastCheques(t *testing.T) {
 			LastSent: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary2.String(),
 				Chequebook:  chequebookAddress2.String(),
-				Payout:      cumulativePayout2,
+				Payout:      bigint.Wrap(cumulativePayout2),
 			},
 		},
 		{
@@ -301,7 +302,7 @@ func TestChequebookLastCheques(t *testing.T) {
 			LastSent: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary3.String(),
 				Chequebook:  chequebookAddress3.String(),
-				Payout:      cumulativePayout3,
+				Payout:      bigint.Wrap(cumulativePayout3),
 			},
 		},
 		{
@@ -309,7 +310,7 @@ func TestChequebookLastCheques(t *testing.T) {
 			LastReceived: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary.String(),
 				Chequebook:  chequebookAddress4.String(),
-				Payout:      cumulativePayout5,
+				Payout:      bigint.Wrap(cumulativePayout5),
 			},
 			LastSent: nil,
 		},
@@ -318,7 +319,7 @@ func TestChequebookLastCheques(t *testing.T) {
 			LastReceived: &debugapi.ChequebookLastChequePeerResponse{
 				Beneficiary: beneficiary.String(),
 				Chequebook:  chequebookAddress5.String(),
-				Payout:      cumulativePayout6,
+				Payout:      bigint.Wrap(cumulativePayout6),
 			},
 			LastSent: nil,
 		},
@@ -389,12 +390,12 @@ func TestChequebookLastChequesPeer(t *testing.T) {
 		LastReceived: &debugapi.ChequebookLastChequePeerResponse{
 			Beneficiary: beneficiary0.String(),
 			Chequebook:  chequebookAddress.String(),
-			Payout:      cumulativePayout2,
+			Payout:      bigint.Wrap(cumulativePayout2),
 		},
 		LastSent: &debugapi.ChequebookLastChequePeerResponse{
 			Beneficiary: beneficiary1.String(),
 			Chequebook:  chequebookAddress.String(),
-			Payout:      cumulativePayout1,
+			Payout:      bigint.Wrap(cumulativePayout1),
 		},
 	}
 
@@ -528,15 +529,15 @@ func TestChequebookCashoutStatus(t *testing.T) {
 			TransactionHash: &actionTxHash,
 			Cheque: &debugapi.ChequebookLastChequePeerResponse{
 				Chequebook:  chequebookAddress.String(),
-				Payout:      cumulativePayout,
+				Payout:      bigint.Wrap(cumulativePayout),
 				Beneficiary: cheque.Beneficiary.String(),
 			},
 			Result: &debugapi.SwapCashoutStatusResult{
 				Recipient:  recipientAddress,
-				LastPayout: totalPayout,
+				LastPayout: bigint.Wrap(totalPayout),
 				Bounced:    false,
 			},
-			UncashedAmount: uncashedAmount,
+			UncashedAmount: bigint.Wrap(uncashedAmount),
 		}
 
 		var got *debugapi.SwapCashoutStatusResponse
@@ -572,11 +573,11 @@ func TestChequebookCashoutStatus(t *testing.T) {
 			TransactionHash: &actionTxHash,
 			Cheque: &debugapi.ChequebookLastChequePeerResponse{
 				Chequebook:  chequebookAddress.String(),
-				Payout:      cumulativePayout,
+				Payout:      bigint.Wrap(cumulativePayout),
 				Beneficiary: cheque.Beneficiary.String(),
 			},
 			Result:         nil,
-			UncashedAmount: uncashedAmount,
+			UncashedAmount: bigint.Wrap(uncashedAmount),
 		}
 
 		var got *debugapi.SwapCashoutStatusResponse
@@ -607,7 +608,7 @@ func TestChequebookCashoutStatus(t *testing.T) {
 			TransactionHash: nil,
 			Cheque:          nil,
 			Result:          nil,
-			UncashedAmount:  uncashedAmount,
+			UncashedAmount:  bigint.Wrap(uncashedAmount),
 		}
 
 		var got *debugapi.SwapCashoutStatusResponse

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -26,6 +26,7 @@ type (
 	SwapCashoutStatusResponse         = swapCashoutStatusResponse
 	SwapCashoutStatusResult           = swapCashoutStatusResult
 	TagResponse                       = tagResponse
+	ReserveStateResponse              = reserveStateResponse
 )
 
 var (

--- a/pkg/debugapi/postage.go
+++ b/pkg/debugapi/postage.go
@@ -7,9 +7,24 @@ package debugapi
 import (
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 )
 
+type reserveStateResponse struct {
+	Radius    uint8          `json:"radius"`
+	Available int64          `json:"available"`
+	Outer     *bigint.BigInt `json:"outer"` // lower value limit for outer layer = the further half of chunks
+	Inner     *bigint.BigInt `json:"inner"`
+}
+
 func (s *Service) reserveStateHandler(w http.ResponseWriter, r *http.Request) {
-	jsonhttp.OK(w, s.batchStore.GetReserveState())
+	state := s.batchStore.GetReserveState()
+
+	jsonhttp.OK(w, reserveStateResponse{
+		Radius:    state.Radius,
+		Available: state.Available,
+		Outer:     bigint.Wrap(state.Outer),
+		Inner:     bigint.Wrap(state.Inner),
+	})
 }

--- a/pkg/debugapi/postage_test.go
+++ b/pkg/debugapi/postage_test.go
@@ -5,9 +5,12 @@
 package debugapi_test
 
 import (
+	"math/big"
 	"net/http"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/bigint"
+	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/postage/batchstore/mock"
@@ -18,13 +21,17 @@ func TestReservestate(t *testing.T) {
 	ts := newTestServer(t, testServerOptions{
 		BatchStore: mock.New(mock.WithReserveState(&postage.Reservestate{
 			Radius: 5,
+			Outer:  big.NewInt(5),
+			Inner:  big.NewInt(5),
 		})),
 	})
 
 	t.Run("ok", func(t *testing.T) {
 		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/reservestate", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&postage.Reservestate{
+			jsonhttptest.WithExpectedJSONResponse(&debugapi.ReserveStateResponse{
 				Radius: 5,
+				Outer:  bigint.Wrap(big.NewInt(5)),
+				Inner:  bigint.Wrap(big.NewInt(5)),
 			}),
 		)
 	})

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/settlement"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -21,14 +22,14 @@ var (
 )
 
 type settlementResponse struct {
-	Peer               string   `json:"peer"`
-	SettlementReceived *big.Int `json:"received"`
-	SettlementSent     *big.Int `json:"sent"`
+	Peer               string         `json:"peer"`
+	SettlementReceived *bigint.BigInt `json:"received"`
+	SettlementSent     *bigint.BigInt `json:"sent"`
 }
 
 type settlementsResponse struct {
-	TotalSettlementReceived *big.Int             `json:"totalReceived"`
-	TotalSettlementSent     *big.Int             `json:"totalSent"`
+	TotalSettlementReceived *bigint.BigInt       `json:"totalReceived"`
+	TotalSettlementSent     *bigint.BigInt       `json:"totalSent"`
 	Settlements             []settlementResponse `json:"settlements"`
 }
 
@@ -57,8 +58,8 @@ func (s *Service) settlementsHandler(w http.ResponseWriter, r *http.Request) {
 	for a, b := range settlementsSent {
 		settlementResponses[a] = settlementResponse{
 			Peer:               a,
-			SettlementSent:     b,
-			SettlementReceived: big.NewInt(0),
+			SettlementSent:     bigint.Wrap(b),
+			SettlementReceived: bigint.Wrap(big.NewInt(0)),
 		}
 		totalSent.Add(b, totalSent)
 	}
@@ -66,13 +67,13 @@ func (s *Service) settlementsHandler(w http.ResponseWriter, r *http.Request) {
 	for a, b := range settlementsReceived {
 		if _, ok := settlementResponses[a]; ok {
 			t := settlementResponses[a]
-			t.SettlementReceived = b
+			t.SettlementReceived = bigint.Wrap(b)
 			settlementResponses[a] = t
 		} else {
 			settlementResponses[a] = settlementResponse{
 				Peer:               a,
-				SettlementSent:     big.NewInt(0),
-				SettlementReceived: b,
+				SettlementSent:     bigint.Wrap(big.NewInt(0)),
+				SettlementReceived: bigint.Wrap(b),
 			}
 		}
 		totalReceived.Add(b, totalReceived)
@@ -85,7 +86,7 @@ func (s *Service) settlementsHandler(w http.ResponseWriter, r *http.Request) {
 		i++
 	}
 
-	jsonhttp.OK(w, settlementsResponse{TotalSettlementReceived: totalReceived, TotalSettlementSent: totalSent, Settlements: settlementResponsesArray})
+	jsonhttp.OK(w, settlementsResponse{TotalSettlementReceived: bigint.Wrap(totalReceived), TotalSettlementSent: bigint.Wrap(totalSent), Settlements: settlementResponsesArray})
 }
 
 func (s *Service) peerSettlementsHandler(w http.ResponseWriter, r *http.Request) {
@@ -139,7 +140,7 @@ func (s *Service) peerSettlementsHandler(w http.ResponseWriter, r *http.Request)
 
 	jsonhttp.OK(w, settlementResponse{
 		Peer:               peer.String(),
-		SettlementReceived: received,
-		SettlementSent:     sent,
+		SettlementReceived: bigint.Wrap(received),
+		SettlementSent:     bigint.Wrap(sent),
 	})
 }

--- a/pkg/debugapi/settlements_test.go
+++ b/pkg/debugapi/settlements_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/bigint"
 	"github.com/ethersphere/bee/pkg/debugapi"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
@@ -40,28 +41,28 @@ func TestSettlements(t *testing.T) {
 	})
 
 	expected := &debugapi.SettlementsResponse{
-		TotalSettlementReceived: big.NewInt(15000),
-		TotalSettlementSent:     big.NewInt(80000),
+		TotalSettlementReceived: bigint.Wrap(big.NewInt(15000)),
+		TotalSettlementSent:     bigint.Wrap(big.NewInt(80000)),
 		Settlements: []debugapi.SettlementResponse{
 			{
 				Peer:               "DEAD",
-				SettlementReceived: big.NewInt(0),
-				SettlementSent:     big.NewInt(10000),
+				SettlementReceived: bigint.Wrap(big.NewInt(0)),
+				SettlementSent:     bigint.Wrap(big.NewInt(10000)),
 			},
 			{
 				Peer:               "BEEF",
-				SettlementReceived: big.NewInt(10000),
-				SettlementSent:     big.NewInt(20000),
+				SettlementReceived: bigint.Wrap(big.NewInt(10000)),
+				SettlementSent:     bigint.Wrap(big.NewInt(20000)),
 			},
 			{
 				Peer:               "FFFF",
-				SettlementReceived: big.NewInt(0),
-				SettlementSent:     big.NewInt(50000),
+				SettlementReceived: bigint.Wrap(big.NewInt(0)),
+				SettlementSent:     bigint.Wrap(big.NewInt(50000)),
 			},
 			{
 				Peer:               "EEEE",
-				SettlementReceived: big.NewInt(5000),
-				SettlementSent:     big.NewInt(0),
+				SettlementReceived: bigint.Wrap(big.NewInt(5000)),
+				SettlementSent:     bigint.Wrap(big.NewInt(0)),
 			},
 		},
 	}
@@ -107,8 +108,8 @@ func TestSettlementsPeers(t *testing.T) {
 	jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.SettlementResponse{
 			Peer:               peer,
-			SettlementSent:     big.NewInt(1000000000000000000),
-			SettlementReceived: big.NewInt(0),
+			SettlementSent:     bigint.Wrap(big.NewInt(1000000000000000000)),
+			SettlementReceived: bigint.Wrap(big.NewInt(0)),
 		}),
 	)
 }
@@ -133,8 +134,8 @@ func TestSettlementsPeersNoSettlements(t *testing.T) {
 		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(debugapi.SettlementResponse{
 				Peer:               peer,
-				SettlementSent:     big.NewInt(0),
-				SettlementReceived: big.NewInt(1000000000000000000),
+				SettlementSent:     bigint.Wrap(big.NewInt(0)),
+				SettlementReceived: bigint.Wrap(big.NewInt(1000000000000000000)),
 			}),
 		)
 	})
@@ -150,8 +151,8 @@ func TestSettlementsPeersNoSettlements(t *testing.T) {
 		jsonhttptest.Request(t, testServer.Client, http.MethodGet, "/settlements/"+peer, http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(debugapi.SettlementResponse{
 				Peer:               peer,
-				SettlementSent:     big.NewInt(1000000000000000000),
-				SettlementReceived: big.NewInt(0),
+				SettlementSent:     bigint.Wrap(big.NewInt(1000000000000000000)),
+				SettlementReceived: bigint.Wrap(big.NewInt(0)),
 			}),
 		)
 	})
@@ -217,11 +218,11 @@ func equalSettlements(a, b *debugapi.SettlementsResponse) bool {
 		}
 	}
 
-	if a.TotalSettlementReceived.Cmp(b.TotalSettlementReceived) != 0 {
+	if a.TotalSettlementReceived.Cmp(b.TotalSettlementReceived.Int) != 0 {
 		return false
 	}
 
-	if a.TotalSettlementSent.Cmp(b.TotalSettlementSent) != 0 {
+	if a.TotalSettlementSent.Cmp(b.TotalSettlementSent.Int) != 0 {
 		return false
 	}
 

--- a/pkg/postage/reservestate.go
+++ b/pkg/postage/reservestate.go
@@ -7,8 +7,8 @@ package postage
 import "math/big"
 
 type Reservestate struct {
-	Radius    uint8    `json:"radius"`
-	Available int64    `json:"available"`
-	Outer     *big.Int `json:"outer"` // lower value limit for outer layer = the further half of chunks
-	Inner     *big.Int `json:"inner"`
+	Radius    uint8
+	Available int64
+	Outer     *big.Int // lower value limit for outer layer = the further half of chunks
+	Inner     *big.Int
 }


### PR DESCRIPTION
Closes #1561 and closes #756.

It creates `BigInt` struct that is applied only to API layer, while all internal calculations are still kept in `big.Int`.

It introduces breaking changes for several DebugAPI endpoints where amounts are converted from numbers to strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1627)
<!-- Reviewable:end -->
