### PR TITLE
feat: chunk stream upload endpoint

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -175,7 +175,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
       responses:
         "200":
-          description: "Returns a Websocket connection on which stream of chunks can be uploaded. Each chunk sent is acknowledged using a text response `success`. Chunks should be packaged as binary messages for uploading."
+          description: "Returns a Websocket connection on which stream of chunks can be uploaded. Each chunk sent is acknowledged using a binary response `0` which serves as confirmation of upload of single chunk. Chunks should be packaged as binary messages for uploading."
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         default:

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -164,6 +164,22 @@ paths:
         default:
           description: Default response
 
+  "/chunks/stream":
+    get:
+      summary: "Upload stream of chunks"
+      tags:
+        - Chunk
+      parameters:
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmTagParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPinParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
+      responses:
+        "200":
+          description: "Returns a Websocket connection on which stream of chunks can be uploaded. Each chunk sent is acknowledged using a text response `success`. Chunks should be packaged as binary messages for uploading."
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        default:
+          description: Default response
   "/bzz":
     post:
       summary: "Upload file or a collection of files"

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -71,6 +71,7 @@ type testServerOptions struct {
 	PostageContract    postagecontract.Interface
 	Post               postage.Service
 	Steward            steward.Reuploader
+	WsHeaders          http.Header
 }
 
 func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.Conn, string) {
@@ -115,7 +116,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 
 	if o.WsPath != "" {
 		u := url.URL{Scheme: "ws", Host: ts.Listener.Addr().String(), Path: o.WsPath}
-		conn, _, err = websocket.DefaultDialer.Dial(u.String(), nil)
+		conn, _, err = websocket.DefaultDialer.Dial(u.String(), o.WsHeaders)
 		if err != nil {
 			t.Fatalf("dial: %v. url %v", err, u.String())
 		}

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -57,7 +57,7 @@ func (s *server) processUploadRequest(
 
 	putter, err = newStamperPutter(s.storer, s.post, s.signer, batch)
 	if err != nil {
-		s.logger.Debugf("chunk upload: putter:%v", err)
+		s.logger.Debugf("chunk upload: putter: %v", err)
 		s.logger.Error("chunk upload: putter")
 		switch {
 		case errors.Is(err, postage.ErrNotFound):
@@ -65,7 +65,7 @@ func (s *server) processUploadRequest(
 		case errors.Is(err, postage.ErrNotUsable):
 			return nil, nil, nil, errors.New("batch not usable")
 		}
-		return nil, nil, nil, errors.New("")
+		return nil, nil, nil, err
 	}
 
 	return ctx, tag, putter, nil

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -133,7 +133,9 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 			jsonhttp.BadRequest(w, "increment tag")
 			return
 		}
-	} else if tag != nil {
+	}
+
+	if tag != nil {
 		// indicate that the chunk is stored
 		err = tag.Inc(tags.StateStored)
 		if err != nil {
@@ -149,9 +151,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		if err := s.pinning.CreatePin(ctx, chunk.Address(), false); err != nil {
 			s.logger.Debugf("chunk upload: creation of pin for %q failed: %v", chunk.Address(), err)
 			s.logger.Error("chunk upload: creation of pin failed")
-			// since we already increment the pin counter because of the ModePut, we need
-			// to delete the pin here to prevent the pin counter from never going to 0
-			err = s.pinning.DeletePin(ctx, chunk.Address())
+			err = s.storer.Set(ctx, storage.ModeSetUnpin, chunk.Address())
 			if err != nil {
 				s.logger.Debugf("chunk upload: deletion of pin for %q failed: %v", chunk.Address(), err)
 				s.logger.Error("chunk upload: deletion of pin failed")

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -153,7 +153,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("chunk upload: creation of pin failed")
 			err = s.storer.Set(ctx, storage.ModeSetUnpin, chunk.Address())
 			if err != nil {
-				s.logger.Debugf("chunk upload: deletion of pin for %q failed: %v", chunk.Address(), err)
+				s.logger.Debugf("chunk upload: deletion of pin for %s failed: %v", chunk.Address(), err)
 				s.logger.Error("chunk upload: deletion of pin failed")
 			}
 			jsonhttp.InternalServerError(w, nil)

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -44,14 +44,6 @@ func (s *server) processUploadRequest(
 
 		// add the tag to the context if it exists
 		ctx = sctx.SetTag(r.Context(), tag)
-
-		// increment the StateSplit here since we dont have a splitter for the file upload
-		err = tag.Inc(tags.StateSplit)
-		if err != nil {
-			s.logger.Debugf("chunk upload: increment tag: %v", err)
-			s.logger.Error("chunk upload: increment tag")
-			return nil, nil, nil, errors.New("cannot increment tag")
-		}
 	} else {
 		ctx = r.Context()
 	}
@@ -80,7 +72,6 @@ func (s *server) processUploadRequest(
 }
 
 func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("handling")
 	ctx, tag, putter, err := s.processUploadRequest(r)
 	if err != nil {
 		jsonhttp.BadRequest(w, err.Error())

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -199,7 +199,7 @@ func (s *server) handleUploadStream(
 				// to delete the pin here to prevent the pin counter from never going to 0
 				err = s.storer.Set(ctx, storage.ModeSetUnpin, chunk.Address())
 				if err != nil {
-					s.logger.Debugf("chunk stream handler: deletion of pin for %q failed: %v", chunk.Address(), err)
+					s.logger.Debugf("chunk stream handler: deletion of pin for %s failed: %v", chunk.Address(), err)
 					s.logger.Error("chunk stream handler: deletion of pin failed")
 				}
 				sendErrorClose(websocket.CloseInternalServerErr, "failed creating pin")

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -183,6 +183,13 @@ func (s *server) handleUploadStream(
 			if err := s.pinning.CreatePin(ctx, chunk.Address(), false); err != nil {
 				s.logger.Debugf("chunk stream handler: creation of pin for %q failed: %v", chunk.Address(), err)
 				s.logger.Error("chunk stream handler: creation of pin failed")
+				// since we already increment the pin counter because of the ModePut, we need
+				// to delete the pin here to prevent the pin counter from never going to 0
+				err = s.pinning.DeletePin(ctx, chunk.Address())
+				if err != nil {
+					s.logger.Debugf("chunk stream handler: deletion of pin for %q failed: %v", chunk.Address(), err)
+					s.logger.Error("chunk stream handler: deletion of pin failed")
+				}
 				sendErrorClose(websocket.CloseInternalServerErr, "failed creating pin")
 				return
 			}

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var successWsMsg = []byte("successful")
+var successWsMsg = []byte{}
 
 func (s *server) chunkUploadStreamHandler(w http.ResponseWriter, r *http.Request) {
 
@@ -188,7 +188,7 @@ func (s *server) handleUploadStream(
 			}
 		}
 
-		err = sendMsg(websocket.TextMessage, successWsMsg)
+		err = sendMsg(websocket.BinaryMessage, successWsMsg)
 		if err != nil {
 			s.logger.Debugf("chunk stream handler: failed sending success msg: %v", err)
 			s.logger.Error("chunk stream handler: failed sending confirmation")

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/cac"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/tags"
+	"github.com/gorilla/websocket"
+)
+
+func (s *server) chunkUploadStreamHandler(w http.ResponseWriter, r *http.Request) {
+
+	ctx, tag, putter, err := s.processUploadRequest(r)
+	if err != nil {
+		jsonhttp.BadRequest(w, err.Error())
+		return
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  swarm.ChunkSize,
+		WriteBufferSize: swarm.ChunkSize,
+		CheckOrigin:     s.checkOrigin,
+	}
+
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Debugf("chunk stream handler failed upgrading: %v", err)
+		s.logger.Error("chunk stream handler: upgrading")
+		jsonhttp.BadRequest(w, "not a websocket connection")
+		return
+	}
+
+	s.wsWg.Add(1)
+	go s.handleUploadStream(
+		ctx,
+		c,
+		tag,
+		putter,
+		requestModePut(r),
+		strings.ToLower(r.Header.Get(SwarmPinHeader)) == "true",
+	)
+}
+
+func (s *server) handleUploadStream(
+	ctx context.Context,
+	conn *websocket.Conn,
+	tag *tags.Tag,
+	putter storage.Putter,
+	mode storage.ModePut,
+	pin bool,
+) {
+	defer s.wsWg.Done()
+
+	var (
+		gone   = make(chan struct{})
+		ticker = time.NewTicker(time.Second * 4)
+		err    error
+	)
+	defer func() {
+		ticker.Stop()
+		_ = conn.Close()
+	}()
+
+	conn.SetCloseHandler(func(code int, text string) error {
+		s.logger.Debugf("chunk stream handler: client gone. code %d message %s", code, text)
+		close(gone)
+		return nil
+	})
+
+	// default handlers for ping/pong
+	conn.SetPingHandler(nil)
+	conn.SetPongHandler(nil)
+
+	sendMsg := func(msgType int, buf []byte) error {
+		err := conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+		if err != nil {
+			return err
+		}
+		err = conn.WriteMessage(msgType, buf)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	sendErrorAndClose := func(errmsg string) error {
+		return sendMsg(websocket.CloseMessage, []byte(errmsg))
+	}
+
+	for {
+		select {
+		case <-s.quit:
+			// shutdown
+			err = sendErrorAndClose("node shutting down")
+			if err != nil {
+				s.logger.Debugf("failed sending close message: %v", err)
+			}
+			return
+		case <-gone:
+			// client gone
+			return
+		case <-ticker.C:
+			err = sendMsg(websocket.PingMessage, nil)
+			if err != nil {
+				s.logger.Debugf("failed sending ping message: %v", err)
+				return
+			}
+		default:
+			// if there is no indication to stop, go ahead and read the next message
+		}
+
+		err = conn.SetReadDeadline(time.Now().Add(readDeadline))
+		if err != nil {
+			s.logger.Debugf("chunk stream set read deadline: %v", err)
+			return
+		}
+
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			s.logger.Debugf("chunk stream handler read message error: %v", err)
+			return
+		}
+
+		if mt != websocket.BinaryMessage {
+			s.logger.Debug("unexpected message received from client", mt)
+			sendErrorAndClose("invalid message")
+			return
+		}
+
+		if len(msg) < swarm.SpanSize {
+			s.logger.Debug("chunk upload: not enough data")
+			return
+		}
+
+		chunk, err := cac.NewWithDataSpan(msg)
+		if err != nil {
+			s.logger.Debugf("chunk upload: create chunk error: %v", err)
+			return
+		}
+
+		seen, err := putter.Put(ctx, mode, chunk)
+		if err != nil {
+			s.logger.Debugf("chunk upload: chunk write error: %v, addr %s", err, chunk.Address())
+			switch {
+			case errors.Is(err, postage.ErrBucketFull):
+				sendErrorAndClose("batch is overissued")
+			default:
+				sendErrorAndClose("chunk write error")
+			}
+			return
+		} else if len(seen) > 0 && seen[0] && tag != nil {
+			err := tag.Inc(tags.StateSeen)
+			if err != nil {
+				s.logger.Debugf("chunk upload: increment tag", err)
+				sendErrorAndClose("failed incrementing tag")
+				return
+			}
+		}
+
+		if tag != nil {
+			// indicate that the chunk is stored
+			err = tag.Inc(tags.StateStored)
+			if err != nil {
+				s.logger.Debugf("chunk upload: increment tag", err)
+				sendErrorAndClose("failed incrementing tag")
+				return
+			}
+		}
+
+		if pin {
+			if err := s.pinning.CreatePin(ctx, chunk.Address(), false); err != nil {
+				s.logger.Debugf("chunk upload: creation of pin for %q failed: %v", chunk.Address(), err)
+				sendErrorAndClose("failed creating pin")
+				return
+			}
+		}
+
+		err = sendMsg(websocket.TextMessage, []byte("success"))
+		if err != nil {
+			s.logger.Debugf("failed sending success msg: %v", err)
+			return
+		}
+	}
+}

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -16,8 +16,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-const uploadPingTimout = time.Second * 4
-
 var successWsMsg = []byte("successful")
 
 func (s *server) chunkUploadStreamHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -1,0 +1,127 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/api"
+	"github.com/ethersphere/bee/pkg/logging"
+	pinning "github.com/ethersphere/bee/pkg/pinning/mock"
+	mockpost "github.com/ethersphere/bee/pkg/postage/mock"
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/mock"
+	testingc "github.com/ethersphere/bee/pkg/storage/testing"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/tags"
+	"github.com/gorilla/websocket"
+)
+
+func TestChunkUploadStream(t *testing.T) {
+
+	wsHeaders := http.Header{}
+	wsHeaders.Set("Content-Type", "application/octet-stream")
+	wsHeaders.Set("Swarm-Postage-Batch-Id", batchOkStr)
+
+	var (
+		statestoreMock = statestore.NewStateStore()
+		logger         = logging.New(ioutil.Discard, 0)
+		tag            = tags.NewTags(statestoreMock, logger)
+		storerMock     = mock.NewStorer()
+		pinningMock    = pinning.NewServiceMock()
+		_, wsConn, _   = newTestServer(t, testServerOptions{
+			Storer:    storerMock,
+			Pinning:   pinningMock,
+			Tags:      tag,
+			Post:      mockpost.New(mockpost.WithAcceptAll()),
+			WsPath:    "/stream/chunks",
+			WsHeaders: wsHeaders,
+		})
+	)
+
+	t.Run("upload and verify", func(t *testing.T) {
+		chsToGet := []swarm.Chunk{}
+		for i := 0; i < 5; i++ {
+			ch := testingc.GenerateTestRandomChunk()
+
+			err := wsConn.SetWriteDeadline(time.Now().Add(time.Second))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = wsConn.WriteMessage(websocket.BinaryMessage, ch.Data())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = wsConn.SetReadDeadline(time.Now().Add(time.Second))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mt, msg, err := wsConn.ReadMessage()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if mt != websocket.TextMessage || !bytes.Equal(msg, api.SuccessWsMsg) {
+				t.Fatal("invalid response", mt, string(msg))
+			}
+
+			chsToGet = append(chsToGet, ch)
+		}
+
+		for _, c := range chsToGet {
+			ch, err := storerMock.Get(context.Background(), storage.ModeGetRequest, c.Address())
+			if err != nil {
+				t.Fatal("failed to get chunk after upload", err)
+			}
+			if !ch.Equal(c) {
+				t.Fatal("invalid chunk read")
+			}
+		}
+	})
+
+	t.Run("close on incorrect msg", func(t *testing.T) {
+		serverClosed := make(chan struct{})
+		var errResponse string
+		wsConn.SetCloseHandler(func(code int, msg string) error {
+			errResponse = msg
+			close(serverClosed)
+			return nil
+		})
+
+		err := wsConn.SetWriteDeadline(time.Now().Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = wsConn.WriteMessage(websocket.TextMessage, []byte("incorrect msg"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = wsConn.SetReadDeadline(time.Now().Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, err = wsConn.ReadMessage()
+		if err == nil {
+			t.Fatal("expected failure on read")
+		}
+
+		select {
+		case <-time.After(time.Second * 5):
+			t.Fatal("waited 5 secs for server to close on error")
+		case <-serverClosed:
+			if errResponse != "invalid message" {
+				t.Fatalf("incorrect response on error, exp: (invalid message) got (%s)", errResponse)
+			}
+		}
+	})
+}

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -108,10 +108,8 @@ func TestChunkUploadStream(t *testing.T) {
 		}
 		if cerr, ok := err.(*websocket.CloseError); !ok {
 			t.Fatal("invalid error on read")
-		} else {
-			if cerr.Text != "invalid message" {
-				t.Fatalf("incorrect response on error, exp: (invalid message) got (%s)", cerr.Text)
-			}
+		} else if cerr.Text != "invalid message" {
+			t.Fatalf("incorrect response on error, exp: (invalid message) got (%s)", cerr.Text)
 		}
 	})
 }

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -38,7 +38,7 @@ func TestChunkUploadStream(t *testing.T) {
 			Pinning:   pinningMock,
 			Tags:      tag,
 			Post:      mockpost.New(mockpost.WithAcceptAll()),
-			WsPath:    "/stream/chunks",
+			WsPath:    "/chunks/stream",
 			WsHeaders: wsHeaders,
 		})
 	)

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package api_test
 
 import (

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -72,7 +72,7 @@ func TestChunkUploadStream(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if mt != websocket.TextMessage || !bytes.Equal(msg, api.SuccessWsMsg) {
+			if mt != websocket.BinaryMessage || !bytes.Equal(msg, api.SuccessWsMsg) {
 				t.Fatal("invalid response", mt, string(msg))
 			}
 

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -42,6 +42,8 @@ var (
 	FeedMetadataEntryOwner = feedMetadataEntryOwner
 	FeedMetadataEntryTopic = feedMetadataEntryTopic
 	FeedMetadataEntryType  = feedMetadataEntryType
+
+	SuccessWsMsg = successWsMsg
 )
 
 func (s *Server) ResolveNameOrAddress(str string) (swarm.Address, error) {

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var (
+const (
 	writeDeadline   = 4 * time.Second // write deadline. should be smaller than the shutdown timeout on api close
 	readDeadline    = 4 * time.Second // read deadline. should be smaller than the shutdown timeout on api close
 	targetMaxLength = 2               // max target length in bytes, in order to prevent grieving by excess computation

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	writeDeadline   = 4 * time.Second // write deadline. should be smaller than the shutdown timeout on api close
+	readDeadline    = 4 * time.Second // read deadline. should be smaller than the shutdown timeout on api close
 	targetMaxLength = 2               // max target length in bytes, in order to prevent grieving by excess computation
 )
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -63,6 +63,11 @@ func (s *server) setupRouting() {
 		),
 	})
 
+	handle("/stream/chunks", web.ChainHandlers(
+		s.gatewayModeForbidEndpointHandler,
+		web.FinalHandlerFunc(s.chunkUploadStreamHandler),
+	))
+
 	handle("/chunks/{addr}", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.chunkGetHandler),
 	})

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -63,8 +63,8 @@ func (s *server) setupRouting() {
 		),
 	})
 
-	handle("/stream/chunks", web.ChainHandlers(
-		s.gatewayModeForbidEndpointHandler,
+	handle("/chunks/stream", web.ChainHandlers(
+		s.newTracingHandler("chunks-stream-upload"),
 		web.FinalHandlerFunc(s.chunkUploadStreamHandler),
 	))
 


### PR DESCRIPTION
Currently in the `/chunks` API we only support single chunk upload

Applications using the `/chunks` endpoint need to loop while sending multiple chunks. This can cause server to hit issues due to too many connections (or on client-side while re-using connections we might see an EOF).

As we already use the `gorilla/websocket` library, I think it would be better to have a client-side streaming endpoint to upload multiple chunks. This will be easier on the server side as well as would re-use all the resources initialised for the first chunk upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2230)
<!-- Reviewable:end -->
