### PR TITLE
feat(postage): stampissuer usability

### DIFF
--- a/.github/patches/postageservice.patch
+++ b/.github/patches/postageservice.patch
@@ -1,0 +1,4 @@
+21c21
+< 	blockThreshold = 10
+---
+> 	blockThreshold = 0

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -43,6 +43,7 @@ jobs:
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve.patch
           patch pkg/postage/postagecontract/contract.go .github/patches/postagecontract.patch
           patch pkg/postage/listener/listener.go .github/patches/listener.patch
+          patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare local cluster
         run: |
           printf ${{ secrets.CR_PAT }} | docker login ghcr.io -u bee-worker --password-stdin

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -319,6 +319,8 @@ components:
           $ref: "#/components/schemas/BatchID"
         utilization:
           type: integer
+        usable:
+          type: boolean
 
     Settlement:
       type: object

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -267,7 +267,7 @@ func TestPostageHeaderError(t *testing.T) {
 		mockStorer     = mock.NewStorer()
 		mockStatestore = statestore.NewStateStore()
 		logger         = logging.New(ioutil.Discard, 5)
-		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 		client, _, _   = newTestServer(t, testServerOptions{
 			Storer: mockStorer,
 			Tags:   tags.NewTags(mockStatestore, logger),

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -57,7 +57,14 @@ func (s *server) bzzUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Debugf("bzz upload: putter: %v", err)
 		logger.Error("bzz upload: putter")
-		jsonhttp.BadRequest(w, nil)
+		switch {
+		case errors.Is(err, postage.ErrNotFound):
+			jsonhttp.BadRequest(w, "batch not found")
+		case errors.Is(err, postage.ErrNotUsable):
+			jsonhttp.BadRequest(w, "batch not usable yet")
+		default:
+			jsonhttp.BadRequest(w, nil)
+		}
 		return
 	}
 

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -154,7 +154,7 @@ func TestFeed_Post(t *testing.T) {
 		logger         = logging.New(ioutil.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
 		topic          = "aabbcc"
-		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 		mockStorer     = mock.NewStorer()
 		client, _, _   = newTestServer(t, testServerOptions{
 			Storer: mockStorer,

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -99,6 +99,7 @@ func (s *server) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 type postageStampResponse struct {
 	BatchID     batchID `json:"batchID"`
 	Utilization uint32  `json:"utilization"`
+	Usable      bool    `json:"usable"`
 }
 
 type postageStampsResponse struct {
@@ -109,7 +110,11 @@ func (s *server) postageGetStampsHandler(w http.ResponseWriter, r *http.Request)
 	issuers := s.post.StampIssuers()
 	resp := postageStampsResponse{}
 	for _, v := range issuers {
-		issuer := postageStampResponse{BatchID: v.ID(), Utilization: v.Utilization()}
+		issuer := postageStampResponse{
+			BatchID:     v.ID(),
+			Utilization: v.Utilization(),
+			Usable:      s.post.IssuerUsable(v),
+		}
 		resp.Stamps = append(resp.Stamps, issuer)
 	}
 	jsonhttp.OK(w, resp)
@@ -140,6 +145,7 @@ func (s *server) postageGetStampHandler(w http.ResponseWriter, r *http.Request) 
 	resp := postageStampResponse{
 		BatchID:     id,
 		Utilization: issuer.Utilization(),
+		Usable:      s.post.IssuerUsable(issuer),
 	}
 	jsonhttp.OK(w, &resp)
 }

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -192,7 +192,7 @@ func TestPostageCreateStamp(t *testing.T) {
 }
 
 func TestPostageGetStamps(t *testing.T) {
-	mp := mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+	mp := mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 	client, _, _ := newTestServer(t, testServerOptions{Post: mp})
 
 	jsonhttptest.Request(t, client, http.MethodGet, "/stamps", http.StatusOK,
@@ -208,7 +208,7 @@ func TestPostageGetStamps(t *testing.T) {
 }
 
 func TestPostageGetStamp(t *testing.T) {
-	mp := mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+	mp := mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 	client, _, _ := newTestServer(t, testServerOptions{Post: mp})
 
 	t.Run("ok", func(t *testing.T) {

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -201,6 +201,7 @@ func TestPostageGetStamps(t *testing.T) {
 				{
 					BatchID:     batchOk,
 					Utilization: 0,
+					Usable:      true,
 				},
 			},
 		}),
@@ -216,6 +217,7 @@ func TestPostageGetStamp(t *testing.T) {
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampResponse{
 				BatchID:     batchOk,
 				Utilization: 0,
+				Usable:      true,
 			}),
 		)
 	})

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -88,7 +88,14 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Debugf("pss: postage batch issuer: %v", err)
 		s.logger.Error("pss: postage batch issue")
-		jsonhttp.BadRequest(w, "postage stamp issuer")
+		switch {
+		case errors.Is(err, postage.ErrNotFound):
+			jsonhttp.BadRequest(w, "batch not found")
+		case errors.Is(err, postage.ErrNotUsable):
+			jsonhttp.BadRequest(w, "batch not usable yet")
+		default:
+			jsonhttp.BadRequest(w, "postage stamp issuer")
+		}
 		return
 	}
 	stamper := postage.NewStamper(i, s.signer)

--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -185,7 +185,7 @@ func TestPssSend(t *testing.T) {
 			mtx.Unlock()
 			return err
 		}
-		mp           = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+		mp           = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 		p            = newMockPss(sendFn)
 		client, _, _ = newTestServer(t, testServerOptions{
 			Pss:    p,

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -32,7 +32,7 @@ func TestSOC(t *testing.T) {
 		mockStatestore = statestore.NewStateStore()
 		logger         = logging.New(ioutil.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
-		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10)))
+		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, 11, 10, 1000)))
 		mockStorer     = mock.NewStorer()
 		client, _, _   = newTestServer(t, testServerOptions{
 			Storer: mockStorer,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -347,7 +347,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		return nil, fmt.Errorf("batchstore: %w", err)
 	}
 	validStamp := postage.ValidStamp(batchStore)
-	post, err := postage.NewService(stateStore, chainID)
+	post, err := postage.NewService(stateStore, batchStore, chainID)
 	if err != nil {
 		return nil, fmt.Errorf("postage service load: %w", err)
 	}

--- a/pkg/postage/export_test.go
+++ b/pkg/postage/export_test.go
@@ -5,6 +5,7 @@
 package postage
 
 var (
-	IndexToBytes = indexToBytes
-	BytesToIndex = bytesToIndex
+	IndexToBytes   = indexToBytes
+	BytesToIndex   = bytesToIndex
+	BlockThreshold = blockThreshold
 )

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -64,6 +64,10 @@ func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, error) {
 	return nil, errors.New("stampissuer not found")
 }
 
+func (m *mockPostage) IssuerUsable(_ *postage.StampIssuer) bool {
+	return true
+}
+
 func (m *mockPostage) Close() error {
 	return nil
 }

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -54,7 +54,7 @@ func (m *mockPostage) StampIssuers() []*postage.StampIssuer {
 
 func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, error) {
 	if m.acceptAll {
-		return postage.NewStampIssuer("test fallback", "test identity", id, 24, 6), nil
+		return postage.NewStampIssuer("test fallback", "test identity", id, 24, 6, 1000), nil
 	}
 
 	if m.i != nil {

--- a/pkg/postage/postagecontract/contract.go
+++ b/pkg/postage/postagecontract/contract.go
@@ -192,6 +192,7 @@ func (c *postageContract) CreateBatch(ctx context.Context, initialBalance *big.I
 				batchID,
 				depth,
 				createdEvent.BucketDepth,
+				ev.BlockNumber,
 			))
 
 			return createdEvent.BatchId[:], nil

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -17,8 +17,7 @@ import (
 const (
 	postagePrefix = "postage"
 	// blockThreshold is used to allow threshold no of blocks to be synced before a
-	// batch is usable. This is to allow upstream peers to see the batch before
-	// we start using it
+	// batch is usable.
 	blockThreshold = 10
 )
 
@@ -95,10 +94,10 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, error) {
 	defer ps.lock.Unlock()
 	for _, st := range ps.issuers {
 		if bytes.Equal(batchID, st.batchID) {
-			// this allowes some threshold blocks to be seen on the blockchain before
-			// we start using a stamp issuer. The threshold is meant to allow enough
-			// time for upstream peers to see the batch and hence validate the stamps
-			// issued
+			// this checks atleast threshold blocks are seen on the blockchain after
+			// the batch creation, before we start using a stamp issuer. The threshold
+			// is meant to allow enough time for upstream peers to see the batch and
+			// hence validate the stamps issued
 			if cs.Block < st.blockNumber || (cs.Block-st.blockNumber) < blockThreshold {
 				return nil, ErrNotUsable
 			}

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -74,7 +74,7 @@ func TestValidStamp(t *testing.T) {
 	b := postagetesting.MustNewBatch(postagetesting.WithOwner(owner))
 	bs := mock.New(mock.WithBatch(b))
 	signer := crypto.NewDefaultSigner(privKey)
-	issuer := postage.NewStampIssuer("label", "keyID", b.ID, b.Depth, b.BucketDepth)
+	issuer := postage.NewStampIssuer("label", "keyID", b.ID, b.Depth, b.BucketDepth, 1000)
 	stamper := postage.NewStamper(issuer, signer)
 
 	// this creates a chunk with a mocked stamp. ValidStamp will override this

--- a/pkg/postage/stamper_test.go
+++ b/pkg/postage/stamper_test.go
@@ -44,7 +44,7 @@ func TestStamperStamping(t *testing.T) {
 
 	// tests a valid stamp
 	t.Run("valid stamp", func(t *testing.T) {
-		st := newTestStampIssuer(t)
+		st := newTestStampIssuer(t, 1000)
 		stamper := postage.NewStamper(st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		if err := stamp.Valid(chunkAddr, owner, 12, 8, true); err != nil {
@@ -54,7 +54,7 @@ func TestStamperStamping(t *testing.T) {
 
 	// tests that Stamps returns with postage.ErrBucketMismatch
 	t.Run("bucket mismatch", func(t *testing.T) {
-		st := newTestStampIssuer(t)
+		st := newTestStampIssuer(t, 1000)
 		stamper := postage.NewStamper(st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		a := chunkAddr.Bytes()
@@ -66,7 +66,7 @@ func TestStamperStamping(t *testing.T) {
 
 	// tests that Stamps returns with postage.ErrInvalidIndex
 	t.Run("invalid index", func(t *testing.T) {
-		st := newTestStampIssuer(t)
+		st := newTestStampIssuer(t, 1000)
 		stamper := postage.NewStamper(st, signer)
 		// issue 1 stamp
 		chunkAddr, _ := createStamp(t, stamper)
@@ -90,8 +90,8 @@ func TestStamperStamping(t *testing.T) {
 	// tests that Stamps returns with postage.ErrBucketFull iff
 	// issuer has the corresponding collision bucket filled]
 	t.Run("bucket full", func(t *testing.T) {
-		st := newTestStampIssuer(t)
-		st = postage.NewStampIssuer("", "", st.ID(), 12, 8)
+		st := newTestStampIssuer(t, 1000)
+		st = postage.NewStampIssuer("", "", st.ID(), 12, 8, 1000)
 		stamper := postage.NewStamper(st, signer)
 		// issue 1 stamp
 		chunkAddr, _ := createStamp(t, stamper)
@@ -112,7 +112,7 @@ func TestStamperStamping(t *testing.T) {
 	// tests return with ErrOwnerMismatch
 	t.Run("owner mismatch", func(t *testing.T) {
 		owner[0] ^= 0xff // bitflip the owner first byte, this case must come last!
-		st := newTestStampIssuer(t)
+		st := newTestStampIssuer(t, 1000)
 		stamper := postage.NewStamper(st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		if err := stamp.Valid(chunkAddr, owner, 12, 8, true); !errors.Is(err, postage.ErrOwnerMismatch) {

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestStampIssuerMarshalling tests the idempotence  of binary marshal/unmarshal.
 func TestStampIssuerMarshalling(t *testing.T) {
-	st := newTestStampIssuer(t)
+	st := newTestStampIssuer(t, 1000)
 	buf, err := st.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -30,12 +30,12 @@ func TestStampIssuerMarshalling(t *testing.T) {
 	}
 }
 
-func newTestStampIssuer(t *testing.T) *postage.StampIssuer {
+func newTestStampIssuer(t *testing.T, block uint64) *postage.StampIssuer {
 	t.Helper()
 	id := make([]byte, 32)
 	_, err := io.ReadFull(crand.Reader, id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return postage.NewStampIssuer("label", "keyID", id, 12, 8)
+	return postage.NewStampIssuer("label", "keyID", id, 12, 8, block)
 }


### PR DESCRIPTION
#2038

Steps:

1. We create the StampIssuer with the blockNumber of the batch creation event on-chain.
  - New `blockNumber` field added to StampIssuer
  - Marshal/Unmarshal changes to store the same to statestore
2. StampIssuer uses the postage store to read the current chain state which informs us what the current block number the node is synced to.
3. When the postage service provides the StampIssuer, we will check the current block number the node is synced to is greater than the batch creation block number by a certain amount (`blockThreshold (default: 10)`). This is done to give the best chance to upstream peers to get notified of the batch and hence validate the stamps issued by this Issuer.


@agazso @AuHau 
Please note the changes in API spec. Some more errors related to postage stamps being added here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2063)
<!-- Reviewable:end -->
