### PR TITLE
docs: pin endpoint also returns 200

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -477,8 +477,14 @@ paths:
       tags:
         - Root hash pinning
       responses:
+        "200":
+          description: Pin already exists, so no operation
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/Response"
         "201":
-          description: Pinning root hash with reference
+          description: New pin with root reference was created
           content:
             application/json:
               schema:


### PR DESCRIPTION
Just one small inconsistency in OpenAPI related to `POST /pins` endpoint.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1788)
<!-- Reviewable:end -->
