### PR TITLE
feat: retry push in neighborhood

### DIFF
--- a/pkg/pushsync/export_test.go
+++ b/pkg/pushsync/export_test.go
@@ -5,8 +5,10 @@
 package pushsync
 
 var (
-	ProtocolName    = protocolName
-	ProtocolVersion = protocolVersion
-	StreamName      = streamName
-	NewPeerSkipList = newPeerSkipList
+	ProtocolName     = protocolName
+	ProtocolVersion  = protocolVersion
+	StreamName       = streamName
+	NewPeerSkipList  = newPeerSkipList
+	DefaultTtl       = &defaultTTL
+	SendReceiptDelay = &sendReceiptDelay
 )

--- a/pkg/pushsync/export_test.go
+++ b/pkg/pushsync/export_test.go
@@ -4,6 +4,8 @@
 
 package pushsync
 
+import "github.com/ethersphere/bee/pkg/swarm"
+
 var (
 	ProtocolName     = protocolName
 	ProtocolVersion  = protocolVersion
@@ -12,3 +14,7 @@ var (
 	DefaultTtl       = &defaultTTL
 	SendReceiptDelay = &sendReceiptDelay
 )
+
+func (ps *PushSync) ShouldSkip(peer swarm.Address) bool {
+	return ps.skipList.ShouldSkip(peer)
+}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -365,7 +365,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
 				// if the node has warmed up AND no other closer peer has been tried
-				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) {
+				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && ps.topologyDriver.IsWithinDepth(ch.Address()) {
 					ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
 				}
 			}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -299,23 +299,26 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				count := 0
-				// Push the chunk to some peers in the neighborhood in parallel for replication.
-				// Any errors here should NOT impact the rest of the handler.
-				_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
-					// skip forwarding peer
-					if peer.Equal(origin) {
-						return false, false, nil
-					}
+				if ps.topologyDriver.IsWithinDepth(ch.Address()) {
+					count := 0
+					// Push the chunk to some peers in the neighborhood in parallel for replication.
+					// Any errors here should NOT impact the rest of the handler.
+					_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+						// skip forwarding peer
+						if peer.Equal(origin) {
+							return false, false, nil
+						}
 
-					if count == nPeersToPushsync {
-						return true, false, nil
-					}
-					count++
-					go ps.pushToNeighbour(peer, ch, retryAllowed)
-					return false, false, nil
-				})
-				return nil, err
+						if count == nPeersToPushsync {
+							return true, false, nil
+						}
+						count++
+						go ps.pushToNeighbour(peer, ch, retryAllowed)
+						return false, false, nil
+					})
+					return nil, err
+				}
+				return nil, fmt.Errorf("closest peer: none available")
 			}
 			return nil, fmt.Errorf("closest peer: %w", err)
 		}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -409,6 +409,8 @@ func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.C
 	// compute the price we pay for this receipt and reserve it for the rest of this function
 	receiptPrice := ps.pricer.PeerPrice(peer, ch.Address())
 
+	fmt.Printf("peer: %v\n", peer)
+
 	// Reserve to see whether we can make the request
 	err := ps.accounting.Reserve(ctx, peer, receiptPrice)
 	if err != nil {

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -37,7 +37,7 @@ const (
 )
 
 const (
-	maxPeers           = 3
+	maxPeers           = 16
 	maxAttempts        = 16
 	skipPeerExpiration = time.Minute
 )
@@ -78,7 +78,8 @@ type PushSync struct {
 	skipList       *peerSkipList
 }
 
-var defaultTTL = 20 * time.Second                     // request time to live
+var defaultTTL = 15 * time.Second // request time to live
+var preemptiveTTL = 9 * time.Second
 var timeToWaitForPushsyncToNeighbor = 3 * time.Second // time to wait to get a receipt for a chunk
 var nPeersToPushsync = 3                              // number of peers to replicate to as receipt is sent upstream
 
@@ -123,6 +124,7 @@ func (s *PushSync) Protocol() p2p.ProtocolSpec {
 func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
 	w, r := protobuf.NewWriterAndReader(stream)
 	ctx, cancel := context.WithTimeout(ctx, defaultTTL)
+
 	defer cancel()
 	defer func() {
 		if err != nil {
@@ -191,7 +193,8 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 	// forwarding replication
 	storedChunk := false
-	if ps.topologyDriver.IsWithinDepth(chunk.Address()) {
+	retryAllow := ps.topologyDriver.IsWithinDepth(chunk.Address())
+	if retryAllow {
 		_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
 		if err != nil {
 			ps.logger.Warningf("pushsync: within depth peer's attempt to store chunk failed: %v", err)
@@ -203,7 +206,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	span, _, ctx := ps.tracer.StartSpanFromContext(ctx, "pushsync-handler", ps.logger, opentracing.Tag{Key: "address", Value: chunk.Address().String()})
 	defer span.Finish()
 
-	receipt, err := ps.pushToClosest(ctx, chunk, false, p.Address)
+	receipt, err := ps.pushToClosest(ctx, chunk, retryAllow, false, p.Address)
 	if err != nil {
 		if errors.Is(err, topology.ErrWantSelf) {
 			if !storedChunk {
@@ -254,7 +257,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 // a receipt from that peer and returns error or nil based on the receiving and
 // the validity of the receipt.
 func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Receipt, error) {
-	r, err := ps.pushToClosest(ctx, ch, true, swarm.ZeroAddress)
+	r, err := ps.pushToClosest(ctx, ch, true, true, swarm.ZeroAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -270,10 +273,12 @@ type pushResult struct {
 	attempted bool
 }
 
-func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllowed bool, origin swarm.Address) (*pb.Receipt, error) {
+func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllowed, originated bool, origin swarm.Address) (*pb.Receipt, error) {
 	span, logger, ctx := ps.tracer.StartSpanFromContext(ctx, "push-closest", ps.logger, opentracing.Tag{Key: "address", Value: ch.Address().String()})
 	defer span.Finish()
 	defer ps.skipList.PruneExpired()
+
+	preemptiveLimit := time.After(time.Second * 9)
 
 	var (
 		skipPeers      []swarm.Address
@@ -283,9 +288,11 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 	)
 
 	if retryAllowed {
-		// only originator retries
+		// only originator and peers in neighborhood of chunk retry
 		allowedRetries = maxPeers
 	}
+
+	chunkInNeighborhood := ps.topologyDriver.IsWithinDepth(ch.Address())
 
 	for i := maxAttempts; allowedRetries > 0 && i > 0; i-- {
 		// find the next closest peer
@@ -299,7 +306,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				if !ps.topologyDriver.IsWithinDepth(ch.Address()) {
+				if !chunkInNeighborhood {
 					return nil, ErrNoPush
 				}
 
@@ -316,7 +323,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 						return true, false, nil
 					}
 					count++
-					go ps.pushToNeighbour(peer, ch, retryAllowed)
+					go ps.pushToNeighbour(peer, ch, originated)
 					return false, false, nil
 				})
 				return nil, err
@@ -337,7 +344,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 			ctxd, canceld := context.WithTimeout(ctx, defaultTTL)
 			defer canceld()
 
-			r, attempted, err := ps.pushPeer(ctxd, peer, ch, retryAllowed)
+			r, attempted, err := ps.pushPeer(ctxd, peer, ch, originated)
 			// attempted is true if we get past accounting and actually attempt
 			// to send the request to the peer. If we dont get past accounting, we
 			// should not count the retry and try with a different peer again
@@ -355,23 +362,46 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 			}
 		}(peer, ch)
 
-		select {
-		case r := <-resultC:
-			// receipt received for chunk
-			if r.receipt != nil {
-				ps.skipList.PruneChunk(ch.Address())
-				return r.receipt, nil
-			}
-			if r.err != nil && r.attempted {
-				ps.metrics.TotalFailedSendAttempts.Inc()
-
-				// if the node has warmed up AND no other closer peer has been tried
-				if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && ps.topologyDriver.IsWithinDepth(ch.Address()) {
-					ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+		if !chunkInNeighborhood {
+			select {
+			case r := <-resultC:
+				// receipt received for chunk
+				if r.receipt != nil {
+					ps.skipList.PruneChunk(ch.Address())
+					return r.receipt, nil
 				}
+				if r.err != nil && r.attempted {
+					ps.metrics.TotalFailedSendAttempts.Inc()
+
+					// if the node has warmed up AND no other closer peer has been tried
+					if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && chunkInNeighborhood && errors.Is(err, context.DeadlineExceeded) {
+						ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+					}
+				}
+			case <-ctx.Done():
+				return nil, ctx.Err()
 			}
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		} else {
+			select {
+			case r := <-resultC:
+				// receipt received for chunk
+				if r.receipt != nil {
+					ps.skipList.PruneChunk(ch.Address())
+					return r.receipt, nil
+				}
+				if r.err != nil && r.attempted {
+					ps.metrics.TotalFailedSendAttempts.Inc()
+					// if the node has warmed up AND no other closer peer has been tried
+					if time.Now().After(ps.warmupPeriod) && !ps.skipList.HasChunk(ch.Address()) && chunkInNeighborhood && errors.Is(err, context.DeadlineExceeded) {
+						ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
+					}
+				}
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-preemptiveLimit:
+				go ps.establishStorage(ch, origin, originated, resultC)
+				allowedRetries++
+			}
 		}
 	}
 
@@ -572,4 +602,44 @@ func (l *peerSkipList) PruneExpired() {
 			delete(l.skipExpiration, k)
 		}
 	}
+}
+
+func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, originated bool, resultC chan<- *pushResult) {
+
+	count := 0
+	// Push the chunk to some peers in the neighborhood in parallel for replication.
+	// Any errors here should NOT impact the rest of the handler.
+	_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+		// skip forwarding peer
+		if peer.Equal(origin) {
+			return false, false, nil
+		}
+
+		if count == nPeersToPushsync {
+			return true, false, nil
+		}
+		count++
+		go ps.pushToNeighbour(peer, ch, originated)
+		return false, false, nil
+	})
+
+	bytes := ch.Address().Bytes()
+
+	signature, err := ps.signer.Sign(bytes)
+	if err != nil {
+		resultC <- &pushResult{
+			receipt:   nil,
+			err:       err,
+			attempted: true,
+		}
+		return
+	}
+
+	receipt := pb.Receipt{Address: bytes, Signature: signature, BlockHash: ps.blockHash}
+	resultC <- &pushResult{
+		receipt:   &receipt,
+		err:       err,
+		attempted: true,
+	}
+
 }

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -46,7 +46,6 @@ var (
 	ErrOutOfDepthReplication = errors.New("replication outside of the neighborhood")
 	ErrNoPush                = errors.New("could not push chunk")
 	ErrWarmup                = errors.New("node warmup time not complete")
-	ErrSelfSignFail          = errors.New("creating storage receipt failed")
 )
 
 type PushSyncer interface {
@@ -627,7 +626,7 @@ func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, origi
 	if err != nil {
 		resultC <- &pushResult{
 			receipt:   nil,
-			err:       ErrSelfSignFail,
+			err:       err,
 			attempted: true,
 		}
 		return

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -46,7 +46,6 @@ var (
 	ErrOutOfDepthReplication = errors.New("replication outside of the neighborhood")
 	ErrNoPush                = errors.New("could not push chunk")
 	ErrWarmup                = errors.New("node warmup time not complete")
-	ErrSelfSignFail          = errors.New("creating storage receipt failed")
 )
 
 type PushSyncer interface {
@@ -367,7 +366,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, originate
 			if r.err != nil && r.attempted {
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
-				if errors.Is(err, ErrSelfSignFail) && results > attempts {
+				if results > attempts {
 					return nil, ErrNoPush
 				}
 
@@ -612,7 +611,7 @@ func (ps *PushSync) establishStorage(ch swarm.Chunk, origin swarm.Address, origi
 	if err != nil {
 		resultC <- &pushResult{
 			receipt:   nil,
-			err:       ErrSelfSignFail,
+			err:       err,
 			attempted: true,
 		}
 		return

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -395,6 +395,8 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin sw
 			if r.err != nil && r.attempted {
 				ps.metrics.TotalFailedSendAttempts.Inc()
 
+				// if we have received 1 more results than peers attempted, return
+				// this means all attempts including establishing storage have already failed
 				if results > attempts {
 					return nil, ErrNoPush
 				}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -299,26 +299,27 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					return nil, ErrWarmup
 				}
 
-				if ps.topologyDriver.IsWithinDepth(ch.Address()) {
-					count := 0
-					// Push the chunk to some peers in the neighborhood in parallel for replication.
-					// Any errors here should NOT impact the rest of the handler.
-					_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
-						// skip forwarding peer
-						if peer.Equal(origin) {
-							return false, false, nil
-						}
-
-						if count == nPeersToPushsync {
-							return true, false, nil
-						}
-						count++
-						go ps.pushToNeighbour(peer, ch, retryAllowed)
-						return false, false, nil
-					})
-					return nil, err
+				if !ps.topologyDriver.IsWithinDepth(ch.Address()) {
+					return nil, ErrNoPush
 				}
-				return nil, fmt.Errorf("closest peer: none available")
+
+				count := 0
+				// Push the chunk to some peers in the neighborhood in parallel for replication.
+				// Any errors here should NOT impact the rest of the handler.
+				_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
+					// skip forwarding peer
+					if peer.Equal(origin) {
+						return false, false, nil
+					}
+
+					if count == nPeersToPushsync {
+						return true, false, nil
+					}
+					count++
+					go ps.pushToNeighbour(peer, ch, retryAllowed)
+					return false, false, nil
+				})
+				return nil, err
 			}
 			return nil, fmt.Errorf("closest peer: %w", err)
 		}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -130,13 +130,9 @@ func TestReplicateBeforeReceipt(t *testing.T) {
 	defer storerEmpty.Close()
 	emptyRecorder := streamtest.New(streamtest.WithProtocols(psEmpty.Protocol()), streamtest.WithBaseAddr(secondPeer))
 
-	wFunc := func(addr swarm.Address) bool {
-		return true
-	}
-
 	// node that is connected to closestPeer
 	// will receieve chunk from closestPeer
-	psSecond, storerSecond, _, secondAccounting := createPushSyncNode(t, secondPeer, defaultPrices, emptyRecorder, nil, defaultSigner, mock.WithPeers(emptyPeer), mock.WithIsWithinFunc(wFunc))
+	psSecond, storerSecond, _, secondAccounting := createPushSyncNode(t, secondPeer, defaultPrices, emptyRecorder, nil, defaultSigner, mock.WithPeers(emptyPeer))
 	defer storerSecond.Close()
 	secondRecorder := streamtest.New(streamtest.WithProtocols(psSecond.Protocol()), streamtest.WithBaseAddr(closestPeer))
 

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1505,11 +1505,6 @@ func TestRaceStorerReceipt(t *testing.T) {
 						return errors.New("peer error")
 					}
 
-					// simulate timing out for peer4
-					// if failCountNeighborhood == 2 {
-					// 	time.Sleep(time.Millisecond * 1100)
-					// }
-
 					if err := h(ctx, peer, stream); err != nil {
 						return err
 					}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1089,9 +1089,9 @@ func TestPreemptiveReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, defaultSigner, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1214,10 +1214,10 @@ func TestPreemptiveReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)
@@ -1238,12 +1238,12 @@ func TestPreemptiveReceipt(t *testing.T) {
 		t.Fatal("receipt signature is invalid")
 	}
 
-	if psPeer2.ShouldSkip(peer3) {
-		t.Fatalf("peer %v should NOT be skipped", peer3.String())
+	if !psPeer2.ShouldSkip(peer3) {
+		t.Fatalf("peer %v should be skipped", peer3.String())
 	}
 
-	if !psPeer2.ShouldSkip(peer4) {
-		t.Fatalf("peer %v should be skipped", peer4.String())
+	if psPeer2.ShouldSkip(peer4) {
+		t.Fatalf("peer %v should NOT be skipped", peer4.String())
 	}
 }
 
@@ -1279,9 +1279,9 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, signerPeer4, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1402,10 +1402,10 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)
@@ -1471,9 +1471,9 @@ func TestRaceStorerReceipt(t *testing.T) {
 	pivotNode := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 
 	peer1 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
-	peer2 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
-	peer3 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
-	peer4 := swarm.MustParseHexAddress("8000000000000000000000000000000000000000000000000000000000000000")
+	peer2 := swarm.MustParseHexAddress("5000000000000000000000000000000000000000000000000000000000000000")
+	peer3 := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	peer4 := swarm.MustParseHexAddress("7000000000000000000000000000000000000000000000000000000000000000")
 
 	psPeer4, storerPeer4, _, _ := createPushSyncNode(t, peer4, defaultPrices, nil, nil, signerPeer4, mock.WithClosestPeerErr(topology.ErrWantSelf))
 	defer storerPeer4.Close()
@@ -1594,10 +1594,10 @@ func TestRaceStorerReceipt(t *testing.T) {
 	waitOnRecordNAndTest(t, peer3, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), chunk.Data(), 1)
 
 	// this intercepts the outgoing delivery message
-	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 2)
+	waitOnRecordNAndTest(t, peer4, peer2Recorder, chunk.Address(), nil, 1)
 
 	// this intercepts the outgoing delivery message
 	waitOnRecordNAndTest(t, peer2, peer1Recorder, chunk.Address(), nil, 2)

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -1439,7 +1439,8 @@ func TestRacePreemptiveReceipt(t *testing.T) {
 	}
 }
 
-func Test_(t *testing.T) {
+// TestRaceStorerReceipt tests that the preemptive receipt creation can overtake the passing back of the receipt from a downstream peer
+func TestRaceStorerReceipt(t *testing.T) {
 
 	defer func(t time.Duration) {
 		*pushsync.DefaultTtl = t

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -164,7 +164,7 @@ func (m *mock) IsWithinDepth(addr swarm.Address) bool {
 	if m.isWithinFunc != nil {
 		return m.isWithinFunc(addr)
 	}
-	return false
+	return true
 }
 
 func (m *mock) EachNeighbor(f topology.EachPeerFunc) error {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -107,7 +107,7 @@ func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }
 
-func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
 		if d.closestPeerErr != nil {
 			return d.closestPeer, d.closestPeerErr
@@ -147,8 +147,13 @@ func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Addres
 	}
 
 	if peerAddr.IsZero() {
-		return peerAddr, topology.ErrNotFound
+		if wantSelf {
+			return peerAddr, topology.ErrWantSelf
+		} else {
+			return peerAddr, topology.ErrNotFound
+		}
 	}
+
 	return peerAddr, nil
 }
 


### PR DESCRIPTION
This pr implements 
- Retrial of pushing / establishing storage for in-neighborhood content for the purposes of pushsync
- Preemptive receipt signing behaviour within neighborhood depth to chunk after 9 seconds of not receiving a storage receipt from neighborhood peers
- If the preemptive storage establishment is in progress, the pending pushed peer can still succeed in passing a receipt back first
- Increases the number of originator retrials for the same chunk to increase the possibility of finding separate routes to neighborhoods without relying on the expiring skiplist
- If an in-neighborhood peer times out while being pushed, it is added to the skiplist for 1 minute. This is not feasible for forwarders outside the neighborhood as those peers might be timed out on by their downstream without being able to preemptively sign a receipt for this case
- Only using peers further away from the chunk for in-neighborhood immediate replication, as other peers could take it as a regular push attempt towards them, and cascade the immediate replication


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2264)
<!-- Reviewable:end -->
