### PR TITLE
 fix: replicate with peers further from the chunk

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -335,6 +335,12 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 						return false, false, nil
 					}
 
+					// here we skip the peer if the peer is closer to the chunk than us
+					// we replicate with peers that are further away than us because we are the storer
+					if dcmp, _ := swarm.DistanceCmp(ch.Address().Bytes(), peer.Bytes(), ps.address.Bytes()); dcmp == 1 {
+						return false, false, nil
+					}
+
 					if count == nPeersToPushsync {
 						return true, false, nil
 					}


### PR DESCRIPTION
Only using peers further away from the chunk for in-neighborhood immediate replication, as other peers could take it as a regular push attempt towards them, and cascade the immediate replication

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2293)
<!-- Reviewable:end -->
