### PR TITLE
fix: check network id before backend call

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -166,6 +166,10 @@ func (s *Service) Handshake(ctx context.Context, stream p2p.Stream, peerMultiadd
 
 	overlay := swarm.NewAddress(resp.Ack.Address.Overlay)
 
+	if resp.Ack.NetworkID != s.networkID {
+		return nil, ErrNetworkIDIncompatible
+	}
+
 	blockHash, err := s.senderMatcher.Matches(ctx, resp.Ack.Transaction, s.networkID, overlay)
 	if err != nil {
 		return nil, fmt.Errorf("overlay %v verification failed: %w", overlay, err)
@@ -327,10 +331,6 @@ func buildFullMA(addr ma.Multiaddr, peerID libp2ppeer.ID) (ma.Multiaddr, error) 
 }
 
 func (s *Service) parseCheckAck(ack *pb.Ack, blockHash []byte) (*bzz.Address, error) {
-	if ack.NetworkID != s.networkID {
-		return nil, ErrNetworkIDIncompatible
-	}
-
 	bzzAddress, err := bzz.ParseAddress(ack.Address.Underlay, ack.Address.Overlay, ack.Address.Signature, ack.Transaction, blockHash, s.networkID)
 	if err != nil {
 		return nil, ErrInvalidAck

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -282,6 +282,10 @@ func (s *Service) Handle(ctx context.Context, stream p2p.Stream, remoteMultiaddr
 		return nil, fmt.Errorf("read ack message: %w", err)
 	}
 
+	if ack.NetworkID != s.networkID {
+		return nil, ErrNetworkIDIncompatible
+	}
+
 	overlay := swarm.NewAddress(ack.Address.Overlay)
 
 	blockHash, err := s.senderMatcher.Matches(ctx, ack.Transaction, s.networkID, overlay)


### PR DESCRIPTION
The handshake will now try to do the non-minable overlay check before it would do the network id check. If there is a network id mismatch, the blockchain verification will fail while the actual part that explicitly checks the network ID will never be reached. This PR moves this explicit check before the backend call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2170)
<!-- Reviewable:end -->
