### PR TITLE
fix: retry in neighbourhood

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -305,8 +305,9 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 		includeSelf    = ps.isFullNode
 	)
 
-	if retryAllowed {
-		// only originator retries
+	chunkInNeighbourhood := ps.topologyDriver.IsWithinDepth(ch.Address())
+
+	if retryAllowed || chunkInNeighbourhood {
 		allowedRetries = maxPeers
 	}
 
@@ -318,17 +319,18 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 			// in which case we should return immediately.
 			// if ErrWantSelf is returned, it means we are the closest peer.
 			if errors.Is(err, topology.ErrWantSelf) {
+
 				if time.Now().Before(ps.warmupPeriod) {
 					return nil, ErrWarmup
 				}
 
-				if !ps.topologyDriver.IsWithinDepth(ch.Address()) {
+				if !chunkInNeighbourhood {
 					return nil, ErrNoPush
 				}
 
-				count := 0
 				// Push the chunk to some peers in the neighborhood in parallel for replication.
 				// Any errors here should NOT impact the rest of the handler.
+				count := 0
 				_ = ps.topologyDriver.EachNeighbor(func(peer swarm.Address, po uint8) (bool, bool, error) {
 					// skip forwarding peer
 					if peer.Equal(origin) {
@@ -342,6 +344,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					go ps.pushToNeighbour(peer, ch, retryAllowed)
 					return false, false, nil
 				})
+
 				return nil, err
 			}
 			return nil, fmt.Errorf("closest peer: %w", err)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -362,7 +362,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 		go func(peer swarm.Address, ch swarm.Chunk) {
 			ctxd, canceld := context.WithTimeout(ctx, defaultTTL)
 			defer canceld()
-
+			fmt.Println(peer)
 			r, attempted, err := ps.pushPeer(ctxd, peer, ch, retryAllowed)
 			// attempted is true if we get past accounting and actually attempt
 			// to send the request to the peer. If we dont get past accounting, we

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -362,7 +362,6 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 		go func(peer swarm.Address, ch swarm.Chunk) {
 			ctxd, canceld := context.WithTimeout(ctx, defaultTTL)
 			defer canceld()
-			fmt.Println(peer)
 			r, attempted, err := ps.pushPeer(ctxd, peer, ch, retryAllowed)
 			// attempted is true if we get past accounting and actually attempt
 			// to send the request to the peer. If we dont get past accounting, we

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -902,10 +902,9 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 	}
 }
 
-// TestForwarderRetriesInNeighborhood tests that the out of depth forwarder does not retry, and
-// the forwarding peer inside the neighborhood retries.
-// P -> F -> | N1 -> N2 (fails), N1 -> N3
-func TestForwarderRetriesInNeighborhood(t *testing.T) {
+// TestForwarderRetriesInNeighborhoodAndEstablishesStorage tests that retries occur when a chunk lands in the neighborhood and that
+// in neighboor replication is occuring.
+func TestForwarderRetriesInNeighborhoodAndEstablishesStorage(t *testing.T) {
 
 	// chunk data to upload
 	chunk := testingc.FixtureChunk("7000")
@@ -1026,7 +1025,8 @@ func TestForwarderRetriesInNeighborhood(t *testing.T) {
 	}
 }
 
-func Test_ForwarderRetriesInNeighborhood(t *testing.T) {
+// TestForwarderRetriesInNeighborhood tests that retries occur when a chunk lands in the neighborhood.
+func TestForwarderRetriesInNeighborhood(t *testing.T) {
 
 	// chunk data to upload
 	chunk := testingc.FixtureChunk("7000")

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -902,8 +902,8 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 	}
 }
 
-// TestForwarderRetriesInNeighborhoodAndEstablishesStorage tests that retries occur when a chunk lands in the neighborhood and that
-// in neighboor replication is occuring.
+// TestForwarderRetriesInNeighborhoodAndEstablishesStorage tests that retries occur when a chunk lands in the neighborhood
+// and that in neighborhood replication is occuring.
 func TestForwarderRetriesInNeighborhoodAndEstablishesStorage(t *testing.T) {
 
 	// chunk data to upload

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -903,7 +903,7 @@ func TestPushChunkToClosestSkipFailed(t *testing.T) {
 }
 
 // TestForwarderRetriesInNeighborhoodAndEstablishesStorage tests that retries occur when a chunk lands in the neighborhood
-// and that in neighborhood replication is occuring.
+// and that in neighborhood replication is occurring.
 func TestForwarderRetriesInNeighborhoodAndEstablishesStorage(t *testing.T) {
 
 	// chunk data to upload

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -107,7 +107,7 @@ func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }
 
-func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
 		if d.closestPeerErr != nil {
 			return d.closestPeer, d.closestPeerErr
@@ -147,7 +147,11 @@ func (d *mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Addres
 	}
 
 	if peerAddr.IsZero() {
-		return peerAddr, topology.ErrNotFound
+		if wantSelf {
+			return peerAddr, topology.ErrWantSelf
+		} else {
+			return peerAddr, topology.ErrNotFound
+		}
 	}
 	return peerAddr, nil
 }


### PR DESCRIPTION
Retrial of pushing / establishing storage for in-neighborhood content for the purposes of pushsync

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2294)
<!-- Reviewable:end -->
