### PR TITLE
fix: dont stamp dupes

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -329,18 +329,19 @@ func newStamperPutter(s storage.Storer, post postage.Service, signer crypto.Sign
 	return &stamperPutter{Storer: s, stamper: stamper}, nil
 }
 
-func (p *stamperPutter) Put(ctx context.Context, mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err error) {
+func (p *stamperPutter) Put(ctx context.Context, mode storage.ModePut, chs ...swarm.Chunk) (exists []bool, err error) {
 	var (
 		ctp []swarm.Chunk
 		idx []int
 	)
+	exists = make([]bool, len(chs))
 
 	for i, c := range chs {
 		has, err := p.Storer.Has(ctx, c.Address())
 		if err != nil {
 			return nil, err
 		}
-		if containsChunk(c.Address(), chs[:i]...) || has {
+		if has || containsChunk(c.Address(), chs[:i]...) {
 			exists[i] = true
 			continue
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -330,15 +330,37 @@ func newStamperPutter(s storage.Storer, post postage.Service, signer crypto.Sign
 }
 
 func (p *stamperPutter) Put(ctx context.Context, mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err error) {
+	var (
+		ctp []swarm.Chunk
+		idx []int
+	)
+
 	for i, c := range chs {
+		has, err := p.Storer.Has(ctx, c.Address())
+		if err != nil {
+			return nil, err
+		}
+		if containsChunk(c.Address(), chs[:i]...) || has {
+			exists[i] = true
+			continue
+		}
 		stamp, err := p.stamper.Stamp(c.Address())
 		if err != nil {
 			return nil, err
 		}
 		chs[i] = c.WithStamp(stamp)
+		ctp = append(ctp, chs[i])
+		idx = append(idx, i)
 	}
 
-	return p.Storer.Put(ctx, mode, chs...)
+	exists2, err := p.Storer.Put(ctx, mode, ctp...)
+	if err != nil {
+		return nil, err
+	}
+	for i, v := range idx {
+		exists[v] = exists2[i]
+	}
+	return exists, nil
 }
 
 type pipelineFunc func(context.Context, io.Reader) (swarm.Address, error)
@@ -379,4 +401,15 @@ func requestCalculateNumberOfChunks(r *http.Request) int64 {
 		return calculateNumberOfChunks(r.ContentLength, requestEncrypt(r))
 	}
 	return 0
+}
+
+// containsChunk returns true if the chunk with a specific address
+// is present in the provided chunk slice.
+func containsChunk(addr swarm.Address, chs ...swarm.Chunk) bool {
+	for _, c := range chs {
+		if addr.Equal(c.Address()) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This makes sure that duplicate chunks don't get stamped twice. It might not be performance optimized since we're incurring more db ops per insert but at least for now it would help us maintain with relative good certainty the assumption of uniform distribution of chunks over collision buckets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1772)
<!-- Reviewable:end -->
