### PR TITLE
fix: zero batch value

### DIFF
--- a/pkg/postage/batchstore/reserve.go
+++ b/pkg/postage/batchstore/reserve.go
@@ -252,7 +252,7 @@ func (rs *reserveState) size(depth uint8, t tier) int64 {
 func (rs *reserveState) tier(x *big.Int) tier {
 
 	// x < rs.Inner || x == 0
-	if x.Cmp(rs.Inner) < 0 || rs.Inner.Cmp(big.NewInt(0)) == 0 {
+	if x.Cmp(rs.Inner) < 0 || x.Cmp(big.NewInt(0)) == 0 {
 		return unreserved
 	}
 


### PR DESCRIPTION
a mishandling of the zero batch value can lead to the batch being considered as reserved for inner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2314)
<!-- Reviewable:end -->
