### PR TITLE
feat: only check once per transaction

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	maxDelay          = 1 * time.Minute
-	cancellationDepth = 6
+	cancellationDepth = 12
 )
 
 // InitChain will initialize the Ethereum backend at the given endpoint and


### PR DESCRIPTION
don't do multiple receipt lookups for the same tx. that way we cannot get inconsistent results.
also increase cancellation depth as there might be lagging nodes behind some balancers.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2393)
<!-- Reviewable:end -->
