### PR TITLE
refactor: improve shutdown sequence

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -157,7 +157,7 @@ func (s *server) Close() error {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(1 * time.Second):
 		return errors.New("api shutting down with open websockets")
 	}
 

--- a/pkg/p2p/mock/mock.go
+++ b/pkg/p2p/mock/mock.go
@@ -166,6 +166,8 @@ func (s *Service) GetWelcomeMessage() string {
 	return s.welcomeMessage
 }
 
+func (s *Service) Halt() {}
+
 func (s *Service) Blocklist(overlay swarm.Address, duration time.Duration) error {
 	if s.blocklistFunc == nil {
 		return errors.New("function blocklist not configured")

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -26,6 +26,7 @@ type Service interface {
 	BlocklistedPeers() ([]Peer, error)
 	Addresses() ([]ma.Multiaddr, error)
 	SetPickyNotifier(PickyNotifier)
+	Halter
 }
 
 type Disconnecter interface {
@@ -33,6 +34,11 @@ type Disconnecter interface {
 	// Blocklist will disconnect a peer and put it on a blocklist (blocking in & out connections) for provided duration
 	// duration 0 is treated as an infinite duration
 	Blocklist(overlay swarm.Address, duration time.Duration) error
+}
+
+type Halter interface {
+	// Halt new incoming connections while shutting down
+	Halt()
 }
 
 // PickyNotifer can decide whether a peer should be picked

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -252,6 +252,11 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 	go func() {
 		err := listenf()
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				// context cancelled is returned on shutdown,
+				// therefore we do nothing here
+				return
+			}
 			l.logger.Errorf("failed syncing event listener, shutting down node err: %v", err)
 			if l.shutdowner != nil {
 				err = l.shutdowner.Shutdown(context.Background())

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -422,14 +422,6 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 func (p *Puller) Close() error {
 	p.logger.Info("puller shutting down")
 	close(p.quit)
-	p.syncPeersMtx.Lock()
-	defer p.syncPeersMtx.Unlock()
-	for i := uint8(0); i < p.bins; i++ {
-		binPeers := p.syncPeers[i]
-		for _, peer := range binPeers {
-			peer.gone()
-		}
-	}
 	cc := make(chan struct{})
 	go func() {
 		defer close(cc)

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -514,7 +514,7 @@ func (s *Syncer) Close() error {
 
 	select {
 	case <-cc:
-	case <-time.After(10 * time.Second):
+	case <-time.After(5 * time.Second):
 		s.logger.Warning("pull syncer shutting down with running goroutines")
 	}
 	return nil

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -182,9 +182,8 @@ func (m *Mock) ResetPeers() {
 	m.eachPeerRev = nil
 }
 
-func (m *Mock) Close() error {
-	panic("not implemented") // TODO: Implement
-}
+func (d *Mock) Halt()        {}
+func (m *Mock) Close() error { return nil }
 
 func (m *Mock) Snapshot() *topology.KadParams {
 	panic("not implemented") // TODO: Implement

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -193,9 +193,8 @@ func (d *mock) Snapshot() *topology.KadParams {
 	return new(topology.KadParams)
 }
 
-func (d *mock) Close() error {
-	return nil
-}
+func (d *mock) Halt()        {}
+func (d *mock) Close() error { return nil }
 
 type Option interface {
 	apply(*mock)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -28,6 +28,7 @@ type Driver interface {
 	NeighborhoodDepth() uint8
 	SubscribePeersChange() (c <-chan struct{}, unsubscribe func())
 	io.Closer
+	Halter
 	Snapshot() *KadParams
 }
 
@@ -129,4 +130,10 @@ type KadParams struct {
 	Depth          uint8     `json:"depth"`          // current depth
 	Bins           KadBins   `json:"bins"`           // individual bin info
 	LightNodes     BinInfo   `json:"lightNodes"`     // light nodes bin info
+}
+
+type Halter interface {
+	// Halt the topology from initiating new connections
+	// while allowing it to still run.
+	Halt()
 }


### PR DESCRIPTION
This PR improves the shutdown sequence by introducing a few changes to the way we do shutdowns:
1. kademlia and libp2p are now `Halt`ed before anything else happens in the shutdown, this will prevent _new_ outgoing and incoming connections to be established, however existing connections will remain untouched. This will also improve exit time of kademlia when it is finally shut down since the number of ongoing goroutines dailing will be smaller, so we would need to wait less.
2. more components are shut down in parallel
3. api shutdown timeout is decreased, since shutting down with running websockets is not critical, while slowing down the rest of the process _is_
4. kademlia `Close` is bumped _before_ statestore is closed. Since metrics need to be saved before shutting down, this can result in a panic
5. eth dependent components are shut down before the eth client is closed. On shutdown, it can result in an unnecessary panic right now, since the eth client might close while the listener is querying the backend, resulting in an error, therefore calling `Shutdown` on `node.go` twice, which might result in a panic
6. explicit check for `context.Cancelled` is therefore needed in `listener.go`, so that shutdown is not called twice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1926)
<!-- Reviewable:end -->
