### PR TITLE
docs: correct types for transaction listing and tweaks

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -475,16 +475,16 @@ components:
 
     TransactionHash:
       type: string
-      pattern: "^[A-Fa-f0-9]{64}$"
-      example: "e28a34ffe7b1710c1baf97ca6d71d81b7f159a9920910876856c8d94dd7be4ae"
+      pattern: "^0x[A-Fa-f0-9]{64}$"
+      example: "0x780cb6a37d1946978087896e1e489c37e30fe3e329510fff8d97360f73529f5a"
 
     TransactionResponse:
       type: object
       properties:
         transactionHash:
           $ref: "#/components/schemas/TransactionHash"
-    
-    TransactionInfoResponse:
+
+    TransactionInfo:
       type: object
       properties:
         transactionHash:
@@ -506,14 +506,14 @@ components:
         value:
           $ref: "#/components/schemas/BigInt"
 
-    PendingTransactionReponse:
+    PendingTransactionsResponse:
       type: object
       properties:
         pendingTransactions:
           type: array
           nullable: true
           items:
-            $ref: "#/components/schemas/TransactionHash"
+            $ref: "#/components/schemas/TransactionInfo"
 
     Uid:
       type: integer

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -680,7 +680,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "SwarmCommon.yaml#/components/schemas/PendingTransactionReponse"
+                $ref: "SwarmCommon.yaml#/components/schemas/PendingTransactionsResponse"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -704,7 +704,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "SwarmCommon.yaml#/components/schemas/TransactionInfoResponse"
+                $ref: "SwarmCommon.yaml#/components/schemas/TransactionInfo"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":


### PR DESCRIPTION
This PR fixes few things in the OpenAPI regarding the pending transactions API:

 - TransactionHash is to my knowledge prefixed with `0x` as all the Ethereum hashes should be...
 - The `/transactions` endpoint actually provides all the `TransactionInfo` and not only `TransactionHashes`
 - Fixing some typos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2439)
<!-- Reviewable:end -->
