### PR TITLE
feat: Always reset balances to zero after disconnection or blocklisting

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -87,10 +87,12 @@ type accountingPeer struct {
 	lock                           sync.Mutex // lock to be held during any accounting action for this peer
 	reservedBalance                *big.Int   // amount currently reserved for active peer interaction
 	shadowReservedBalance          *big.Int   // amount potentially to be debited for active peer interaction
+	ghostBalance                   *big.Int   // amount potentially could have been debited for but was not
 	paymentThreshold               *big.Int   // the threshold at which the peer expects us to pay
 	refreshTimestamp               int64      // last time we attempted time-based settlement
 	paymentOngoing                 bool       // indicate if we are currently settling with the peer
-	lastSettlementFailureTimestamp int64      // time of last unsuccessful attempt to issue a cheque
+	reconnectAllowTimestamp        int64
+	lastSettlementFailureTimestamp int64 // time of last unsuccessful attempt to issue a cheque
 }
 
 // Accounting is the main implementation of the accounting interface.
@@ -120,6 +122,7 @@ type Accounting struct {
 	pricing        pricing.Interface
 	metrics        metrics
 	wg             sync.WaitGroup
+	p2p            p2p.Service
 	timeNow        func() time.Time
 }
 
@@ -143,6 +146,8 @@ func NewAccounting(
 	Store storage.StateStorer,
 	Pricing pricing.Interface,
 	refreshRate *big.Int,
+	p2pService p2p.Service,
+
 ) (*Accounting, error) {
 	return &Accounting{
 		accountingPeers:  make(map[string]*accountingPeer),
@@ -157,6 +162,7 @@ func NewAccounting(
 		refreshRate:      refreshRate,
 		timeNow:          time.Now,
 		minimumPayment:   new(big.Int).Div(refreshRate, big.NewInt(minimumPaymentDivisor)),
+		p2p:              p2pService,
 	}, nil
 }
 
@@ -485,6 +491,7 @@ func (a *Accounting) getAccountingPeer(peer swarm.Address) *accountingPeer {
 		peerData = &accountingPeer{
 			reservedBalance:       big.NewInt(0),
 			shadowReservedBalance: big.NewInt(0),
+			ghostBalance:          big.NewInt(0),
 			// initially assume the peer has the same threshold as us
 			paymentThreshold: new(big.Int).Set(a.paymentThreshold),
 		}
@@ -627,6 +634,36 @@ func (a *Accounting) PeerDebt(peer swarm.Address) (*big.Int, error) {
 	peerDebt := new(big.Int).Add(balance, accountingPeer.shadowReservedBalance)
 
 	if peerDebt.Cmp(zero) < 0 {
+		return zero, nil
+	}
+
+	return peerDebt, nil
+}
+
+// peerLatentDebt returns the sum of the positive part of the outstanding balance, shadow reserve and the ghost balance
+func (a *Accounting) peerLatentDebt(peer swarm.Address) (*big.Int, error) {
+
+	accountingPeer := a.getAccountingPeer(peer)
+
+	balance := new(big.Int)
+	zero := big.NewInt(0)
+
+	err := a.store.Get(peerBalanceKey(peer), &balance)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			return nil, err
+		}
+		balance = big.NewInt(0)
+	}
+
+	if balance.Cmp(zero) < 0 {
+		balance.Set(zero)
+	}
+
+	peerDebt := new(big.Int).Add(balance, accountingPeer.shadowReservedBalance)
+	peerLatentDebt := new(big.Int).Add(peerDebt, accountingPeer.ghostBalance)
+
+	if peerLatentDebt.Cmp(zero) < 0 {
 		return zero, nil
 	}
 
@@ -940,7 +977,13 @@ func (d *debitAction) Apply() error {
 	if nextBalance.Cmp(a.disconnectLimit) >= 0 {
 		// peer too much in debt
 		a.metrics.AccountingDisconnectsCount.Inc()
-		return p2p.NewBlockPeerError(24*time.Hour, ErrDisconnectThresholdExceeded)
+
+		disconnectFor, err := a.blocklistUntil(d.peer, 1)
+		if err != nil {
+			return p2p.NewBlockPeerError(24*time.Hour, ErrDisconnectThresholdExceeded)
+		}
+		return p2p.NewBlockPeerError(time.Duration(disconnectFor), ErrDisconnectThresholdExceeded)
+
 	}
 
 	return nil
@@ -951,7 +994,59 @@ func (d *debitAction) Cleanup() {
 	if !d.applied {
 		d.accountingPeer.lock.Lock()
 		defer d.accountingPeer.lock.Unlock()
+		a := d.accounting
 		d.accountingPeer.shadowReservedBalance = new(big.Int).Sub(d.accountingPeer.shadowReservedBalance, d.price)
+		d.accountingPeer.ghostBalance = new(big.Int).Add(d.accountingPeer.ghostBalance, d.price)
+		if d.accountingPeer.ghostBalance.Cmp(a.disconnectLimit) > 0 {
+			_ = a.blocklist(d.peer, 1)
+		}
+	}
+}
+
+func (a *Accounting) blocklistUntil(peer swarm.Address, multiplier int64) (int64, error) {
+
+	debt, err := a.peerLatentDebt(peer)
+	if err != nil {
+		return 0, err
+	}
+
+	if debt.Cmp(a.refreshRate) < 0 {
+		debt.Set(a.refreshRate)
+	}
+
+	multiplyDebt := new(big.Int).Mul(debt, big.NewInt(multiplier))
+
+	additionalDebt := new(big.Int).Add(multiplyDebt, a.paymentThreshold)
+
+	k := new(big.Int).Div(additionalDebt, a.refreshRate)
+
+	kInt := k.Int64()
+
+	return kInt, nil
+}
+
+func (a *Accounting) blocklist(peer swarm.Address, multiplier int64) error {
+
+	disconnectFor, err := a.blocklistUntil(peer, multiplier)
+	if err != nil {
+		return a.p2p.Blocklist(peer, 1*time.Hour)
+	}
+
+	return a.p2p.Blocklist(peer, time.Duration(disconnectFor)*time.Second)
+}
+
+func (a *Accounting) Connect(peer swarm.Address) {
+	accountingPeer := a.getAccountingPeer(peer)
+
+	accountingPeer.lock.Lock()
+	defer accountingPeer.lock.Unlock()
+
+	if accountingPeer.reconnectAllowTimestamp != 0 {
+		timeNow := a.timeNow().Unix()
+		if timeNow < accountingPeer.reconnectAllowTimestamp {
+			disconnectFor := accountingPeer.reconnectAllowTimestamp - timeNow
+			a.p2p.Blocklist(peer, time.Duration(disconnectFor)*time.Second)
+		}
 	}
 }
 
@@ -1001,6 +1096,42 @@ func (a *Accounting) decreaseOriginatedBalanceBy(peer swarm.Address, amount *big
 	a.logger.Tracef("decreasing originated balance to peer %v by amount %d to current balance %d", peer, amount, newOriginatedBalance)
 
 	return nil
+}
+
+func (a *Accounting) Disconnect(peer swarm.Address) {
+	accountingPeer := a.getAccountingPeer(peer)
+
+	zero := big.NewInt(0)
+	accountingPeer.lock.Lock()
+	defer func() {
+
+		accountingPeer.shadowReservedBalance.Set(zero)
+		accountingPeer.ghostBalance.Set(zero)
+		accountingPeer.reservedBalance.Set(zero)
+
+		err := a.store.Put(peerBalanceKey(peer), zero)
+		if err != nil {
+			a.logger.Errorf("failed to persist balance: %w", err)
+		}
+
+		err = a.store.Put(peerSurplusBalanceKey(peer), zero)
+		if err != nil {
+			a.logger.Errorf("failed to persist surplus balance: %w", err)
+		}
+
+		accountingPeer.lock.Unlock()
+
+	}()
+
+	timeNow := a.timeNow().Unix()
+
+	disconnectFor, err := a.blocklistUntil(peer, 1)
+	if err != nil {
+		disconnectFor = int64(60)
+	}
+	timestamp := timeNow + disconnectFor
+
+	accountingPeer.reconnectAllowTimestamp = timestamp
 }
 
 func (a *Accounting) SetRefreshFunc(f RefreshFunc) {

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -1060,7 +1060,7 @@ func (a *Accounting) Connect(peer swarm.Address) {
 		timeNow := a.timeNow().Unix()
 		if timeNow < accountingPeer.reconnectAllowTimestamp {
 			disconnectFor := accountingPeer.reconnectAllowTimestamp - timeNow
-			a.p2p.Blocklist(peer, time.Duration(disconnectFor)*time.Second)
+			_ = a.p2p.Blocklist(peer, time.Duration(disconnectFor)*time.Second)
 		}
 	}
 }

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -1014,11 +1014,11 @@ func (a *Accounting) blocklistUntil(peer swarm.Address, multiplier int64) (int64
 		debt.Set(a.refreshRate)
 	}
 
-	multiplyDebt := new(big.Int).Mul(debt, big.NewInt(multiplier))
+	additionalDebt := new(big.Int).Add(debt, a.paymentThreshold)
 
-	additionalDebt := new(big.Int).Add(multiplyDebt, a.paymentThreshold)
+	multiplyDebt := new(big.Int).Mul(additionalDebt, big.NewInt(multiplier))
 
-	k := new(big.Int).Div(additionalDebt, a.refreshRate)
+	k := new(big.Int).Div(multiplyDebt, a.refreshRate)
 
 	kInt := k.Int64()
 

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -667,7 +667,7 @@ func (a *Accounting) peerLatentDebt(peer swarm.Address) (*big.Int, error) {
 		return zero, nil
 	}
 
-	return peerDebt, nil
+	return peerLatentDebt, nil
 }
 
 // shadowBalance returns the current debt reduced by any potentially debitable amount stored in shadowReservedBalance
@@ -980,7 +980,7 @@ func (d *debitAction) Apply() error {
 
 		disconnectFor, err := a.blocklistUntil(d.peer, 1)
 		if err != nil {
-			return p2p.NewBlockPeerError(24*time.Hour, ErrDisconnectThresholdExceeded)
+			return p2p.NewBlockPeerError(1*time.Minute, ErrDisconnectThresholdExceeded)
 		}
 		return p2p.NewBlockPeerError(time.Duration(disconnectFor), ErrDisconnectThresholdExceeded)
 
@@ -1029,7 +1029,7 @@ func (a *Accounting) blocklist(peer swarm.Address, multiplier int64) error {
 
 	disconnectFor, err := a.blocklistUntil(peer, multiplier)
 	if err != nil {
-		return a.p2p.Blocklist(peer, 1*time.Hour)
+		return a.p2p.Blocklist(peer, 1*time.Minute)
 	}
 
 	return a.p2p.Blocklist(peer, time.Duration(disconnectFor)*time.Second)

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/ethersphere/bee/pkg/accounting"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
+	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/statestore/mock"
+
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -53,7 +55,7 @@ func TestAccountingAddBalance(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +224,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +253,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	acc, err = accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err = accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +284,7 @@ func TestAccountingReserve(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +312,7 @@ func TestAccountingDisconnect(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +351,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +474,7 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,7 +591,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -729,7 +731,7 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 	debt := uint64(500)
 	earlyPayment := big.NewInt(1000)
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, earlyPayment, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, earlyPayment, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +790,7 @@ func TestAccountingSurplusBalance(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, big.NewInt(0), big.NewInt(0), logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, big.NewInt(0), big.NewInt(0), logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -900,7 +902,7 @@ func TestAccountingNotifyPaymentReceived(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -957,7 +959,7 @@ func TestAccountingConnected(t *testing.T) {
 
 	pricing := &pricingMock{}
 
-	_, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, pricing, big.NewInt(testRefreshRate))
+	_, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, pricing, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -993,7 +995,7 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 
 	pricing := &pricingMock{}
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, big.NewInt(0), logger, store, pricing, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, big.NewInt(0), logger, store, pricing, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1055,7 +1057,7 @@ func TestAccountingPeerDebt(t *testing.T) {
 
 	pricing := &pricingMock{}
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, big.NewInt(0), logger, store, pricing, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, big.NewInt(0), logger, store, pricing, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -116,7 +116,7 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1108,7 +1108,7 @@ func TestAccountingCallPaymentFailureRetries(t *testing.T) {
 	store := mock.NewStateStore()
 	defer store.Close()
 
-	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(1))
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(1), p2pmock.New())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -1333,7 +1333,7 @@ func TestAccountingReconnectBeforeAllowed(t *testing.T) {
 		t.Fatalf("unexpected blocklisting time, got %v expected %v", blocklistTime, 4*paymentThresholdInRefreshmentSeconds)
 	}
 
-	// 30 seconds pass, check whether we blocklist for the correct leftover time
+	// 30 seconds pass, check whether we blocklist for the correct leftover time after a later connect attempt
 
 	ts = int64(1030)
 	acc.SetTime(ts)

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -1211,3 +1211,62 @@ func TestAccountingCallPaymentFailureRetries(t *testing.T) {
 
 	acc.Release(peer1Addr, 1)
 }
+
+func TestAccountingReconnectBlocklistOverdraft(t *testing.T) {
+	logger := logging.New(ioutil.Discard, 0)
+
+	store := mock.NewStateStore()
+	defer store.Close()
+
+	var blocklistTime int64
+
+	paymentThresholdInRefreshmentSeconds := new(big.Int).Div(testPaymentThreshold, big.NewInt(testRefreshRate)).Uint64()
+
+	f := func(s swarm.Address, t time.Duration) error {
+		blocklistTime = int64(t.Seconds())
+		return nil
+	}
+
+	acc, err := accounting.NewAccounting(testPaymentThreshold, testPaymentTolerance, testPaymentEarly, logger, store, nil, big.NewInt(testRefreshRate), p2pmock.New(p2pmock.WithBlocklistFunc(f)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := int64(1000)
+	acc.SetTime(ts)
+
+	peer, err := swarm.ParseHexAddress("00112233")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestPrice := testPaymentThreshold.Uint64()
+
+	debitActionNormal := acc.PrepareDebit(peer, requestPrice)
+	err = debitActionNormal.Apply()
+	if err != nil {
+		t.Fatal(err)
+	}
+	debitActionNormal.Cleanup()
+
+	// debit ghost balance
+	debitActionGhost := acc.PrepareDebit(peer, requestPrice)
+	debitActionGhost.Cleanup()
+
+	// increase shadow reserve
+	debitActionShadow := acc.PrepareDebit(peer, requestPrice)
+	_ = debitActionShadow
+
+	if blocklistTime != 0 {
+		t.Fatal("unexpected blocklist")
+	}
+
+	// ghost overdraft triggering blocklist
+	debitAction4 := acc.PrepareDebit(peer, requestPrice)
+	debitAction4.Cleanup()
+
+	if blocklistTime != int64(5*paymentThresholdInRefreshmentSeconds) {
+		t.Fatalf("unexpected blocklisting time, got %v expected %v", blocklistTime, 5*paymentThresholdInRefreshmentSeconds)
+	}
+
+}

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -227,6 +227,14 @@ func (s *Service) CompensatedBalances() (map[string]*big.Int, error) {
 	return s.balances, nil
 }
 
+func (s *Service) Connect(peer swarm.Address) {
+
+}
+
+func (s *Service) Disconnect(peer swarm.Address) {
+
+}
+
 //
 func (s *Service) SurplusBalance(peer swarm.Address) (*big.Int, error) {
 	if s.balanceFunc != nil {

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -22,7 +22,7 @@ type Service struct {
 	reserveFunc             func(ctx context.Context, peer swarm.Address, price uint64) error
 	releaseFunc             func(peer swarm.Address, price uint64)
 	creditFunc              func(peer swarm.Address, price uint64, orig bool) error
-	prepareDebitFunc        func(peer swarm.Address, price uint64) accounting.Action
+	prepareDebitFunc        func(peer swarm.Address, price uint64) (accounting.Action, error)
 	balanceFunc             func(swarm.Address) (*big.Int, error)
 	shadowBalanceFunc       func(swarm.Address) (*big.Int, error)
 	balancesFunc            func() (map[string]*big.Int, error)
@@ -61,7 +61,7 @@ func WithCreditFunc(f func(peer swarm.Address, price uint64, orig bool) error) O
 }
 
 // WithDebitFunc sets the mock Debit function
-func WithPrepareDebitFunc(f func(peer swarm.Address, price uint64) accounting.Action) Option {
+func WithPrepareDebitFunc(f func(peer swarm.Address, price uint64) (accounting.Action, error)) Option {
 	return optionFunc(func(s *Service) {
 		s.prepareDebitFunc = f
 	})
@@ -144,7 +144,7 @@ func (s *Service) Credit(peer swarm.Address, price uint64, orig bool) error {
 }
 
 // Debit is the mock function wrapper that calls the set implementation
-func (s *Service) PrepareDebit(peer swarm.Address, price uint64) accounting.Action {
+func (s *Service) PrepareDebit(peer swarm.Address, price uint64) (accounting.Action, error) {
 	if s.prepareDebitFunc != nil {
 		return s.prepareDebitFunc(peer, price)
 	}
@@ -155,7 +155,7 @@ func (s *Service) PrepareDebit(peer swarm.Address, price uint64) accounting.Acti
 		price:      bigPrice,
 		peer:       peer,
 		applied:    false,
-	}
+	}, nil
 
 }
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -517,6 +517,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		stateStore,
 		pricing,
 		big.NewInt(refreshRate),
+		p2ps,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("accounting: %w", err)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -163,7 +163,10 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 					return fmt.Errorf("chunk store: %w", err)
 				}
 
-				debit := ps.accounting.PrepareDebit(p.Address, price)
+				debit, err := ps.accounting.PrepareDebit(p.Address, price)
+				if err != nil {
+					return fmt.Errorf("prepare debit to peer %s before writeback: %w", p.Address.String(), err)
+				}
 				defer debit.Cleanup()
 
 				// return back receipt
@@ -308,7 +311,10 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			}
 
 			// return back receipt
-			debit := ps.accounting.PrepareDebit(p.Address, price)
+			debit, err := ps.accounting.PrepareDebit(p.Address, price)
+			if err != nil {
+				return fmt.Errorf("prepare debit to peer %s before writeback: %w", p.Address.String(), err)
+			}
 			defer debit.Cleanup()
 
 			receipt := pb.Receipt{Address: chunk.Address().Bytes(), Signature: signature}
@@ -322,7 +328,10 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 	}
 
-	debit := ps.accounting.PrepareDebit(p.Address, price)
+	debit, err := ps.accounting.PrepareDebit(p.Address, price)
+	if err != nil {
+		return fmt.Errorf("prepare debit to peer %s before writeback: %w", p.Address.String(), err)
+	}
 	defer debit.Cleanup()
 
 	// pass back the receipt

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -429,7 +429,10 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	}
 
 	chunkPrice := s.pricer.Price(chunk.Address())
-	debit := s.accounting.PrepareDebit(p.Address, chunkPrice)
+	debit, err := s.accounting.PrepareDebit(p.Address, chunkPrice)
+	if err != nil {
+		return fmt.Errorf("prepare debit to peer %s before writeback: %w", p.Address.String(), err)
+	}
 	defer debit.Cleanup()
 
 	if err := w.WriteMsgWithContext(ctx, &pb.Delivery{

--- a/pkg/settlement/interface.go
+++ b/pkg/settlement/interface.go
@@ -32,4 +32,6 @@ type Accounting interface {
 	NotifyPaymentReceived(peer swarm.Address, amount *big.Int) error
 	NotifyPaymentSent(peer swarm.Address, amount *big.Int, receivedError error)
 	NotifyRefreshmentReceived(peer swarm.Address, amount *big.Int) error
+	Connect(peer swarm.Address)
+	Disconnect(peer swarm.Address)
 }

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -102,6 +102,7 @@ func (s *Service) init(ctx context.Context, p p2p.Peer) error {
 		s.peers[p.Address.String()] = peerData
 	}
 
+	s.accounting.Connect(p.Address)
 	return nil
 }
 
@@ -110,6 +111,8 @@ func (s *Service) terminate(p p2p.Peer) error {
 	defer s.peersMu.Unlock()
 
 	delete(s.peers, p.Address.String())
+
+	s.accounting.Disconnect(p.Address)
 	return nil
 }
 

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -61,6 +61,14 @@ func (t *testObserver) PeerDebt(peer swarm.Address) (*big.Int, error) {
 	return nil, errors.New("Peer not listed")
 }
 
+func (t *testObserver) Connect(peer swarm.Address) {
+
+}
+
+func (t *testObserver) Disconnect(peer swarm.Address) {
+
+}
+
 func (t *testObserver) NotifyRefreshmentReceived(peer swarm.Address, amount *big.Int) error {
 	t.receivedCalled <- notifyPaymentReceivedCall{
 		peer:   peer,

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -83,6 +83,14 @@ func (t *testObserver) NotifyPaymentSent(peer swarm.Address, amount *big.Int, er
 	}
 }
 
+func (t *testObserver) Connect(peer swarm.Address) {
+
+}
+
+func (t *testObserver) Disconnect(peer swarm.Address) {
+
+}
+
 type addressbookMock struct {
 	beneficiary     func(peer swarm.Address) (beneficiary common.Address, known bool, err error)
 	chequebook      func(peer swarm.Address) (chequebookAddress common.Address, known bool, err error)


### PR DESCRIPTION
This PR introduces a failsafe mechanism for unforeseeable problems that can result in accounting discrepancies and enabling nodes to be able to recover a state of symmetric balances afterwards while inhibiting nodes of taking advantage of the failsafe mechanism.
The failsafe mechanism is that both peers start with 0 balances upon a new establishment of the connection in a peer to peer relationship.
The safety of this mechanism is guaranteed by not allowing reconnections by the same peer until the refreshement rate would remove the outstanding debt plus one times paymentthreshold worth of credit space, in case a peer disconnects from us.

This pr also introduces ghost debt, meaning we account for requests that the node attempted to serve as a forwarder - meaning it successfully requested it and got a response for the same request from a third peer - but, for some reason, was unable to write back the result and thereby could not actually debit for these 'ghosted' requests. 

Once the cumulative amount of ghost balance reaches the disconnect limit, the peer in ghost debt is blocklisted by the node based on the time the refreshement rate would take to remove the outstanding debt plus one times paymentthreshold worth of credit space.

For all such blocklisting purposes, the outstanding debt is defined as the sum of:
- debt shown by the accounting balance, 
- shadow reserved debt (requests already served by downstream, which could be debited for once response was wrote back to upstream peer) 
- ghost debt



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/1983)
<!-- Reviewable:end -->
