### PR TITLE
fix(libp2p): add full node info to peer

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -399,6 +399,7 @@ func TestTopologyNotifier(t *testing.T) {
 			mtx.Lock()
 			defer mtx.Unlock()
 			expectZeroAddress(t, n1connectedPeer.Address) // fail if set more than once
+			expectFullNode(t, p)
 			n1connectedPeer = p
 			return nil
 		}
@@ -413,6 +414,7 @@ func TestTopologyNotifier(t *testing.T) {
 			defer mtx.Unlock()
 			expectZeroAddress(t, n2connectedPeer.Address) // fail if set more than once
 			n2connectedPeer = p
+			expectFullNode(t, p)
 			return nil
 		}
 		n2d = func(p p2p.Peer) {
@@ -677,6 +679,12 @@ func expectStreamReset(t *testing.T, s io.ReadCloser, err error) {
 				t.Errorf("expected stream reset error, got %v", err)
 			}
 		}
+	}
+}
+func expectFullNode(t *testing.T, p p2p.Peer) {
+	t.Helper()
+	if !p.FullNode {
+		t.Fatal("expected peer to be a full node")
 	}
 }
 

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -94,7 +94,8 @@ type StreamSpec struct {
 
 // Peer holds information about a Peer.
 type Peer struct {
-	Address swarm.Address `json:"address"`
+	Address  swarm.Address `json:"address"`
+	FullNode bool          `json:"fullNode"`
 }
 
 // HandlerFunc handles a received Stream from a Peer.


### PR DESCRIPTION
adds needed information about whether a peer is a full node or not into the `p2p.Peer` type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1741)
<!-- Reviewable:end -->
