### PR TITLE
fix: duplicate stampissuers

### DIFF
--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -78,6 +78,12 @@ func NewService(store storage.StateStorer, postageStore Storer, chainID int64) (
 func (ps *service) Add(st *StampIssuer) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
+
+	for _, v := range ps.issuers {
+		if bytes.Equal(st.data.BatchID, v.data.BatchID) {
+			return
+		}
+	}
 	ps.issuers = append(ps.issuers, st)
 }
 
@@ -85,19 +91,16 @@ func (ps *service) Add(st *StampIssuer) {
 // a batch creation event from the blockchain listener to ensure that if a stamp
 // issuer was not created initially, we will create it here.
 func (ps *service) Handle(b *Batch) {
-	_, err := ps.GetStampIssuer(b.ID)
-	if errors.Is(err, ErrNotFound) {
-		ps.Add(NewStampIssuer(
-			"recovered",
-			string(b.Owner),
-			b.ID,
-			b.Value,
-			b.Depth,
-			b.BucketDepth,
-			b.Start,
-			b.Immutable,
-		))
-	}
+	ps.Add(NewStampIssuer(
+		"recovered",
+		string(b.Owner),
+		b.ID,
+		b.Value,
+		b.Depth,
+		b.BucketDepth,
+		b.Start,
+		b.Immutable,
+	))
 }
 
 // StampIssuers returns the currently active stamp issuers.


### PR DESCRIPTION
This PR fixes a condition in which two stamp issuers might be generated for the same batch. It introduces a check against duplicate stamp issuers in the `Add` call that adds the issuer to the postage service.

addresses #2121

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2128)
<!-- Reviewable:end -->
