### PR TITLE
fix: remove unnecessary dependencies for traversal

### DIFF
--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -27,14 +27,19 @@ type Traverser interface {
 	Traverse(context.Context, swarm.Address, swarm.AddressIterFunc) error
 }
 
+type PutGetter interface {
+	storage.Putter
+	storage.Getter
+}
+
 // New constructs for a new Traverser.
-func New(store storage.Storer) Traverser {
+func New(store PutGetter) Traverser {
 	return &service{store: store}
 }
 
 // service is implementation of Traverser using storage.Storer as its storage.
 type service struct {
-	store storage.Storer
+	store PutGetter
 }
 
 // Traverse implements Traverser.Traverse method.


### PR DESCRIPTION
Traversal package doesnt need access to all the functions defined in the Storer interface. Only Putter and Getter interfaces are required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2218)
<!-- Reviewable:end -->
