### PR TITLE
ci: conventional commits linting in ci flow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        fetch-depth: 0
+    - name: Commit linting
+      if: matrix.os == 'ubuntu-latest'
+      uses: wagoid/commitlint-github-action@v2
     - name: Cache Go modules
       uses: actions/cache@v1
       with:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,40 @@
+module.exports = {
+	parserPreset: 'conventional-changelog-conventionalcommits',
+	rules: {
+		'body-leading-blank': [2, 'always'],
+		'body-max-line-length': [2, 'always', 72],
+    'body-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+		],
+		'footer-leading-blank': [1, 'always'],
+		'footer-max-line-length': [2, 'always', 72],
+		'header-max-length': [2, 'always', 72],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'build',
+				'chore',
+				'ci',
+				'docs',
+				'feat',
+				'fix',
+				'perf',
+				'refactor',
+				'revert',
+				'test',
+			],
+		],
+	},
+};


### PR DESCRIPTION
The commit police is here :police_car: :police_car: :police_car: :ambulance: :police_car: 

Howto:
https://www.conventionalcommits.org/en/v1.0.0/#summary
https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#commit (minus `style`)

More:
https://github.com/conventional-changelog/commitlint

Future todo:
https://github.com/buchanae/github-release-notes
https://github.com/miniscruff/changie
https://github.com/googleapis/release-please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1684)
<!-- Reviewable:end -->
