### PR TITLE
fix: build custom beekeeper

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -14,7 +14,6 @@ jobs:
       REPLICA: 3
       RUN_TYPE: "PR RUN"
       SETUP_CONTRACT_IMAGE_TAG: "0.2.0"
-      BEEKEEPER_BRANCH: "auth-health-check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -14,6 +14,7 @@ jobs:
       REPLICA: 3
       RUN_TYPE: "PR RUN"
       SETUP_CONTRACT_IMAGE_TAG: "0.2.0"
+      BEEKEEPER_BRANCH: "master"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -14,6 +14,7 @@ jobs:
       REPLICA: 3
       RUN_TYPE: "PR RUN"
       SETUP_CONTRACT_IMAGE_TAG: "0.2.0"
+      BEEKEEPER_BRANCH: "auth-health-check"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2456)
<!-- Reviewable:end -->
To build, install and use custom beekeeper branch you can set env variable globally or set it in make command
```
jobs:
  beekeeper:
    name: Infra tests
    env:
      REPLICA: 3
      RUN_TYPE: "PR RUN"
      SETUP_CONTRACT_IMAGE_TAG: "0.2.0"
      BEEKEEPER_BRANCH: "CUSTOM-BRANCH"
```

`Line 51` of `beekeeper.yaml`
```
make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true BEEKEEPER_BRANCH=CUSTOM-BRANCH
```