### PR TITLE
chore: change initial deposit to 10000000000000000 PLUR (1BZZ)

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -229,7 +229,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNameSwapEndpoint, "http://localhost:8545", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory addresses")
 	cmd.Flags().StringSlice(optionNameSwapLegacyFactoryAddresses, nil, "legacy swap factory addresses")
-	cmd.Flags().String(optionNameSwapInitialDeposit, "100000000000000000", "initial deposit if deploying a new chequebook")
+	cmd.Flags().String(optionNameSwapInitialDeposit, "10000000000000000", "initial deposit if deploying a new chequebook")
 	cmd.Flags().Bool(optionNameSwapEnable, true, "enable swap")
 	cmd.Flags().Bool(optionNameFullNode, false, "cause the node to start in full mode")
 	cmd.Flags().String(optionNamePostageContractAddress, "", "postage stamp contract address")

--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -64,8 +64,8 @@ password-file: /var/lib/bee/password
 swap-endpoint: https://rpc.slock.it/goerli
 ## swap factory address
 # swap-factory-address: ""
-## initial deposit if deploying a new chequebook (default 100000000000000000)
-# swap-initial-deposit: 100000000000000000
+## initial deposit if deploying a new chequebook (default 10000000000000000)
+# swap-initial-deposit: 10000000000000000
 ## enable tracing
 # tracing-enable: false
 ## endpoint to send tracing data (default "127.0.0.1:6831")

--- a/packaging/homebrew/bee.yaml
+++ b/packaging/homebrew/bee.yaml
@@ -64,8 +64,8 @@ password-file: /usr/local/var/lib/swarm-bee/password
 swap-endpoint: https://rpc.slock.it/goerli
 ## swap factory address
 # swap-factory-address: ""
-## initial deposit if deploying a new chequebook (default 100000000000000000)
-# swap-initial-deposit: 100000000000000000
+## initial deposit if deploying a new chequebook (default 10000000000000000)
+# swap-initial-deposit: 10000000000000000
 ## enable tracing
 # tracing-enable: false
 ## endpoint to send tracing data (default "127.0.0.1:6831")

--- a/packaging/scoop/bee.yaml
+++ b/packaging/scoop/bee.yaml
@@ -54,8 +54,8 @@ password-file: ./password
 swap-endpoint: https://rpc.slock.it/goerli
 ## swap factory address
 # swap-factory-address: ""
-## initial deposit if deploying a new chequebook (default 100000000)
-# swap-initial-deposit: 100000000
+## initial deposit if deploying a new chequebook (default 10000000000000000)
+# swap-initial-deposit: 10000000000000000
 ## enable tracing
 # tracing-enable: false
 ## endpoint to send tracing data (default "127.0.0.1:6831")


### PR DESCRIPTION
1gBZZ is sufficient for most users for a long time. Heavy users can always add more to the initial deposit. This helps with the current shortage of gBZZ and gETH. 
Scoop package still had the old default initial deposit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1747)
<!-- Reviewable:end -->
