### PR TITLE
fix: removed kademlia and libp2p discrepancy kludge

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1055,6 +1055,7 @@ func (k *Kad) ClosestPeer(addr swarm.Address, includeSelf bool, skipPeers ...swa
 
 		// kludge: hotfix for topology peer inconsistencies bug
 		if !isIn(peer, peers) {
+			k.metrics.P2PKademliaDiscrepancy.Inc()
 			a := swarm.NewAddress(peer.Bytes())
 			peersToDisconnect = append(peersToDisconnect, a)
 			return false, false, nil

--- a/pkg/topology/kademlia/metrics.go
+++ b/pkg/topology/kademlia/metrics.go
@@ -27,7 +27,6 @@ type metrics struct {
 	TotalOutboundConnectionFailedAttempts prometheus.Counter
 	TotalBootNodesConnectionAttempts      prometheus.Counter
 	StartAddAddressBookOverlaysTime       prometheus.Histogram
-	P2PKademliaDiscrepancy                prometheus.Counter
 }
 
 // newMetrics is a convenient constructor for creating new metrics.
@@ -130,12 +129,6 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "start_add_addressbook_overlays_time",
 			Help:      "The time spent adding overlays peers from addressbook on kademlia start.",
-		}),
-		P2PKademliaDiscrepancy: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "p2p_kademlia_discrepancy",
-			Help:      "Discrepancy counter between lists of peers in kademlia and libp2p",
 		}),
 	}
 }

--- a/pkg/topology/kademlia/metrics.go
+++ b/pkg/topology/kademlia/metrics.go
@@ -27,6 +27,7 @@ type metrics struct {
 	TotalOutboundConnectionFailedAttempts prometheus.Counter
 	TotalBootNodesConnectionAttempts      prometheus.Counter
 	StartAddAddressBookOverlaysTime       prometheus.Histogram
+	P2PKademliaDiscrepancy                prometheus.Counter
 }
 
 // newMetrics is a convenient constructor for creating new metrics.
@@ -129,6 +130,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "start_add_addressbook_overlays_time",
 			Help:      "The time spent adding overlays peers from addressbook on kademlia start.",
+		}),
+		P2PKademliaDiscrepancy: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "p2p_kademlia_discrepancy",
+			Help:      "Discrepancy counter between lists of peers in kademlia and libp2p",
 		}),
 	}
 }


### PR DESCRIPTION
After running a bee node in main-net for two days with the discrepancy metric, it was discovered that the issue has been fixed and the kludge can be removed.

PR includes deepsource fixes:
`kad.connected` renamed to `kad.onConnected`
`pslice.exists` renamed to `pslice.index`
`Announce`, `Connected`, `AnnounceTo` split into two new functions to avoid control coupling or simplified

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2429)
<!-- Reviewable:end -->
