### PR TITLE
fix: replace readAll with limit readers

### DIFF
--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -7,7 +7,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -45,8 +44,11 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 }
 
 func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
+	tagr := tagRequest{}
+
+	defer r.Body.Close()
+
+	if err := json.NewDecoder(r.Body).Decode(&tagr); err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
 		}
@@ -54,17 +56,6 @@ func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("create tag: read request body error")
 		jsonhttp.InternalServerError(w, "cannot read request")
 		return
-	}
-
-	tagr := tagRequest{}
-	if len(body) > 0 {
-		err = json.Unmarshal(body, &tagr)
-		if err != nil {
-			s.logger.Debugf("create tag: unmarshal tag name error: %v", err)
-			s.logger.Errorf("create tag: unmarshal tag name error")
-			jsonhttp.InternalServerError(w, "error unmarshaling metadata")
-			return
-		}
 	}
 
 	tag, err := s.tags.Create(0)
@@ -147,8 +138,11 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
+	tagr := tagRequest{}
+
+	defer r.Body.Close()
+
+	if err := json.NewDecoder(r.Body).Decode(&tagr); err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
 		}
@@ -156,17 +150,6 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("done split tag: read request body error")
 		jsonhttp.InternalServerError(w, "cannot read request")
 		return
-	}
-
-	tagr := tagRequest{}
-	if len(body) > 0 {
-		err = json.Unmarshal(body, &tagr)
-		if err != nil {
-			s.logger.Debugf("done split tag: unmarshal tag name error: %v", err)
-			s.logger.Errorf("done split tag: unmarshal tag name error")
-			jsonhttp.InternalServerError(w, "error unmarshaling metadata")
-			return
-		}
 	}
 
 	tag, err := s.tags.Get(uint32(id))


### PR DESCRIPTION
**SWA-01-005 WP2: Usage of ioutil.ReadAll in client API can result in DoS** _(Low)_

During a source code review of the bee repository, it was spotted that various client API
handler routines are using  ioutil.ReadAll  for reading user-input transmitted as part of
HTTP requests within the body. The usage of ioutil.ReadAll is dangerous2 and can result
in a DoS situation as this function continues to read data into a buffer allocated on the
system heap until it has received EOF. A malicious user could leverage this behavior by
sending HTTP requests to a bee node in order to cause an out-of-memory situation.

This is closed due to the fact that all the http routes that receive content are wrapped in a `NewMaxBodyBytesHandler` that makes sure that the content size is limited.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2460)
<!-- Reviewable:end -->
