### PR TITLE
fix: allow dirty metrics shutdown

### DIFF
--- a/pkg/topology/kademlia/internal/metrics/metrics_test.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics_test.go
@@ -5,6 +5,7 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func TestPeerMetricsCollector(t *testing.T) {
 
 	// Finalize.
 	mc.Record(addr, metrics.PeerLogIn(t1, metrics.PeerConnectionDirectionInbound))
-	if err := mc.Finalize(t3); err != nil {
+	if err := mc.Finalize(context.Background(), t3); err != nil {
 		t.Fatalf("Finalize(%s): unexpected error: %v", t3, err)
 	}
 	if have, want := len(mc.Snapshot(t2, addr)), 0; have != want {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1321,9 +1321,11 @@ func (k *Kad) Close() error {
 	case <-time.After(5 * time.Second):
 		k.logger.Warning("kademlia manage loop did not shut down properly")
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
 	k.logger.Info("kademlia persisting peer metrics")
-	if err := k.collector.Finalize(time.Now()); err != nil {
+	if err := k.collector.Finalize(ctx, time.Now()); err != nil {
 		k.logger.Debugf("kademlia: unable to finalize open sessions: %v", err)
 	}
 


### PR DESCRIPTION
this PR introduces an expiring context to the metrics finalizer in kademlia. as noted by @ldeffenb the shutdown takes too long and we should not wait indefinitely there. this is a stopgap solution until we come up with a better persistence solution that doesn't burden the shed abstraction with too much IO with regards to these metrics. We also need metrics pruning, since this can just burden other components with statestore size at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2428)
<!-- Reviewable:end -->
