### PR TITLE
fix: blocklist for less time in pseudosettle

### DIFF
--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -322,7 +322,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int, 
 
 	if expectedAllowance.Cmp(acceptedAmount) > 0 {
 		// disconnect peer
-		err = s.p2pService.Blocklist(peer, 10000*time.Hour)
+		err = s.p2pService.Blocklist(peer, 1*time.Hour)
 		if err != nil {
 			return nil, 0, err
 		}


### PR DESCRIPTION
decrease blocklisting time in pseudosettle, so the network is not permanently defunct if something is wrong there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1750)
<!-- Reviewable:end -->
