### PR TITLE
feat: Retrial behavior in retrieval

### DIFF
--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -47,7 +47,7 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			// request from network
-			ch, err = s.retrieval.RetrieveChunk(ctx, addr)
+			ch, err = s.retrieval.RetrieveChunk(ctx, addr, true)
 			if err != nil {
 				targets := sctx.GetTargets(ctx)
 				if targets == nil || s.recoveryCallback == nil {

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -200,7 +200,7 @@ type retrievalMock struct {
 	addr      swarm.Address
 }
 
-func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk swarm.Chunk, err error) {
+func (r *retrievalMock) RetrieveChunk(ctx context.Context, addr swarm.Address, orig bool) (chunk swarm.Chunk, err error) {
 	if r.failure {
 		return nil, fmt.Errorf("chunk not found")
 	}
@@ -219,7 +219,7 @@ func (mr *mockRecovery) recovery(chunkAddress swarm.Address, targets pss.Targets
 	mr.callbackC <- true
 }
 
-func (r *mockRecovery) RetrieveChunk(ctx context.Context, addr swarm.Address) (chunk swarm.Chunk, err error) {
+func (r *mockRecovery) RetrieveChunk(ctx context.Context, addr swarm.Address, orig bool) (chunk swarm.Chunk, err error) {
 	return nil, fmt.Errorf("chunk not found")
 }
 

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -230,6 +230,7 @@ func newTestNetStore(t *testing.T, recoveryFunc recovery.Callback) storage.Store
 	server := retrieval.New(swarm.ZeroAddress, mockStorer, nil, ps, logger, serverMockAccounting, pricerMock, nil)
 	recorder := streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
+		streamtest.WithBaseAddr(peerID),
 	)
 	retrieve := retrieval.New(swarm.ZeroAddress, mockStorer, recorder, ps, logger, serverMockAccounting, pricerMock, nil)
 	validStamp := func(ch swarm.Chunk, stamp []byte) (swarm.Chunk, error) {

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -255,7 +255,6 @@ func (s mockPeerSuggester) EachPeer(topology.EachPeerFunc) error {
 	return errors.New("not implemented")
 }
 func (s mockPeerSuggester) EachPeerRev(f topology.EachPeerFunc) error {
-	//panic("EachPeerRev")
 	return s.eachPeerRevFunc(f)
 }
 

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -227,7 +227,13 @@ func newTestNetStore(t *testing.T, recoveryFunc recovery.Callback) storage.Store
 		_, _, _ = f(peerID, 0)
 		return nil
 	}}
-	server := retrieval.New(swarm.ZeroAddress, mockStorer, nil, ps, logger, serverMockAccounting, pricerMock, nil)
+
+	ps0 := mockPeerSuggester{eachPeerRevFunc: func(f topology.EachPeerFunc) error {
+		// not calling peer iterator on server as it would cause dereference of non existing streamer
+		return nil
+	}}
+
+	server := retrieval.New(swarm.ZeroAddress, mockStorer, nil, ps0, logger, serverMockAccounting, pricerMock, nil)
 	recorder := streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
 		streamtest.WithBaseAddr(peerID),
@@ -249,6 +255,7 @@ func (s mockPeerSuggester) EachPeer(topology.EachPeerFunc) error {
 	return errors.New("not implemented")
 }
 func (s mockPeerSuggester) EachPeerRev(f topology.EachPeerFunc) error {
+	//panic("EachPeerRev")
 	return s.eachPeerRevFunc(f)
 }
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -130,7 +130,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 		)
 
 		requestAttempt := 0
-		emptyRounds := 0
 
 		lastTime := time.Now().Unix()
 
@@ -159,7 +158,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 				if res.retrieved {
 					if res.err != nil {
 						if !res.peer.IsZero() {
-							emptyRounds++
 							logger.Debugf("retrieval: failed to get chunk %s from peer %s: %v", addr, res.peer, res.err)
 						}
 						peersResults++
@@ -200,10 +198,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 				}
 			}
 
-			if emptyRounds >= maxSelects {
-				requestAttempt++
-				emptyRounds = 0
-			}
 		}
 
 		// if we have not managed to get results after 5 rounds of peer selections, give up

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -98,7 +98,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 	maxPeers := 1
 
 	if origin {
-		maxPeers = 5
+		maxPeers = 8
 	}
 
 	v, err, _ := s.singleflight.Do(addr.String(), func() (interface{}, error) {
@@ -161,6 +161,11 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 			if peersResults >= maxPeers {
 				logger.Tracef("retrieval: failed to get chunk %s", addr)
 				return nil, storage.ErrNotFound
+			}
+
+			if peerAttempt >= maxPeers {
+				// wait and reset skiplist
+				sp = newSkipPeers()
 			}
 		}
 	})

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -179,7 +179,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 			// if we have not counted enough successful attempts but out of selection amount, reset
 			if peerAttempt >= maxSelects {
-				if origin {
+				if !origin {
 					return nil, storage.ErrNotFound
 				}
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -96,6 +96,7 @@ func (s *Service) Protocol() p2p.ProtocolSpec {
 const (
 	retrieveChunkTimeout          = 10 * time.Second
 	retrieveRetryIntervalDuration = 5 * time.Second
+	maxRequestRounds              = 5
 	maxSelects                    = 8
 	originSuffix                  = "_origin"
 )
@@ -130,7 +131,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 		lastTime := time.Now().Unix()
 
-		for requestAttempt < 5 {
+		for requestAttempt < maxRequestRounds {
 
 			if peerAttempt < maxSelects {
 
@@ -201,7 +202,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 		}
 
-		// if we have not managed to get results after 5 rounds of peer selections, give up
+		// if we have not managed to get results after 5 (maxRequestRounds) rounds of peer selections, give up
 		return nil, storage.ErrNotFound
 
 	})

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/tracing"
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/sync/singleflight"
+	"resenje.org/singleflight"
 )
 
 type requestSourceContextKey struct{}
@@ -108,7 +108,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 		flightRoute = addr.String() + originSuffix
 	}
 
-	v, err, _ := s.singleflight.Do(flightRoute, func() (interface{}, error) {
+	v, _, err := s.singleflight.Do(ctx, flightRoute, func(ctx context.Context) (interface{}, error) {
 
 		maxPeers := 1
 		if origin {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -417,7 +417,6 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	}
 
 	chunkPrice := s.pricer.Price(chunk.Address())
-	fmt.Println("I")
 	debit := s.accounting.PrepareDebit(p.Address, chunkPrice)
 	defer debit.Cleanup()
 
@@ -425,12 +424,10 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		Data:  chunk.Data(),
 		Stamp: stamp,
 	}); err != nil {
-		fmt.Println("III", err)
 		return fmt.Errorf("write delivery: %w peer %s", err, p.Address.String())
 	}
 
 	s.logger.Tracef("retrieval protocol debiting peer %s", p.Address.String())
-	fmt.Println("II")
 	// debit price from p's balance
 	return debit.Apply()
 }

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -364,7 +364,6 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 					}
 				},
 			),
-			streamtest.WithBaseAddr(clientAddress),
 		)
 
 		client := retrieval.New(clientAddress, nil, recorder, peerSuggesterFn(peers...), logger, accountingmock.NewAccounting(), pricerMock, nil)

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -81,7 +81,7 @@ func TestDelivery(t *testing.T) {
 	client := retrieval.New(clientAddr, clientMockStorer, recorder, ps, logger, clientMockAccounting, pricerMock, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
-	v, err := client.RetrieveChunk(ctx, chunk.Address())
+	v, err := client.RetrieveChunk(ctx, chunk.Address(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestRetrieveChunk(t *testing.T) {
 		}}
 		client := retrieval.New(clientAddress, nil, recorder, clientSuggester, logger, accountingmock.NewAccounting(), pricer, nil)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestRetrieveChunk(t *testing.T) {
 			nil,
 		)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -332,7 +332,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 
 		client := retrieval.New(clientAddress, nil, recorder, peerSuggesterFn(peers...), logger, accountingmock.NewAccounting(), pricerMock, nil)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -368,7 +368,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 
 		client := retrieval.New(clientAddress, nil, recorder, peerSuggesterFn(peers...), logger, accountingmock.NewAccounting(), pricerMock, nil)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -432,7 +432,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 
 		client := retrieval.New(clientAddress, nil, recorder, peerSuggesterFn(peers...), logger, clientMockAccounting, pricerMock, nil)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -484,7 +484,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 		// client only knows about server 1
 		client := retrieval.New(clientAddress, nil, clientRecorder, peerSuggesterFn(serverAddress1), logger, accountingmock.NewAccounting(), pricerMock, nil)
 
-		got, err := client.RetrieveChunk(context.Background(), chunk.Address())
+		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -364,6 +364,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 					}
 				},
 			),
+			streamtest.WithBaseAddr(clientAddress),
 		)
 
 		client := retrieval.New(clientAddress, nil, recorder, peerSuggesterFn(peers...), logger, accountingmock.NewAccounting(), pricerMock, nil)

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -437,6 +437,8 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		fmt.Println("GOT ", got)
+
 		if !bytes.Equal(got.Data(), chunk.Data()) {
 			t.Fatalf("got data %x, want %x", got.Data(), chunk.Data())
 		}

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -437,8 +437,6 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		fmt.Println("GOT ", got)
-
 		if !bytes.Equal(got.Data(), chunk.Data()) {
 			t.Fatalf("got data %x, want %x", got.Data(), chunk.Data())
 		}

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -30,7 +30,6 @@ func (s *skipPeers) All() []swarm.Address {
 func (s *skipPeers) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	s.overdraftAddresses = []swarm.Address{}
 }
 


### PR DESCRIPTION
This pr attempts to mirror some of the push sync behaviour changes introduced in #1662 and to enable retrying until a chunk is attempted to be retrieved from at least one peer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1780)
<!-- Reviewable:end -->
