### PR TITLE
feat: verify chunk availability before concluding synced status

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -642,7 +642,8 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 		b.recoveryHandleCleanup = pssService.Register(recovery.Topic, chunkRepairHandler)
 	}
 
-	pusherService := pusher.New(networkID, storer, kad, pushSyncProtocol, tagService, logger, tracer, warmupTime)
+	pusherService := pusher.New(networkID, storer, kad, pushSyncProtocol, retrieve, tagService, logger, tracer, warmupTime)
+
 	b.pusherCloser = pusherService
 
 	pullStorage := pullstorage.New(storer)

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethersphere/bee/pkg/pusher"
 	"github.com/ethersphere/bee/pkg/pushsync"
 	pushsyncmock "github.com/ethersphere/bee/pkg/pushsync/mock"
+	retrievalmock "github.com/ethersphere/bee/pkg/retrieval/mock"
 	"github.com/ethersphere/bee/pkg/storage"
 	testingc "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -432,6 +433,8 @@ func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.Pus
 		t.Fatal(err)
 	}
 
+	retrievalService := retrievalmock.New(nil)
+
 	mockStatestore := statestore.NewStateStore()
 	mtags := tags.NewTags(mockStatestore, logger)
 	pusherStorer := &Store{
@@ -442,7 +445,7 @@ func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.Pus
 	}
 	peerSuggester := mock.NewTopologyDriver(mockOpts...)
 
-	pusherService := pusher.New(1, pusherStorer, peerSuggester, pushSyncService, mtags, logger, nil, 0)
+	pusherService := pusher.New(1, pusherStorer, peerSuggester, pushSyncService, retrievalService, mtags, logger, nil, 0)
 	return mtags, pusherService, pusherStorer
 }
 

--- a/pkg/pushsync/export_test.go
+++ b/pkg/pushsync/export_test.go
@@ -5,8 +5,10 @@
 package pushsync
 
 var (
-	ProtocolName    = protocolName
-	ProtocolVersion = protocolVersion
-	StreamName      = streamName
-	NewPeerSkipList = newPeerSkipList
+	ProtocolName     = protocolName
+	ProtocolVersion  = protocolVersion
+	StreamName       = streamName
+	NewPeerSkipList  = newPeerSkipList
+	DefaultTtl       = &defaultTTL
+	SendReceiptDelay = &sendReceiptDelay
 )

--- a/pkg/pushsync/export_test.go
+++ b/pkg/pushsync/export_test.go
@@ -4,6 +4,8 @@
 
 package pushsync
 
+import "github.com/ethersphere/bee/pkg/swarm"
+
 var (
 	ProtocolName     = protocolName
 	ProtocolVersion  = protocolVersion
@@ -12,3 +14,7 @@ var (
 	DefaultTtl       = &defaultTTL
 	SendReceiptDelay = &sendReceiptDelay
 )
+
+func (ps *PushSync) ShouldSkip(peer swarm.Address) bool {
+	return ps.skipList.ShouldSkip(peer)
+}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -365,7 +365,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
 				// if the node has warmed up AND no other closer peer has been tried
-				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) {
+				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && ps.topologyDriver.IsWithinDepth(ch.Address()) {
 					ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
 				}
 			}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -299,23 +299,26 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				count := 0
-				// Push the chunk to some peers in the neighborhood in parallel for replication.
-				// Any errors here should NOT impact the rest of the handler.
-				_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
-					// skip forwarding peer
-					if peer.Equal(origin) {
-						return false, false, nil
-					}
+				if ps.topologyDriver.IsWithinDepth(ch.Address()) {
+					count := 0
+					// Push the chunk to some peers in the neighborhood in parallel for replication.
+					// Any errors here should NOT impact the rest of the handler.
+					_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+						// skip forwarding peer
+						if peer.Equal(origin) {
+							return false, false, nil
+						}
 
-					if count == nPeersToPushsync {
-						return true, false, nil
-					}
-					count++
-					go ps.pushToNeighbour(peer, ch, retryAllowed)
-					return false, false, nil
-				})
-				return nil, err
+						if count == nPeersToPushsync {
+							return true, false, nil
+						}
+						count++
+						go ps.pushToNeighbour(peer, ch, retryAllowed)
+						return false, false, nil
+					})
+					return nil, err
+				}
+				return nil, fmt.Errorf("closest peer: none available")
 			}
 			return nil, fmt.Errorf("closest peer: %w", err)
 		}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -409,6 +409,8 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 	// compute the price we pay for this receipt and reserve it for the rest of this function
 	receiptPrice := ps.pricer.PeerPrice(peer, ch.Address())
 
+	fmt.Printf("peer: %v\n", peer)
+
 	// Reserve to see whether we can make the request
 	err := ps.accounting.Reserve(ctx, peer, receiptPrice)
 	if err != nil {

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -37,7 +37,7 @@ const (
 )
 
 const (
-	maxPeers           = 3
+	maxPeers           = 16
 	maxAttempts        = 16
 	skipPeerExpiration = time.Minute
 )
@@ -78,7 +78,8 @@ type PushSync struct {
 	skipList       *peerSkipList
 }
 
-var defaultTTL = 20 * time.Second                     // request time to live
+var defaultTTL = 15 * time.Second // request time to live
+var preemptiveTTL = 9 * time.Second
 var timeToWaitForPushsyncToNeighbor = 3 * time.Second // time to wait to get a receipt for a chunk
 var nPeersToPushsync = 3                              // number of peers to replicate to as receipt is sent upstream
 
@@ -123,6 +124,7 @@ func (s *PushSync) Protocol() p2p.ProtocolSpec {
 func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
 	w, r := protobuf.NewWriterAndReader(stream)
 	ctx, cancel := context.WithTimeout(ctx, defaultTTL)
+
 	defer cancel()
 	defer func() {
 		if err != nil {
@@ -191,7 +193,8 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 	// forwarding replication
 	storedChunk := false
-	if ps.topologyDriver.IsWithinDepth(chunk.Address()) {
+	retryAllow := ps.topologyDriver.IsWithinDepth(chunk.Address())
+	if retryAllow {
 		_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
 		if err != nil {
 			ps.logger.Warningf("pushsync: within depth peer's attempt to store chunk failed: %v", err)
@@ -203,7 +206,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	span, _, ctx := ps.tracer.StartSpanFromContext(ctx, "pushsync-handler", ps.logger, opentracing.Tag{Key: "address", Value: chunk.Address().String()})
 	defer span.Finish()
 
-	receipt, err := ps.pushToClosest(ctx, chunk, false, p.Address)
+	receipt, err := ps.pushToClosest(ctx, chunk, retryAllow, false, p.Address)
 	if err != nil {
 		if errors.Is(err, topology.ErrWantSelf) {
 			if !storedChunk {
@@ -254,7 +257,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 // a receipt from that peer and returns error or nil based on the receiving and
 // the validity of the receipt.
 func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Receipt, error) {
-	r, err := ps.pushToClosest(ctx, ch, true, swarm.ZeroAddress)
+	r, err := ps.pushToClosest(ctx, ch, true, true, swarm.ZeroAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -270,10 +273,12 @@ type pushResult struct {
 	attempted bool
 }
 
-func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllowed bool, origin swarm.Address) (*pb.Receipt, error) {
+func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllowed, originated bool, origin swarm.Address) (*pb.Receipt, error) {
 	span, logger, ctx := ps.tracer.StartSpanFromContext(ctx, "push-closest", ps.logger, opentracing.Tag{Key: "address", Value: ch.Address().String()})
 	defer span.Finish()
 	defer ps.skipList.PruneExpired()
+
+	preemptiveLimit := time.After(time.Second * 9)
 
 	var (
 		skipPeers      []swarm.Address
@@ -283,9 +288,11 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 	)
 
 	if retryAllowed {
-		// only originator retries
+		// only originator and peers in neighborhood of chunk retry
 		allowedRetries = maxPeers
 	}
+
+	chunkInNeighborhood := ps.topologyDriver.IsWithinDepth(ch.Address())
 
 	for i := maxAttempts; allowedRetries > 0 && i > 0; i-- {
 		// find the next closest peer
@@ -299,7 +306,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				if !ps.topologyDriver.IsWithinDepth(ch.Address()) {
+				if !chunkInNeighborhood {
 					return nil, ErrNoPush
 				}
 
@@ -316,7 +323,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 						return true, false, nil
 					}
 					count++
-					go ps.pushToNeighbour(peer, ch, retryAllowed)
+					go ps.pushToNeighbour(peer, ch, originated)
 					return false, false, nil
 				})
 				return nil, err
@@ -337,7 +344,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 			ctxd, canceld := context.WithTimeout(ctx, defaultTTL)
 			defer canceld()
 
-			r, attempted, err := ps.pushPeer(ctxd, peer, ch, retryAllowed)
+			r, attempted, err := ps.pushPeer(ctxd, peer, ch, originated)
 			// attempted is true if we get past accounting and actually attempt
 			// to send the request to the peer. If we dont get past accounting, we
 			// should not count the retry and try with a different peer again
@@ -355,23 +362,46 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 			}
 		}(peer, ch)
 
-		select {
-		case r := <-resultC:
-			// receipt received for chunk
-			if r.receipt != nil {
-				ps.skipList.PruneChunk(ch.Address())
-				return r.receipt, nil
-			}
-			if r.err != nil && r.attempted {
-				ps.metrics.TotalFailedSendAttempts.Inc()
-
-				// if the node has warmed up AND no other closer peer has been tried
-				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && ps.topologyDriver.IsWithinDepth(ch.Address()) {
-					ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+		if !chunkInNeighborhood {
+			select {
+			case r := <-resultC:
+				// receipt received for chunk
+				if r.receipt != nil {
+					ps.skipList.PruneChunk(ch.Address())
+					return r.receipt, nil
 				}
+				if r.err != nil && r.attempted {
+					ps.metrics.TotalFailedSendAttempts.Inc()
+
+					// if the node has warmed up AND no other closer peer has been tried
+					if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && chunkInNeighborhood && errors.Is(err, context.DeadlineExceeded) {
+						ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+					}
+				}
+			case <-ctx.Done():
+				return nil, ctx.Err()
 			}
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		} else {
+			select {
+			case r := <-resultC:
+				// receipt received for chunk
+				if r.receipt != nil {
+					ps.skipList.PruneChunk(ch.Address())
+					return r.receipt, nil
+				}
+				if r.err != nil && r.attempted {
+					ps.metrics.TotalFailedSendAttempts.Inc()
+					// if the node has warmed up AND no other closer peer has been tried
+					if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && chunkInNeighborhood && errors.Is(err, context.DeadlineExceeded) {
+						ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+					}
+				}
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-preemptiveLimit:
+				go ps.establishStorage(ch, origin, originated, resultC)
+				allowedRetries++
+			}
 		}
 	}
 
@@ -572,4 +602,44 @@ func (l *peerSkipList) PruneExpired() {
 			delete(l.skipExpiration, k)
 		}
 	}
+}
+
+func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, originated bool, resultC chan<- *pushResult) {
+
+	count := 0
+	// Push the chunk to some peers in the neighborhood in parallel for replication.
+	// Any errors here should NOT impact the rest of the handler.
+	_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+		// skip forwarding peer
+		if peer.Equal(origin) {
+			return false, false, nil
+		}
+
+		if count == nPeersToPushsync {
+			return true, false, nil
+		}
+		count++
+		go ps.pushToNeighbour(peer, ch, originated)
+		return false, false, nil
+	})
+
+	bytes := ch.Address().Bytes()
+
+	signature, err := ps.signer.Sign(bytes)
+	if err != nil {
+		resultC <- &pushResult{
+			receipt:   nil,
+			err:       err,
+			attempted: true,
+		}
+		return
+	}
+
+	receipt := pb.Receipt{Address: bytes, Signature: signature, BlockHash: ps.blockHash}
+	resultC <- &pushResult{
+		receipt:   &receipt,
+		err:       err,
+		attempted: true,
+	}
+
 }

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -46,7 +46,6 @@ var (
 	ErrOutOfDepthReplication = errors.New("replication outside of the neighborhood")
 	ErrNoPush                = errors.New("could not push chunk")
 	ErrWarmup                = errors.New("node warmup time not complete")
-	ErrSelfSignFail          = errors.New("creating storage receipt failed")
 )
 
 type PushSyncer interface {
@@ -627,7 +626,7 @@ func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, origi
 	if err != nil {
 		resultC <- &pushResult{
 			receipt:   nil,
-			err:       ErrSelfSignFail,
+			err:       err,
 			attempted: true,
 		}
 		return

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -46,7 +46,6 @@ var (
 	ErrOutOfDepthReplication = errors.New("replication outside of the neighborhood")
 	ErrNoPush                = errors.New("could not push chunk")
 	ErrWarmup                = errors.New("node warmup time not complete")
-	ErrSelfSignFail          = errors.New("creating storage receipt failed")
 )
 
 type PushSyncer interface {
@@ -367,7 +366,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, originate
 			if r.err != nil && r.attempted {
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
-				if errors.Is(err, ErrSelfSignFail) && results > attempts {
+				if results > attempts {
 					return nil, ErrNoPush
 				}
 
@@ -612,7 +611,7 @@ func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, origi
 	if err != nil {
 		resultC <- &pushResult{
 			receipt:   nil,
-			err:       ErrSelfSignFail,
+			err:       err,
 			attempted: true,
 		}
 		return

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -395,6 +395,8 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin sw
 			if r.err != nil && r.attempted {
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
+				// if we have received 1 more results than peers attempted, return
+				// this means all attempts including establishing storage have already failed
 				if results > attempts {
 					return nil, ErrNoPush
 				}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -299,26 +299,27 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				if ps.topologyDriver.IsWithinDepth(ch.Address()) {
-					count := 0
-					// Push the chunk to some peers in the neighborhood in parallel for replication.
-					// Any errors here should NOT impact the rest of the handler.
-					_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
-						// skip forwarding peer
-						if peer.Equal(origin) {
-							return false, false, nil
-						}
-
-						if count == nPeersToPushsync {
-							return true, false, nil
-						}
-						count++
-						go ps.pushToNeighbour(peer, ch, retryAllowed)
-						return false, false, nil
-					})
-					return nil, err
+				if !ps.topologyDriver.IsWithinDepth(ch.Address()) {
+					return nil, ErrNoPush
 				}
-				return nil, fmt.Errorf("closest peer: none available")
+
+				count := 0
+				// Push the chunk to some peers in the neighborhood in parallel for replication.
+				// Any errors here should NOT impact the rest of the handler.
+				_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+					// skip forwarding peer
+					if peer.Equal(origin) {
+						return false, false, nil
+					}
+
+					if count == nPeersToPushsync {
+						return true, false, nil
+					}
+					count++
+					go ps.pushToNeighbour(peer, ch, retryAllowed)
+					return false, false, nil
+				})
+				return nil, err
 			}
 			return nil, fmt.Errorf("closest peer: %w", err)
 		}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -130,13 +130,9 @@ func TestReplicateBeforeReceipt(t *testing.T) {
 	defer storerEmpty.Close()
 	emptyRecorder := streamtest.New(streamtest.WithProtocols(psEmpty.Protocol()), streamtest.WithBaseAddr(secondPeer))
 
-	wFunc := func(addr swarm.Address) bool {
-		return true
-	}
-
 	// node that is connected to closestPeer
 	// will receieve chunk from closestPeer
-	psSecond, storerSecond, _, secondAccounting := createPushSyncNode(t, secondPeer, defaultPrices, emptyRecorder, nil, defaultSigner, mock.WithPeers(emptyPeer), mock.WithIsWithinFunc(wFunc))
+	psSecond, storerSecond, _, secondAccounting := createPushSyncNode(t, secondPeer, defaultPrices, emptyRecorder, nil, defaultSigner, mock.WithPeers(emptyPeer))
 	defer storerSecond.Close()
 	secondRecorder := streamtest.New(streamtest.WithProtocols(psSecond.Protocol()), streamtest.WithBaseAddr(closestPeer))
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1505,11 +1505,6 @@ func TestRaceStorerReceipt(t *testing.T) {
 						return errors.New("peer error")
 					}
 
-					// simulate timing out for peer4
-					// if failCountNeighborhood == 2 {
-					// 	time.Sleep(time.Millisecond * 1100)
-					// }
-
 					if err := h(ctx, peer, stream); err != nil {
 						return err
 					}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1089,9 +1089,9 @@ func TestPreemptiveReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, defaultSigner, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1214,10 +1214,10 @@ func TestPreemptiveReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)
@@ -1238,12 +1238,12 @@ func TestPreemptiveReceipt(t *testing.T) {
 		t.Fatal("receipt signature is invalid")
 	}
 
-	if psPeer2.ShouldSkip(peer3) {
-		t.Fatalf("peer %v should NOT be skipped", peer3.String())
+	if !psPeer2.ShouldSkip(peer3) {
+		t.Fatalf("peer %v should be skipped", peer3.String())
 	}
 
-	if !psPeer2.ShouldSkip(peer4) {
-		t.Fatalf("peer %v should be skipped", peer4.String())
+	if psPeer2.ShouldSkip(peer4) {
+		t.Fatalf("peer %v should NOT be skipped", peer4.String())
 	}
 }
 
@@ -1279,9 +1279,9 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, signerPeer4, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1402,10 +1402,10 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)
@@ -1471,9 +1471,9 @@ func TestRaceStorerReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, signerPeer4, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1594,10 +1594,10 @@ func TestRaceStorerReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1439,7 +1439,8 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	}
 }
 
-func Test_(t *testing.T) {
+// TestRaceStorerReceipt tests that the preemptive receipt creation can overtake the passing back of the receipt from a downstream peer
+func TestRaceStorerReceipt(t *testing.T) {
 
 	defer func(t time.Duration) {
 		*pushsync.DefaultTtl = t

--- a/pkg/retrieval/mock/mock.go
+++ b/pkg/retrieval/mock/mock.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mock
+
+import (
+	"context"
+	"github.com/ethersphere/bee/pkg/retrieval"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type mock struct {
+	checkAvailableChunkFunc func(ctx context.Context, addr swarm.Address) (err error)
+}
+
+func New(checkAvailableChunk func(ctx context.Context, addr swarm.Address) error) retrieval.Verifier {
+	return &mock{checkAvailableChunkFunc: checkAvailableChunk}
+}
+
+func (s *mock) CheckAvailableChunk(ctx context.Context, addr swarm.Address) (err error) {
+	if s.checkAvailableChunkFunc != nil {
+		return s.checkAvailableChunkFunc(ctx, addr)
+	}
+
+	return nil
+}

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -53,6 +53,10 @@ type retrievalResult struct {
 	retrieved bool
 }
 
+type Verifier interface {
+	CheckAvailableChunk(ctx context.Context, addr swarm.Address) (err error)
+}
+
 type Service struct {
 	addr          swarm.Address
 	streamer      p2p.Streamer
@@ -445,4 +449,114 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	s.logger.Tracef("retrieval protocol debiting peer %s", p.Address.String())
 	// debit price from p's balance
 	return debit.Apply()
+}
+
+//
+//
+//
+//
+
+func (s *Service) CheckAvailableChunk(ctx context.Context, addr swarm.Address) (err error) {
+
+	ctx, cancel := context.WithTimeout(ctx, retrieveChunkTimeout)
+	defer cancel()
+	peer, err := s.farthestPeer(addr)
+	if err != nil {
+		return fmt.Errorf("get farthest for address %s, allow upstream %v: %w", addr.String(), err)
+	}
+
+	// compute the peer's price for this chunk for price header
+	chunkPrice := s.pricer.PeerPrice(peer, addr)
+
+	s.logger.Tracef("retrieval: requesting chunk %s from peer %s", addr, peer)
+	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
+	if err != nil {
+		s.metrics.TotalErrors.Inc()
+		return fmt.Errorf("new stream: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = stream.Reset()
+		} else {
+			go stream.FullClose()
+		}
+	}()
+
+	// Reserve to see whether we can request the chunk
+	err = s.accounting.Reserve(ctx, peer, chunkPrice)
+	if err != nil {
+		return err
+	}
+	defer s.accounting.Release(peer, chunkPrice)
+
+	w, r := protobuf.NewWriterAndReader(stream)
+	if err := w.WriteMsgWithContext(ctx, &pb.Request{
+		Addr: addr.Bytes(),
+	}); err != nil {
+		return fmt.Errorf("write request: %w peer %s", err, peer.String())
+	}
+
+	var d pb.Delivery
+	if err := r.ReadMsgWithContext(ctx, &d); err != nil {
+		return fmt.Errorf("read delivery: %w peer %s", err, peer.String())
+	}
+
+	stamp := new(postage.Stamp)
+	err = stamp.UnmarshalBinary(d.Stamp)
+	if err != nil {
+		return fmt.Errorf("stamp unmarshal: %w", err)
+	}
+	chunk := swarm.NewChunk(addr, d.Data).WithStamp(stamp)
+	if !cac.Valid(chunk) {
+		if !soc.Valid(chunk) {
+			s.metrics.InvalidChunkRetrieved.Inc()
+			s.metrics.TotalErrors.Inc()
+			return swarm.ErrInvalidChunk
+		}
+	}
+
+	// credit the peer after successful delivery
+	err = s.accounting.Credit(peer, chunkPrice)
+	if err != nil {
+		return err
+	}
+	s.metrics.ChunkPrice.Observe(float64(chunkPrice))
+
+	return nil
+}
+
+func (s *Service) farthestPeer(addr swarm.Address) (swarm.Address, error) {
+	farthest := swarm.Address{}
+	err := s.peerSuggester.EachPeerRev(func(peer swarm.Address, po uint8) (bool, bool, error) {
+		if farthest.IsZero() {
+			farthest = peer
+			return false, false, nil
+		}
+		dcmp, err := swarm.DistanceCmp(addr.Bytes(), farthest.Bytes(), peer.Bytes())
+		if err != nil {
+			return false, false, fmt.Errorf("distance compare error. addr %s farthest %s peer %s: %w", addr.String(), farthest.String(), peer.String(), err)
+		}
+		switch dcmp {
+		case 0:
+			// do nothing
+		case 1:
+			// current peer is farther
+			farthest = peer
+		case -1:
+			// farthest is already farther from chunk
+			// do nothing
+		}
+		return false, false, nil
+	})
+	if err != nil {
+		return swarm.Address{}, err
+	}
+
+	// check if found
+	if farthest.IsZero() {
+		return swarm.Address{}, topology.ErrNotFound
+	}
+
+	return farthest, nil
 }

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -497,7 +497,7 @@ func (s *Service) checkAvailableChunk(ctx context.Context, addr swarm.Address, s
 
 	peer, err := s.farthestPeer(addr, sp.All())
 	if err != nil {
-		return false, fmt.Errorf("get farthest for address %s, allow upstream %v: %w", addr.String(), err)
+		return false, fmt.Errorf("get farthest for address %s: %w", addr.String(), err)
 	}
 
 	// compute the peer's price for this chunk for price header
@@ -555,7 +555,7 @@ func (s *Service) checkAvailableChunk(ctx context.Context, addr swarm.Address, s
 	}
 
 	// credit the peer after successful delivery
-	_ = s.accounting.Credit(peer, chunkPrice)
+	_ = s.accounting.Credit(peer, chunkPrice, true)
 
 	return true, nil
 }

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -482,6 +482,9 @@ func (s *Service) CheckAvailableChunk(ctx context.Context, addr swarm.Address) (
 		} else {
 			select {
 			case <-time.After(600 * time.Millisecond):
+			case <-ctx.Done():
+				s.logger.Tracef("retrieval: failed to verify chunk %s available: %v", addr, ctx.Err())
+				return fmt.Errorf("retrieval: %w", ctx.Err())
 			}
 		}
 

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -164,7 +164,7 @@ func (m *mock) IsWithinDepth(addr swarm.Address) bool {
 	if m.isWithinFunc != nil {
 		return m.isWithinFunc(addr)
 	}
-	return false
+	return true
 }
 
 func (m *mock) EachNeighbor(f topology.EachPeerFunc) error {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -107,7 +107,7 @@ func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }
 
-func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
 		if d.closestPeerErr != nil {
 			return d.closestPeer, d.closestPeerErr
@@ -147,8 +147,13 @@ func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Addres
 	}
 
 	if peerAddr.IsZero() {
-		return peerAddr, topology.ErrNotFound
+		if wantSelf {
+			return peerAddr, topology.ErrWantSelf
+		} else {
+			return peerAddr, topology.ErrNotFound
+		}
 	}
+
 	return peerAddr, nil
 }
 


### PR DESCRIPTION
This is an experimental change to increase push reliability
The availability check is done by attempting to retrieve through a peer farther away from the chunk as the node, to minimize the probability of merging/rejoining routes used for the push and verification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2036)
<!-- Reviewable:end -->
