### PR TITLE
fix: reduce retrieval result chan buffer

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -130,7 +130,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 		var (
 			peerAttempt  int
 			peersResults int
-			resultC      = make(chan retrievalResult, 1)
+			resultC      = make(chan retrievalResult, 2)
 		)
 
 		requestAttempt := 0

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -130,7 +130,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 		var (
 			peerAttempt  int
 			peersResults int
-			resultC      = make(chan retrievalResult, maxSelects)
+			resultC      = make(chan retrievalResult, 1)
 		)
 
 		requestAttempt := 0


### PR DESCRIPTION
This PR intends to fix a memory overuse issue on oversized result channel buffers in retrieval 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2229)
<!-- Reviewable:end -->
