### PR TITLE
feat(pushsync): add metrics to push flow

### DIFF
--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -70,8 +70,8 @@ func newMetrics() metrics {
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
-				Name:      "response_code_count",
-				Help:      "Response count grouped by status code",
+				Name:      "failed_cache_hits",
+				Help:      "FailedRequestCache hits",
 			},
 			[]string{"peer", "chunk"},
 		),

--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -10,11 +10,14 @@ import (
 )
 
 type metrics struct {
-	TotalSent            prometheus.Counter
-	TotalReceived        prometheus.Counter
-	TotalErrors          prometheus.Counter
-	TotalReplicated      prometheus.Counter
-	TotalReplicatedError prometheus.Counter
+	TotalSent               prometheus.Counter
+	TotalReceived           prometheus.Counter
+	TotalErrors             prometheus.Counter
+	TotalReplicated         prometheus.Counter
+	TotalReplicatedError    prometheus.Counter
+	TotalSendAttempts       prometheus.Counter
+	TotalFailedSendAttempts prometheus.Counter
+	FailedCacheHits         *prometheus.CounterVec
 }
 
 func newMetrics() metrics {
@@ -51,6 +54,27 @@ func newMetrics() metrics {
 			Name:      "total_replication_error",
 			Help:      "Total no of failed replication chunks.",
 		}),
+		TotalSendAttempts: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_send_attempts",
+			Help:      "Total no of attempts to push chunk.",
+		}),
+		TotalFailedSendAttempts: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_failed_send_attempts",
+			Help:      "Total no of failed attempts to push chunk.",
+		}),
+		FailedCacheHits: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "response_code_count",
+				Help:      "Response count grouped by status code",
+			},
+			[]string{"peer", "chunk"},
+		),
 	}
 }
 


### PR DESCRIPTION
Following metrics are added:

- TotalSendAttempts
These are meant to see how many peers were considered for the push. We already track no. of successful pushes with `TotalSent`. So we should be able to infer how many failed in all with this.

- TotalFailedSendAttempts
This counter will count the no. of failed attempts. A failed attempt is when we actually made an attempt to send the data to the peer. This doesn't count the errors caused by accounting. However `TotalSendAttempts - (TotalSent + TotalFailedSendAttempts)` should tell us that.

- FailedCacheHits
This counter vector keeps track of failedRequestCache hits. It will use the `peer` and `chunk` labels to track traces for a {peer, chunk} send-request. We should ensure this no. does not rise to a high value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1691)
<!-- Reviewable:end -->
