### PR TITLE
fix: don't log checking pending transactions as errors

### DIFF
--- a/pkg/transaction/monitor.go
+++ b/pkg/transaction/monitor.go
@@ -150,7 +150,8 @@ func (tm *transactionMonitor) watchPending() {
 		}
 
 		if err := tm.checkPending(block); err != nil {
-			tm.logger.Errorf("error while checking pending transactions: %v", err)
+			tm.logger.Tracef("error while checking pending transactions: %v", err)
+			continue
 		}
 
 		lastBlock = block


### PR DESCRIPTION
* don't log checking pending transactions as errors. this can happen frequently with load-balanced eth backends where later requests hit a node which has not seen the same block yet.
* don't update `lastBlock` so we retry on the next iteration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2046)
<!-- Reviewable:end -->
