### PR TITLE
chore(openapi): add missing HTTP responses

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -666,6 +666,12 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
+    "429":
+      description: Too many requests
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
     "500":
       description: Internal Server Error
       content:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -538,6 +538,8 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/TransactionResponse"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
+        "429":
+          $ref: "SwarmCommon.yaml#/components/responses/429"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -864,6 +866,8 @@ paths:
                 $ref: "SwarmCommon.yaml#/components/schemas/BatchIDResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
+        "429":
+          $ref: "SwarmCommon.yaml#/components/responses/429"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:


### PR DESCRIPTION
Adds missing HTTP responses to the POST `/stamps/{amount}/{depth}`
and POST `/chequebook/cashout/{peer}` endpoints

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2387)
<!-- Reviewable:end -->
