### PR TITLE
refactor(postage): make key string

### DIFF
--- a/pkg/postage/batchstore/export_test.go
+++ b/pkg/postage/batchstore/export_test.go
@@ -5,6 +5,7 @@
 package batchstore
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -24,7 +25,11 @@ var Exp2 = exp2
 func IterateAll(bs postage.Storer, f func(b *postage.Batch) (bool, error)) error {
 	s := bs.(*store)
 	return s.store.Iterate(batchKeyPrefix, func(key []byte, _ []byte) (bool, error) {
-		b, err := s.Get(key[len(key)-32:])
+		k, err := hex.DecodeString(string(key[len(key)-64:]))
+		if err != nil {
+			return true, err
+		}
+		b, err := s.Get(k)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -167,7 +167,7 @@ func (s *store) SetRadiusSetter(r postage.RadiusSetter) {
 
 // batchKey returns the index key for the batch ID used in the by-ID batch index.
 func batchKey(id []byte) string {
-	return batchKeyPrefix + string(id)
+	return batchKeyPrefix + hex.EncodeToString(id)
 }
 
 // valueKey returns the index key for the batch ID used in the by-ID batch index.


### PR DESCRIPTION
if we ever need to migrate those we can display some info about them to user. right now they are being accidentally cleaned up in the intervals migration but that's a non-problem
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1757)
<!-- Reviewable:end -->
