### PR TITLE
fix: api errors related to postage stamps

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -59,6 +59,8 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/ReferenceResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "403":
           $ref: "SwarmCommon.yaml#/components/responses/403"
         "500":
@@ -153,6 +155,8 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/Status"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -216,6 +220,8 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/ReferenceResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "403":
           $ref: "SwarmCommon.yaml#/components/responses/403"
         "500":
@@ -589,6 +595,8 @@ paths:
           description: Subscribed to topic
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -570,6 +570,12 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
+    "402":
+      description: Payment Required
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
     "403":
       description: Forbidden
       content:

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -70,7 +70,7 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Debugf("bytes upload: split write all: %v", err)
 		logger.Error("bytes upload: split write all")
-		jsonhttp.InternalServerError(w, nil)
+		mappedHTTPErr(w, err, nil)
 		return
 	}
 

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -5,11 +5,13 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/sctx"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -70,7 +72,12 @@ func (s *server) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Debugf("bytes upload: split write all: %v", err)
 		logger.Error("bytes upload: split write all")
-		mappedHTTPErr(w, err, nil)
+		switch {
+		case errors.Is(err, postage.ErrBucketFull):
+			jsonhttp.PaymentRequired(w, "batch is overissued")
+		default:
+			jsonhttp.InternalServerError(w, nil)
+		}
 		return
 	}
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -104,7 +104,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Debugf("chunk upload: chunk write error: %v, addr %s", err, chunk.Address())
 		s.logger.Error("chunk upload: chunk write error")
-		jsonhttp.BadRequest(w, "chunk write error")
+		mappedHTTPErr(w, err, "chunk write error")
 		return
 	} else if len(seen) > 0 && seen[0] && tag != nil {
 		err := tag.Inc(tags.StateSeen)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -86,7 +86,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request, storer
 	if err != nil {
 		logger.Debugf("bzz upload dir: store dir err: %v", err)
 		logger.Errorf("bzz upload dir: store dir")
-		jsonhttp.InternalServerError(w, errDirectoryStore)
+		mappedHTTPErr(w, err, errDirectoryStore)
 		return
 	}
 	if created {

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -96,7 +96,7 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Debugf("pss send payload: %v. topic: %s", err, topicVar)
 		s.logger.Error("pss send payload")
-		jsonhttp.InternalServerError(w, nil)
+		mappedHTTPErr(w, err, nil)
 		return
 	}
 

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -96,7 +97,12 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Debugf("pss send payload: %v. topic: %s", err, topicVar)
 		s.logger.Error("pss send payload")
-		mappedHTTPErr(w, err, nil)
+		switch {
+		case errors.Is(err, postage.ErrBucketFull):
+			jsonhttp.PaymentRequired(w, "batch is overissued")
+		default:
+			jsonhttp.InternalServerError(w, nil)
+		}
 		return
 	}
 


### PR DESCRIPTION
This PR attempts to solve #2026 in part.

This particular change tries to address the postage bucket full error which is annoying as the user does not understand that he cannot use the batch anymore.

We can create a separate `errors.go` file in `pkg/api` which could house all these error case handlers. This way we can edit the same file from time to time to add special case handling.

@acud @agazso @AuHau @Eknir

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2037)
<!-- Reviewable:end -->
