### PR TITLE
debugapi: less messages on pingpong

### DIFF
--- a/pkg/debugapi/pingpong.go
+++ b/pkg/debugapi/pingpong.go
@@ -32,7 +32,7 @@ func (s *Service) pingpongHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rtt, err := s.pingpong.Ping(ctx, address, "hey", "there", ",", "how are", "you", "?")
+	rtt, err := s.pingpong.Ping(ctx, address, "ping")
 	if err != nil {
 		logger.Debugf("pingpong: ping %s: %v", peerID, err)
 		if errors.Is(err, p2p.ErrPeerNotFound) {


### PR DESCRIPTION
Long standing cleanup that just sends a ping and a pong in the protocol when querying through the debugapi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2107)
<!-- Reviewable:end -->
