### PR TITLE
refactor: puller always send cancel ruid

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -354,7 +354,6 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.HistWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)
@@ -401,7 +400,6 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			}
 			if ruid == 0 {
 				p.metrics.LiveWorkerErrCounter.Inc()
-				return
 			}
 			if err := p.syncer.CancelRuid(ctx, peer, ruid); err != nil && logMore {
 				p.logger.Debugf("histSyncWorker cancel ruid: %v", err)


### PR DESCRIPTION
This change makes sure we send out puller `SyncInterval` requests anyway when the context expires.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1888)
<!-- Reviewable:end -->
