### PR TITLE
chore(deps): update linter version to make linting work on macs with M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 GOLANGCI_LINT ?= $$($(GO) env GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.30.0
+GOLANGCI_LINT_VERSION ?= v1.37.0
 GOGOPROTOBUF ?= protoc-gen-gogofaster
 GOGOPROTOBUF_VERSION ?= v1.3.1
 BEEKEEPER_INSTALL_DIR ?= $$($(GO) env GOPATH)/bin


### PR DESCRIPTION
Updated to the earliest version that supports M1 chip. This should not change any linter rules. See the corresponding issue https://github.com/golangci/golangci-lint/issues/1725

Feel free to reject this if you have different workflow to update dependencies.

NOTE: tests still don't work as these would require beekeeper to be compiled to M1 chip

before:
`make lint`
```sh
test -f $(go env GOPATH)/bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
golangci/golangci-lint info checking GitHub for tag 'v1.30.0'
golangci/golangci-lint info found version: 1.30.0 for v1.30.0/darwin/arm64
make: *** [linter] Error 1
```

after:
`make lint`
```sh
test -f $(go env GOPATH)/bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0
$(go env GOPATH)/bin/golangci-lint run
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2407)
<!-- Reviewable:end -->
