### PR TITLE
fix(puller): cursors length panic

### DIFF
--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -6,8 +6,8 @@ package puller_test
 
 import (
 	"errors"
+	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 	"time"
 
@@ -123,7 +123,7 @@ func TestSyncFlow_PeerWithinDepth_Live(t *testing.T) {
 					), mockk.WithDepth(1),
 				},
 				pullSync: []mockps.Option{mockps.WithCursors(tc.cursors), mockps.WithLiveSyncReplies(tc.liveReplies...)},
-				bins:     5,
+				bins:     2,
 			})
 			t.Cleanup(func() {
 				pullsync.Close()
@@ -199,7 +199,7 @@ func TestSyncFlow_PeerWithinDepth_Historical(t *testing.T) {
 					), mockk.WithDepth(1),
 				},
 				pullSync: []mockps.Option{mockps.WithCursors(tc.cursors), mockps.WithAutoReply(), mockps.WithLiveSyncBlock()},
-				bins:     5,
+				bins:     2,
 			})
 			defer puller.Close()
 			defer pullsync.Close()
@@ -592,7 +592,7 @@ func newPuller(ops opts) (*puller.Puller, storage.StateStorer, *mockk.Mock, *moc
 	s := mock.NewStateStore()
 	ps := mockps.NewPullSync(ops.pullSync...)
 	kad := mockk.NewMockKademlia(ops.kad...)
-	logger := logging.New(os.Stdout, 5)
+	logger := logging.New(ioutil.Discard, 0)
 
 	o := puller.Options{
 		Bins: ops.bins,


### PR DESCRIPTION
It appears that due to the airdrop process and the dirty state of the clusters some users have taken steps to update the handshake protocol version of their nodes so that they can still "participate" in the airdrop while running the old node version. This causes a panic in pull syncing due to incompatible length of cursors returned from the peer.
A more strict check is therefore added as a stopgap solution.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1851)
<!-- Reviewable:end -->
