### PR TITLE
fix: check existence of legacy flag correctly

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -105,7 +105,7 @@ func InitChequebookFactory(
 		logger.Infof("using custom factory address: %x", currentFactory)
 	}
 
-	if legacyFactoryAddresses == nil {
+	if len(legacyFactoryAddresses) == 0 {
 		if found {
 			legacyFactories = foundLegacyFactories
 		}


### PR DESCRIPTION
wrong if broke legacy factory address auto-discovery.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1740)
<!-- Reviewable:end -->
