### PR TITLE
revert: pullstorage iterator share

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -324,7 +324,6 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.HistWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)
@@ -368,7 +367,6 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.LiveWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	logMore = false // enable this to get more logging
+	logMore = true // enable this to get more logging
 )
 
 type Options struct {
@@ -324,6 +324,7 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.HistWorkerErrCounter.Inc()
+				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)
@@ -335,6 +336,9 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			p.metrics.HistWorkerErrCounter.Inc()
 			p.logger.Errorf("could not persist interval for peer %s, quitting", peer)
 			return
+		}
+		if logMore {
+			p.logger.Debugf("histSyncWorker pulled bin %d [%d:%d], peer %s", bin, s, top, peer)
 		}
 	}
 }
@@ -367,6 +371,7 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.LiveWorkerErrCounter.Inc()
+				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)
@@ -379,6 +384,10 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			p.logger.Errorf("liveSyncWorker exit on add peer interval. peer %s bin %d from %d err %v", peer, bin, from, err)
 			return
 		}
+		if logMore {
+			p.logger.Debugf("liveSyncWorker pulled bin %d [%d:%d], peer %s", bin, from, top, peer)
+		}
+
 		from = top + 1
 	}
 }

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -6,8 +6,8 @@ package puller_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -37,7 +37,7 @@ func TestOneSync(t *testing.T) {
 	var (
 		addr        = test.RandomAddress()
 		cursors     = []uint64{1000, 1000, 1000}
-		liveReplies = []uint64{1}
+		liveReplies = []uint64{1001}
 	)
 
 	puller, _, kad, pullsync := newPuller(opts{
@@ -592,7 +592,7 @@ func newPuller(ops opts) (*puller.Puller, storage.StateStorer, *mockk.Mock, *moc
 	s := mock.NewStateStore()
 	ps := mockps.NewPullSync(ops.pullSync...)
 	kad := mockk.NewMockKademlia(ops.kad...)
-	logger := logging.New(ioutil.Discard, 6)
+	logger := logging.New(os.Stdout, 5)
 
 	o := puller.Options{
 		Bins: ops.bins,

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -129,25 +129,6 @@ func TestIntervalChunks_GetChunksLater(t *testing.T) {
 	}
 }
 
-func TestIntervalChunks_Blocking(t *testing.T) {
-	desc := someDescriptors(0, 2)
-	ps, _ := newPullStorage(t, mock.WithSubscribePullChunks(desc...), mock.WithPartialInterval(true))
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		<-time.After(100 * time.Millisecond)
-		cancel()
-	}()
-
-	_, _, err := ps.IntervalChunks(ctx, 0, 0, 5, limit)
-	if err == nil {
-		t.Fatal("expected error but got none")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatal(err)
-	}
-}
-
 func TestIntervalChunks_DbShutdown(t *testing.T) {
 	ps, db := newPullStorage(t, mock.WithPartialInterval(true))
 

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -21,7 +21,6 @@ type MockStorer struct {
 	pinnedAddress   []swarm.Address // Stores the pinned address
 	pinnedCounter   []uint64        // and its respective counter. These are stored as slices to preserve the order.
 	subpull         []storage.Descriptor
-	subpullCalls    int
 	partialInterval bool
 	morePull        chan struct{}
 	mtx             sync.Mutex
@@ -221,7 +220,6 @@ func (m *MockStorer) LastPullSubscriptionBinID(bin uint8) (id uint64, err error)
 }
 
 func (m *MockStorer) SubscribePull(ctx context.Context, bin uint8, since, until uint64) (<-chan storage.Descriptor, <-chan struct{}, func()) {
-	m.subpullCalls++
 	c := make(chan storage.Descriptor)
 	done := make(chan struct{})
 	stop := func() {
@@ -275,10 +273,6 @@ func (m *MockStorer) SubscribePull(ctx context.Context, bin uint8, since, until 
 
 	}()
 	return c, m.quit, stop
-}
-
-func (m *MockStorer) SubscribePullCalls() int {
-	return m.subpullCalls
 }
 
 func (m *MockStorer) MorePull(d ...storage.Descriptor) {


### PR DESCRIPTION
We have a goroutine leak due to the iterator share change. The context propagation in this case is really not trivial to do and it appears that we have some quirks that need to be thoroughly fleshed out before this lands in `master`. Reverting for now so that release can be communicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1832)
<!-- Reviewable:end -->
