### PR TITLE
fix(node): remove state-store close call on nil reference

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -202,7 +202,6 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 
 	stateStore, err := InitStateStore(logger, o.DataDir)
 	if err != nil {
-		_ = stateStore.Close()
 		return nil, err
 	}
 	b.stateStoreCloser = stateStore


### PR DESCRIPTION
This is a fix for the following reported issue #1801

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1807)
<!-- Reviewable:end -->
