### PR TITLE
fix: least authority gcSizeChange bug

### DIFF
--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -137,8 +137,8 @@ func (db *DB) put(mode storage.ModePut, chs ...swarm.Chunk) (exist []bool, err e
 				if err != nil {
 					return nil, err
 				}
+				gcSizeChange += c
 			}
-			gcSizeChange += c
 		}
 
 	case storage.ModePutSync:

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -260,6 +260,7 @@ func TestModePutUpload(t *testing.T) {
 				newPinIndexTest(db, ch, leveldb.ErrNotFound)(t)
 			}
 			newItemsCountTest(db.postageIndexIndex, tc.count)(t)
+			newIndexGCSizeTest(db)(t)
 		})
 	}
 }
@@ -298,6 +299,7 @@ func TestModePutUploadPin(t *testing.T) {
 				newPinIndexTest(db, ch, nil)(t)
 			}
 			newItemsCountTest(db.postageIndexIndex, tc.count)(t)
+			newIndexGCSizeTest(db)(t)
 		})
 	}
 }
@@ -484,6 +486,7 @@ func TestModePut_sameChunk(t *testing.T) {
 						newItemsCountTest(db.retrievalDataIndex, tc.count)(t)
 						newItemsCountTest(db.pullIndex, count(tcn.pullIndex))(t)
 						newItemsCountTest(db.pushIndex, count(tcn.pushIndex))(t)
+						newIndexGCSizeTest(db)(t)
 					}
 				})
 			}


### PR DESCRIPTION
as reported by the Least Authority audit team, we would be doing unnecessary increments to gcSize when uploading. A subsequent migration that reindexes the gcSize index is needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2296)
<!-- Reviewable:end -->
