### PR TITLE
cmd: send version info to stdout

### DIFF
--- a/cmd/bee/cmd/version.go
+++ b/cmd/bee/cmd/version.go
@@ -5,17 +5,21 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/ethersphere/bee"
 
 	"github.com/spf13/cobra"
 )
 
 func (c *command) initVersionCmd() {
-	c.root.AddCommand(&cobra.Command{
+	v := &cobra.Command{
 		Use:   "version",
 		Short: "Print version number",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Println(bee.Version)
 		},
-	})
+	}
+	v.SetOut(os.Stdout)
+	c.root.AddCommand(v)
 }

--- a/cmd/bee/cmd/version.go
+++ b/cmd/bee/cmd/version.go
@@ -5,8 +5,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/ethersphere/bee"
 
 	"github.com/spf13/cobra"
@@ -20,6 +18,6 @@ func (c *command) initVersionCmd() {
 			cmd.Println(bee.Version)
 		},
 	}
-	v.SetOut(os.Stdout)
+	v.SetOut(c.root.OutOrStdout())
 	c.root.AddCommand(v)
 }

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -345,8 +345,8 @@ func TestBlocklisting(t *testing.T) {
 		t.Fatal("expected error during connection, got nil")
 	}
 
-	expectPeers(t, s1)
-	expectPeersEventually(t, s2)
+	expectPeersEventually(t, s1)
+	expectPeers(t, s2)
 }
 
 func TestTopologyNotifier(t *testing.T) {


### PR DESCRIPTION
This PR sends the `bee version` command output to stdout. `cobra` defaults to `stderr` if output is not explicitly set.

fixes #1648

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1660)
<!-- Reviewable:end -->
