### PR TITLE
fix: use our own timestamp in too soon check

### DIFF
--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -262,7 +262,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 	}
 
 	currentTime := s.timeNow().Unix()
-	if currentTime == lastTime.Timestamp {
+	if currentTime == lastTime.CheckTimestamp {
 		return nil, 0, ErrSettlementTooSoon
 	}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2358)
<!-- Reviewable:end -->
