### PR TITLE
feat: allow setting tracing-endpoint using host and port

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -43,6 +43,8 @@ const (
 	optionNameStandalone                 = "standalone"
 	optionNameTracingEnabled             = "tracing-enable"
 	optionNameTracingEndpoint            = "tracing-endpoint"
+	optionNameTracingHost                = "tracing-host"
+	optionNameTracingPort                = "tracing-port"
 	optionNameTracingServiceName         = "tracing-service-name"
 	optionNameVerbosity                  = "verbosity"
 	optionNameGlobalPinningEnabled       = "global-pinning-enable"
@@ -218,6 +220,8 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameStandalone, false, "whether we want the node to start with no listen addresses for p2p")
 	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
 	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")
+	cmd.Flags().String(optionNameTracingHost, "", "host to send tracing data")
+	cmd.Flags().String(optionNameTracingPort, "", "port to send tracing data")
 	cmd.Flags().String(optionNameTracingServiceName, "bee", "service name identifier for tracing")
 	cmd.Flags().String(optionNameVerbosity, "info", "log verbosity level 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=trace")
 	cmd.Flags().String(optionWelcomeMessage, "", "send a welcome message string during handshakes")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -151,6 +151,12 @@ inability to use, or your interaction with other nodes or the software.`)
 				networkConfig.blockTime = blockTime
 			}
 
+			tracingEndpoint := c.config.GetString(optionNameTracingEndpoint)
+
+			if c.config.IsSet(optionNameTracingHost) && c.config.IsSet(optionNameTracingPort) {
+				tracingEndpoint = strings.Join([]string{c.config.GetString(optionNameTracingHost), c.config.GetString(optionNameTracingPort)}, ":")
+			}
+
 			b, err := node.NewBee(c.config.GetString(optionNameP2PAddr), signerConfig.publicKey, signerConfig.signer, networkID, logger, signerConfig.libp2pPrivateKey, signerConfig.pssPrivateKey, &node.Options{
 				DataDir:                    c.config.GetString(optionNameDataDir),
 				CacheCapacity:              c.config.GetUint64(optionNameCacheCapacity),
@@ -169,7 +175,7 @@ inability to use, or your interaction with other nodes or the software.`)
 				CORSAllowedOrigins:         c.config.GetStringSlice(optionCORSAllowedOrigins),
 				Standalone:                 c.config.GetBool(optionNameStandalone),
 				TracingEnabled:             c.config.GetBool(optionNameTracingEnabled),
-				TracingEndpoint:            c.config.GetString(optionNameTracingEndpoint),
+				TracingEndpoint:            tracingEndpoint,
 				TracingServiceName:         c.config.GetString(optionNameTracingServiceName),
 				Logger:                     logger,
 				GlobalPinningEnabled:       c.config.GetBool(optionNameGlobalPinningEnabled),


### PR DESCRIPTION
There is a need for k8s deployment to be able to define tracing-endpoint using HOST and PORT variables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2323)
<!-- Reviewable:end -->
