### PR TITLE
feat(libp2p): add custom user agent and log it on connection

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -875,10 +875,11 @@ func testUserAgentLogLine(t *testing.T, logs bytes.Buffer, substring string) {
 					t.Errorf("log line %q does not contain an expected User Agent %q", line, wantUserAgent)
 				}
 			}
+			t.Log(line)
 		}
 	}
 	if !foundLogLine {
-		t.Errorf("log line with %s string was not found", logLineMarker)
+		t.Errorf("log line with %q string was not found", logLineMarker)
 	}
 }
 

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -5,14 +5,17 @@
 package libp2p_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/addressbook"
+	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
@@ -815,6 +818,68 @@ func TestWithBlocklistStreams(t *testing.T) {
 
 	expectPeersEventually(t, s2)
 	expectPeersEventually(t, s1)
+}
+
+func TestUserAgentLogging(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		s1Logs bytes.Buffer
+		s2Logs bytes.Buffer
+	)
+
+	s1, _ := newService(t, 1, libp2pServiceOpts{
+		libp2pOpts: libp2p.Options{
+			FullNode: true,
+		},
+		Logger: logging.New(&s1Logs, 5),
+	})
+	s2, _ := newService(t, 1, libp2pServiceOpts{
+		Logger: logging.New(&s2Logs, 5),
+	})
+
+	addr := serviceUnderlayAddress(t, s1)
+
+	_, err := s2.Connect(ctx, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testUserAgentLogLine(t, s1Logs, "(inbound)")
+	testUserAgentLogLine(t, s2Logs, "(outbound)")
+}
+
+func testUserAgentLogLine(t *testing.T, logs bytes.Buffer, substring string) {
+	t.Helper()
+
+	wantUserAgent := libp2p.UserAgent()
+	if wantUserAgent == "" {
+		t.Fatal("libp2p.UserAgent(): got empty user agent")
+	}
+
+	logLineMarker := "successfully connected to peer"
+	var foundLogLine bool
+	for {
+		line, err := logs.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if strings.Contains(line, logLineMarker) {
+			if strings.Contains(line, substring) {
+				foundLogLine = true
+				if !strings.Contains(line, wantUserAgent) {
+					t.Errorf("log line %q does not contain an expected User Agent %q", line, wantUserAgent)
+				}
+			}
+		}
+	}
+	if !foundLogLine {
+		t.Errorf("log line with %s string was not found", logLineMarker)
+	}
 }
 
 func expectStreamReset(t *testing.T, s io.ReadCloser, err error) {

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -871,6 +871,7 @@ func testUserAgentLogLine(t *testing.T, logs *buffer, substring string) {
 			}
 			t.Fatal(err)
 		}
+		t.Log(line)
 		if strings.Contains(line, logLineMarker) && strings.Contains(line, substring) {
 			foundLogLine = true
 			if !strings.Contains(line, wantUserAgent) {

--- a/pkg/p2p/libp2p/export_test.go
+++ b/pkg/p2p/libp2p/export_test.go
@@ -31,3 +31,5 @@ func WithHostFactory(factory func(context.Context, ...libp2pm.Option) (host.Host
 		hostFactory: factory,
 	}
 }
+
+var UserAgent = userAgent

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -889,9 +889,6 @@ func (s *Service) peerUserAgent(peerID libp2ppeer.ID) string {
 		// error is ignored as user agent is informative only
 		return ""
 	}
-	if v == nil {
-		return ""
-	}
 	ua, ok := v.(string)
 	if !ok {
 		return ""


### PR DESCRIPTION
This PR add a custom User Agent string to libp2p host which is communicated between peers over the internal libp2p Identify protocol. On every connection, the user agent is logged if it exists.

The current proposal for the user agent is in this form: `bee/<version> <goversion> <GOOS>/<GOARCH>`. For example `bee/1.1.1-dev go1.15.14 darwin/amd64`. It is debatable if all of these information should be included. It is encouraged to give your opinions on this subject.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2462)
<!-- Reviewable:end -->
