### PR TITLE
feat: flush metrics in separate goroutine

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -532,6 +532,8 @@ func (k *Kad) manage() {
 		select {
 		case <-k.quit:
 			return
+		case <-time.After(15 * time.Second):
+			k.notifyManageLoop()
 		case <-k.manageC:
 			start := time.Now()
 


### PR DESCRIPTION
Fixes #2423 

This PR moves the kademlia metrics flushing out of the main ManageC loop and into a dedicated goroutine.  This solves the issue of the 15 second timer never (or rarely) actually firing and the metrics never actually flushing until the node is terminated.  The new goroutine is added to the wait group and marks itself done when it exits so that the kademlia shutdown logic remains consistent.

I also changed the timer to 5 minutes since the metrics do actually get flushed now without competing with the connector.  The shutdown logic in Close still Finalizes the metrics collector which will ensure that the most recent updates are still persisted.

You will also notice a new Tracef log showing that the flush happened and how long it took to execute. This is similar to the existing log in the connector loop that shows activity along with the new depth.  At least with this log, we can be sure that the metrics are flushing periodically.

I did consider if this is "safe" to write the metrics from an independent goroutine for locking and consistency purposes, and given the "dirty" CAS counter on the individual metrics, I'm certain that metrics consistency will be eventually attained even if a given peer metric changes while being persisted.  This seems to be the only reason for the dirty counter on the metrics anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2424)
<!-- Reviewable:end -->
