### PR TITLE
feat: transact batchstore

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -362,7 +362,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		eventListener := listener.New(logger, swapBackend, postageContractAddress, o.BlockTime)
 		b.listenerCloser = eventListener
 
-		batchSvc = batchservice.New(batchStore, logger, eventListener)
+		batchSvc = batchservice.New(stateStore, batchStore, logger, eventListener)
 
 		erc20Address, err := postagecontract.LookupERC20Address(p2pCtx, transactionService, postageContractAddress)
 		if err != nil {
@@ -436,7 +436,10 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	batchStore.SetRadiusSetter(kad)
 
 	if batchSvc != nil {
-		syncedChan := batchSvc.Start(postageSyncStart)
+		syncedChan, err := batchSvc.Start(postageSyncStart)
+		if err != nil {
+			return nil, fmt.Errorf("unable to start batch service: %w", err)
+		}
 		// wait for the postage contract listener to sync
 		logger.Info("waiting to sync postage contract data, this may take a while... more info available in Debug loglevel")
 

--- a/pkg/postage/batchstore/mock/store.go
+++ b/pkg/postage/batchstore/mock/store.go
@@ -24,6 +24,7 @@ type BatchStore struct {
 	getErrDelayCnt int
 	putErr         error
 	putErrDelayCnt int
+	resetCallCount int
 }
 
 // Option is a an option passed to New
@@ -133,4 +134,13 @@ func (bs *BatchStore) GetReserveState() *postage.ReserveState {
 
 func (bs *BatchStore) SetRadiusSetter(r postage.RadiusSetter) {
 	panic("not implemented")
+}
+
+func (bs *BatchStore) Reset() error {
+	bs.resetCallCount++
+	return nil
+}
+
+func (bs *BatchStore) ResetCalls() int {
+	return bs.resetCallCount
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -17,7 +17,10 @@ type EventUpdater interface {
 	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int) error
 	UpdatePrice(price *big.Int) error
 	UpdateBlockNumber(blockNumber uint64) error
-	Start(startBlock uint64) <-chan struct{}
+	Start(startBlock uint64) (<-chan struct{}, error)
+
+	TransactionStart() error
+	TransactionEnd() error
 }
 
 // Storer represents the persistence layer for batches on the current (highest
@@ -29,6 +32,8 @@ type Storer interface {
 	GetChainState() *ChainState
 	GetReserveState() *ReserveState
 	SetRadiusSetter(RadiusSetter)
+
+	Reset() error
 }
 
 type RadiusSetter interface {

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -194,6 +194,10 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 				return err
 			}
 
+			if err := updater.TransactionStart(); err != nil {
+				return err
+			}
+
 			for _, e := range events {
 				err = updater.UpdateBlockNumber(e.BlockNumber)
 				if err != nil {
@@ -206,6 +210,10 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 
 			err = updater.UpdateBlockNumber(to)
 			if err != nil {
+				return err
+			}
+
+			if err := updater.TransactionEnd(); err != nil {
 				return err
 			}
 

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -300,7 +300,9 @@ func (u *updater) UpdateBlockNumber(blockNumber uint64) error {
 	return nil
 }
 
-func (u *updater) Start(_ uint64) <-chan struct{} { return nil }
+func (u *updater) Start(_ uint64) (<-chan struct{}, error) { return nil, nil }
+func (u *updater) TransactionStart() error                 { return nil }
+func (u *updater) TransactionEnd() error                   { return nil }
 
 type mockFilterer struct {
 	filterLogEvents    []types.Log


### PR DESCRIPTION
This PR adds a change to prevent inconsistencies when syncing the postage data from the chain.

We've found that during shutdown, the block height might be persisted before an event (or a bunch of events) are processed. This sends the node into an inconsistent state since the next time it will boot up, syncing chain data will commence from `<previous persisted block>+1`.

Due to this, we've introduced a stopgap solution that detects whether a shutdown happened while updating a batch.
Once a dirty shutdown is detected on boot up sequence, the batch store keys are swiped and the node starts to resync the chain data from the start block number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1793)
<!-- Reviewable:end -->
