### PR TITLE
perf(pslice): optimize Add method

### DIFF
--- a/pkg/topology/pslice/pslice_test.go
+++ b/pkg/topology/pslice/pslice_test.go
@@ -413,3 +413,23 @@ func chkNotExists(t *testing.T, ps *pslice.PSlice, addrs ...swarm.Address) {
 		}
 	}
 }
+
+func BenchmarkAdd(b *testing.B) {
+	var (
+		ps   = pslice.New(16)
+		base = test.RandomAddress()
+	)
+
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 300; j++ {
+			ps.Add(test.RandomAddressAt(base, i), uint8(i))
+		}
+	}
+
+	const po = 8
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ps.Add(test.RandomAddressAt(base, po), po)
+	}
+}


### PR DESCRIPTION
This PR addresses a performance problem found in profiling when adding new peer address to PSlice with a larger number of peers in it. This is manifested as a very high node start time with a large number of overlay addresses in the addressbook, directly impacting bootnode's performance.

Two improvements combined give significantly better results in newley added BenchmarkAdd test:

- optimized insertAddresses based on https://github.com/golang/go/wiki/SliceTricks#insertvector
- making the copied peers slice capacity larger by one to avoid extending the slice

The improvements are in execution time and also memory and allocations which is reducing the pressure on the gc.

The results are:

```
goos: darwin
goarch: amd64
pkg: github.com/ethersphere/bee/pkg/topology/pslice
cpu: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz

// Code state on the mster branch (baseline)
BenchmarkAdd
BenchmarkAdd-8   	    9228	    381933 ns/op	  689114 B/op	       5 allocs/op

// Only using insertAddresses instead append function (one optimization)
BenchmarkAdd
BenchmarkAdd-8   	   10000	    278262 ns/op	  478792 B/op	       4 allocs/op

// insertAddresses and peerExtraCap in the copy method (both optimizations)
BenchmarkAdd
BenchmarkAdd-8   	   10000	    171411 ns/op	  239487 B/op	       3 allocs/op
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1824)
<!-- Reviewable:end -->
