### PR TITLE
docs: gateway mode forbidden and tweaks

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -10,7 +10,7 @@ security:
 
 externalDocs:
   description: Browse the documentation @ the Swarm Docs
-  url: "https://docs.swarm.eth"
+  url: "https://docs.ethswarm.org"
 
 servers:
   - url: "http://{apiRoot}:{port}/v1"

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 0.6.0
+  version: 1.0.0
   title: Swarm API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 
@@ -62,7 +62,7 @@ paths:
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -157,6 +157,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
+        "403":
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -223,7 +225,7 @@ paths:
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -354,7 +356,7 @@ paths:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/TagsList"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -377,7 +379,7 @@ paths:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/NewTagResponse"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -405,7 +407,7 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"    
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
@@ -429,7 +431,7 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
@@ -462,7 +464,7 @@ paths:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/Status"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
@@ -498,7 +500,7 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
@@ -519,7 +521,7 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -538,7 +540,7 @@ paths:
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":
@@ -559,7 +561,7 @@ paths:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/SwarmOnlyReferencesList"
         "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -597,6 +599,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
+        "403":
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -617,6 +621,8 @@ paths:
       responses:
         "200":
           description: Returns a WebSocket with a subscription for incoming message data on the requested topic.
+        "403":
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -660,6 +666,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/401"
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
+        "403":
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -704,6 +712,8 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/401"
         "402":
           $ref: "SwarmCommon.yaml#/components/responses/402"
+        "403":
+          $ref: "SwarmCommon.yaml#/components/responses/GatewayForbidden"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -252,7 +252,7 @@ paths:
     get:
       summary: "Get file or index document from a collection of files"
       tags:
-        - Collection
+        - BZZ
       parameters:
         - in: path
           name: reference
@@ -287,7 +287,7 @@ paths:
     get:
       summary: "Get referenced file from a collection of files"
       tags:
-        - Collection
+        - BZZ
       parameters:
         - in: path
           name: reference

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -173,8 +173,7 @@ paths:
         A multipart request is treated as a collection regardless of whether the swarm-collection header is present. This means in order to serve single files
         uploaded as a multipart request, the swarm-index-document header should be used with the name of the file."
       tags:
-        - File
-        - Collection
+        - BZZ
       parameters:
         - in: query
           name: name
@@ -235,15 +234,14 @@ paths:
     patch:
       summary: "Reupload a root hash to the network"
       tags:
-        - Reupload file
-        - Reupload collection
+        - BZZ
       parameters:
         - in: path
           name: reference
           schema:
             $ref: "SwarmCommon.yaml#/components/schemas/SwarmReference"
           required: true
-          description: Root hash of content
+          description: "Root hash of content (can be of any type: collection, file, chunk)"
       responses:
         "200":
           description: Ok
@@ -483,7 +481,7 @@ paths:
     post:
       summary: Pin the root hash with the given reference
       tags:
-        - Root hash pinning
+        - Pinning
       responses:
         "200":
           description: Pin already exists, so no operation
@@ -510,7 +508,7 @@ paths:
     delete:
       summary: Unpin the root hash with the given reference
       tags:
-        - Root hash pinning
+        - Pinning
       responses:
         "200":
           description: Unpinning root hash with reference
@@ -529,7 +527,7 @@ paths:
     get:
       summary: Get pinning status of the root hash with the given reference
       tags:
-        - Root hash pinning
+        - Pinning
       responses:
         "200":
           description: Reference of the pinned root hash
@@ -552,7 +550,7 @@ paths:
     get:
       summary: Get the list of pinned root hash references
       tags:
-        - Root hash pinning
+        - Pinning
       responses:
         "200":
           description: List of pinned root hash references
@@ -812,7 +810,8 @@ paths:
 
   "/stamps/{amount}/{depth}":
     post:
-      summary: Buy a new postage batch. Be aware, this endpoint create an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance!
+      summary: Buy a new postage batch.
+      description: Be aware, this endpoint creates an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance!
       deprecated: true
       tags:
         - Postage Stamps

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -555,10 +555,9 @@ components:
         type: boolean
       required: false
       description: >
-      Represents if the uploaded data should be also locally pinned on the node.
+        Represents if the uploaded data should be also locally pinned on the node.
 
-      Warning! Not available for nodes that run in Gateway mode!
-
+        Warning! Not available for nodes that run in Gateway mode!
 
     SwarmEncryptParameter:
       in: header
@@ -567,10 +566,9 @@ components:
         type: boolean
       required: false
       description: >
-      Represents the encrypting state of the file
+        Represents the encrypting state of the file
 
-      Warning! Not available for nodes that run in Gateway mode!
-
+        Warning! Not available for nodes that run in Gateway mode!
 
     ContentTypePreserved:
       in: header

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.6.0
+  version: 1.0.0
   title: Common Data Types
   description: |
     \*****bzzz*****
@@ -609,7 +609,7 @@ components:
       description: "ID of Postage Batch that is used to upload data with"
       required: true
       schema:
-        $ref: "SwarmCommon.yaml#/components/schemas/SwarmAddress"
+        $ref: "#/components/schemas/SwarmAddress"
 
   responses:
     "204":

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -554,7 +554,10 @@ components:
       schema:
         type: boolean
       required: false
-      description: Represents the pinning state of the chunk
+      description: >
+      Represents if the uploaded data should be also locally pinned on the node.
+
+      Warning! Not available for nodes that run in Gateway mode!
 
     SwarmEncryptParameter:
       in: header
@@ -562,7 +565,10 @@ components:
       schema:
         type: boolean
       required: false
-      description: Represents the encrypting state of the file
+      description: >
+      Represents the encrypting state of the file
+
+      Warning! Not available for nodes that run in Gateway mode!
 
     ContentTypePreserved:
       in: header
@@ -626,12 +632,6 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-    "403":
-      description: Forbidden
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
     "404":
       description: Not Found
       content:
@@ -640,6 +640,13 @@ components:
             $ref: "#/components/schemas/ProblemDetails"
     "500":
       description: Internal Server Error
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+
+    "GatewayForbidden":
+      description: Endpoint or specific header (pinning or encryption headers) forbidden in Gateway mode
       content:
         application/problem+json:
           schema:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -559,6 +559,7 @@ components:
 
       Warning! Not available for nodes that run in Gateway mode!
 
+
     SwarmEncryptParameter:
       in: header
       name: swarm-encrypt
@@ -569,6 +570,7 @@ components:
       Represents the encrypting state of the file
 
       Warning! Not available for nodes that run in Gateway mode!
+
 
     ContentTypePreserved:
       in: header
@@ -646,7 +648,7 @@ components:
             $ref: "#/components/schemas/ProblemDetails"
 
     "GatewayForbidden":
-      description: Endpoint or specific header (pinning or encryption headers) forbidden in Gateway mode
+      description: "Endpoint or specific header (pinning or encryption headers) forbidden in Gateway mode"
       content:
         application/problem+json:
           schema:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -646,7 +646,7 @@ components:
             $ref: "#/components/schemas/ProblemDetails"
 
     "GatewayForbidden":
-      description: "Endpoint or specific header (pinning or encryption headers) forbidden in Gateway mode"
+      description: "Endpoint or header (pinning or encryption headers) forbidden in Gateway mode"
       content:
         application/problem+json:
           schema:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -830,7 +830,6 @@ paths:
           schema:
             type: boolean
           required: false
-          description:
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
       responses:
         "201":

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -9,7 +9,7 @@ security:
 
 externalDocs:
   description: Browse the documentation @ the Swarm Docs
-  url: "https://docs.swarm.eth"
+  url: "https://docs.ethswarm.org"
 
 servers:
   - url: "http://{apiRoot}:{port}"

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.6.0
+  version: 1.0.0
   title: Bee Debug API
   description: "A list of the currently provided debug interfaces to interact with the bee node"
 
@@ -663,8 +663,6 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/NewTagDebugResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
-        "403":
-          $ref: "SwarmCommon.yaml#/components/responses/403"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -804,7 +802,8 @@ paths:
 
   "/stamps/{amount}/{depth}":
     post:
-      summary: Buy a new postage batch. Be aware, this endpoint create an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance!
+      summary: Buy a new postage batch.
+      description: Be aware, this endpoint creates an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance!
       tags:
         - Postage Stamps
       parameters:
@@ -826,6 +825,12 @@ paths:
             type: string
           required: false
           description: An optional label for this batch
+        - in: header
+          name: immutable
+          schema:
+            type: boolean
+          required: false
+          description:
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
       responses:
         "201":


### PR DESCRIPTION
As part of working on documentation for `bee-js` I was investigating the exact sets of endpoints which are/are not available in Gateway mode. I have updated your docs with my findings and also included few tweaks and improvements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2325)
<!-- Reviewable:end -->
