### PR TITLE
fix: deepsource

### DIFF
--- a/pkg/debugapi/peer.go
+++ b/pkg/debugapi/peer.go
@@ -35,7 +35,7 @@ func (s *Service) peerConnectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.topologyDriver.Connected(r.Context(), p2p.Peer{Address: bzzAddr.Overlay}, true); err != nil {
+	if err := s.topologyDriver.ConnectedForce(r.Context(), p2p.Peer{Address: bzzAddr.Overlay}); err != nil {
 		_ = s.p2p.Disconnect(bzzAddr.Overlay)
 		s.logger.Debugf("debug api: peer connect handler %s: %v", addr, err)
 		s.logger.Errorf("unable to connect to peer %s", addr)
@@ -81,13 +81,13 @@ type peersResponse struct {
 	Peers []Peer `json:"peers"`
 }
 
-func (s *Service) peersHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) peersHandler(w http.ResponseWriter, _ *http.Request) {
 	jsonhttp.OK(w, peersResponse{
 		Peers: mapPeers(s.p2p.Peers()),
 	})
 }
 
-func (s *Service) blocklistedPeersHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Service) blocklistedPeersHandler(w http.ResponseWriter, _ *http.Request) {
 	peers, err := s.p2p.BlocklistedPeers()
 	if err != nil {
 		s.logger.Debugf("debug api: blocklisted peers: %v", err)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -416,17 +416,14 @@ func (s *Service) handleIncoming(stream network.Stream) {
 			// when a full node connects, we gossip about it to the
 			// light nodes so that they can also have a chance at building
 			// a solid topology.
-
-			if i.FullNode {
-				_ = s.lightNodes.EachPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
-					go func(addressee, peer swarm.Address) {
-						if err := s.notifier.AnnounceTo(s.ctx, addressee, peer); err != nil {
-							s.logger.Debugf("stream handler: notifier.Announce to light node %s %s: %v", addressee.String(), peer.String(), err)
-						}
-					}(addr, peer.Address)
-					return false, false, nil
-				})
-			}
+			_ = s.lightNodes.EachPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+				go func(addressee, peer swarm.Address) {
+					if err := s.notifier.AnnounceTo(s.ctx, addressee, peer); err != nil {
+						s.logger.Debugf("stream handler: notifier.Announce to light node %s %s: %v", addressee.String(), peer.String(), err)
+					}
+				}(addr, peer.Address)
+				return false, false, nil
+			})
 		}
 	}
 

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -48,10 +48,12 @@ type PickyNotifier interface {
 }
 
 type Notifier interface {
-	Connected(context.Context, Peer, bool) error
+	Connected(context.Context, Peer) error
+	ConnectedForce(context.Context, Peer) error
 	Disconnected(Peer)
-	Announce(ctx context.Context, peer swarm.Address, fullnode bool) error
-	AnnounceTo(ctx context.Context, addressee, peer swarm.Address, fullnode bool) error
+	Announce(ctx context.Context, peer swarm.Address) error
+	AnnouncePeers(ctx context.Context, peer swarm.Address) error
+	AnnounceTo(ctx context.Context, addressee, peer swarm.Address) error
 }
 
 // DebugService extends the Service with method used for debugging.

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -61,23 +61,23 @@ func NewMockKademlia(o ...Option) *Mock {
 
 // AddPeers is called when a peers are added to the topology backlog
 // for further processing by connectivity strategy.
-func (m *Mock) AddPeers(addr ...swarm.Address) {
+func (*Mock) AddPeers(...swarm.Address) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) ClosestPeer(addr swarm.Address, _ bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (*Mock) ClosestPeer(swarm.Address, swarm.Address, ...swarm.Address) (peerAddr swarm.Address, err error) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) IsWithinDepth(adr swarm.Address) bool {
+func (*Mock) IsWithinDepth(swarm.Address) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) EachNeighbor(topology.EachPeerFunc) error {
+func (*Mock) EachNeighbor(topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) EachNeighborRev(topology.EachPeerFunc) error {
+func (*Mock) EachNeighborRev(topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -126,11 +126,16 @@ func (m *Mock) NeighborhoodDepth() uint8 {
 }
 
 // Connected is called when a peer dials in.
-func (m *Mock) Connected(_ context.Context, peer p2p.Peer, _ bool) error {
+func (m *Mock) Connected(_ context.Context, peer p2p.Peer) error {
 	m.mtx.Lock()
 	m.peers = append(m.peers, peer.Address)
 	m.mtx.Unlock()
 	m.Trigger()
+	return nil
+}
+
+// Connected is called when a peer dials in.
+func (*Mock) ConnectedForce(context.Context, p2p.Peer) error {
 	return nil
 }
 
@@ -148,11 +153,15 @@ func (m *Mock) Disconnected(peer p2p.Peer) {
 	m.Trigger()
 }
 
-func (m *Mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
+func (*Mock) Announce(_ context.Context, _ swarm.Address) error {
 	return nil
 }
 
-func (m *Mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+func (*Mock) AnnouncePeers(_ context.Context, _ swarm.Address) error {
+	return nil
+}
+
+func (*Mock) AnnounceTo(_ context.Context, _, _ swarm.Address) error {
 	return nil
 }
 
@@ -200,10 +209,10 @@ func (m *Mock) ResetPeers() {
 	m.eachPeerRev = nil
 }
 
-func (d *Mock) Halt()        {}
-func (m *Mock) Close() error { return nil }
+func (*Mock) Halt()        {}
+func (*Mock) Close() error { return nil }
 
-func (m *Mock) Snapshot() *topology.KadParams {
+func (*Mock) Snapshot() *topology.KadParams {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -82,8 +82,12 @@ func (d *mock) AddPeers(addrs ...swarm.Address) {
 	d.peers = append(d.peers, addrs...)
 }
 
-func (d *mock) Connected(ctx context.Context, peer p2p.Peer, _ bool) error {
+func (d *mock) Connected(_ context.Context, peer p2p.Peer) error {
 	d.AddPeers(peer.Address)
+	return nil
+}
+
+func (*mock) ConnectedForce(context.Context, p2p.Peer) error {
 	return nil
 }
 
@@ -99,11 +103,15 @@ func (d *mock) Disconnected(peer p2p.Peer) {
 	}
 }
 
-func (d *mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
+func (*mock) Announce(_ context.Context, _ swarm.Address) error {
 	return nil
 }
 
-func (d *mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+func (*mock) AnnouncePeers(_ context.Context, _ swarm.Address) error {
+	return nil
+}
+
+func (*mock) AnnounceTo(_ context.Context, _, _ swarm.Address) error {
 	return nil
 }
 
@@ -111,7 +119,7 @@ func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }
 
-func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (d *mock) ClosestPeer(addr, base swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
 		if d.closestPeerErr != nil {
 			return d.closestPeer, d.closestPeerErr
@@ -151,7 +159,7 @@ func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm
 	}
 
 	if peerAddr.IsZero() {
-		if wantSelf {
+		if !base.IsZero() {
 			return peerAddr, topology.ErrWantSelf
 		} else {
 			return peerAddr, topology.ErrNotFound
@@ -161,7 +169,7 @@ func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, skipPeers ...swarm
 	return peerAddr, nil
 }
 
-func (d *mock) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
+func (*mock) SubscribePeersChange() (c <-chan struct{}, unsubscribe func()) {
 	return c, unsubscribe
 }
 
@@ -218,12 +226,12 @@ func (d *mock) EachPeerRev(f topology.EachPeerFunc) (err error) {
 	return nil
 }
 
-func (d *mock) Snapshot() *topology.KadParams {
+func (*mock) Snapshot() *topology.KadParams {
 	return new(topology.KadParams)
 }
 
-func (d *mock) Halt()        {}
-func (d *mock) Close() error { return nil }
+func (*mock) Halt()        {}
+func (*mock) Close() error { return nil }
 
 type Option interface {
 	apply(*mock)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -44,7 +44,7 @@ type ClosestPeerer interface {
 	// given chunk address.
 	// This function will ignore peers with addresses provided in skipPeers.
 	// Returns topology.ErrWantSelf in case base is the closest to the address.
-	ClosestPeer(addr swarm.Address, includeSelf bool, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
+	ClosestPeer(addr swarm.Address, base swarm.Address, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
 }
 
 type EachPeerer interface {


### PR DESCRIPTION
PR includes deepsource fixes:
`kad.connected` renamed to `kad.onConnected`
`pslice.exists` renamed to `pslice.index`
`Announce`, `Connected`, `AnnounceTo` split into two new functions to avoid control coupling or simplified, etc....


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2455)
<!-- Reviewable:end -->
