### PR TITLE
perf(pullsync): release reader buffer in handler

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -260,7 +260,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 
 // handler handles an incoming request to sync an interval
 func (s *Syncer) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
-	w, r := protobuf.NewWriterAndReader(stream)
+	r := protobuf.NewReader(stream)
 	defer func() {
 		if err != nil {
 			_ = stream.Reset()
@@ -310,6 +310,11 @@ func (s *Syncer) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (er
 	if err != nil {
 		return fmt.Errorf("make offer: %w", err)
 	}
+
+	// recreate the reader to allow the first one to be garbage collected
+	// before the makeOffer function call, to reduce the total memory allocated
+	// while makeOffer is executing (waiting for the new chunks)
+	w, r := protobuf.NewWriterAndReader(stream)
 
 	if err := w.WriteMsgWithContext(ctx, offer); err != nil {
 		return fmt.Errorf("write offer: %w", err)


### PR DESCRIPTION
After profiling existing goroutines running on a node, it is found that pullsync.Syncer.handler goroutine number is larger with the number of connected peers. One approach to optimize was to reuse the iterators but the number of handler goroutines is still high as every peer needs to have a stream opened for pull syncing, most notably live pull syncing for proximity bins.

Profiling shows that a larger meemory allocated at protobuf reader

```
(pprof) top -cum
Showing nodes accounting for 134.09MB, 23.39% of 573.29MB total
Dropped 278 nodes (cum <= 2.87MB)
Showing top 10 nodes out of 205
      flat  flat%   sum%        cum   cum%
         0     0%     0%   221.12MB 38.57%  github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandlerMatch.func1
         0     0%     0%   205.17MB 35.79%  github.com/ethersphere/bee/pkg/p2p/libp2p.(*Service).AddProtocol.func1
    3.60MB  0.63%  0.63%   154.62MB 26.97%  github.com/ethersphere/bee/pkg/pullsync.(*Syncer).handler
         0     0%  0.63%   128.49MB 22.41%  bufio.NewReader (inline)
  128.49MB 22.41% 23.04%   128.49MB 22.41%  bufio.NewReaderSize (inline)
         0     0% 23.04%   127.47MB 22.24%  github.com/ethersphere/bee/pkg/p2p/protobuf.NewWriterAndReader
         0     0% 23.04%   124.97MB 21.80%  github.com/ethersphere/bee/pkg/p2p/protobuf.NewReader (inline)
       2MB  0.35% 23.39%   124.97MB 21.80%  github.com/gogo/protobuf/io.NewDelimitedReader
         0     0% 23.39%    89.70MB 15.65%  github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).identifyConn
         0     0% 23.39%    87.70MB 15.30%  github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).consumeMessage
```

More precisely on line 263:

```
ROUTINE ======================== github.com/ethersphere/bee/pkg/pullsync.(*Syncer).handler in github.com/ethersphere/bee/pkg/pullsync/pullsync.go
    3.60MB   154.62MB (flat, cum) 26.97% of Total
         .          .    258:	return offer.Topmost, ru.Ruid, nil
         .          .    259:}
         .          .    260:
         .          .    261:// handler handles an incoming request to sync an interval
         .          .    262:func (s *Syncer) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
         .   126.47MB    263:	w, r := protobuf.NewWriterAndReader(stream)
         .          .    264:	defer func() {
         .          .    265:		if err != nil {
         .          .    266:			_ = stream.Reset()
         .          .    267:		} else {
         .          .    268:			_ = stream.FullClose()
         .          .    269:		}
         .          .    270:	}()
         .          .    271:	var ru pb.Ruid
         .        3MB    272:	if err := r.ReadMsgWithContext(ctx, &ru); err != nil {
         .          .    273:		return fmt.Errorf("send ruid: %w", err)
         .          .    274:	}
         .          .    275:
         .     5.50MB    276:	ctx, cancel := context.WithCancel(ctx)
         .          .    277:	s.ruidMtx.Lock()
    1.10MB     1.10MB    278:	s.ruidCtx[ru.Ruid] = cancel
         .          .    279:	s.ruidMtx.Unlock()
    2.50MB     2.50MB    280:	cc := make(chan struct{})
         .          .    281:	defer close(cc)
         .          .    282:	go func() {
         .          .    283:		select {
         .          .    284:		case <-s.quit:
         .          .    285:		case <-ctx.Done():
         .          .    286:		case <-cc:
         .          .    287:		}
         .          .    288:		cancel()
         .          .    289:		s.ruidMtx.Lock()
         .          .    290:		delete(s.ruidCtx, ru.Ruid)
         .          .    291:		s.ruidMtx.Unlock()
         .          .    292:	}()
         .          .    293:
         .          .    294:	select {
         .          .    295:	case <-s.quit:
         .          .    296:		return nil
         .          .    297:	default:
         .          .    298:	}
         .          .    299:
         .          .    300:	s.wg.Add(1)
         .          .    301:	defer s.wg.Done()
         .          .    302:
         .          .    303:	var rn pb.GetRange
         .     1.50MB    304:	if err := r.ReadMsgWithContext(ctx, &rn); err != nil {
         .          .    305:		return fmt.Errorf("read get range: %w", err)
         .          .    306:	}
         .          .    307:
         .          .    308:	// make an offer to the upstream peer in return for the requested range
         .     7.50MB    309:	offer, _, err := s.makeOffer(ctx, rn)
         .          .    310:	if err != nil {
         .          .    311:		return fmt.Errorf("make offer: %w", err)
         .          .    312:	}
         .          .    313:
         .          .    314:	if err := w.WriteMsgWithContext(ctx, offer); err != nil {
         .          .    315:		return fmt.Errorf("write offer: %w", err)
         .          .    316:	}
         .          .    317:
         .          .    318:	// we don't have any hashes to offer in this range (the
         .          .    319:	// interval is empty). nothing more to do
         .          .    320:	if len(offer.Hashes) == 0 {
         .          .    321:		return nil
         .          .    322:	}
         .          .    323:
         .          .    324:	var want pb.Want
         .          .    325:	if err := r.ReadMsgWithContext(ctx, &want); err != nil {
         .          .    326:		return fmt.Errorf("read want: %w", err)
         .          .    327:	}
         .          .    328:
         .     7.05MB    329:	chs, err := s.processWant(ctx, offer, &want)
         .          .    330:	if err != nil {
         .          .    331:		return fmt.Errorf("process want: %w", err)
         .          .    332:	}
         .          .    333:
         .          .    334:	for _, v := range chs {
```

The reader is allocating a buffer of 4096 bytes (bufio.Reader) and holding it from Go's CG while waiting for new chunks at line 329 on `makeOffer` call which is blocking until there are new chunks (expected behaviour). The allocated reader is not and could be released, but it is not as it can be used further down the function execution path. Wit higher number of goroutines these buffers take more memory, which is not needed during `makeOffer` call.

This PR allows for the reader to be garbage collected as a new one is created after the `makeOffer` call. This approach creates additional allocation of 4096 bytes, but allows Go's GC to garbage collect the buffer and reduce the total allocated memory, resulting the handler goroutine allocations to look like this:

```
ROUTINE ======================== github.com/ethersphere/bee/pkg/pullsync.(*Syncer).handler in github.com/ethersphere/bee/pkg/pullsync/pullsync.go
  512.05kB     8.03MB (flat, cum)  7.06% of Total
         .          .    267:		} else {
         .          .    268:			_ = stream.FullClose()
         .          .    269:		}
         .          .    270:	}()
         .          .    271:	var ru pb.Ruid
         .   512.05kB    272:	if err := r.ReadMsgWithContext(ctx, &ru); err != nil {
         .          .    273:		return fmt.Errorf("send ruid: %w", err)
         .          .    274:	}
         .          .    275:
         .        1MB    276:	ctx, cancel := context.WithCancel(ctx)
         .          .    277:	s.ruidMtx.Lock()
         .          .    278:	s.ruidCtx[ru.Ruid] = cancel
         .          .    279:	s.ruidMtx.Unlock()
  512.05kB   512.05kB    280:	cc := make(chan struct{})
         .          .    281:	defer close(cc)
         .          .    282:	go func() {
         .          .    283:		select {
         .          .    284:		case <-s.quit:
         .          .    285:		case <-ctx.Done():
         .          .    286:		case <-cc:
         .          .    287:		}
         .          .    288:		cancel()
         .          .    289:		s.ruidMtx.Lock()
         .          .    290:		delete(s.ruidCtx, ru.Ruid)
         .          .    291:		s.ruidMtx.Unlock()
         .          .    292:	}()
         .          .    293:
         .          .    294:	select {
         .          .    295:	case <-s.quit:
         .          .    296:		return nil
         .          .    297:	default:
         .          .    298:	}
         .          .    299:
         .          .    300:	s.wg.Add(1)
         .          .    301:	defer s.wg.Done()
         .          .    302:
         .          .    303:	var rn pb.GetRange
         .        1MB    304:	if err := r.ReadMsgWithContext(ctx, &rn); err != nil {
         .          .    305:		return fmt.Errorf("read get range: %w", err)
         .          .    306:	}
         .          .    307:
         .          .    308:	// make an offer to the upstream peer in return for the requested range
         .   512.02kB    309:	offer, _, err := s.makeOffer(ctx, rn)
         .          .    310:	if err != nil {
         .          .    311:		return fmt.Errorf("make offer: %w", err)
         .          .    312:	}
         .          .    313:
         .          .    314:	w, r := protobuf.NewWriterAndReader(stream)
         .          .    315:
         .          .    316:	if err := w.WriteMsgWithContext(ctx, offer); err != nil {
         .          .    317:		return fmt.Errorf("write offer: %w", err)
         .          .    318:	}
         .          .    319:
         .          .    320:	// we don't have any hashes to offer in this range (the
         .          .    321:	// interval is empty). nothing more to do
         .          .    322:	if len(offer.Hashes) == 0 {
         .          .    323:		return nil
         .          .    324:	}
         .          .    325:
         .          .    326:	var want pb.Want
         .          .    327:	if err := r.ReadMsgWithContext(ctx, &want); err != nil {
         .          .    328:		return fmt.Errorf("read want: %w", err)
         .          .    329:	}
         .          .    330:
         .     4.53MB    331:	chs, err := s.processWant(ctx, offer, &want)
         .          .    332:	if err != nil {
         .          .    333:		return fmt.Errorf("process want: %w", err)
         .          .    334:	}
         .          .    335:
         .          .    336:	for _, v := range chs {
```

No allocations are held by the first created reader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1917)
<!-- Reviewable:end -->
