### PR TITLE
fix: restore initial balance check

### DIFF
--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -131,11 +131,9 @@ func Init(
 		}
 		if err == storage.ErrNotFound {
 			logger.Info("no chequebook found, deploying new one.")
-			if swapInitialDeposit.Cmp(big.NewInt(0)) != 0 {
-				err = checkBalance(ctx, logger, swapInitialDeposit, swapBackend, chainId, overlayEthAddress, erc20Service)
-				if err != nil {
-					return nil, err
-				}
+			err = checkBalance(ctx, logger, swapInitialDeposit, swapBackend, chainId, overlayEthAddress, erc20Service)
+			if err != nil {
+				return nil, err
 			}
 
 			nonce := make([]byte, 32)


### PR DESCRIPTION
always run `checkBalance` so we don't send txs if we don't have any eth. not sure why this was removed in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2337)
<!-- Reviewable:end -->
