### PR TITLE
feat: balancer connector skips unpopulated, out of depth bins

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -252,7 +252,7 @@ func (k *Kad) connectBalanced(wg *sync.WaitGroup, peerConnChan chan<- *peerConnI
 
 	for i := range k.commonBinPrefixes {
 
-		binPeersLength := k.knownPeers.BinPeersLength(uint8(i))
+		binPeersLength := k.knownPeers.BinSize(uint8(i))
 
 		// balancer should skip on bins where neighborhood connector would connect to peers anyway
 		// and there are not enough peers in known addresses to properly balance the bin

--- a/pkg/topology/pslice/pslice.go
+++ b/pkg/topology/pslice/pslice.go
@@ -96,6 +96,26 @@ func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 	return nil
 }
 
+func (s *PSlice) BinPeersLength(bin uint8) int {
+
+	s.RLock()
+	defer s.RUnlock()
+
+	b := int(bin)
+	if b >= len(s.bins) {
+		return 0
+	}
+
+	var bEnd int
+	if b == len(s.bins)-1 {
+		bEnd = len(s.peers)
+	} else {
+		bEnd = int(s.bins[b+1])
+	}
+
+	return bEnd - int(s.bins[b])
+}
+
 func (s *PSlice) BinPeers(bin uint8) []swarm.Address {
 	s.RLock()
 	defer s.RUnlock()

--- a/pkg/topology/pslice/pslice.go
+++ b/pkg/topology/pslice/pslice.go
@@ -96,7 +96,7 @@ func (s *PSlice) EachBinRev(pf topology.EachPeerFunc) error {
 	return nil
 }
 
-func (s *PSlice) BinPeersLength(bin uint8) int {
+func (s *PSlice) BinSize(bin uint8) int {
 
 	s.RLock()
 	defer s.RUnlock()

--- a/pkg/topology/pslice/pslice_test.go
+++ b/pkg/topology/pslice/pslice_test.go
@@ -284,6 +284,9 @@ func TestBinPeers(t *testing.T) {
 				if !isEqual(binPeers[bin], ps.BinPeers(uint8(bin))) {
 					t.Fatal("peers list do not match")
 				}
+				if len(binPeers[bin]) != ps.BinPeersLength(uint8(bin)) {
+					t.Fatal("peers list lengths do not match")
+				}
 			}
 
 			// out of bound bin check

--- a/pkg/topology/pslice/pslice_test.go
+++ b/pkg/topology/pslice/pslice_test.go
@@ -284,7 +284,7 @@ func TestBinPeers(t *testing.T) {
 				if !isEqual(binPeers[bin], ps.BinPeers(uint8(bin))) {
 					t.Fatal("peers list do not match")
 				}
-				if len(binPeers[bin]) != ps.BinPeersLength(uint8(bin)) {
+				if len(binPeers[bin]) != ps.BinSize(uint8(bin)) {
 					t.Fatal("peers list lengths do not match")
 				}
 			}


### PR DESCRIPTION
PR intends to limit the balanced connector's domain of work to bins that could be balanced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2430)
<!-- Reviewable:end -->
