### PR TITLE
feat: Constantly monitor depth during kademlia saturation

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -294,9 +294,9 @@ func (k *Kad) connectNeighbours(wg *sync.WaitGroup, peerConnChan chan<- *peerCon
 	// The topology.EachPeerFunc doesn't return an error
 	// so we ignore the error returned from EachBinRev.
 
-	depth := k.NeighborhoodDepth()
-
 	_ = k.knownPeers.EachBinRev(func(addr swarm.Address, po uint8) (bool, bool, error) {
+
+		depth := k.NeighborhoodDepth()
 
 		if po < depth {
 			return false, true, nil


### PR DESCRIPTION
While the depth is low (early in the node uptime) connectpeers has an unintended sideeffect of connecting all low po peers treating them as neighbors before checking whether depth have changed. 
This change intends to catch depth change by checking depth before every new connection attempt, counting on that when successful connections are made the depth is recalculated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1907)
<!-- Reviewable:end -->
