### PR TITLE
feat: schema migrations to clean interval keys

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -202,6 +202,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 
 	stateStore, err := InitStateStore(logger, o.DataDir)
 	if err != nil {
+		_ = stateStore.Close()
 		return nil, err
 	}
 	b.stateStoreCloser = stateStore

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -60,7 +60,7 @@ func migrateGrace(s *store) error {
 			len(k) > 32 &&
 			!strings.Contains(stk, "swap") &&
 			!strings.Contains(stk, "peer") {
-			s.logger.Infof("found key designated to deletion", string(k))
+			s.logger.Infof("found key designated to deletion %s", k)
 			collectedKeys = append(collectedKeys, stk)
 		}
 
@@ -72,12 +72,12 @@ func migrateGrace(s *store) error {
 	for _, v := range collectedKeys {
 		err := s.Delete(v)
 		if err != nil {
-			s.logger.Infof("error deleting key", v)
+			s.logger.Infof("error deleting key %s", v)
 			continue
 		}
-		s.logger.Infof("deleted key", v)
+		s.logger.Infof("deleted key %s", v)
 	}
-	s.logger.Infof("deleted keys:", len(collectedKeys))
+	s.logger.Infof("deleted keys: %d", len(collectedKeys))
 
 	return nil
 }

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -60,7 +60,7 @@ func migrateGrace(s *store) error {
 			len(k) > 32 &&
 			!strings.Contains(stk, "swap") &&
 			!strings.Contains(stk, "peer") {
-			s.logger.Infof("found key designated to deletion %s", k)
+			s.logger.Debugf("found key designated to deletion %s", k)
 			collectedKeys = append(collectedKeys, stk)
 		}
 
@@ -72,12 +72,12 @@ func migrateGrace(s *store) error {
 	for _, v := range collectedKeys {
 		err := s.Delete(v)
 		if err != nil {
-			s.logger.Infof("error deleting key %s", v)
+			s.logger.Debugf("error deleting key %s", v)
 			continue
 		}
-		s.logger.Infof("deleted key %s", v)
+		s.logger.Debugf("deleted key %s", v)
 	}
-	s.logger.Infof("deleted keys: %d", len(collectedKeys))
+	s.logger.Debugf("deleted keys: %d", len(collectedKeys))
 
 	return nil
 }
@@ -93,7 +93,7 @@ func (s *store) migrate(schemaName string) error {
 		return nil
 	}
 
-	s.logger.Infof("statestore: need to run %d data migrations to schema %s", len(migrations), schemaName)
+	s.logger.Debugf("statestore: need to run %d data migrations to schema %s", len(migrations), schemaName)
 	for i := 0; i < len(migrations); i++ {
 		err := migrations[i].fn(s)
 		if err != nil {
@@ -107,7 +107,7 @@ func (s *store) migrate(schemaName string) error {
 		if err != nil {
 			return err
 		}
-		s.logger.Infof("statestore: successfully ran migration: id %d current schema: %s", i, schemaName)
+		s.logger.Debugf("statestore: successfully ran migration: id %d current schema: %s", i, schemaName)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func getMigrations(currentSchema, targetSchema string, allSchemeMigrations []mig
 				return nil, errors.New("found schema name for the second time when looking for migrations")
 			}
 			foundCurrent = true
-			store.logger.Infof("statestore migration: found current schema %s, migrate to %s, total migrations %d", currentSchema, dbSchemaCurrent, len(allSchemeMigrations)-i)
+			store.logger.Debugf("statestore migration: found current schema %s, migrate to %s, total migrations %d", currentSchema, dbSchemaCurrent, len(allSchemeMigrations)-i)
 			continue // current schema migration should not be executed (already has been when schema was migrated to)
 		case targetSchema:
 			foundTarget = true


### PR DESCRIPTION
this are the log lines it produces when migrating an existent statestore:

```
...
DEBU[2021-05-18T12:50:47+03:00] deleted key fdb1d222ae51ef3d48c9ec50f7e02d73713ee049d723edc580f003ff0da17344|15 
DEBU[2021-05-18T12:50:47+03:00] deleted keys: 675                            
DEBU[2021-05-18T12:50:47+03:00] statestore: successfully ran migration: id 0 current schema: drain 
DEBU[2021-05-18T12:50:47+03:00] deleted keys: 0                              
DEBU[2021-05-18T12:50:47+03:00] statestore: successfully ran migration: id 1 current schema: clean-interval 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1734)
<!-- Reviewable:end -->