### PR TITLE
fix(pushsync, retrieval): avoid deadlocks on context done

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -381,7 +381,10 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, retryAllo
 					ps.skipList.Add(peer, ch.Address(), skipPeerExpiration)
 				}
 
-				resultC <- &pushResult{err: err, attempted: attempted}
+				select {
+				case resultC <- &pushResult{err: err, attempted: attempted}:
+				case <-ctx.Done():
+				}
 				return
 			}
 			select {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -154,16 +154,22 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 					defer cancel()
 
 					chunk, peer, requested, err := s.retrieveChunk(ctx, addr, sp, origin)
-					resultC <- retrievalResult{
+					select {
+					case resultC <- retrievalResult{
 						chunk:     chunk,
 						peer:      peer,
 						err:       err,
 						retrieved: requested,
+					}:
+					case <-ctx.Done():
 					}
 
 				}()
 			} else {
-				resultC <- retrievalResult{}
+				select {
+				case resultC <- retrievalResult{}:
+				case <-ctx.Done():
+				}
 			}
 
 			select {


### PR DESCRIPTION
This PR addresses a deadlock issue discovered with @acud and @aloknerurkar on production cluster.

It handles the context cancelation in the minimal way to solve blocking on pushToClosest:

```
goroutine profile: total 31463
16690 @ 0x43a885 0x405aea 0x405895 0xe06266 0x470b81
#    0xe06265    github.com/ethersphere/bee/pkg/pushsync.(*PushSync).pushToClosest.func2+0x265    github.com/ethersphere/bee/pkg/pushsync/pushsync.go:345

2992 @ 0x43a885 0x44a9ef 0x11f0025 0x470b81
#    0x11f0024    github.com/ethersphere/bee/pkg/pullsync.(*Syncer).handler.func2+0x104    github.com/ethersphere/bee/pkg/pullsync/pullsync.go:283

...
```

Additionally, the similar fix is done in the retrieval protocol preemptive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2327)
<!-- Reviewable:end -->
