### PR TITLE
fix(retrieval): flaky retrieval test

### DIFF
--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -513,10 +513,18 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 		if !bytes.Equal(got.Data(), chunk.Data()) {
 			t.Fatalf("got data %x, want %x", got.Data(), chunk.Data())
 		}
-
-		if got, _ := serverStorer1.Has(context.Background(), chunk.Address()); !got {
+		has := false
+		for i := 0; i < 10; i++ {
+			has, _ = serverStorer1.Has(context.Background(), chunk.Address())
+			if has {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if !has {
 			t.Fatalf("forwarder node does not have chunk")
 		}
+
 	})
 }
 


### PR DESCRIPTION
Add retries to checking whether a forwarding node has the chunk or not. This is caused by a possible data race which allows for the retrieve request answer to come back to the origin, while the forwarder does the caching after answering the request. This is in order not to burden the request propagation time with latencies caused by local storage on the forwarder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2345)
<!-- Reviewable:end -->
