### PR TITLE
fix: verify signer result

### DIFF
--- a/pkg/crypto/clef/clef.go
+++ b/pkg/crypto/clef/clef.go
@@ -136,7 +136,7 @@ func (c *clefSigner) SignTx(transaction *types.Transaction, chainID *big.Int) (*
 	}
 
 	if chainID.Cmp(tx.ChainId()) != 0 {
-		return nil, fmt.Errorf("misconfigured signer. wrong chain id %d, wanted %d", tx.ChainId(), chainID)
+		return nil, fmt.Errorf("misconfigured signer: wrong chain id %d; wanted %d", tx.ChainId(), chainID)
 	}
 
 	return tx, nil

--- a/pkg/crypto/clef/clef.go
+++ b/pkg/crypto/clef/clef.go
@@ -7,6 +7,7 @@ package clef
 import (
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -129,7 +130,16 @@ func (c *clefSigner) Sign(data []byte) ([]byte, error) {
 // SignTx signs an ethereum transaction.
 func (c *clefSigner) SignTx(transaction *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
 	// chainId is nil here because it is set on the clef side
-	return c.clef.SignTx(c.account, transaction, nil)
+	tx, err := c.clef.SignTx(c.account, transaction, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if chainID.Cmp(tx.ChainId()) != 0 {
+		return nil, fmt.Errorf("misconfigured signer. wrong chain id %d, wanted %d", tx.ChainId(), chainID)
+	}
+
+	return tx, nil
 }
 
 // EthereumAddress returns the ethereum address this signer uses.


### PR DESCRIPTION
Adds some verification on the data we get back from the signer and detect if it is configured for the wrong chain.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2214)
<!-- Reviewable:end -->
