### PR TITLE
fix: don't disconnect on non-swap peers

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -245,7 +245,6 @@ func InitSwap(
 		swapAddressBook,
 		networkID,
 		cashoutService,
-		p2ps,
 		accounting,
 	)
 

--- a/pkg/settlement/swap/swap.go
+++ b/pkg/settlement/swap/swap.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/logging"
-	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/settlement"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 	"github.com/ethersphere/bee/pkg/settlement/swap/swapprotocol"
@@ -58,13 +57,12 @@ type Service struct {
 	chequebook  chequebook.Service
 	chequeStore chequebook.ChequeStore
 	cashout     chequebook.CashoutService
-	p2pService  p2p.Service
 	addressbook Addressbook
 	networkID   uint64
 }
 
 // New creates a new swap Service.
-func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64, cashout chequebook.CashoutService, p2pService p2p.Service, accounting settlement.Accounting) *Service {
+func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64, cashout chequebook.CashoutService, accounting settlement.Accounting) *Service {
 	return &Service{
 		proto:       proto,
 		logger:      logger,
@@ -75,7 +73,6 @@ func New(proto swapprotocol.Interface, logger logging.Logger, store storage.Stat
 		addressbook: addressbook,
 		networkID:   networkID,
 		cashout:     cashout,
-		p2pService:  p2pService,
 		accounting:  accounting,
 	}
 }
@@ -134,11 +131,6 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int) 
 		return
 	}
 	if !known {
-		s.logger.Warningf("disconnecting non-swap peer %v", peer)
-		err = s.p2pService.Disconnect(peer)
-		if err != nil {
-			return
-		}
 		err = ErrUnknownBeneficary
 		return
 	}

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/logging"
-	mockp2p "github.com/ethersphere/bee/pkg/p2p/mock"
 	"github.com/ethersphere/bee/pkg/settlement/swap"
 	"github.com/ethersphere/bee/pkg/settlement/swap/chequebook"
 	mockchequebook "github.com/ethersphere/bee/pkg/settlement/swap/chequebook/mock"
@@ -212,7 +211,6 @@ func TestReceiveCheque(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		observer,
 	)
 
@@ -286,7 +284,6 @@ func TestReceiveChequeReject(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		observer,
 	)
 
@@ -342,7 +339,6 @@ func TestReceiveChequeWrongChequebook(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		observer,
 	)
 
@@ -406,7 +402,6 @@ func TestPay(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		observer,
 	)
 
@@ -449,7 +444,6 @@ func TestPayIssueError(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		nil,
 	)
 
@@ -491,7 +485,6 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 
 	observer := newTestObserver()
 
-	var disconnectCalled bool
 	swapService := swap.New(
 		&swapProtocolMock{},
 		logger,
@@ -501,15 +494,6 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 		addressbook,
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(
-			mockp2p.WithDisconnectFunc(func(disconnectPeer swarm.Address) error {
-				if !peer.Equal(disconnectPeer) {
-					t.Fatalf("disconnecting wrong peer. wanted %v, got %v", peer, disconnectPeer)
-				}
-				disconnectCalled = true
-				return nil
-			}),
-		),
 		observer,
 	)
 
@@ -517,7 +501,6 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 
 	select {
 	case call := <-observer.sentCalled:
-
 		if !call.peer.Equal(peer) {
 			t.Fatalf("observer called with wrong peer. got %v, want %v", call.peer, peer)
 		}
@@ -527,10 +510,6 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 
 	case <-time.After(time.Second):
 		t.Fatal("expected observer to be called")
-	}
-
-	if !disconnectCalled {
-		t.Fatal("disconnect was not called")
 	}
 }
 
@@ -560,7 +539,6 @@ func TestHandshake(t *testing.T) {
 		},
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		nil,
 	)
 
@@ -600,7 +578,6 @@ func TestHandshakeNewPeer(t *testing.T) {
 		},
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		nil,
 	)
 
@@ -631,7 +608,6 @@ func TestHandshakeWrongBeneficiary(t *testing.T) {
 		&addressbookMock{},
 		networkID,
 		&cashoutMock{},
-		mockp2p.New(),
 		nil,
 	)
 
@@ -681,7 +657,6 @@ func TestCashout(t *testing.T) {
 				return txHash, nil
 			},
 		},
-		mockp2p.New(),
 		nil,
 	)
 
@@ -728,7 +703,6 @@ func TestCashoutStatus(t *testing.T) {
 				return expectedStatus, nil
 			},
 		},
-		mockp2p.New(),
 		nil,
 	)
 


### PR DESCRIPTION
don't disconnect on non-swap peers. no longer necessary as we can wait for time settlement as a fallback.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2102)
<!-- Reviewable:end -->
