### PR TITLE
feat: enable support for releasing rc

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: bee
 
+release:
+  prerelease: auto
+
 builds:
   - id: linux
     main: ./cmd/bee


### PR DESCRIPTION
Enable support for auto marking a release as a `pre-release` if release tag has `-rcX` suffix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2060)
<!-- Reviewable:end -->
