### PR TITLE
feat: disable lightnodes puller

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -568,8 +568,11 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 	pullSyncProtocol := pullsync.New(p2ps, pullStorage, pssService.TryUnwrap, validStamp, logger)
 	b.pullSyncCloser = pullSyncProtocol
 
-	pullerService := puller.New(stateStore, kad, pullSyncProtocol, logger, puller.Options{})
-	b.pullerCloser = pullerService
+	var pullerService *puller.Puller
+	if o.FullNodeMode {
+		pullerService := puller.New(stateStore, kad, pullSyncProtocol, logger, puller.Options{})
+		b.pullerCloser = pullerService
+	}
 
 	retrieveProtocolSpec := retrieve.Protocol()
 	pushSyncProtocolSpec := pushSyncProtocol.Protocol()
@@ -641,7 +644,11 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		debugAPIService.MustRegisterMetrics(pingPong.Metrics()...)
 		debugAPIService.MustRegisterMetrics(acc.Metrics()...)
 		debugAPIService.MustRegisterMetrics(storer.Metrics()...)
-		debugAPIService.MustRegisterMetrics(pullerService.Metrics()...)
+
+		if pullerService != nil {
+			debugAPIService.MustRegisterMetrics(pullerService.Metrics()...)
+		}
+
 		debugAPIService.MustRegisterMetrics(pushSyncProtocol.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pusherService.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pullSyncProtocol.Metrics()...)


### PR DESCRIPTION
as discussed on the debugging session we are temporarily disabling pull syncing on light nodes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1883)
<!-- Reviewable:end -->
