### PR TITLE
fix: include reserve capacity in estimate

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -200,7 +200,7 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 // gcTrigger retruns the absolute value for garbage collection
 // target value, calculated from db.capacity and gcTargetRatio.
 func (db *DB) gcTarget() (target uint64) {
-	return uint64(float64(db.capacity) * gcTargetRatio)
+	return uint64(float64(db.cacheCapacity) * gcTargetRatio)
 }
 
 // triggerGarbageCollection signals collectGarbageWorker
@@ -242,7 +242,7 @@ func (db *DB) incGCSizeInBatch(batch *leveldb.Batch, change int64) (err error) {
 	db.metrics.GCSize.Set(float64(newSize))
 
 	// trigger garbage collection if we reached the capacity
-	if newSize >= db.capacity {
+	if newSize >= db.cacheCapacity {
 		db.triggerGarbageCollection()
 	}
 	return nil

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -343,7 +343,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 	addrs := make([]swarm.Address, 0)
 
 	// upload random chunks just up to the capacity
-	for i := 0; i < int(db.capacity)-1; i++ {
+	for i := 0; i < int(db.cacheCapacity)-1; i++ {
 		ch := generateTestRandomChunk()
 		// call unreserve on the batch with radius 0 so that
 		// localstore is aware of the batch and the chunk can

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -45,7 +45,7 @@ var (
 
 var (
 	// Default value for Capacity DB option.
-	defaultCapacity uint64 = 1000000
+	defaultCacheCapacity uint64 = 1000000
 	// Limit the number of goroutines created by Getters
 	// that call updateGC function. Value 0 sets no limit.
 	maxParallelUpdateGC = 1000
@@ -177,7 +177,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 	if o == nil {
 		// default options
 		o = &Options{
-			Capacity: defaultCapacity,
+			Capacity: defaultCacheCapacity,
 		}
 	}
 
@@ -196,7 +196,7 @@ func New(path string, baseKey []byte, o *Options, logger logging.Logger) (db *DB
 		logger:                   logger,
 	}
 	if db.cacheCapacity == 0 {
-		db.cacheCapacity = defaultCapacity
+		db.cacheCapacity = defaultCacheCapacity
 	}
 
 	capacityMB := float64((db.cacheCapacity+uint64(batchstore.Capacity))*swarm.ChunkSize) * 9.5367431640625e-7

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -63,7 +63,7 @@ func TestDBCapacity(t *testing.T) {
 		Capacity: 500,
 	}
 	db := newTestDB(t, &lo)
-	if db.capacity != 500 {
+	if db.cacheCapacity != 500 {
 		t.Fatal("could not set db capacity")
 	}
 }

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -80,7 +80,7 @@ func (db *DB) UnreserveBatch(id []byte, radius uint8) error {
 		return err
 	}
 	// trigger garbage collection if we reached the capacity
-	if gcSize >= db.capacity {
+	if gcSize >= db.cacheCapacity {
 		db.triggerGarbageCollection()
 	}
 


### PR DESCRIPTION
this change enables a correct estimate:

```
time="2021-05-18T17:52:10+03:00" level=info msg="database capacity: 1000000 chunks (approximately 36.7GB)"
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1767)
<!-- Reviewable:end -->
