### PR TITLE
refactor(loadsave): simplify interface

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
+	"github.com/ethersphere/bee/pkg/file/pipeline"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/logging"
 	m "github.com/ethersphere/bee/pkg/metrics"
@@ -371,6 +372,13 @@ func requestPipelineFn(s storage.Putter, r *http.Request) pipelineFunc {
 	return func(ctx context.Context, r io.Reader) (swarm.Address, error) {
 		pipe := builder.NewPipelineBuilder(ctx, s, mode, encrypt)
 		return builder.FeedPipeline(ctx, pipe, r)
+	}
+}
+
+func requestPipelineFactory(ctx context.Context, s storage.Putter, r *http.Request) func() pipeline.Interface {
+	mode, encrypt := requestModePut(r), requestEncrypt(r)
+	return func() pipeline.Interface {
+		return builder.NewPipelineBuilder(ctx, s, mode, encrypt)
 	}
 }
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -6,6 +6,7 @@ package api_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -21,6 +22,8 @@ import (
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
+	"github.com/ethersphere/bee/pkg/file/pipeline"
+	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/pinning"
@@ -146,6 +149,12 @@ func request(t *testing.T, client *http.Client, method, resource string, body io
 		t.Fatalf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
 	}
 	return resp
+}
+
+func pipelineFactory(s storage.Putter, mode storage.ModePut, encrypt bool) func() pipeline.Interface {
+	return func() pipeline.Interface {
+		return builder.NewPipelineBuilder(context.Background(), s, mode, encrypt)
+	}
 }
 
 func TestParseName(t *testing.T) {

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -142,7 +142,8 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request, store
 	}
 
 	encrypt := requestEncrypt(r)
-	l := loadsave.New(storer, requestModePut(r), encrypt)
+	factory := requestPipelineFactory(ctx, storer, r)
+	l := loadsave.New(storer, factory)
 
 	m, err := manifest.NewDefaultManifest(l, encrypt)
 	if err != nil {
@@ -238,7 +239,7 @@ func (s *server) fileUploadHandler(w http.ResponseWriter, r *http.Request, store
 
 func (s *server) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
-	ls := loadsave.New(s.storer, storage.ModePutRequest, false)
+	ls := loadsave.NewReadonly(s.storer)
 	feedDereferenced := false
 
 	targets := r.URL.Query().Get("targets")

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -576,7 +576,7 @@ func TestFeedIndirection(t *testing.T) {
 		t.Fatal(err)
 	}
 	m, err := manifest.NewDefaultManifest(
-		loadsave.New(storer, storage.ModePutUpload, false),
+		loadsave.New(storer, pipelineFactory(storer, storage.ModePutUpload, false)),
 		false,
 	)
 	if err != nil {

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -78,7 +78,7 @@ func (s *server) dirUploadHandler(w http.ResponseWriter, r *http.Request, storer
 		dReader,
 		s.logger,
 		requestPipelineFn(storer, r),
-		loadsave.New(storer, requestModePut(r), requestEncrypt(r)),
+		loadsave.New(storer, requestPipelineFactory(ctx, storer, r)),
 		r.Header.Get(SwarmIndexDocumentHeader),
 		r.Header.Get(SwarmErrorDocumentHeader),
 		tag,

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethersphere/bee/pkg/manifest"
 	mockpost "github.com/ethersphere/bee/pkg/postage/mock"
 	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -288,7 +287,7 @@ func TestDirs(t *testing.T) {
 			// verify manifest content
 			verifyManifest, err := manifest.NewDefaultManifestReference(
 				resp.Reference,
-				loadsave.New(storer, storage.ModePutRequest, false),
+				loadsave.NewReadonly(storer),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -164,7 +164,7 @@ func (s *server) feedPostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	l := loadsave.New(putter, requestModePut(r), false)
+	l := loadsave.New(putter, requestPipelineFactory(r.Context(), putter, r))
 	feedManifest, err := manifest.NewDefaultManifest(l, false)
 	if err != nil {
 		s.logger.Debugf("feed put: new manifest: %v", err)

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -27,7 +27,6 @@ import (
 	mockpost "github.com/ethersphere/bee/pkg/postage/mock"
 	testingsoc "github.com/ethersphere/bee/pkg/soc/testing"
 	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storage/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
@@ -174,7 +173,7 @@ func TestFeed_Post(t *testing.T) {
 			}),
 		)
 
-		ls := loadsave.New(mockStorer, storage.ModePutUpload, false)
+		ls := loadsave.NewReadonly(mockStorer)
 		i, err := manifest.NewMantarayManifestReference(expReference, ls)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/file/loadsave/export_test.go
+++ b/pkg/file/loadsave/export_test.go
@@ -1,0 +1,7 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package loadsave
+
+var ReadonlyLoadSaveError = readonlyLoadsaveError

--- a/pkg/file/loadsave/loadsave.go
+++ b/pkg/file/loadsave/loadsave.go
@@ -1,15 +1,25 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package loadsave provides lightweight persistence abstraction
+// for manifest operations.
 package loadsave
 
 import (
 	"bytes"
 	"context"
+	"errors"
 
 	"github.com/ethersphere/bee/pkg/file"
 	"github.com/ethersphere/bee/pkg/file/joiner"
+	"github.com/ethersphere/bee/pkg/file/pipeline"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
+
+var readonlyLoadsaveError = errors.New("readonly manifest loadsaver")
 
 type PutGetter interface {
 	storage.Putter
@@ -21,16 +31,23 @@ type PutGetter interface {
 // package abstractions. use with caution since Loader will
 // load all of the subtrie of a given hash in memory.
 type loadSave struct {
-	storer    PutGetter
-	mode      storage.ModePut
-	encrypted bool
+	storer     PutGetter
+	pipelineFn func() pipeline.Interface
 }
 
-func New(storer PutGetter, mode storage.ModePut, enc bool) file.LoadSaver {
+// New returns a new read-write load-saver.
+func New(storer PutGetter, pipelineFn func() pipeline.Interface) file.LoadSaver {
 	return &loadSave{
-		storer:    storer,
-		mode:      mode,
-		encrypted: enc,
+		storer:     storer,
+		pipelineFn: pipelineFn,
+	}
+}
+
+// NewReadonly returns a new read-only load-saver
+// which will error on write.
+func NewReadonly(storer PutGetter) file.LoadSaver {
+	return &loadSave{
+		storer: storer,
 	}
 }
 
@@ -50,12 +67,15 @@ func (ls *loadSave) Load(ctx context.Context, ref []byte) ([]byte, error) {
 }
 
 func (ls *loadSave) Save(ctx context.Context, data []byte) ([]byte, error) {
-	pipe := builder.NewPipelineBuilder(ctx, ls.storer, ls.mode, ls.encrypted)
+	if ls.pipelineFn == nil {
+		return nil, readonlyLoadsaveError
+	}
+
+	pipe := ls.pipelineFn()
 	address, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data))
 	if err != nil {
 		return swarm.ZeroAddress.Bytes(), err
 	}
 
 	return address.Bytes(), nil
-
 }

--- a/pkg/file/loadsave/loadsave_test.go
+++ b/pkg/file/loadsave/loadsave_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package loadsave_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/file/loadsave"
+	"github.com/ethersphere/bee/pkg/file/pipeline"
+	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var (
+	data    = []byte{0, 1, 2, 3}
+	expHash = "4f7e85bb4282fd468a9ce4e6e50b6c4b8e6a34aa33332b604c83fb9b2e55978a"
+)
+
+func TestLoadSave(t *testing.T) {
+	store := mock.NewStorer()
+	ls := loadsave.New(store, pipelineFn(store))
+	ref, err := ls.Save(context.Background(), data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := hex.EncodeToString(ref); r != expHash {
+		t.Fatalf("expected hash %s got %s", expHash, r)
+	}
+	b, err := ls.Load(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, b) {
+		t.Fatal("wrong data in response")
+	}
+}
+
+func TestReadonlyLoadSave(t *testing.T) {
+	store := mock.NewStorer()
+	factory := pipelineFn(store)
+	ls := loadsave.NewReadonly(store)
+	_, err := ls.Save(context.Background(), data)
+	if !errors.Is(err, loadsave.ReadonlyLoadSaveError) {
+		t.Fatal("expected error but got none")
+	}
+
+	_, err = builder.FeedPipeline(context.Background(), factory(), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := ls.Load(context.Background(), swarm.MustParseHexAddress(expHash).Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, b) {
+		t.Fatal("wrong data in response")
+	}
+}
+
+func pipelineFn(s storage.Storer) func() pipeline.Interface {
+	return func() pipeline.Interface {
+		return builder.NewPipelineBuilder(context.Background(), s, storage.ModePutRequest, false)
+	}
+}

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -56,7 +56,7 @@ func (s *service) Traverse(ctx context.Context, addr swarm.Address, iterFn swarm
 		return nil
 	}
 
-	ls := loadsave.New(s.store, storage.ModePutRequest, false)
+	ls := loadsave.NewReadonly(s.store)
 	switch mf, err := manifest.NewDefaultManifestReference(addr, ls); {
 	case errors.Is(err, manifest.ErrInvalidManifestType):
 		break

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/pkg/file/loadsave"
+	"github.com/ethersphere/bee/pkg/file/pipeline"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/manifest"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -250,7 +251,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ls := loadsave.New(storerMock, storage.ModePutRequest, false)
+			ls := loadsave.New(storerMock, pipelineFactory(storerMock, storage.ModePutRequest, false))
 			fManifest, err := manifest.NewDefaultManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -404,7 +405,7 @@ func TestTraversalManifest(t *testing.T) {
 			}
 			wantHashes = append(wantHashes, tc.manifestHashes...)
 
-			ls := loadsave.New(storerMock, storage.ModePutRequest, false)
+			ls := loadsave.New(storerMock, pipelineFactory(storerMock, storage.ModePutRequest, false))
 			dirManifest, err := manifest.NewMantarayManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -454,5 +455,11 @@ func TestTraversalManifest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func pipelineFactory(s storage.Putter, mode storage.ModePut, encrypt bool) func() pipeline.Interface {
+	return func() pipeline.Interface {
+		return builder.NewPipelineBuilder(context.Background(), s, mode, encrypt)
 	}
 }


### PR DESCRIPTION
this PR simplifies the `loadsave` abstraction to remove state like encryption and mode. those are now injected through a pipeline factory. It also handles more explicitly the cases where a readonly loadsaver is needed, so that readonly operations on manifest can happen. this is now possible by requesting explicitly a read-only loadsaver.

also adds missing unit test coverage and documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2443)
<!-- Reviewable:end -->
