### PR TITLE
fix(pusher): flaky test

### DIFF
--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -89,6 +89,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 
 	mtags, p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
 	defer storer.Close()
+	defer p.Close()
 
 	ta, err := mtags.Create(1)
 	if err != nil {
@@ -119,8 +120,6 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 	if ta.Get(tags.StateSynced) != 1 {
 		t.Fatalf("tags error")
 	}
-
-	p.Close()
 }
 
 // TestSendChunkToPushSyncWithoutTag is similar to TestSendChunkToPushSync, excep that the tags are not
@@ -146,6 +145,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 
 	_, p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
 	defer storer.Close()
+	defer p.Close()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -155,7 +155,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 	// Check is the chunk is set as synced in the DB.
 	for i := 0; i < noOfRetries; i++ {
 		// Give some time for chunk to be pushed and receipt to be received
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err == nil {
@@ -165,7 +165,6 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Close()
 }
 
 // TestSendChunkAndReceiveInvalidReceipt sends a chunk to pushsync to be sent ot its closest peer and
@@ -184,6 +183,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 
 	_, p, storer := createPusher(t, triggerPeer, pushSyncService, mock.WithClosestPeer(closestPeer))
 	defer storer.Close()
+	defer p.Close()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -203,7 +203,6 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 	if err == nil {
 		t.Fatalf("chunk not syned error expected")
 	}
-	p.Close()
 }
 
 // TestSendChunkAndTimeoutinReceivingReceipt sends a chunk to pushsync to be sent ot its closest peer and


### PR DESCRIPTION
This PR addresses two related issues with TestSendChunkToPushSyncWithoutTag reported in issue https://github.com/ethersphere/bee/issues/1556.

The first one is the test failure `pusher_test.go:166: Chunk not synced` which is due to too short time waiting for chunk to be synced in the retry loop. It is addressed by raising the value to 50ms from 10ms for every retry iteration. It is possible that with race detector scheduler is not able to execute all required goroutines for test to pass even with retries. This was validate locally and validated that it does not happen with this change by running the test tens of thousand times.

The second issue is with the Closing sequence when the failure above occurs. It is incorrect to have the pusher Close only at the end of the function as it will not be called on the failure (additional side effect is a memory leak). Beside that store Close is called in the defer function, which will be called even if the failure occurs. This creates a possible situation where the pusher is still calling SubscribePush and localstore's s.subscritionsWG.Add(1) after the test finishes with a failure, and the localstore's Close is calling db.subscritionsWG.Wait() in test's defer. This results with a Panic reported in the issue. This PR sets up the proper resource cleanup and termination.

Additionally, the closing sequence is changed in two other tests in the same file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1800)
<!-- Reviewable:end -->
