### PR TITLE
feat: rename log field traceid to traceID

### DIFF
--- a/pkg/tracing/doc.go
+++ b/pkg/tracing/doc.go
@@ -34,7 +34,7 @@ Once the operation is finished, the open span should be finished:
 	span.Finish()
 
 The tracing package also provides a function for creating a logger which will
-inject a "traceid" field entry to the log line, which helps in finding out which
+inject a "traceID" field entry to the log line, which helps in finding out which
 log lines belong to a specific trace.
 
 To create a logger with trace just wrap an existing logger:
@@ -46,6 +46,6 @@ To create a logger with trace just wrap an existing logger:
 Which will result in following log line (if the context contains tracing
 information):
 
-	time="2015-09-07T08:48:33Z" level=info msg="some message" traceid=ed65818cc1d30c
+	time="2015-09-07T08:48:33Z" level=info msg="some message" traceID=ed65818cc1d30c
 */
 package tracing

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -34,7 +34,7 @@ var (
 type contextKey struct{}
 
 // LogField is the key in log message field that holds tracing id value.
-const LogField = "traceid"
+const LogField = "traceID"
 
 const (
 	// TraceContextHeaderName is the http header name used to propagate tracing context.
@@ -91,7 +91,7 @@ func NewTracer(o *Options) (*Tracer, io.Closer, error) {
 
 // StartSpanFromContext starts a new tracing span that is either a root one or a
 // child of existing one from the provided Context. If logger is provided, a new
-// log Entry will be returned with "traceid" log field.
+// log Entry will be returned with "traceID" log field.
 func (t *Tracer) StartSpanFromContext(ctx context.Context, operationName string, l logging.Logger, opts ...opentracing.StartSpanOption) (opentracing.Span, *logrus.Entry, context.Context) {
 	if t == nil {
 		t = noopTracer
@@ -239,7 +239,7 @@ func FromContext(ctx context.Context) opentracing.SpanContext {
 	return c
 }
 
-// NewLoggerWithTraceID creates a new log Entry with "traceid" field added if it
+// NewLoggerWithTraceID creates a new log Entry with "traceID" field added if it
 // exists in tracing span context stored from go context.
 func NewLoggerWithTraceID(ctx context.Context, l logging.Logger) *logrus.Entry {
 	return loggerWithTraceID(FromContext(ctx), l)


### PR DESCRIPTION
In all grafana docs its `traceID` and not `traceid`, while field name is configurable for connecting logs to traces for grafana cloud its much easier to go with a default value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2324)
<!-- Reviewable:end -->
