### PR TITLE
refactor: simplify kademlia announce to

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -563,7 +563,7 @@ func TestTopologyAnnounce(t *testing.T) {
 			mtx.Unlock()
 			return nil
 		}
-		n1at = func(context.Context, swarm.Address, swarm.Address, bool) error {
+		n1at = func(context.Context, swarm.Address, swarm.Address) error {
 			mtx.Lock()
 			announceToCalled = true
 			mtx.Unlock()
@@ -914,8 +914,8 @@ func (n *notifiee) Announce(ctx context.Context, a swarm.Address, full bool) err
 	return n.announce(ctx, a, full)
 }
 
-func (n *notifiee) AnnounceTo(ctx context.Context, a, b swarm.Address, full bool) error {
-	return n.announceTo(ctx, a, b, full)
+func (n *notifiee) AnnounceTo(ctx context.Context, a, b swarm.Address) error {
+	return n.announceTo(ctx, a, b)
 }
 
 func mockNotifier(c cFunc, d dFunc, pick bool) p2p.PickyNotifier {
@@ -930,10 +930,10 @@ type (
 	cFunc          func(context.Context, p2p.Peer, bool) error
 	dFunc          func(p2p.Peer)
 	announceFunc   func(context.Context, swarm.Address, bool) error
-	announceToFunc func(context.Context, swarm.Address, swarm.Address, bool) error
+	announceToFunc func(context.Context, swarm.Address, swarm.Address) error
 )
 
 var noopCf = func(context.Context, p2p.Peer, bool) error { return nil }
 var noopDf = func(p2p.Peer) {}
 var noopAnnounce = func(context.Context, swarm.Address, bool) error { return nil }
-var noopAnnounceTo = func(context.Context, swarm.Address, swarm.Address, bool) error { return nil }
+var noopAnnounceTo = func(context.Context, swarm.Address, swarm.Address) error { return nil }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -417,11 +417,11 @@ func (s *Service) handleIncoming(stream network.Stream) {
 			// light nodes so that they can also have a chance at building
 			// a solid topology.
 			_ = s.lightNodes.EachPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
-				go func(addressee, peer swarm.Address, fullnode bool) {
-					if err := s.notifier.AnnounceTo(s.ctx, addressee, peer, fullnode); err != nil {
+				go func(addressee, peer swarm.Address) {
+					if err := s.notifier.AnnounceTo(s.ctx, addressee, peer); err != nil {
 						s.logger.Debugf("stream handler: notifier.Announce to light node %s %s: %v", addressee.String(), peer.String(), err)
 					}
-				}(addr, peer.Address, i.FullNode)
+				}(addr, peer.Address)
 				return false, false, nil
 			})
 		}

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -51,7 +51,7 @@ type Notifier interface {
 	Connected(context.Context, Peer, bool) error
 	Disconnected(Peer)
 	Announce(ctx context.Context, peer swarm.Address, fullnode bool) error
-	AnnounceTo(ctx context.Context, addressee, peer swarm.Address, fullnode bool) error
+	AnnounceTo(ctx context.Context, addressee, peer swarm.Address) error
 }
 
 // DebugService extends the Service with method used for debugging.

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -50,10 +50,9 @@ var (
 )
 
 var (
-	errOverlayMismatch   = errors.New("overlay mismatch")
-	errPruneEntry        = errors.New("prune entry")
-	errEmptyBin          = errors.New("empty bin")
-	errAnnounceLightNode = errors.New("announcing light node")
+	errOverlayMismatch = errors.New("overlay mismatch")
+	errPruneEntry      = errors.New("prune entry")
+	errEmptyBin        = errors.New("empty bin")
 )
 
 type (
@@ -844,11 +843,7 @@ func (k *Kad) Announce(ctx context.Context, peer swarm.Address, fullnode bool) e
 }
 
 // AnnounceTo announces a selected peer to another.
-func (k *Kad) AnnounceTo(ctx context.Context, addressee, peer swarm.Address, fullnode bool) error {
-	if !fullnode {
-		return errAnnounceLightNode
-	}
-
+func (k *Kad) AnnounceTo(ctx context.Context, addressee, peer swarm.Address) error {
 	return k.discovery.BroadcastPeers(ctx, addressee, peer)
 }
 

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -687,14 +687,10 @@ func TestAnnounceTo(t *testing.T) {
 	addOne(t, signer, kad, ab, p1)
 	waitConn(t, &conns)
 
-	if err := kad.AnnounceTo(context.Background(), p1, p2, true); err != nil {
+	if err := kad.AnnounceTo(context.Background(), p1, p2); err != nil {
 		t.Fatal(err)
 	}
 	waitBcast(t, disc, p1, p2)
-
-	if err := kad.AnnounceTo(context.Background(), p1, p2, false); err == nil {
-		t.Fatal("expected error")
-	}
 }
 
 func TestBackoff(t *testing.T) {

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -152,7 +152,7 @@ func (m *Mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
 	return nil
 }
 
-func (m *Mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+func (m *Mock) AnnounceTo(_ context.Context, _, _ swarm.Address) error {
 	return nil
 }
 

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -103,7 +103,7 @@ func (d *mock) Announce(_ context.Context, _ swarm.Address, _ bool) error {
 	return nil
 }
 
-func (d *mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
+func (d *mock) AnnounceTo(_ context.Context, _, _ swarm.Address) error {
 	return nil
 }
 


### PR DESCRIPTION
AnnounceTo is only called by libp2p package in cases where a newly connected peer is a full node which then gets announced to already connected light nodes. The function itself has an unnecessary full-node check, which this PR removes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2467)
<!-- Reviewable:end -->
