### PR TITLE
chore: adjust flipflop worst case time

### DIFF
--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -54,7 +54,7 @@ var (
 	// values needed to adjust subscription trigger
 	// buffer time.
 	flipFlopBufferDuration    = 150 * time.Millisecond
-	flipFlopWorstCaseDuration = 20 * time.Second
+	flipFlopWorstCaseDuration = 10 * time.Second
 )
 
 // DB is the local store implementation and holds


### PR DESCRIPTION
This adjusts the worst case timing for the flipflop subscription debouncer, as it helps with the performance of our integration tests (chunks get pushed faster).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2352)
<!-- Reviewable:end -->
