### PR TITLE
feat: announce to lightnodes

### DIFF
--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -50,7 +50,8 @@ type PickyNotifier interface {
 type Notifier interface {
 	Connected(context.Context, Peer, bool) error
 	Disconnected(Peer)
-	Announce(context.Context, swarm.Address, bool) error
+	Announce(ctx context.Context, peer swarm.Address, fullnode bool) error
+	AnnounceTo(ctx context.Context, addressee, peer swarm.Address, fullnode bool) error
 }
 
 // DebugService extends the Service with method used for debugging.

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -50,9 +50,10 @@ var (
 )
 
 var (
-	errOverlayMismatch = errors.New("overlay mismatch")
-	errPruneEntry      = errors.New("prune entry")
-	errEmptyBin        = errors.New("empty bin")
+	errOverlayMismatch   = errors.New("overlay mismatch")
+	errPruneEntry        = errors.New("prune entry")
+	errEmptyBin          = errors.New("empty bin")
+	errAnnounceLightNode = errors.New("announcing light node")
 )
 
 type (
@@ -840,6 +841,15 @@ func (k *Kad) Announce(ctx context.Context, peer swarm.Address, fullnode bool) e
 	}
 
 	return err
+}
+
+// AnnounceTo announces a selected peer to another.
+func (k *Kad) AnnounceTo(ctx context.Context, addressee, peer swarm.Address, fullnode bool) error {
+	if !fullnode {
+		return errAnnounceLightNode
+	}
+
+	return k.discovery.BroadcastPeers(ctx, addressee, peer)
 }
 
 // AddPeers adds peers to the knownPeers list.

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -671,6 +671,32 @@ func TestDiscoveryHooks(t *testing.T) {
 	waitBcast(t, disc, p3, p1, p2)
 }
 
+func TestAnnounceTo(t *testing.T) {
+	var (
+		conns                    int32
+		_, kad, ab, disc, signer = newTestKademlia(t, &conns, nil, kademlia.Options{})
+		p1, p2                   = test.RandomAddress(), test.RandomAddress()
+	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer kad.Close()
+
+	// first add a peer from AddPeers, wait for the connection
+	addOne(t, signer, kad, ab, p1)
+	waitConn(t, &conns)
+
+	if err := kad.AnnounceTo(context.Background(), p1, p2, true); err != nil {
+		t.Fatal(err)
+	}
+	waitBcast(t, disc, p1, p2)
+
+	if err := kad.AnnounceTo(context.Background(), p1, p2, false); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestBackoff(t *testing.T) {
 	// cheat and decrease the timer
 	defer func(t time.Duration) {

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -152,6 +152,10 @@ func (m *Mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
 	return nil
 }
 
+func (m *Mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+	return nil
+}
+
 func (m *Mock) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
 	channel := make(chan struct{}, 1)
 	var closeOnce sync.Once

--- a/pkg/topology/lightnode/container.go
+++ b/pkg/topology/lightnode/container.go
@@ -96,6 +96,10 @@ PICKPEER:
 	return addr, nil
 }
 
+func (c *Container) EachPeer(pf topology.EachPeerFunc) error {
+	return c.connectedPeers.EachBin(pf)
+}
+
 func (c *Container) PeerInfo() topology.BinInfo {
 	return topology.BinInfo{
 		BinPopulation:     uint(c.connectedPeers.Length()),

--- a/pkg/topology/lightnode/container_test.go
+++ b/pkg/topology/lightnode/container_test.go
@@ -6,6 +6,7 @@ package lightnode_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -61,6 +62,18 @@ func TestContainer(t *testing.T) {
 		}
 		if !p.Equal(p1) {
 			t.Fatalf("expected p2 but got %s", p.String())
+		}
+
+		i := 0
+		peers := []swarm.Address{p2, p1}
+		if err = c.EachPeer(func(p swarm.Address, _ uint8) (bool, bool, error) {
+			if !p.Equal(peers[i]) {
+				return false, false, errors.New("peer not in order")
+			}
+			i++
+			return false, false, nil
+		}); err != nil {
+			t.Fatal(err)
 		}
 	})
 	t.Run("empty container after peer disconnect", func(t *testing.T) {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -103,6 +103,10 @@ func (d *mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
 	return nil
 }
 
+func (d *mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+	return nil
+}
+
 func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }


### PR DESCRIPTION
Right now we announce nodes to light nodes only when they connect. This does not allow them to know about new nodes as they join the network. This also causes the integration tests to fail, as light nodes may connect early to the bootnode, never knowing anything about any other node in the network, leaving them only with a connection to the bootnode, which results in the tests to flake much more, since they overdraft with the bootnode very quickly, which then eventually results in errors in retrieval.

This PR rectifies this by notifying light nodes about new full nodes as they join the network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2351)
<!-- Reviewable:end -->
