### PR TITLE
feat: allow transaction from another sender for identity tx

### DIFF
--- a/pkg/transaction/sender_matcher.go
+++ b/pkg/transaction/sender_matcher.go
@@ -154,9 +154,9 @@ func (m *Matcher) Matches(ctx context.Context, tx []byte, networkID uint64, send
 		return nil, fmt.Errorf("receipt hash %x does not match block's parent hash %x: %w", receiptBlockHash, nextBlockParentHash, ErrBlockHashMismatch)
 	}
 
-	expectedRemoteBzzAddressTypeSigner := crypto.NewOverlayFromEthereumAddress(attestedOverlay.Bytes(), networkID, nextBlockHash)
+	expectedRemoteBzzAddress := crypto.NewOverlayFromEthereumAddress(attestedOverlay.Bytes(), networkID, nextBlockHash)
 
-	if !expectedRemoteBzzAddressTypeSigner.Equal(senderOverlay) {
+	if !expectedRemoteBzzAddress.Equal(senderOverlay) {
 		err2 := m.storage.Put(peerOverlayKey(senderOverlay, incomingTx), &overlayVerification{
 			TimeStamp: m.timeNow(),
 			Verified:  false,

--- a/pkg/transaction/sender_matcher_test.go
+++ b/pkg/transaction/sender_matcher_test.go
@@ -109,7 +109,7 @@ func TestMatchesSender(t *testing.T) {
 		}
 	})
 
-	t.Run("sender matches", func(t *testing.T) {
+	t.Run("sender matches signer type", func(t *testing.T) {
 
 		trxBlock := common.HexToHash("0x2")
 		nextBlockHeader := &types.Header{
@@ -145,7 +145,7 @@ func TestMatchesSender(t *testing.T) {
 		}
 	})
 
-	t.Run("sender matches type2", func(t *testing.T) {
+	t.Run("sender matches data type", func(t *testing.T) {
 		trxBlock := common.HexToHash("0x2")
 		nextBlockHeader := &types.Header{
 			ParentHash: trxBlock,
@@ -153,7 +153,7 @@ func TestMatchesSender(t *testing.T) {
 
 		overlayEth := common.HexToAddress("0xff")
 
-		signedTx := types.NewTransaction(nonce, recipient, value, estimatedGasLimit, suggestedGasPrice, overlayEth.Bytes())
+		signedTx := types.NewTransaction(nonce, recipient, value, estimatedGasLimit, suggestedGasPrice, overlayEth.Hash().Bytes())
 
 		trxReceipt := backendmock.WithTransactionReceiptFunc(func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 			return &types.Receipt{
@@ -181,6 +181,13 @@ func TestMatchesSender(t *testing.T) {
 		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay)
 		if err != nil {
 			t.Fatalf("expected match. got %v", err)
+		}
+
+		senderOverlay = crypto.NewOverlayFromEthereumAddress(signer.addr.Bytes(), 0, nextBlockHeader.Hash().Bytes())
+
+		_, err = matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		if err == nil {
+			t.Fatalf("matched signer for data tx")
 		}
 	})
 


### PR DESCRIPTION
allow transactions whose transaction data matches the overlay eth address exactly (a 32-byte data), regardless of sender. the first 4 bytes are required to be 0 to distinguish it from a 32-byte data transaction from the overlay. That way every tx can only be valid for one overlay.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2409)
<!-- Reviewable:end -->
