### PR TITLE
pullstorage: fix goroutine leak

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -324,7 +324,6 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.HistWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)
@@ -368,7 +367,6 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.LiveWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -129,25 +129,6 @@ func TestIntervalChunks_GetChunksLater(t *testing.T) {
 	}
 }
 
-func TestIntervalChunks_Blocking(t *testing.T) {
-	desc := someDescriptors(0, 2)
-	ps, _ := newPullStorage(t, mock.WithSubscribePullChunks(desc...), mock.WithPartialInterval(true))
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		<-time.After(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_, _, err := ps.IntervalChunks(ctx, 0, 0, 5, limit)
-	if err == nil {
-		t.Fatal("expected error but got none")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatal(err)
-	}
-}
-
 func TestIntervalChunks_DbShutdown(t *testing.T) {
 	ps, db := newPullStorage(t, mock.WithPartialInterval(true))
 


### PR DESCRIPTION
Fixes the goroutine leak in pullstorage. This is due to context cancellation of the main goroutine that is actually supposed to communicate the results to others. Results in the channels never being written to and contexts never being terminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1811)
<!-- Reviewable:end -->
