### PR TITLE
fix: added "format: int64" where required in openapi

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -796,6 +796,7 @@ paths:
           name: amount
           schema:
             type: integer
+            format: int64
           required: true
           description: Amount of BZZ added that the postage batch will have.
         - in: path
@@ -824,4 +825,3 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
           description: Default response
-

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -41,20 +41,26 @@ components:
           type: integer
         available:
           type: integer
+          format: int64
         outer:
           type: integer
+          format: int64
         inner:
           type: integer
+          format: int64
 
     ChainState:
       type: object
       properties:
         block:
           type: integer
+          format: int64
         totalAmount:
           type: integer
+          format: int64
         currentPrice:
           type: integer
+          format: int64
 
     Balance:
       type: object
@@ -63,6 +69,7 @@ components:
           $ref: "#/components/schemas/SwarmAddress"
         balance:
           type: integer
+          format: int64
 
     Balances:
       type: object
@@ -110,6 +117,7 @@ components:
           $ref: "#/components/schemas/EthereumAddress"
         payout:
           type: integer
+          format: int64
 
     ChequeAllPeersResponse:
       type: object
@@ -135,8 +143,10 @@ components:
       properties:
         totalBalance:
           type: integer
+          format: int64
         availableBalance:
           type: integer
+          format: int64
 
     ChequebookAddress:
       type: object
@@ -165,11 +175,13 @@ components:
 
     GasLimit:
       type: integer
+      format: int64
       minimum: 0
       maximum: 18446744073709551615
 
     GasPrice:
       type: integer
+      format: int64
 
     Hash:
       type: object
@@ -200,26 +212,35 @@ components:
           $ref: "#/components/schemas/DateTime"
         total:
           type: integer
+          format: int64
         processed:
           type: integer
+          format: int64
         synced:
           type: integer
+          format: int64
 
     NewTagDebugResponse:
       type: object
       properties:
         total:
           type: integer
+          format: int64
         split:
           type: integer
+          format: int64
         seen:
           type: integer
+          format: int64
         stored:
           type: integer
+          format: int64
         sent:
           type: integer
+          format: int64
         synced:
           type: integer
+          format: int64
         uid:
           $ref: "#/components/schemas/Uid"
         address:
@@ -317,16 +338,20 @@ components:
           $ref: "#/components/schemas/SwarmAddress"
         received:
           type: integer
+          format: int64
         sent:
           type: integer
+          format: int64
 
     Settlements:
       type: object
       properties:
         totalReceived:
           type: integer
+          format: int64
         totalSent:
           type: integer
+          format: int64
         settlements:
           type: array
           nullable: true
@@ -384,6 +409,7 @@ components:
           $ref: "#/components/schemas/EthereumAddress"
         lastPayout:
           type: integer
+          format: int64
         bounced:
           type: boolean
 
@@ -400,6 +426,7 @@ components:
           $ref: "#/components/schemas/SwapCashoutResult"
         uncashedAmount:
           type: integer
+          format: int64
 
     TagName:
       type: string

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -596,6 +596,7 @@ paths:
           name: amount
           schema:
             type: integer
+            format: int64
           required: true
           description: amount of tokens to deposit
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
@@ -623,6 +624,7 @@ paths:
           name: amount
           schema:
             type: integer
+            format: int64
           required: true
           description: amount of tokens to withdraw
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"


### PR DESCRIPTION
Fixes #1726.

I think to have identified all int64 values in open api definition, but please verify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1964)
<!-- Reviewable:end -->
