### PR TITLE
docs: document reupload

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -224,6 +224,25 @@ paths:
           description: Default response
 
   "/bzz/{reference}":
+    patch:
+      summary: "Reupload a root hash to the network"
+      tags:
+        - Reupload file
+        - Reupload collection
+      parameters:
+        - in: path
+          name: reference
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/SwarmReference"
+          required: true
+          description: Root hash of content
+      responses:
+        "200":
+          description: Ok
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
     get:
       summary: "Get file or index document from a collection of files"
       tags:


### PR DESCRIPTION
adds the reupload functionality to the openapi spec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1755)
<!-- Reviewable:end -->
