### PR TITLE
feat(lightnode,libp2p): add prometheus metrics

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -662,6 +662,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		debugAPIService.MustRegisterMetrics(pullSyncProtocol.Metrics()...)
 		debugAPIService.MustRegisterMetrics(pullStorage.Metrics()...)
 		debugAPIService.MustRegisterMetrics(retrieve.Metrics()...)
+		debugAPIService.MustRegisterMetrics(lightNodes.Metrics()...)
 
 		if bs, ok := batchStore.(metrics.Collector); ok {
 			debugAPIService.MustRegisterMetrics(bs.Metrics()...)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -377,6 +377,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 					return
 				} else {
 					s.logger.Tracef("stream handler: kicking away light node %s to make room for %s", p.String(), peer.Address.String())
+					s.metrics.KickedOutPeersCount.Inc()
 					_ = s.Disconnect(p)
 					return
 				}

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -22,6 +22,7 @@ type metrics struct {
 	DisconnectCount            prometheus.Counter
 	ConnectBreakerCount        prometheus.Counter
 	UnexpectedProtocolReqCount prometheus.Counter
+	KickedOutPeersCount        prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -81,6 +82,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "unexpected_protocol_request_count",
 			Help:      "Number of requests the peer is not expecting.",
+		}),
+		KickedOutPeersCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "total_kickedout_peers",
+			Help:      "Number of total kicked-out peers.",
 		}),
 	}
 }

--- a/pkg/topology/lightnode/container.go
+++ b/pkg/topology/lightnode/container.go
@@ -18,9 +18,10 @@ import (
 
 type Container struct {
 	base              swarm.Address
+	peerMu            sync.Mutex // peerMu guards connectedPeers and disconnectedPeers.
 	connectedPeers    *pslice.PSlice
 	disconnectedPeers *pslice.PSlice
-	peerMu            sync.Mutex
+	metrics           metrics
 }
 
 func NewContainer(base swarm.Address) *Container {
@@ -28,6 +29,7 @@ func NewContainer(base swarm.Address) *Container {
 		base:              base,
 		connectedPeers:    pslice.New(1, base),
 		disconnectedPeers: pslice.New(1, base),
+		metrics:           newMetrics(),
 	}
 }
 
@@ -38,6 +40,9 @@ func (c *Container) Connected(ctx context.Context, peer p2p.Peer) {
 	addr := peer.Address
 	c.connectedPeers.Add(addr)
 	c.disconnectedPeers.Remove(addr)
+
+	c.metrics.CurrentlyConnectedPeers.Set(float64(c.connectedPeers.Length()))
+	c.metrics.CurrentlyDisconnectedPeers.Set(float64(c.disconnectedPeers.Length()))
 }
 
 func (c *Container) Disconnected(peer p2p.Peer) {
@@ -49,6 +54,9 @@ func (c *Container) Disconnected(peer p2p.Peer) {
 		c.connectedPeers.Remove(addr)
 		c.disconnectedPeers.Add(addr)
 	}
+
+	c.metrics.CurrentlyConnectedPeers.Set(float64(c.connectedPeers.Length()))
+	c.metrics.CurrentlyDisconnectedPeers.Set(float64(c.disconnectedPeers.Length()))
 }
 
 func (c *Container) Count() int {

--- a/pkg/topology/lightnode/metrics.go
+++ b/pkg/topology/lightnode/metrics.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lightnode
+
+import (
+	m "github.com/ethersphere/bee/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metrics groups lightnode related prometheus counters.
+type metrics struct {
+	CurrentlyConnectedPeers    prometheus.Gauge
+	CurrentlyDisconnectedPeers prometheus.Gauge
+}
+
+// newMetrics is a convenient constructor for creating new metrics.
+func newMetrics() metrics {
+	const subsystem = "lightnode"
+
+	return metrics{
+		CurrentlyConnectedPeers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "currently_connected_peers",
+			Help:      "Number of currently connected peers.",
+		}),
+		CurrentlyDisconnectedPeers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "currently_disconnected_peers",
+			Help:      "Number of currently disconnected peers.",
+		})}
+}
+
+// Metrics returns set of prometheus collectors.
+func (c *Container) Metrics() []prometheus.Collector {
+	return m.PrometheusCollectorsFromFields(c.metrics)
+}


### PR DESCRIPTION
Adds the following metrics:
- number of currently connected peers
- number of currently disconnected peers
- total number of kicked out peers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1979)
<!-- Reviewable:end -->
