### PR TITLE
build: add -buildid='' so that the binaries are reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BEEKEEPER_BRANCH ?= master
 COMMIT_HASH ?= "$(shell git describe --long --dirty --always --match "" || true)"
 CLEAN_COMMIT ?= "$(shell git describe --long --always --match "" || true)"
 COMMIT_TIME ?= "$(shell git show -s --format=%ct $(CLEAN_COMMIT) || true)"
-LDFLAGS ?= -s -w -X github.com/ethersphere/bee.commitHash="$(COMMIT_HASH)" -X github.com/ethersphere/bee.commitTime="$(COMMIT_TIME)"
+LDFLAGS ?= -buildid='' -s -w -X github.com/ethersphere/bee.commitHash="$(COMMIT_HASH)" -X github.com/ethersphere/bee.commitTime="$(COMMIT_TIME)"
 
 .PHONY: all
 all: build lint vet test-race binary


### PR DESCRIPTION
ideally, this should be tested by the CI so that it doesn't break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2474)
<!-- Reviewable:end -->
