### PR TITLE
Fix incorrect zero of existing failedAttempts

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -857,7 +857,11 @@ func (k *Kad) Disconnected(peer p2p.Peer) {
 	k.connectedPeers.Remove(peer.Address, po)
 
 	k.waitNextMu.Lock()
-	k.waitNext[peer.Address.String()] = retryInfo{tryAfter: time.Now().Add(timeToRetry), failedAttempts: 0}
+	newInfo := retryInfo{tryAfter: time.Now().Add(timeToRetry), failedAttempts: 0}
+	if info, ok := k.waitNext[peer.Address.String()]; ok {
+		newInfo.failedAttempts = info.failedAttempts
+	}
+	k.waitNext[peer.Address.String()] = newInfo
 	k.waitNextMu.Unlock()
 
 	if err := k.collector.Record(


### PR DESCRIPTION
This fixes #1825 by looking up and preserving the failedAttempts for a known peer instead of zeroing it.  This is ok because the entire retryInfo record is deleted for this peer if it ever is successfully connected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1826)
<!-- Reviewable:end -->
