### PR TITLE
fix: http response of pinning non-existing chunks

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -463,6 +463,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
           $ref: "SwarmCommon.yaml#/components/responses/403"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/pkg/api/pin.go
+++ b/pkg/api/pin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/pinning"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/gorilla/mux"
 )
@@ -36,8 +37,11 @@ func (s *server) pinRootHash(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.pinning.CreatePin(r.Context(), ref, true)
-	if err != nil {
+	switch err = s.pinning.CreatePin(r.Context(), ref, true); {
+	case errors.Is(err, storage.ErrNotFound):
+		jsonhttp.NotFound(w, nil)
+		return
+	case err != nil:
 		s.logger.Debugf("pin root hash: creation of tracking pin for %q failed: %v", ref, err)
 		s.logger.Error("pin root hash: creation of tracking pin failed")
 		jsonhttp.InternalServerError(w, nil)


### PR DESCRIPTION
The POST pinning endpoint returns now 404 on non-existing chunks
instead of 500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1712)
<!-- Reviewable:end -->
