### PR TITLE
fix(libp2p): remove disconnect call with empty overlay

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -379,7 +379,6 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			peerID := streamlibp2p.Conn().RemotePeer()
 			overlay, found := s.peers.overlay(peerID)
 			if !found {
-				_ = s.Disconnect(overlay)
 				_ = streamlibp2p.Reset()
 				s.logger.Debugf("overlay address for peer %q not found", peerID)
 				return
@@ -595,10 +594,8 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 
 func (s *Service) Disconnect(overlay swarm.Address) error {
 	s.metrics.DisconnectCount.Inc()
+
 	found, peerID := s.peers.remove(overlay)
-	if !found {
-		return p2p.ErrPeerNotFound
-	}
 
 	_ = s.host.Network().ClosePeer(peerID)
 
@@ -619,6 +616,10 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 	}
 	if s.lightNodes != nil {
 		s.lightNodes.Disconnected(peer)
+	}
+
+	if !found {
+		return p2p.ErrPeerNotFound
 	}
 
 	return nil


### PR DESCRIPTION
When overlay address does not exist, no call to Disconnect should be made inside AddProtocol stream handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1693)
<!-- Reviewable:end -->
