### PR TITLE
feat: limit number of light nodes

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 	"github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/swarm/test"
+	"github.com/ethersphere/bee/pkg/topology/lightnode"
 	"github.com/libp2p/go-libp2p-core/mux"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
@@ -80,6 +82,46 @@ func TestConnectToLightPeer(t *testing.T) {
 
 	expectPeers(t, s2)
 	expectPeersEventually(t, s1)
+}
+
+func TestLightPeerLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		limit     = 3
+		container = lightnode.NewContainer(test.RandomAddress())
+		sf, _     = newService(t, 1, libp2pServiceOpts{lightNodes: container,
+			libp2pOpts: libp2p.Options{
+				LightnodeLimit: limit,
+				FullNode:       true,
+			}})
+
+		notifier = mockNotifier(noopCf, noopDf, true)
+	)
+	sf.SetPickyNotifier(notifier)
+
+	addr := serviceUnderlayAddress(t, sf)
+
+	for i := 0; i < 5; i++ {
+		sl, _ := newService(t, 1, libp2pServiceOpts{
+			libp2pOpts: libp2p.Options{
+				FullNode: false,
+			}})
+		_, err := sl.Connect(ctx, addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < 20; i++ {
+		if cnt := container.Count(); cnt == limit {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatal("timed out waiting for correct number of lightnodes")
 }
 
 func TestDoubleConnect(t *testing.T) {
@@ -754,3 +796,9 @@ func mockNotifier(c cFunc, d dFunc, pick bool) p2p.PickyNotifier {
 
 type cFunc func(context.Context, p2p.Peer) error
 type dFunc func(p2p.Peer)
+
+var noopCf = func(_ context.Context, _ p2p.Peer) error {
+	return nil
+}
+
+var noopDf = func(p p2p.Peer) {}

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -93,7 +93,7 @@ func TestLightPeerLimit(t *testing.T) {
 		container = lightnode.NewContainer(test.RandomAddress())
 		sf, _     = newService(t, 1, libp2pServiceOpts{lightNodes: container,
 			libp2pOpts: libp2p.Options{
-				LightnodeLimit: limit,
+				LightNodeLimit: limit,
 				FullNode:       true,
 			}})
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -48,7 +48,7 @@ var (
 	_ p2p.DebugService = (*Service)(nil)
 )
 
-const defaultLightnodeLimit = 100
+const defaultLightNodeLimit = 100
 
 type Service struct {
 	ctx               context.Context
@@ -88,7 +88,7 @@ type Options struct {
 	EnableQUIC     bool
 	Standalone     bool
 	FullNode       bool
-	LightnodeLimit int
+	LightNodeLimit int
 	WelcomeMessage string
 	Transaction    []byte
 }
@@ -244,10 +244,9 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 
 	peerRegistry.setDisconnecter(s)
 
-	if o.LightnodeLimit == 0 {
-		s.lightNodeLimit = defaultLightnodeLimit
-	} else {
-		s.lightNodeLimit = o.LightnodeLimit
+	s.lightNodeLimit = defaultLightNodeLimit
+	if o.LightNodeLimit > 0 {
+		s.lightNodeLimit = o.LightNodeLimit
 	}
 
 	// Construct protocols.
@@ -370,6 +369,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 					_ = s.Disconnect(peer.Address)
 					return
 				} else {
+					s.logger.Tracef("stream handler: kicking away light node %s to make room for %s", p.String(), peer.Address.String())
 					_ = s.Disconnect(p)
 					return
 				}

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -31,6 +31,7 @@ type libp2pServiceOpts struct {
 	PrivateKey  *ecdsa.PrivateKey
 	MockPeerKey *ecdsa.PrivateKey
 	libp2pOpts  libp2p.Options
+	lightNodes  *lightnode.Container
 }
 
 // newService constructs a new libp2p service.
@@ -69,14 +70,15 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	lightnodes := lightnode.NewContainer(overlay)
-
+	if o.lightNodes == nil {
+		o.lightNodes = lightnode.NewContainer(overlay)
+	}
 	opts := o.libp2pOpts
 	opts.Transaction = []byte(hexutil.EncodeUint64(o.PrivateKey.Y.Uint64()))
 
 	senderMatcher := &MockSenderMatcher{}
 
-	s, err = libp2p.New(ctx, crypto.NewDefaultSigner(swarmKey), networkID, overlay, addr, o.Addressbook, statestore, lightnodes, senderMatcher, o.Logger, nil, opts)
+	s, err = libp2p.New(ctx, crypto.NewDefaultSigner(swarmKey), networkID, overlay, addr, o.Addressbook, statestore, o.lightNodes, senderMatcher, o.Logger, nil, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/topology/lightnode/container.go
+++ b/pkg/topology/lightnode/container.go
@@ -52,24 +52,14 @@ func (c *Container) Disconnected(peer p2p.Peer) {
 }
 
 func (c *Container) Count() int {
-	c.peerMu.Lock()
-	defer c.peerMu.Unlock()
-
-	return c.count()
-}
-func (c *Container) count() (count int) {
-	_ = c.connectedPeers.EachBinRev(func(peer swarm.Address, _ uint8) (bool, bool, error) {
-		count++
-		return false, false, nil
-	})
-	return count
+	return c.connectedPeers.Length()
 }
 
 func (c *Container) RandomPeer(not swarm.Address) (swarm.Address, error) {
 	c.peerMu.Lock()
 	defer c.peerMu.Unlock()
 	var (
-		cnt   = big.NewInt(int64(c.count()))
+		cnt   = big.NewInt(int64(c.Count()))
 		addr  = swarm.ZeroAddress
 		count = int64(0)
 	)

--- a/pkg/topology/lightnode/container.go
+++ b/pkg/topology/lightnode/container.go
@@ -6,6 +6,8 @@ package lightnode
 
 import (
 	"context"
+	"crypto/rand"
+	"math/big"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -47,6 +49,53 @@ func (c *Container) Disconnected(peer p2p.Peer) {
 		c.connectedPeers.Remove(addr)
 		c.disconnectedPeers.Add(addr)
 	}
+}
+
+func (c *Container) Count() int {
+	c.peerMu.Lock()
+	defer c.peerMu.Unlock()
+
+	return c.count()
+}
+func (c *Container) count() (count int) {
+	_ = c.connectedPeers.EachBinRev(func(peer swarm.Address, _ uint8) (bool, bool, error) {
+		count++
+		return false, false, nil
+	})
+	return count
+}
+
+func (c *Container) RandomPeer(not swarm.Address) (swarm.Address, error) {
+	c.peerMu.Lock()
+	defer c.peerMu.Unlock()
+	var (
+		cnt   = big.NewInt(int64(c.count()))
+		addr  = swarm.ZeroAddress
+		count = int64(0)
+	)
+
+PICKPEER:
+	i, e := rand.Int(rand.Reader, cnt)
+	if e != nil {
+		return swarm.ZeroAddress, e
+	}
+	i64 := i.Int64()
+
+	count = 0
+	_ = c.connectedPeers.EachBinRev(func(peer swarm.Address, _ uint8) (bool, bool, error) {
+		if count == i64 {
+			addr = peer
+			return true, false, nil
+		}
+		count++
+		return false, false, nil
+	})
+
+	if addr.Equal(not) {
+		goto PICKPEER
+	}
+
+	return addr, nil
 }
 
 func (c *Container) PeerInfo() topology.BinInfo {

--- a/pkg/topology/lightnode/container_test.go
+++ b/pkg/topology/lightnode/container_test.go
@@ -55,7 +55,7 @@ func TestContainer(t *testing.T) {
 			t.Fatalf("expected p1 but got %s", p.String())
 		}
 
-		p, err = c.RandomPeer(swarm.NewAddress([]byte("456")))
+		p, err = c.RandomPeer(p2)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/topology/lightnode/container_test.go
+++ b/pkg/topology/lightnode/container_test.go
@@ -33,13 +33,34 @@ func TestContainer(t *testing.T) {
 	t.Run("can add peers to container", func(t *testing.T) {
 		c := lightnode.NewContainer(base)
 
-		c.Connected(context.Background(), p2p.Peer{Address: swarm.NewAddress([]byte("123"))})
-		c.Connected(context.Background(), p2p.Peer{Address: swarm.NewAddress([]byte("456"))})
+		p1 := swarm.NewAddress([]byte("123"))
+		p2 := swarm.NewAddress([]byte("456"))
+		c.Connected(context.Background(), p2p.Peer{Address: p1})
+		c.Connected(context.Background(), p2p.Peer{Address: p2})
 
 		peerCount := len(c.PeerInfo().ConnectedPeers)
 
 		if peerCount != 2 {
 			t.Errorf("expected %d connected peer, got %d", 2, peerCount)
+		}
+
+		if cc := c.Count(); cc != 2 {
+			t.Errorf("expected count 2 got %d", cc)
+		}
+		p, err := c.RandomPeer(p1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !p.Equal(p2) {
+			t.Fatalf("expected p1 but got %s", p.String())
+		}
+
+		p, err = c.RandomPeer(swarm.NewAddress([]byte("456")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !p.Equal(p1) {
+			t.Fatalf("expected p2 but got %s", p.String())
 		}
 	})
 	t.Run("empty container after peer disconnect", func(t *testing.T) {
@@ -58,6 +79,9 @@ func TestContainer(t *testing.T) {
 		connPeerCount := len(c.PeerInfo().ConnectedPeers)
 		if connPeerCount != 0 {
 			t.Errorf("expected %d connected peer, got %d", 0, connPeerCount)
+		}
+		if cc := c.Count(); cc != 0 {
+			t.Errorf("expected count 0 got %d", cc)
 		}
 	})
 }


### PR DESCRIPTION
This PR limits the number of lightnodes we allow to connect inbound. This is to give some safety level to full nodes operators not to be resource overwhelmed by too many light node requests. This sets the initial limit to 100 above which the node will start kicking away other light nodes to accommodate for the new ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1898)
<!-- Reviewable:end -->
