### PR TITLE
fix: add peer in topology through the debug api

### DIFF
--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -35,6 +35,14 @@ func (s *Service) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.topologyDriver.Connected(r.Context(), p2p.Peer{Address: bzzAddr.Overlay}, true); err != nil {
+		_ = s.p2p.Disconnect(bzzAddr.Overlay)
+		s.logger.Debugf("debug api: peer connect handler %s: %v", addr, err)
+		s.logger.Errorf("unable to connect to peer %s", addr)
+		jsonhttp.InternalServerError(w, err)
+		return
+	}
+
 	jsonhttp.OK(w, peerConnectResponse{
 		Address: bzzAddr.Overlay.String(),
 	})

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -363,7 +363,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 	if s.notifier != nil {
 		if !i.FullNode {
 			s.lightNodes.Connected(s.ctx, peer)
-			//light node announces explicitly
+			// light node announces explicitly
 			if err := s.notifier.Announce(s.ctx, peer.Address, i.FullNode); err != nil {
 				s.logger.Debugf("stream handler: notifier.Announce: %s: %v", peer.Address.String(), err)
 			}
@@ -382,7 +382,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 					return
 				}
 			}
-		} else if err := s.notifier.Connected(s.ctx, peer); err != nil {
+		} else if err := s.notifier.Connected(s.ctx, peer, false); err != nil {
 			// full node announces implicitly
 			s.logger.Debugf("stream handler: notifier.Connected: peer disconnected: %s: %v", i.BzzAddress.Overlay, err)
 			// note: this cannot be unit tested since the node
@@ -700,7 +700,6 @@ func (s *Service) Disconnect(overlay swarm.Address) error {
 
 // disconnected is a registered peer registry event
 func (s *Service) disconnected(address swarm.Address) {
-
 	peer := p2p.Peer{Address: address}
 	peerID, found := s.peers.peerID(address)
 	if found {

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -41,14 +41,14 @@ type Halter interface {
 	Halt()
 }
 
-// PickyNotifer can decide whether a peer should be picked
+// PickyNotifier can decide whether a peer should be picked
 type PickyNotifier interface {
 	Pick(Peer) bool
 	Notifier
 }
 
 type Notifier interface {
-	Connected(context.Context, Peer) error
+	Connected(context.Context, Peer, bool) error
 	Disconnected(Peer)
 	Announce(context.Context, swarm.Address, bool) error
 }

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -366,7 +366,6 @@ func TestManageWithBalancing(t *testing.T) {
 	for i := 1; i <= int(swarm.MaxPO); i++ {
 		waitBalanced(t, kad, uint8(i))
 	}
-
 }
 
 // TestBinSaturation tests the builtin binSaturated function.
@@ -1237,12 +1236,11 @@ func connectOne(t *testing.T, signer beeCrypto.Signer, k *kademlia.Kad, ab addre
 	if err := ab.Put(peer, *bzzAddr); err != nil {
 		t.Fatal(err)
 	}
-	err = k.Connected(context.Background(), p2p.Peer{Address: peer})
+	err = k.Connected(context.Background(), p2p.Peer{Address: peer}, false)
 
 	if !errors.Is(err, expErr) {
 		t.Fatalf("expected error %v , got %v", expErr, err)
 	}
-
 }
 
 func addOne(t *testing.T, signer beeCrypto.Signer, k *kademlia.Kad, ab addressbook.Putter, peer swarm.Address) {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/topology"
 )
@@ -74,13 +75,25 @@ func (d *mock) AddPeers(addrs ...swarm.Address) {
 	d.peers = append(d.peers, addrs...)
 }
 
-func (d *mock) Connected(ctx context.Context, addr swarm.Address) error {
-	d.AddPeers(addr)
+func (d *mock) Connected(ctx context.Context, peer p2p.Peer, _ bool) error {
+	d.AddPeers(peer.Address)
 	return nil
 }
 
-func (d *mock) Disconnected(swarm.Address) {
-	panic("todo")
+func (d *mock) Disconnected(peer p2p.Peer) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	for i, addr := range d.peers {
+		if addr.Equal(peer.Address) {
+			d.peers = append(d.peers[:i], d.peers[i+1:]...)
+			break
+		}
+	}
+}
+
+func (d *mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
+	return nil
 }
 
 func (d *mock) Peers() []swarm.Address {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -21,6 +22,7 @@ var (
 )
 
 type Driver interface {
+	p2p.Notifier
 	PeerAdder
 	ClosestPeerer
 	EachPeerer


### PR DESCRIPTION
This PR fixes: https://github.com/ethersphere/bee/issues/1414.

Peers added by using the debug API were not being connected in the kademlia, and thus were not shown in the topology. This PR adds the `p2p.Notifier` to the topology driver to allow peers to be connected in kademlia. It also adds a flag that enables connection to over-saturated peers through the debug API.

The flag is only true if a connection request is made using the `/connect` endpoint in the debug API.
The flag does not affect bootnodes. Bootnodes always follow the saturation function.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2093)
<!-- Reviewable:end -->
