### PR TITLE
fix: dont communicate lightnodes

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -744,7 +744,7 @@ func (n *notifiee) Pick(p p2p.Peer) bool {
 	return n.pick
 }
 
-func (n *notifiee) Announce(context.Context, swarm.Address) error {
+func (n *notifiee) Announce(context.Context, swarm.Address, bool) error {
 	return nil
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -336,7 +336,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			if !i.FullNode {
 				s.lightNodes.Connected(ctx, peer)
 				//light node announces explicitly
-				if err := s.notifier.Announce(ctx, peer.Address); err != nil {
+				if err := s.notifier.Announce(ctx, peer.Address, i.FullNode); err != nil {
 					s.logger.Debugf("stream handler: notifier.Announce: %s: %v", peer.Address.String(), err)
 				}
 			} else if err := s.notifier.Connected(ctx, peer); err != nil { // full node announces implicitly

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -44,7 +44,7 @@ type PickyNotifier interface {
 type Notifier interface {
 	Connected(context.Context, Peer) error
 	Disconnected(Peer)
-	Announce(context.Context, swarm.Address) error
+	Announce(context.Context, swarm.Address, bool) error
 }
 
 // DebugService extends the Service with method used for debugging.

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -689,12 +689,12 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr) 
 		return errOverlayMismatch
 	}
 
-	return k.Announce(ctx, peer)
+	return k.Announce(ctx, peer, true)
 }
 
 // Announce a newly connected peer to our connected peers, but also
 // notify the peer about our already connected peers
-func (k *Kad) Announce(ctx context.Context, peer swarm.Address) error {
+func (k *Kad) Announce(ctx context.Context, peer swarm.Address, fullnode bool) error {
 	addrs := []swarm.Address{}
 
 	for bin := uint8(0); bin < swarm.MaxBins; bin++ {
@@ -711,6 +711,11 @@ func (k *Kad) Announce(ctx context.Context, peer swarm.Address) error {
 
 			addrs = append(addrs, connectedPeer)
 
+			if !fullnode {
+				// we continue here so we dont gossip
+				// about lightnodes to others.
+				continue
+			}
 			k.wg.Add(1)
 			go func(connectedPeer swarm.Address) {
 				defer k.wg.Done()
@@ -791,7 +796,7 @@ connected:
 }
 
 func (k *Kad) connected(ctx context.Context, addr swarm.Address) error {
-	if err := k.Announce(ctx, addr); err != nil {
+	if err := k.Announce(ctx, addr, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR rectifies a problem where information about lightnodes would be communicated to other full nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1895)
<!-- Reviewable:end -->
