### PR TITLE
feat: add bucket data endpoint

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -357,8 +357,6 @@ components:
           items:
             $ref: "#/components/schemas/StampBucketData"
 
-
-
     Settlement:
       type: object
       properties:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -334,6 +334,31 @@ components:
         immutableFlag:
           type: boolean
 
+    StampBucketData:
+      type: object
+      properties:
+        bucketID:
+          type: integer
+        collisions:
+          type: integer
+
+    PostageStampBuckets:
+      type: object
+      properties:
+        depth:
+          type: integer
+        bucketDepth:
+          type: integer
+        bucketUpperBound:
+          type: integer
+        buckets:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/StampBucketData"
+
+
+
     Settlement:
       type: object
       properties:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -802,6 +802,30 @@ paths:
         default:
           description: Default response
 
+  "/stamps/{id}/buckets":
+    parameters:
+      - in: path
+        name: id
+        schema:
+          $ref: "SwarmCommon.yaml#/components/schemas/BatchID"
+        required: true
+        description: Swarm address of the stamp
+    get:
+      summary: Get extended bucket data of a batch
+      tags:
+        - Postage Stamps
+      responses:
+        "200":
+          description: Returns extended bucket data of the provided batch ID
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/PostageStampBuckets"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        default:
+          description: Default response
+
   "/stamps/{amount}/{depth}":
     post:
       summary: Buy a new postage batch. Be aware, this endpoint create an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance!

--- a/pkg/debugapi/export_test.go
+++ b/pkg/debugapi/export_test.go
@@ -34,6 +34,8 @@ type (
 	PostageCreateResponse             = postageCreateResponse
 	PostageStampResponse              = postageStampResponse
 	PostageStampsResponse             = postageStampsResponse
+	PostageStampBucketsResponse       = postageStampBucketsResponse
+	BucketData                        = bucketData
 )
 
 var (

--- a/pkg/debugapi/postage.go
+++ b/pkg/debugapi/postage.go
@@ -138,9 +138,8 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, _ *http.Request
 }
 
 func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.Request) {
-
 	idStr := mux.Vars(r)["id"]
-	if idStr == "" || len(idStr) != 64 {
+	if len(idStr) != 64 {
 		s.logger.Error("get stamp issuer: invalid batchID")
 		jsonhttp.BadRequest(w, "invalid batchID")
 		return
@@ -157,7 +156,7 @@ func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.R
 	if err != nil {
 		s.logger.Error("get stamp issuer: get issuer: %v", err)
 		s.logger.Error("get stamp issuer: get issuer")
-		jsonhttp.BadRequest(w, "cannot get issuer")
+		jsonhttp.BadRequest(w, "cannot get batch")
 		return
 	}
 

--- a/pkg/debugapi/postage_test.go
+++ b/pkg/debugapi/postage_test.go
@@ -264,7 +264,7 @@ func TestPostageGetBuckets(t *testing.T) {
 	mp := mockpost.New(mockpost.WithIssuer(si))
 	ts := newTestServer(t, testServerOptions{Post: mp})
 	buckets := make([]debugapi.BucketData, 1024)
-	for i, _ := range buckets {
+	for i := range buckets {
 		buckets[i] = debugapi.BucketData{BucketID: uint32(i)}
 	}
 

--- a/pkg/debugapi/postage_test.go
+++ b/pkg/debugapi/postage_test.go
@@ -237,7 +237,7 @@ func TestPostageGetStamp(t *testing.T) {
 			}),
 		)
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("bad request", func(t *testing.T) {
 		badBatch := []byte{0, 1, 2}
 
 		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/stamps/"+hex.EncodeToString(badBatch), http.StatusBadRequest,
@@ -247,10 +247,51 @@ func TestPostageGetStamp(t *testing.T) {
 			}),
 		)
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("bad request", func(t *testing.T) {
 		badBatch := []byte{0, 1, 2, 4}
 
 		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/stamps/"+hex.EncodeToString(badBatch), http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "invalid batchID",
+			}),
+		)
+	})
+}
+
+func TestPostageGetBuckets(t *testing.T) {
+	si := postage.NewStampIssuer("", "", batchOk, big.NewInt(3), 11, 10, 1000, true)
+	mp := mockpost.New(mockpost.WithIssuer(si))
+	ts := newTestServer(t, testServerOptions{Post: mp})
+	buckets := make([]debugapi.BucketData, 1024)
+	for i, _ := range buckets {
+		buckets[i] = debugapi.BucketData{BucketID: uint32(i)}
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/stamps/"+batchOkStr+"/buckets", http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(&debugapi.PostageStampBucketsResponse{
+				Depth:            si.Depth(),
+				BucketDepth:      si.BucketDepth(),
+				BucketUpperBound: si.BucketUpperBound(),
+				Buckets:          buckets,
+			}),
+		)
+	})
+	t.Run("bad batch", func(t *testing.T) {
+		badBatch := []byte{0, 1, 2}
+
+		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/stamps/"+hex.EncodeToString(badBatch)+"/buckets", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "invalid batchID",
+			}),
+		)
+	})
+	t.Run("bad batch", func(t *testing.T) {
+		badBatch := []byte{0, 1, 2, 4}
+
+		jsonhttptest.Request(t, ts.Client, http.MethodGet, "/stamps/"+hex.EncodeToString(badBatch)+"/buckets", http.StatusBadRequest,
 			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
 				Code:    http.StatusBadRequest,
 				Message: "invalid batchID",

--- a/pkg/debugapi/router.go
+++ b/pkg/debugapi/router.go
@@ -198,6 +198,12 @@ func (s *Service) newRouter() *mux.Router {
 		})),
 	)
 
+	router.Handle("/stamps/{id}/buckets", web.ChainHandlers(
+		web.FinalHandler(jsonhttp.MethodHandler{
+			"GET": http.HandlerFunc(s.postageGetStampBucketsHandler),
+		})),
+	)
+
 	router.Handle("/stamps/{amount}/{depth}", web.ChainHandlers(
 		web.FinalHandler(jsonhttp.MethodHandler{
 			"POST": http.HandlerFunc(s.postageCreateHandler),

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -145,7 +145,9 @@ func (si *StampIssuer) BucketDepth() uint8 {
 	return si.data.BucketDepth
 }
 
-// BucketDepth the depth of collision Buckets uniformity.
+// BucketUpperBound returns the maximum number of collisions
+// possible in a bucket given the batch's depth and bucket
+// depth.
 func (si *StampIssuer) BucketUpperBound() uint32 {
 	return 1 << (si.Depth() - si.BucketDepth())
 }

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -145,6 +145,11 @@ func (si *StampIssuer) BucketDepth() uint8 {
 	return si.data.BucketDepth
 }
 
+// BucketDepth the depth of collision Buckets uniformity.
+func (si *StampIssuer) BucketUpperBound() uint32 {
+	return 1 << (si.Depth() - si.BucketDepth())
+}
+
 // BlockNumber when this batch was created.
 func (si *StampIssuer) BlockNumber() uint64 {
 	return si.data.BlockNumber
@@ -153,4 +158,12 @@ func (si *StampIssuer) BlockNumber() uint64 {
 // ImmutableFlag immutability of the created batch.
 func (si *StampIssuer) ImmutableFlag() bool {
 	return si.data.ImmutableFlag
+}
+
+func (si *StampIssuer) Buckets() []uint32 {
+	si.bucketMu.Lock()
+	b := make([]uint32, len(si.data.Buckets))
+	copy(b, si.data.Buckets)
+	si.bucketMu.Unlock()
+	return b
 }


### PR DESCRIPTION
This PR adds a debug api endpoint to print out extended debugging information in regards to a single batch, so that we can track collisions on particular buckets (and hopefully plot them to spot anomalies)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2321)
<!-- Reviewable:end -->
