### PR TITLE
fix: delay concluding attempt in pushsync

### DIFF
--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -101,6 +101,7 @@ func (r *Recorder) NewStream(ctx context.Context, addr swarm.Address, h p2p.Head
 			return nil, err
 		}
 	}
+
 	recordIn := newRecord()
 	recordOut := newRecord()
 	streamOut := newStream(recordIn, recordOut)

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -101,7 +101,6 @@ func (r *Recorder) NewStream(ctx context.Context, addr swarm.Address, h p2p.Head
 			return nil, err
 		}
 	}
-
 	recordIn := newRecord()
 	recordOut := newRecord()
 	streamOut := newStream(recordIn, recordOut)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -454,6 +454,15 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 
 	ps.metrics.TotalSent.Inc()
 
+	// if you manage to get a tag, just increment the respective counter
+	t, err := ps.tagger.Get(ch.TagID())
+	if err == nil && t != nil {
+		err = t.Inc(tags.StateSent)
+		if err != nil {
+			return nil, true, fmt.Errorf("tag %d increment: %v", ch.TagID(), err)
+		}
+	}
+
 	var receipt pb.Receipt
 	if err := r.ReadMsgWithContext(ctx, &receipt); err != nil {
 		_ = streamer.Reset()
@@ -468,15 +477,6 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 	err = ps.accounting.Credit(peer, receiptPrice, originated)
 	if err != nil {
 		return nil, true, err
-	}
-
-	// if you manage to get a tag, just increment the respective counter
-	t, err := ps.tagger.Get(ch.TagID())
-	if err == nil && t != nil {
-		err = t.Inc(tags.StateSent)
-		if err != nil {
-			return nil, true, fmt.Errorf("tag %d increment: %v", ch.TagID(), err)
-		}
 	}
 
 	return &receipt, true, nil

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -438,7 +438,7 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 
 	streamer, err := ps.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
-		return nil, true, fmt.Errorf("new stream for peer %s: %w", peer, err)
+		return nil, false, fmt.Errorf("new stream for peer %s: %w", peer, err)
 	}
 	defer streamer.Close()
 
@@ -449,7 +449,7 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 		Stamp:   stamp,
 	}); err != nil {
 		_ = streamer.Reset()
-		return nil, true, fmt.Errorf("chunk %s deliver to peer %s: %w", ch.Address(), peer, err)
+		return nil, false, fmt.Errorf("chunk %s deliver to peer %s: %w", ch.Address(), peer, err)
 	}
 
 	ps.metrics.TotalSent.Inc()

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -454,15 +454,6 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 
 	ps.metrics.TotalSent.Inc()
 
-	// if you manage to get a tag, just increment the respective counter
-	t, err := ps.tagger.Get(ch.TagID())
-	if err == nil && t != nil {
-		err = t.Inc(tags.StateSent)
-		if err != nil {
-			return nil, true, fmt.Errorf("tag %d increment: %v", ch.TagID(), err)
-		}
-	}
-
 	var receipt pb.Receipt
 	if err := r.ReadMsgWithContext(ctx, &receipt); err != nil {
 		_ = streamer.Reset()
@@ -477,6 +468,15 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 	err = ps.accounting.Credit(peer, receiptPrice, originated)
 	if err != nil {
 		return nil, true, err
+	}
+
+	// if you manage to get a tag, just increment the respective counter
+	t, err := ps.tagger.Get(ch.TagID())
+	if err == nil && t != nil {
+		err = t.Inc(tags.StateSent)
+		if err != nil {
+			return nil, true, fmt.Errorf("tag %d increment: %v", ch.TagID(), err)
+		}
 	}
 
 	return &receipt, true, nil

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -961,7 +961,7 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 					if triggerCount < 9 {
 						triggerCount++
 						stream.Close()
-						return errors.New("fmt")
+						return errors.New("new error")
 					}
 
 					if err := h(ctx, peer, stream); err != nil {

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -488,7 +488,7 @@ func TestPushChunkToNextClosest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ta2.Get(tags.StateSent) != 1 {
+	if ta2.Get(tags.StateSent) != 2 {
 		t.Fatalf("tags error")
 	}
 
@@ -1023,7 +1023,7 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 	}
 	// out of 4, 3 peers should return accouting error. So we should have effectively
 	// sent only 1 msg
-	if ta2.Get(tags.StateSent) != 1 {
+	if ta2.Get(tags.StateSent) != 10 {
 		t.Fatalf("tags error")
 	}
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -488,7 +488,7 @@ func TestPushChunkToNextClosest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ta2.Get(tags.StateSent) != 2 {
+	if ta2.Get(tags.StateSent) != 1 {
 		t.Fatalf("tags error")
 	}
 
@@ -940,10 +940,8 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 	)
 	defer storerPeer4.Close()
 
-	var (
-		fail = true
-		lock sync.Mutex
-	)
+	triggerCount := 0
+	var lock sync.Mutex
 
 	recorder := streamtest.New(
 		streamtest.WithPeerProtocols(
@@ -954,15 +952,25 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 				peer4.String(): psPeer4.Protocol(),
 			},
 		),
-		streamtest.WithStreamError(
-			func(addr swarm.Address, _, _, _ string) error {
-				lock.Lock()
-				defer lock.Unlock()
-				if fail && addr.String() != peer4.String() {
-					return errors.New("peer not reachable")
-				}
+		streamtest.WithMiddlewares(
+			func(h p2p.HandlerFunc) p2p.HandlerFunc {
+				return func(ctx context.Context, peer p2p.Peer, stream p2p.Stream) error {
+					lock.Lock()
+					defer lock.Unlock()
 
-				return nil
+					if triggerCount < 9 {
+						triggerCount++
+						stream.Close()
+						return errors.New("fmt")
+					}
+
+					if err := h(ctx, peer, stream); err != nil {
+						return err
+					}
+					// close stream after all previous middlewares wrote to it
+					// so that the receiving peer can get all the post messages
+					return stream.Close()
+				}
 			},
 		),
 		streamtest.WithBaseAddr(pivotNode),


### PR DESCRIPTION
This PR intends to make forwarder behavior ensure that chunk is successfully written to at least one further peer before concluding attempt has been made

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2016)
<!-- Reviewable:end -->
