### PR TITLE
fix(pushsync): originator replication

### DIFF
--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -107,7 +107,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 	// Check is the chunk is set as synced in the DB.
 	for i := 0; i < noOfRetries; i++ {
 		// Give some time for chunk to be pushed and receipt to be received
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		err = checkIfModeSet(chunk.Address(), storage.ModeSetSync, storer)
 		if err == nil {


### PR DESCRIPTION
well noticed by @ralph-pichler is that we are not doing NN replication as originators of requests. This causes the CI to flake (among other things...). This PR rectifies this by moving the code to the area shared by both originator and forwarder nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2115)
<!-- Reviewable:end -->
