### PR TITLE
fix: move metrics collector finalize at the end of the close call

### DIFF
--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -7,7 +7,6 @@
 package metrics
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -16,8 +15,6 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/hashicorp/go-multierror"
 )
-
-var ErrPeerNotFound = errors.New("peer no found")
 
 const (
 	peerLastSeenTimestamp       string = "peer-last-seen-timestamp"
@@ -211,16 +208,42 @@ func (c *Collector) Record(addr swarm.Address, rop ...RecordOp) error {
 // error, it rather continues and all the execution errors are returned together
 // with the successful metrics snapshots.
 func (c *Collector) Snapshot(t time.Time, addresses ...swarm.Address) (map[string]*Snapshot, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	var mErr error
 	snapshot := make(map[string]*Snapshot)
 
 	take := func(addr string) {
-		peerSnapshot, err := c.peer(t, addr)
+		cs := c.counters[addr]
+		if cs == nil {
+			return
+		}
+
+		ls, err := cs.lastSeenTimestamp.Get()
 		if err != nil {
-			mErr = multierror.Append(err)
-		} else {
-			snapshot[addr] = peerSnapshot
+			mErr = multierror.Append(mErr, fmt.Errorf("unable to take last seen snapshot for %q: %w", addr, err))
+		}
+		lastSeenTimestamp := int64(ls)
+
+		cn, err := cs.connTotalDuration.Get()
+		if err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("unable to take connection duration snapshot for %q: %w", addr, err))
+		}
+		connTotalDuration := time.Duration(cn)
+
+		sessionConnDuration := cs.sessionConnDuration
+		if cs.loggedIn {
+			sessionConnDuration = t.Sub(time.Unix(0, lastSeenTimestamp))
+			connTotalDuration += sessionConnDuration
+		}
+
+		snapshot[addr] = &Snapshot{
+			LastSeenTimestamp:          lastSeenTimestamp,
+			SessionConnectionRetry:     cs.sessionConnRetry,
+			ConnectionTotalDuration:    connTotalDuration,
+			SessionConnectionDuration:  sessionConnDuration,
+			SessionConnectionDirection: cs.sessionConnDirection,
 		}
 	}
 
@@ -228,56 +251,12 @@ func (c *Collector) Snapshot(t time.Time, addresses ...swarm.Address) (map[strin
 		take(addr.String())
 	}
 	if len(addresses) == 0 {
-		c.mu.RLock()
 		for addr := range c.counters {
 			take(addr)
 		}
-		c.mu.RUnlock()
 	}
 
 	return snapshot, mErr
-}
-
-func (c *Collector) Peer(t time.Time, addr swarm.Address) (*Snapshot, error) {
-	return c.peer(t, addr.String())
-}
-
-func (c *Collector) peer(t time.Time, addr string) (*Snapshot, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	var mErr error
-
-	cs := c.counters[addr]
-	if cs == nil {
-		return nil, ErrPeerNotFound
-	}
-
-	ls, err := cs.lastSeenTimestamp.Get()
-	if err != nil {
-		mErr = multierror.Append(mErr, fmt.Errorf("unable to take last seen snapshot for %q: %w", addr, err))
-	}
-	lastSeenTimestamp := int64(ls)
-
-	cn, err := cs.connTotalDuration.Get()
-	if err != nil {
-		mErr = multierror.Append(mErr, fmt.Errorf("unable to take connection duration snapshot for %q: %w", addr, err))
-	}
-	connTotalDuration := time.Duration(cn)
-
-	sessionConnDuration := cs.sessionConnDuration
-	if cs.loggedIn {
-		sessionConnDuration = t.Sub(time.Unix(0, lastSeenTimestamp))
-		connTotalDuration += sessionConnDuration
-	}
-
-	return &Snapshot{
-		LastSeenTimestamp:          lastSeenTimestamp,
-		ConnectionTotalDuration:    connTotalDuration,
-		SessionConnectionRetry:     cs.sessionConnRetry,
-		SessionConnectionDuration:  sessionConnDuration,
-		SessionConnectionDirection: cs.sessionConnDirection,
-	}, mErr
 }
 
 // Finalize logs out all ongoing peer sessions

--- a/pkg/topology/kademlia/internal/metrics/metrics_test.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics_test.go
@@ -5,7 +5,6 @@
 package metrics_test
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -138,7 +137,7 @@ func TestPeerMetricsCollector(t *testing.T) {
 		t.Fatalf("Finalize(%s): unexpected error: %v", t3, err)
 	}
 	sss, err := mc.Snapshot(t2, addr)
-	if !errors.Is(err, metrics.ErrPeerNotFound) {
+	if err != nil {
 		t.Fatalf("Snapshot(%q, ...): unexpected error: %v", addr, err)
 	}
 	if have, want := len(sss), 0; have != want {


### PR DESCRIPTION
The Finalize collector method is called after all the waits and the
timeouts for finishing the ongoing connection attempts have finished.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1765)
<!-- Reviewable:end -->
