### PR TITLE
feat: batchstore checksums

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -75,6 +75,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/sha3"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -416,7 +417,10 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 		eventListener = listener.New(logger, swapBackend, postageContractAddress, o.BlockTime, &pidKiller{node: b})
 		b.listenerCloser = eventListener
 
-		batchSvc = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post)
+		batchSvc, err = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256)
+		if err != nil {
+			return nil, err
+		}
 
 		erc20Address, err := postagecontract.LookupERC20Address(p2pCtx, transactionService, postageContractAddress)
 		if err != nil {

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -7,6 +7,7 @@ package batchservice_test
 import (
 	"bytes"
 	"errors"
+	"hash"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -22,8 +23,9 @@ import (
 )
 
 var (
-	testLog = logging.New(ioutil.Discard, 0)
-	errTest = errors.New("fails")
+	testLog    = logging.New(ioutil.Discard, 0)
+	errTest    = errors.New("fails")
+	testTxHash = make([]byte, 32)
 )
 
 type mockListener struct {
@@ -51,6 +53,7 @@ func TestBatchServiceCreate(t *testing.T) {
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchCreationHandler{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
+			t,
 			testBatch.Owner,
 			testBatchListener,
 			mock.WithChainState(testChainState),
@@ -64,6 +67,7 @@ func TestBatchServiceCreate(t *testing.T) {
 			testBatch.Depth,
 			testBatch.BucketDepth,
 			testBatch.Immutable,
+			testTxHash,
 		); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -105,6 +109,7 @@ func TestBatchServiceCreate(t *testing.T) {
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchCreationHandler{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
+			t,
 			testBatch.Owner,
 			testBatchListener,
 			mock.WithChainState(testChainState),
@@ -117,6 +122,7 @@ func TestBatchServiceCreate(t *testing.T) {
 			testBatch.Depth,
 			testBatch.BucketDepth,
 			testBatch.Immutable,
+			testTxHash,
 		); err != nil {
 			t.Fatalf("got error %v", err)
 		}
@@ -135,6 +141,7 @@ func TestBatchServiceCreate(t *testing.T) {
 		rand.Read(owner)
 
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
+			t,
 			owner,
 			testBatchListener,
 			mock.WithChainState(testChainState),
@@ -147,6 +154,7 @@ func TestBatchServiceCreate(t *testing.T) {
 			testBatch.Depth,
 			testBatch.BucketDepth,
 			testBatch.Immutable,
+			testTxHash,
 		); err != nil {
 			t.Fatalf("got error %v", err)
 		}
@@ -164,32 +172,34 @@ func TestBatchServiceTopUp(t *testing.T) {
 
 	t.Run("expect get error", func(t *testing.T) {
 		svc, _, _ := newTestStoreAndService(
+			t,
 			mock.WithGetErr(errTest, 0),
 		)
 
-		if err := svc.TopUp(testBatch.ID, testNormalisedBalance); err == nil {
+		if err := svc.TopUp(testBatch.ID, testNormalisedBalance, testTxHash); err == nil {
 			t.Fatal("expected error")
 		}
 	})
 
 	t.Run("expect put error", func(t *testing.T) {
 		svc, batchStore, _ := newTestStoreAndService(
+			t,
 			mock.WithPutErr(errTest, 1),
 		)
 		putBatch(t, batchStore, testBatch)
 
-		if err := svc.TopUp(testBatch.ID, testNormalisedBalance); err == nil {
+		if err := svc.TopUp(testBatch.ID, testNormalisedBalance, testTxHash); err == nil {
 			t.Fatal("expected error")
 		}
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore, _ := newTestStoreAndService()
+		svc, batchStore, _ := newTestStoreAndService(t)
 		putBatch(t, batchStore, testBatch)
 
 		want := testNormalisedBalance
 
-		if err := svc.TopUp(testBatch.ID, testNormalisedBalance); err != nil {
+		if err := svc.TopUp(testBatch.ID, testNormalisedBalance, testTxHash); err != nil {
 			t.Fatalf("top up: %v", err)
 		}
 
@@ -211,30 +221,32 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 
 	t.Run("expect get error", func(t *testing.T) {
 		svc, _, _ := newTestStoreAndService(
+			t,
 			mock.WithGetErr(errTest, 0),
 		)
 
-		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance); err == nil {
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance, testTxHash); err == nil {
 			t.Fatal("expected get error")
 		}
 	})
 
 	t.Run("expect put error", func(t *testing.T) {
 		svc, batchStore, _ := newTestStoreAndService(
+			t,
 			mock.WithPutErr(errTest, 1),
 		)
 		putBatch(t, batchStore, testBatch)
 
-		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance); err == nil {
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance, testTxHash); err == nil {
 			t.Fatal("expected put error")
 		}
 	})
 
 	t.Run("passes", func(t *testing.T) {
-		svc, batchStore, _ := newTestStoreAndService()
+		svc, batchStore, _ := newTestStoreAndService(t)
 		putBatch(t, batchStore, testBatch)
 
-		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance); err != nil {
+		if err := svc.UpdateDepth(testBatch.ID, testNewDepth, testNormalisedBalance, testTxHash); err != nil {
 			t.Fatalf("update depth: %v", err)
 		}
 
@@ -256,22 +268,24 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 
 	t.Run("expect put error", func(t *testing.T) {
 		svc, batchStore, _ := newTestStoreAndService(
+			t,
 			mock.WithChainState(testChainState),
 			mock.WithPutErr(errTest, 1),
 		)
 		putChainState(t, batchStore, testChainState)
 
-		if err := svc.UpdatePrice(testNewPrice); err == nil {
+		if err := svc.UpdatePrice(testNewPrice, testTxHash); err == nil {
 			t.Fatal("expected error")
 		}
 	})
 
 	t.Run("passes", func(t *testing.T) {
 		svc, batchStore, _ := newTestStoreAndService(
+			t,
 			mock.WithChainState(testChainState),
 		)
 
-		if err := svc.UpdatePrice(testNewPrice); err != nil {
+		if err := svc.UpdatePrice(testNewPrice, testTxHash); err != nil {
 			t.Fatalf("update price: %v", err)
 		}
 
@@ -288,6 +302,7 @@ func TestBatchServiceUpdateBlockNumber(t *testing.T) {
 		TotalAmount:  big.NewInt(100),
 	}
 	svc, batchStore, _ := newTestStoreAndService(
+		t,
 		mock.WithChainState(testChainState),
 	)
 
@@ -305,7 +320,7 @@ func TestBatchServiceUpdateBlockNumber(t *testing.T) {
 }
 
 func TestTransactionOk(t *testing.T) {
-	svc, store, s := newTestStoreAndService()
+	svc, store, s := newTestStoreAndService(t)
 	if _, err := svc.Start(10); err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +333,10 @@ func TestTransactionOk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc2 := batchservice.New(s, store, testLog, newMockListener(), nil, nil)
+	svc2, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := svc2.Start(10); err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +347,7 @@ func TestTransactionOk(t *testing.T) {
 }
 
 func TestTransactionFail(t *testing.T) {
-	svc, store, s := newTestStoreAndService()
+	svc, store, s := newTestStoreAndService(t)
 	if _, err := svc.Start(10); err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +356,10 @@ func TestTransactionFail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc2 := batchservice.New(s, store, testLog, newMockListener(), nil, nil)
+	svc2, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := svc2.Start(10); err != nil {
 		t.Fatal(err)
 	}
@@ -347,19 +368,47 @@ func TestTransactionFail(t *testing.T) {
 		t.Fatalf("expect %d reset calls got %d", 1, c)
 	}
 }
+
+func TestChecksum(t *testing.T) {
+	s := mocks.NewStateStore()
+	store := mock.New()
+	mockHash := &hs{}
+	svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash })
+	if err != nil {
+		t.Fatal(err)
+	}
+	testNormalisedBalance := big.NewInt(2000000000000)
+	testBatch := postagetesting.MustNewBatch()
+	putBatch(t, store, testBatch)
+
+	if err := svc.TopUp(testBatch.ID, testNormalisedBalance, testTxHash); err != nil {
+		t.Fatalf("top up: %v", err)
+	}
+	if m := mockHash.ctr; m != 2 {
+		t.Fatalf("expected %d calls got %d", 2, m)
+	}
+}
+
 func newTestStoreAndServiceWithListener(
+	t *testing.T,
 	owner []byte,
 	batchListener postage.BatchCreationListener,
 	opts ...mock.Option,
 ) (postage.EventUpdater, *mock.BatchStore, storage.StateStorer) {
+	t.Helper()
 	s := mocks.NewStateStore()
 	store := mock.New(opts...)
-	svc := batchservice.New(s, store, testLog, newMockListener(), owner, batchListener)
+	svc, err := batchservice.New(s, store, testLog, newMockListener(), owner, batchListener, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return svc, store, s
 }
 
-func newTestStoreAndService(opts ...mock.Option) (postage.EventUpdater, *mock.BatchStore, storage.StateStorer) {
-	return newTestStoreAndServiceWithListener(nil, nil, opts...)
+func newTestStoreAndService(t *testing.T, opts ...mock.Option) (postage.EventUpdater, *mock.BatchStore, storage.StateStorer) {
+	t.Helper()
+	return newTestStoreAndServiceWithListener(t, nil, nil, opts...)
 }
 
 func putBatch(t *testing.T, store postage.Storer, b *postage.Batch) {
@@ -377,3 +426,11 @@ func putChainState(t *testing.T, store postage.Storer, cs *postage.ChainState) {
 		t.Fatalf("store put chain state: %v", err)
 	}
 }
+
+type hs struct{ ctr uint8 }
+
+func (h *hs) Write(p []byte) (n int, err error) { h.ctr++; return len(p), nil }
+func (h *hs) Sum(b []byte) []byte               { return []byte{h.ctr} }
+func (h *hs) Reset()                            {}
+func (h *hs) Size() int                         { panic("not implemented") }
+func (h *hs) BlockSize() int                    { panic("not implemented") }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -12,10 +12,10 @@ import (
 // EventUpdater interface definitions reflect the updates triggered by events
 // emitted by the postage contract on the blockchain.
 type EventUpdater interface {
-	Create(id []byte, owner []byte, normalisedBalance *big.Int, depth, bucketDepth uint8, immutable bool, txhash []byte) error
-	TopUp(id []byte, normalisedBalance *big.Int, txhash []byte) error
-	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int, txhash []byte) error
-	UpdatePrice(price *big.Int, txhash []byte) error
+	Create(id []byte, owner []byte, normalisedBalance *big.Int, depth, bucketDepth uint8, immutable bool, txHash []byte) error
+	TopUp(id []byte, normalisedBalance *big.Int, txHash []byte) error
+	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int, txHash []byte) error
+	UpdatePrice(price *big.Int, txHash []byte) error
 	UpdateBlockNumber(blockNumber uint64) error
 	Start(startBlock uint64) (<-chan struct{}, error)
 

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -12,10 +12,10 @@ import (
 // EventUpdater interface definitions reflect the updates triggered by events
 // emitted by the postage contract on the blockchain.
 type EventUpdater interface {
-	Create(id []byte, owner []byte, normalisedBalance *big.Int, depth, bucketDepth uint8, immutable bool) error
-	TopUp(id []byte, normalisedBalance *big.Int) error
-	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int) error
-	UpdatePrice(price *big.Int) error
+	Create(id []byte, owner []byte, normalisedBalance *big.Int, depth, bucketDepth uint8, immutable bool, txhash []byte) error
+	TopUp(id []byte, normalisedBalance *big.Int, txhash []byte) error
+	UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int, txhash []byte) error
+	UpdatePrice(price *big.Int, txhash []byte) error
 	UpdateBlockNumber(blockNumber uint64) error
 	Start(startBlock uint64) (<-chan struct{}, error)
 

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -118,6 +118,7 @@ func (l *listener) processEvent(e types.Log, updater postage.EventUpdater) error
 			c.Depth,
 			c.BucketDepth,
 			c.ImmutableFlag,
+			e.TxHash.Bytes(),
 		)
 	case batchTopupTopic:
 		c := &batchTopUpEvent{}
@@ -129,6 +130,7 @@ func (l *listener) processEvent(e types.Log, updater postage.EventUpdater) error
 		return updater.TopUp(
 			c.BatchId[:],
 			c.NormalisedBalance,
+			e.TxHash.Bytes(),
 		)
 	case batchDepthIncreaseTopic:
 		c := &batchDepthIncreaseEvent{}
@@ -141,6 +143,7 @@ func (l *listener) processEvent(e types.Log, updater postage.EventUpdater) error
 			c.BatchId[:],
 			c.NewDepth,
 			c.NormalisedBalance,
+			e.TxHash.Bytes(),
 		)
 	case priceUpdateTopic:
 		c := &priceUpdateEvent{}
@@ -151,6 +154,7 @@ func (l *listener) processEvent(e types.Log, updater postage.EventUpdater) error
 		l.metrics.PriceCounter.Inc()
 		return updater.UpdatePrice(
 			c.Price,
+			e.TxHash.Bytes(),
 		)
 	default:
 		l.metrics.EventErrors.Inc()

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -307,7 +307,7 @@ type updater struct {
 	eventC chan interface{}
 }
 
-func (u *updater) Create(id, owner []byte, normalisedAmount *big.Int, depth, bucketDepth uint8, immutable bool) error {
+func (u *updater) Create(id, owner []byte, normalisedAmount *big.Int, depth, bucketDepth uint8, immutable bool, _ []byte) error {
 	u.eventC <- createArgs{
 		id:               id,
 		owner:            owner,
@@ -319,7 +319,7 @@ func (u *updater) Create(id, owner []byte, normalisedAmount *big.Int, depth, buc
 	return nil
 }
 
-func (u *updater) TopUp(id []byte, normalisedBalance *big.Int) error {
+func (u *updater) TopUp(id []byte, normalisedBalance *big.Int, _ []byte) error {
 	u.eventC <- topupArgs{
 		id:                id,
 		normalisedBalance: normalisedBalance,
@@ -327,7 +327,7 @@ func (u *updater) TopUp(id []byte, normalisedBalance *big.Int) error {
 	return nil
 }
 
-func (u *updater) UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int) error {
+func (u *updater) UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int, _ []byte) error {
 	u.eventC <- depthArgs{
 		id:                id,
 		depth:             depth,
@@ -336,7 +336,7 @@ func (u *updater) UpdateDepth(id []byte, depth uint8, normalisedBalance *big.Int
 	return nil
 }
 
-func (u *updater) UpdatePrice(price *big.Int) error {
+func (u *updater) UpdatePrice(price *big.Int, _ []byte) error {
 	u.eventC <- priceArgs{price}
 	return nil
 }


### PR DESCRIPTION
This PR adds a simple, flattened merkelized hash chain checksum implementation to the batch service which processes events from the postage event listener. It is meant to provide an extra layer of debugging information to compare reserve state across nodes.

It uses a simple sha3-256 hasher and works in the following manner:
0. current checksum of state is written into the hasher (if exists on component bootstrap)
1. transaction hash bytes of event which has been read from the chain is written into the hasher after being processed
2. the sum of the hasher is produced and:
2.1. written to disk
2.2. the hasher is reset to zero, and the sum written into it again
3. repeat steps 1-2 indefinitely

The checksums will be printed alongside each event log line in the terminal.

TODO:
- [x] Unit tests
- ~~metric that communicates the checksum periodically to a field that can be communicated through grafana~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2227)
<!-- Reviewable:end -->
