### PR TITLE
fix: display version with commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BEEKEEPER_BRANCH ?= master
 COMMIT ?= "$(shell git describe --long --dirty --always --match "" || true)"
 CLEAN_COMMIT ?= "$(shell git describe --long --always --match "" || true)"
 COMMIT_TIME ?= "$(shell git show -s --format=%ct $(CLEAN_COMMIT) || true)"
-LDFLAGS ?= -s -w -X github.com/ethersphere/bee.commit="$(COMMIT)" -X github.com/ethersphere/bee.commitTime="$(COMMIT_TIME)"
+LDFLAGS ?= -s -w -X github.com/ethersphere/bee.commitHash="$(COMMIT)" -X github.com/ethersphere/bee.commitTime="$(COMMIT_TIME)"
 
 .PHONY: all
 all: build lint vet test-race binary


### PR DESCRIPTION
At @ldeffenb's request, [ref]( https://github.com/ethersphere/bee/pull/2239)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2240)
<!-- Reviewable:end -->
