### PR TITLE
fix: still update balance on blocklisting

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -849,7 +849,7 @@ func (d *debitAction) Apply() error {
 	if nextBalance.Cmp(a.disconnectLimit) >= 0 {
 		// peer too much in debt
 		a.metrics.AccountingDisconnectsCount.Inc()
-		return p2p.NewBlockPeerError(10000*time.Hour, ErrDisconnectThresholdExceeded)
+		return p2p.NewBlockPeerError(24*time.Hour, ErrDisconnectThresholdExceeded)
 	}
 
 	return nil

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -326,7 +326,6 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int, 
 		if err != nil {
 			return nil, 0, err
 		}
-		return nil, 0, ErrDisconnectAllowanceCheckFailed
 	}
 
 	lastTime.Total = lastTime.Total.Add(lastTime.Total, acceptedAmount)


### PR DESCRIPTION
* still update balance after time settle enforcement check even in case of blocklisting. this should avoid permanent imbalances arising related to enforcement issues.
* reduce the blocklisting time disconnect thresholds
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1753)
<!-- Reviewable:end -->
