### PR TITLE
Winlog linter fix

### DIFF
--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -58,27 +58,27 @@ func (l *windowsEventLogger) Debug(args ...interface{}) {
 }
 
 func (l *windowsEventLogger) Infof(format string, args ...interface{}) {
-	l.winlog.Info(1633, fmt.Sprintf(format, args...))
+	_ = l.winlog.Info(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Info(args ...interface{}) {
-	l.winlog.Info(1633, fmt.Sprint(args...))
+	_ = l.winlog.Info(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) Warningf(format string, args ...interface{}) {
-	l.winlog.Warning(1633, fmt.Sprintf(format, args...))
+	_ = l.winlog.Warning(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Warning(args ...interface{}) {
-	l.winlog.Warning(1633, fmt.Sprint(args...))
+	_ = l.winlog.Warning(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) Errorf(format string, args ...interface{}) {
-	l.winlog.Error(1633, fmt.Sprintf(format, args...))
+	_ = l.winlog.Error(1633, fmt.Sprintf(format, args...))
 }
 
 func (l *windowsEventLogger) Error(args ...interface{}) {
-	l.winlog.Error(1633, fmt.Sprint(args...))
+	_ = l.winlog.Error(1633, fmt.Sprint(args...))
 }
 
 func (l *windowsEventLogger) WithField(key string, value interface{}) *logrus.Entry {


### PR DESCRIPTION
suppress windows platform specific linter error "Error return value of `l.winlog.Error` is not checked (errcheck)" by discarding return value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1659)
<!-- Reviewable:end -->
