### PR TITLE
feat(kademlia): AddPeers batch on Start

### DIFF
--- a/pkg/topology/pslice/pslice.go
+++ b/pkg/topology/pslice/pslice.go
@@ -175,7 +175,7 @@ func (s *PSlice) Add(addrs ...swarm.Address) {
 	for _, addr := range addrs {
 
 		if e, _ := s.exists(addr); e {
-			continue
+			return
 		}
 
 		po := s.po(addr.Bytes())

--- a/pkg/topology/pslice/pslice.go
+++ b/pkg/topology/pslice/pslice.go
@@ -175,7 +175,7 @@ func (s *PSlice) Add(addrs ...swarm.Address) {
 	for _, addr := range addrs {
 
 		if e, _ := s.exists(addr); e {
-			return
+			continue
 		}
 
 		po := s.po(addr.Bytes())


### PR DESCRIPTION
Since the process of adding peers can take a long time, I am adding an iterator that processes them in batches. It is just unclear whether this would result in increased CPU usage while this iterator is open in leveldb (@janos WDYT?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2162)
<!-- Reviewable:end -->
