### PR TITLE
refactor(pushsync): change FailedCacheHit metric from CounterVec to Counter

### DIFF
--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -17,7 +17,7 @@ type metrics struct {
 	TotalReplicatedError    prometheus.Counter
 	TotalSendAttempts       prometheus.Counter
 	TotalFailedSendAttempts prometheus.Counter
-	FailedCacheHits         *prometheus.CounterVec
+	TotalFailedCacheHits    prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -66,15 +66,12 @@ func newMetrics() metrics {
 			Name:      "total_failed_send_attempts",
 			Help:      "Total no of failed attempts to push chunk.",
 		}),
-		FailedCacheHits: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "failed_cache_hits",
-				Help:      "FailedRequestCache hits",
-			},
-			[]string{"peer", "chunk"},
-		),
+		TotalFailedCacheHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_failed_cache_hits",
+			Help:      "Total FailedRequestCache hits",
+		}),
 	}
 }
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -351,7 +351,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 		}
 		if !ps.failedRequests.Useful(peer, ch.Address()) {
 			skipPeers = append(skipPeers, peer)
-			ps.metrics.FailedCacheHits.WithLabelValues(peer.String(), ch.Address().String()).Inc()
+			ps.metrics.TotalFailedCacheHits.Inc()
 			continue
 		}
 		skipPeers = append(skipPeers, peer)


### PR DESCRIPTION
During upgrade, we will see a lot of failures initially which may cause this metric to go out of hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1748)
<!-- Reviewable:end -->
