### PR TITLE
fix: bucket depth size expectation

### DIFF
--- a/pkg/postage/postagecontract/contract.go
+++ b/pkg/postage/postagecontract/contract.go
@@ -146,7 +146,7 @@ func (c *postageContract) getBalance(ctx context.Context) (*big.Int, error) {
 
 func (c *postageContract) CreateBatch(ctx context.Context, initialBalance *big.Int, depth uint8, immutable bool, label string) ([]byte, error) {
 
-	if depth < BucketDepth {
+	if depth <= BucketDepth {
 		return nil, ErrInvalidDepth
 	}
 

--- a/pkg/postage/postagecontract/contract_test.go
+++ b/pkg/postage/postagecontract/contract_test.go
@@ -24,7 +24,7 @@ func TestCreateBatch(t *testing.T) {
 	defer func(b uint8) {
 		postagecontract.BucketDepth = b
 	}(postagecontract.BucketDepth)
-	postagecontract.BucketDepth = 10
+	postagecontract.BucketDepth = 9
 	owner := common.HexToAddress("abcd")
 	label := "label"
 	postageStampAddress := common.HexToAddress("ffff")


### PR DESCRIPTION
Fixing the precondition to be aligned with contract check:

https://github.com/ethersphere/storage-incentives/blob/master/src/PostageStamp.sol#L100

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2099)
<!-- Reviewable:end -->
