### PR TITLE
fix(pss): make sending PSS messages more efficient

### DIFF
--- a/pkg/pss/mining_test.go
+++ b/pkg/pss/mining_test.go
@@ -46,12 +46,13 @@ func BenchmarkWrap(b *testing.B) {
 		b.Fatal(err)
 	}
 	pubkey := &key.PublicKey
+	ctx := context.Background()
 	for _, c := range cases {
 		name := fmt.Sprintf("length:%d,depth:%d", c.length, c.depth)
 		b.Run(name, func(b *testing.B) {
 			targets := newTargets(c.length, c.depth)
 			for i := 0; i < b.N; i++ {
-				if _, err := pss.Wrap(context.Background(), topic, msg, pubkey, targets); err != nil {
+				if _, err := pss.Wrap(ctx, topic, msg, pubkey, targets); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
a minor improvement on pss trojan mining

- code cleanup
- using errgroup
- change to bigendian 
- fix for the parity bit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2140)
<!-- Reviewable:end -->
