### PR TITLE
chore: improve issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Use this template to create a new bug report
 title: General problem description
-labels: 'bug'
+labels: 'needs-triaging'
 assignees: ''
 ---
 
@@ -20,6 +20,9 @@ account of what happened and disclose any possible piece of information related 
 <!-- How did you expect the application to behave -->
 
 #### Actual behavior
-<!-- How did the application behave -->
-
-<!-- Extras: If the problem involves a specific file, providing that file would be helpful; screenshots are welcome too -->
+<!-- How did the application behave? -->
+<!-- Please help us help you:
+- if the problem involves a specific file/dir, providing it might be helpful
+- if the issue is related to an API behavior - please provide the exact command (curl/postman etc) used to call the API. 
+- please try to always provide the node console output preferably in TRACE level
+- screenshots are welcome -->


### PR DESCRIPTION
Changing the default label from `bug` to `needs-triaging` since not every new issue is a bug and issue reports that lack proper description should be closed and not accounted for. This will hopefully lower the psychological barrier of closing sloppily described issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2404)
<!-- Reviewable:end -->
