### PR TITLE
fix: recover stampissuer on batch creation

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -658,6 +658,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "401":
           $ref: "SwarmCommon.yaml#/components/responses/401"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -700,6 +702,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "401":
           $ref: "SwarmCommon.yaml#/components/responses/401"
+        "402":
+          $ref: "SwarmCommon.yaml#/components/responses/402"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -97,7 +97,14 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Debugf("chunk upload: putter:%v", err)
 		s.logger.Error("chunk upload: putter")
-		jsonhttp.BadRequest(w, nil)
+		switch {
+		case errors.Is(err, postage.ErrNotFound):
+			jsonhttp.BadRequest(w, "batch not found")
+		case errors.Is(err, postage.ErrNotUsable):
+			jsonhttp.BadRequest(w, "batch not usable yet")
+		default:
+			jsonhttp.BadRequest(w, nil)
+		}
 		return
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -387,7 +387,7 @@ func NewBee(addr string, swarmAddress swarm.Address, publicKey ecdsa.PublicKey, 
 		eventListener = listener.New(logger, swapBackend, postageContractAddress, o.BlockTime, &pidKiller{node: b})
 		b.listenerCloser = eventListener
 
-		batchSvc = batchservice.New(stateStore, batchStore, logger, eventListener)
+		batchSvc = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post)
 
 		erc20Address, err := postagecontract.LookupERC20Address(p2pCtx, transactionService, postageContractAddress)
 		if err != nil {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -5,6 +5,7 @@
 package batchservice
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -18,10 +19,12 @@ import (
 const dirtyDBKey = "batchservice_dirty_db"
 
 type batchService struct {
-	stateStore storage.StateStorer
-	storer     postage.Storer
-	logger     logging.Logger
-	listener   postage.Listener
+	stateStore    storage.StateStorer
+	storer        postage.Storer
+	logger        logging.Logger
+	listener      postage.Listener
+	owner         []byte
+	batchListener postage.BatchCreationListener
 }
 
 type Interface interface {
@@ -29,8 +32,15 @@ type Interface interface {
 }
 
 // New will create a new BatchService.
-func New(stateStore storage.StateStorer, storer postage.Storer, logger logging.Logger, listener postage.Listener) Interface {
-	return &batchService{stateStore, storer, logger, listener}
+func New(
+	stateStore storage.StateStorer,
+	storer postage.Storer,
+	logger logging.Logger,
+	listener postage.Listener,
+	owner []byte,
+	batchListener postage.BatchCreationListener,
+) Interface {
+	return &batchService{stateStore, storer, logger, listener, owner, batchListener}
 }
 
 // Create will create a new batch with the given ID, owner value and depth and
@@ -49,6 +59,10 @@ func (svc *batchService) Create(id, owner []byte, normalisedBalance *big.Int, de
 	err := svc.storer.Put(b, normalisedBalance, depth)
 	if err != nil {
 		return fmt.Errorf("put: %w", err)
+	}
+
+	if bytes.Equal(svc.owner, owner) {
+		svc.batchListener.Handle(b)
 	}
 
 	svc.logger.Debugf("batch service: created batch id %s", hex.EncodeToString(b.ID))

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -61,7 +61,7 @@ func (svc *batchService) Create(id, owner []byte, normalisedBalance *big.Int, de
 		return fmt.Errorf("put: %w", err)
 	}
 
-	if bytes.Equal(svc.owner, owner) {
+	if bytes.Equal(svc.owner, owner) && svc.batchListener != nil {
 		svc.batchListener.Handle(b)
 	}
 

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -355,9 +355,7 @@ func newTestStoreAndServiceWithListener(
 }
 
 func newTestStoreAndService(opts ...mock.Option) (postage.EventUpdater, *mock.BatchStore, storage.StateStorer) {
-	testBatchListener := &mockBatchCreationHandler{}
-	testBatchOwner := []byte{}
-	return newTestStoreAndServiceWithListener(testBatchOwner, testBatchListener, opts...)
+	return newTestStoreAndServiceWithListener(nil, nil, opts...)
 }
 
 func putBatch(t *testing.T, store postage.Storer, b *postage.Batch) {

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -45,11 +45,11 @@ func (m *mockBatchCreationHandler) Handle(b *postage.Batch) {
 }
 
 func TestBatchServiceCreate(t *testing.T) {
-	testBatch := postagetesting.MustNewBatch()
 	testChainState := postagetesting.NewChainState()
-	testBatchListener := &mockBatchCreationHandler{}
 
 	t.Run("expect put create put error", func(t *testing.T) {
+		testBatch := postagetesting.MustNewBatch()
+		testBatchListener := &mockBatchCreationHandler{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
 			testBatch.Owner,
 			testBatchListener,
@@ -72,7 +72,7 @@ func TestBatchServiceCreate(t *testing.T) {
 		}
 	})
 
-	validateBatch := func(t *testing.T, b *postage.Batch, st *mock.BatchStore) {
+	validateBatch := func(t *testing.T, testBatch *postage.Batch, st *mock.BatchStore) {
 		got, err := st.Get(testBatch.ID)
 		if err != nil {
 			t.Fatalf("batch store get: %v", err)
@@ -102,6 +102,8 @@ func TestBatchServiceCreate(t *testing.T) {
 	}
 
 	t.Run("passes", func(t *testing.T) {
+		testBatch := postagetesting.MustNewBatch()
+		testBatchListener := &mockBatchCreationHandler{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			testBatch.Owner,
 			testBatchListener,
@@ -126,6 +128,8 @@ func TestBatchServiceCreate(t *testing.T) {
 	})
 
 	t.Run("passes without recovery", func(t *testing.T) {
+		testBatch := postagetesting.MustNewBatch()
+		testBatchListener := &mockBatchCreationHandler{}
 		// create a owner different from the batch owner
 		owner := make([]byte, 32)
 		rand.Read(owner)
@@ -146,7 +150,7 @@ func TestBatchServiceCreate(t *testing.T) {
 		); err != nil {
 			t.Fatalf("got error %v", err)
 		}
-		if testBatchListener.count != 1 {
+		if testBatchListener.count != 0 {
 			t.Fatalf("unexpected batch listener count, exp %d found %d", 1, testBatchListener.count)
 		}
 

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -45,3 +45,7 @@ type Listener interface {
 	io.Closer
 	Listen(from uint64, updater EventUpdater) <-chan struct{}
 }
+
+type BatchCreationListener interface {
+	Handle(*Batch)
+}

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -68,6 +68,8 @@ func (m *mockPostage) IssuerUsable(_ *postage.StampIssuer) bool {
 	return true
 }
 
+func (m *mockPostage) Handle(_ *postage.Batch) {}
+
 func (m *mockPostage) Close() error {
 	return nil
 }

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -86,8 +86,7 @@ func (ps *service) Add(st *StampIssuer) {
 // issuer was not created initially, we will create it here.
 func (ps *service) Handle(b *Batch) {
 	_, err := ps.GetStampIssuer(b.ID)
-	switch {
-	case errors.Is(err, ErrNotFound):
+	if errors.Is(err, ErrNotFound) {
 		ps.Add(NewStampIssuer(
 			"recovered",
 			string(b.Owner),

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -34,6 +34,7 @@ type Service interface {
 	StampIssuers() []*StampIssuer
 	GetStampIssuer([]byte) (*StampIssuer, error)
 	IssuerUsable(*StampIssuer) bool
+	BatchCreationListener
 	io.Closer
 }
 
@@ -78,6 +79,24 @@ func (ps *service) Add(st *StampIssuer) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 	ps.issuers = append(ps.issuers, st)
+}
+
+// Handle implements the BatchCreationListener interface. This is fired on receiving
+// a batch creation event from the blockchain listener to ensure that if a stamp
+// issuer was not created initially, we will create it here.
+func (ps *service) Handle(b *Batch) {
+	_, err := ps.GetStampIssuer(b.ID)
+	switch {
+	case errors.Is(err, ErrNotFound):
+		ps.Add(NewStampIssuer(
+			"recovered",
+			string(b.Owner),
+			b.ID,
+			b.Depth,
+			b.BucketDepth,
+			b.Start,
+		))
+	}
 }
 
 // StampIssuers returns the currently active stamp issuers.

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -81,6 +81,9 @@ func TestGetStampIssuer(t *testing.T) {
 			ps.Add(postage.NewStampIssuer(string(id), "", id, 16, 8, validBlockNumber+uint64(i)))
 		}
 	}
+	b := postagetesting.MustNewBatch()
+	b.Start = validBlockNumber
+	ps.Handle(b)
 	t.Run("found", func(t *testing.T) {
 		for _, id := range ids[1:4] {
 			st, err := ps.GetStampIssuer(id)
@@ -104,6 +107,15 @@ func TestGetStampIssuer(t *testing.T) {
 			if err != postage.ErrNotUsable {
 				t.Fatalf("expected ErrNotUsable, got %v", err)
 			}
+		}
+	})
+	t.Run("recovered", func(t *testing.T) {
+		st, err := ps.GetStampIssuer(b.ID)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if st.Label() != "recovered" {
+			t.Fatal("wrong issuer returned")
 		}
 	})
 }


### PR DESCRIPTION
Currently, we create a new stampissuer when the user buys new stamps using the `/stamps` API.

This makes a call to the blockchain to buy a new postage batch. The operation can take some time and if for some reason the node goes down at this point, we might end up in a state where we have bought the postage batch, but a new stampissuer was not created making this batch not useful.

The change ensures that on batch creation event handled by the listener when we get the update from the blockchain, we will check if a stampissuer is present. And if it's not, we will create it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2080)
<!-- Reviewable:end -->
