### PR TITLE
fix: correct blocktime for xdai

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -445,7 +445,7 @@ type networkConfig struct {
 
 func getConfigByNetworkID(networkID uint64, defaultBlockTime uint64) *networkConfig {
 	var config = networkConfig{
-		blockTime: uint64(time.Duration(defaultBlockTime) * time.Second),
+		blockTime: defaultBlockTime,
 	}
 	switch networkID {
 	case 1:

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -450,7 +450,7 @@ func getConfigByNetworkID(networkID uint64, defaultBlockTime uint64) *networkCon
 	switch networkID {
 	case 1:
 		config.bootNodes = []string{"/dnsaddr/mainnet.ethswarm.org"}
-		config.blockTime = uint64(5 * time.Second)
+		config.blockTime = 5
 		config.chainID = 100
 	case 5: //staging
 		config.chainID = 5


### PR DESCRIPTION
blocktime should just be an integer. the `*time.Second` here actually converted it to nanoseconds leading to a blocktime of a million hours later.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2340)
<!-- Reviewable:end -->
