### PR TITLE
feat: allow swap without chequebook

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -60,6 +60,7 @@ const (
 	optionNameSwapLegacyFactoryAddresses = "swap-legacy-factory-addresses"
 	optionNameSwapInitialDeposit         = "swap-initial-deposit"
 	optionNameSwapEnable                 = "swap-enable"
+	optionNameChequebookEnable           = "chequebook-enable"
 	optionNameTransactionHash            = "transaction"
 	optionNameBlockHash                  = "block-hash"
 	optionNameSwapDeploymentGasPrice     = "swap-deployment-gas-price"
@@ -251,6 +252,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice(optionNameSwapLegacyFactoryAddresses, nil, "legacy swap factory addresses")
 	cmd.Flags().String(optionNameSwapInitialDeposit, "10000000000000000", "initial deposit if deploying a new chequebook")
 	cmd.Flags().Bool(optionNameSwapEnable, true, "enable swap")
+	cmd.Flags().Bool(optionNameChequebookEnable, true, "enable chequebook")
 	cmd.Flags().Bool(optionNameFullNode, false, "cause the node to start in full mode")
 	cmd.Flags().String(optionNamePostageContractAddress, "", "postage stamp contract address")
 	cmd.Flags().String(optionNamePriceOracleAddress, "", "price oracle contract address")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -182,6 +182,7 @@ func (c *command) initStartCmd() (err error) {
 				SwapLegacyFactoryAddresses: c.config.GetStringSlice(optionNameSwapLegacyFactoryAddresses),
 				SwapInitialDeposit:         c.config.GetString(optionNameSwapInitialDeposit),
 				SwapEnable:                 c.config.GetBool(optionNameSwapEnable),
+				ChequebookEnable:           c.config.GetBool(optionNameChequebookEnable),
 				FullNodeMode:               fullNode,
 				Transaction:                c.config.GetString(optionNameTransactionHash),
 				BlockHash:                  c.config.GetString(optionNameBlockHash),

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -377,6 +377,10 @@ components:
             * `dev` - development mode; Bee client for development purposes, blockchain operations are mocked
         gatewayMode:
           type: boolean
+        chequebookEnabled:
+          type: boolean
+        swapEnabled:
+          type: boolean
 
     Status:
       type: object

--- a/pkg/debugapi/debugapi.go
+++ b/pkg/debugapi/debugapi.go
@@ -59,6 +59,7 @@ type Service struct {
 	accounting         accounting.Interface
 	pseudosettle       settlement.Interface
 	chequebookEnabled  bool
+	swapEnabled        bool
 	chequebook         chequebook.Service
 	swap               swap.Interface
 	batchStore         postage.Storer
@@ -113,7 +114,7 @@ func New(publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address
 // Configure injects required dependencies and configuration parameters and
 // constructs HTTP routes that depend on them. It is intended and safe to call
 // this method only once.
-func (s *Service) Configure(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, lightNodes *lightnode.Container, storer storage.Storer, tags *tags.Tags, accounting accounting.Interface, pseudosettle settlement.Interface, chequebookEnabled bool, swap swap.Interface, chequebook chequebook.Service, batchStore postage.Storer, post postage.Service, postageContract postagecontract.Interface, traverser traversal.Traverser) {
+func (s *Service) Configure(overlay swarm.Address, p2p p2p.DebugService, pingpong pingpong.Interface, topologyDriver topology.Driver, lightNodes *lightnode.Container, storer storage.Storer, tags *tags.Tags, accounting accounting.Interface, pseudosettle settlement.Interface, swapEnabled bool, chequebookEnabled bool, swap swap.Interface, chequebook chequebook.Service, batchStore postage.Storer, post postage.Service, postageContract postagecontract.Interface, traverser traversal.Traverser) {
 	s.p2p = p2p
 	s.pingpong = pingpong
 	s.topologyDriver = topologyDriver
@@ -122,6 +123,7 @@ func (s *Service) Configure(overlay swarm.Address, p2p p2p.DebugService, pingpon
 	s.accounting = accounting
 	s.chequebookEnabled = chequebookEnabled
 	s.chequebook = chequebook
+	s.swapEnabled = swapEnabled
 	s.swap = swap
 	s.lightNodes = lightNodes
 	s.batchStore = batchStore

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -91,7 +91,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	transaction := transactionmock.New(o.TransactionOpts...)
 	ln := lightnode.NewContainer(o.Overlay)
 	s := debugapi.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(io.Discard, 0), nil, o.CORSAllowedOrigins, big.NewInt(2), transaction, false, nil, false, debugapi.FullMode)
-	s.Configure(o.Overlay, o.P2P, o.Pingpong, topologyDriver, ln, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook, o.BatchStore, o.Post, o.PostageContract, o.Traverser)
+	s.Configure(o.Overlay, o.P2P, o.Pingpong, topologyDriver, ln, o.Storer, o.Tags, acc, settlement, true, true, swapserv, chequebook, o.BatchStore, o.Post, o.PostageContract, o.Traverser)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 
@@ -190,7 +190,7 @@ func TestServer_Configure(t *testing.T) {
 		}),
 	)
 
-	s.Configure(o.Overlay, o.P2P, o.Pingpong, topologyDriver, ln, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook, nil, mockpost.New(), nil, nil)
+	s.Configure(o.Overlay, o.P2P, o.Pingpong, topologyDriver, ln, o.Storer, o.Tags, acc, settlement, true, true, swapserv, chequebook, nil, mockpost.New(), nil, nil)
 
 	testBasicRouter(t, client)
 	jsonhttptest.Request(t, client, http.MethodGet, "/readiness", http.StatusOK,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -212,8 +212,10 @@ func TestServer_Configure(t *testing.T) {
 	)
 	jsonhttptest.Request(t, client, http.MethodGet, "/node", http.StatusOK,
 		jsonhttptest.WithExpectedJSONResponse(debugapi.NodeResponse{
-			BeeMode:     beeMode.String(),
-			GatewayMode: gatewayMode,
+			BeeMode:           beeMode.String(),
+			GatewayMode:       gatewayMode,
+			ChequebookEnabled: true,
+			SwapEnabled:       true,
 		}),
 	)
 }

--- a/pkg/debugapi/node.go
+++ b/pkg/debugapi/node.go
@@ -19,8 +19,10 @@ const (
 )
 
 type nodeResponse struct {
-	BeeMode     string `json:"beeMode"`
-	GatewayMode bool   `json:"gatewayMode"`
+	BeeMode           string `json:"beeMode"`
+	GatewayMode       bool   `json:"gatewayMode"`
+	ChequebookEnabled bool   `json:"chequebookEnabled"`
+	SwapEnabled       bool   `json:"swapEnabled"`
 }
 
 func (b BeeNodeMode) String() string {
@@ -38,7 +40,9 @@ func (b BeeNodeMode) String() string {
 // nodeGetHandler gives back information about the Bee node configuration.
 func (s *Service) nodeGetHandler(w http.ResponseWriter, r *http.Request) {
 	jsonhttp.OK(w, nodeResponse{
-		BeeMode:     s.beeMode.String(),
-		GatewayMode: s.gatewayMode,
+		BeeMode:           s.beeMode.String(),
+		GatewayMode:       s.gatewayMode,
+		ChequebookEnabled: s.chequebookEnabled,
+		SwapEnabled:       s.swapEnabled,
 	})
 }

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -165,13 +165,30 @@ func (s *Service) newRouter() *mux.Router {
 		"GET": http.HandlerFunc(s.settlementsHandlerPseudosettle),
 	})
 
-	if s.chequebookEnabled {
+	if s.swapEnabled {
 		handle("/settlements", jsonhttp.MethodHandler{
 			"GET": http.HandlerFunc(s.settlementsHandler),
 		})
+
 		handle("/settlements/{peer}", jsonhttp.MethodHandler{
 			"GET": http.HandlerFunc(s.peerSettlementsHandler),
 		})
+
+		handle("/chequebook/cheque/{peer}", jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.chequebookLastPeerHandler),
+		})
+
+		handle("/chequebook/cheque", jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.chequebookAllLastHandler),
+		})
+
+		handle("/chequebook/cashout/{peer}", jsonhttp.MethodHandler{
+			"GET":  http.HandlerFunc(s.swapCashoutStatusHandler),
+			"POST": http.HandlerFunc(s.swapCashoutHandler),
+		})
+	}
+
+	if s.chequebookEnabled {
 
 		handle("/chequebook/balance", jsonhttp.MethodHandler{
 			"GET": http.HandlerFunc(s.chequebookBalanceHandler),
@@ -187,19 +204,6 @@ func (s *Service) newRouter() *mux.Router {
 
 		handle("/chequebook/withdraw", jsonhttp.MethodHandler{
 			"POST": http.HandlerFunc(s.chequebookWithdrawHandler),
-		})
-
-		handle("/chequebook/cheque/{peer}", jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.chequebookLastPeerHandler),
-		})
-
-		handle("/chequebook/cheque", jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.chequebookAllLastHandler),
-		})
-
-		handle("/chequebook/cashout/{peer}", jsonhttp.MethodHandler{
-			"GET":  http.HandlerFunc(s.swapCashoutStatusHandler),
-			"POST": http.HandlerFunc(s.swapCashoutHandler),
 		})
 	}
 

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -382,7 +382,7 @@ func NewDevBee(logger logging.Logger, o *DevOptions) (b *DevBee, err error) {
 		)
 
 		// inject dependencies and configure full debug api http path routes
-		debugAPIService.Configure(swarmAddress, p2ps, pingPong, kad, lightNodes, storer, tagService, acc, pseudoset, true, mockSwap, mockChequebook, batchStore, post, postageContract, traversalService)
+		debugAPIService.Configure(swarmAddress, p2ps, pingPong, kad, lightNodes, storer, tagService, acc, pseudoset, true, true, mockSwap, mockChequebook, batchStore, post, postageContract, traversalService)
 	}
 
 	return b, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -149,6 +149,7 @@ type Options struct {
 	SwapLegacyFactoryAddresses []string
 	SwapInitialDeposit         string
 	SwapEnable                 bool
+	ChequebookEnable           bool
 	FullNodeMode               bool
 	Transaction                string
 	BlockHash                  string
@@ -334,21 +335,23 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 			return nil, fmt.Errorf("factory fail: %w", err)
 		}
 
-		chequebookService, err = InitChequebookService(
-			p2pCtx,
-			logger,
-			stateStore,
-			signer,
-			chainID,
-			swapBackend,
-			overlayEthAddress,
-			transactionService,
-			chequebookFactory,
-			o.SwapInitialDeposit,
-			o.DeployGasPrice,
-		)
-		if err != nil {
-			return nil, err
+		if o.ChequebookEnable {
+			chequebookService, err = InitChequebookService(
+				p2pCtx,
+				logger,
+				stateStore,
+				signer,
+				chainID,
+				swapBackend,
+				overlayEthAddress,
+				transactionService,
+				chequebookFactory,
+				o.SwapInitialDeposit,
+				o.DeployGasPrice,
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		chequeStore, cashoutService = initChequeStoreCashout(
@@ -665,7 +668,10 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 			return nil, err
 		}
 		b.priceOracleCloser = priceOracle
-		acc.SetPayFunc(swapService.Pay)
+
+		if o.ChequebookEnable {
+			acc.SetPayFunc(swapService.Pay)
+		}
 	}
 
 	pricing.SetPaymentThresholdObserver(acc)
@@ -853,7 +859,7 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 			debugAPIService.MustRegisterMetrics(chainSyncer.Metrics()...)
 		}
 		// inject dependencies and configure full debug api http path routes
-		debugAPIService.Configure(swarmAddress, p2ps, pingPong, kad, lightNodes, storer, tagService, acc, pseudosettleService, o.SwapEnable, swapService, chequebookService, batchStore, post, postageContractService, traversalService)
+		debugAPIService.Configure(swarmAddress, p2ps, pingPong, kad, lightNodes, storer, tagService, acc, pseudosettleService, o.SwapEnable, o.ChequebookEnable, swapService, chequebookService, batchStore, post, postageContractService, traversalService)
 	}
 
 	if err := kad.Start(p2pCtx); err != nil {


### PR DESCRIPTION
* add a now flag `chequebook-enable` which is true by default.
* if `chequebook-enable` is false but `swap-enable` is true the node will still be able to receive and cash cheques but does not deploy a (or use a preexisting) chequebook and therefore does not send cheques. only time-based settlement will be used.
* transaction hash needs to be supplied manually if started with this and there has been no deployment in the past. as sending a tx manually from the overlay key can be tricky this is best done using the new alternative tx data type (#2409).
* several api endpoints are disabled in this mode.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2236)
<!-- Reviewable:end -->
