### PR TITLE
fix: unnecessary error message on close

### DIFF
--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -124,8 +124,10 @@ func (s *server) handleUploadStream(
 
 		mt, msg, err := conn.ReadMessage()
 		if err != nil {
-			s.logger.Debugf("chunk stream handler: read message error: %v", err)
-			s.logger.Error("chunk stream handler: read message error")
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				s.logger.Debugf("chunk stream handler: read message error: %v", err)
+				s.logger.Error("chunk stream handler: read message error")
+			}
 			return
 		}
 


### PR DESCRIPTION
Don't log an error message on `ReadMessage` if the client closed the connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2445)
<!-- Reviewable:end -->
