### PR TITLE
libp2p: fix shutdown panic

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -53,6 +53,7 @@ type Service struct {
 	host              host.Host
 	natManager        basichost.NATManager
 	natAddrResolver   *staticAddressResolver
+	autonatDialer     host.Host
 	libp2pPeerstore   peerstore.Peerstore
 	metrics           metrics
 	networkID         uint64
@@ -219,6 +220,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		host:              h,
 		natManager:        natManager,
 		natAddrResolver:   natAddrResolver,
+		autonatDialer:     dialer,
 		handshakeService:  handshakeService,
 		libp2pPeerstore:   libp2pPeerstore,
 		metrics:           newMetrics(),
@@ -703,7 +705,12 @@ func (s *Service) Close() error {
 	if err := s.libp2pPeerstore.Close(); err != nil {
 		return err
 	}
-	if err := s.natManager.Close(); err != nil {
+	if s.natManager != nil {
+		if err := s.natManager.Close(); err != nil {
+			return err
+		}
+	}
+	if err := s.autonatDialer.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
as reported by user `eth1` on discord:
```
goroutine 41833 [running]:                                                                                                                           
github.com/ethersphere/bee/pkg/p2p/libp2p.(*Service).Close(0xc0003c0000, 0x0, 0x0)                                                                                                                                                                                                                        
        github.com/ethersphere/bee/pkg/p2p/libp2p/libp2p.go:706 +0x54                                                                                                                                                                                                                                     
github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown(0xc0003bc000, 0x1867100, 0xc000aa4ea0, 0x1867100, 0xc000aa4ea0)                        
        github.com/ethersphere/bee/pkg/node/node.go:693 +0x4ce                                                                                       
github.com/ethersphere/bee/cmd/bee/cmd.(*command).initStartCmd.func1.2.1(0xc00050bbc0, 0xc0003bc000, 0x1879bc0, 0xc00025baa0)                                                                                                                                                                             
        github.com/ethersphere/bee/cmd/bee/cmd/start.go:180 +0xaa                                                                                    
created by github.com/ethersphere/bee/cmd/bee/cmd.(*command).initStartCmd.func1.2                                              
        github.com/ethersphere/bee/cmd/bee/cmd/start.go:174 +0xac
```

fixes #1631