### PR TITLE
fix: retry user agent get from libp2p peerstore

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -824,8 +825,13 @@ func TestWithBlocklistStreams(t *testing.T) {
 	expectPeersEventually(t, s2)
 	expectPeersEventually(t, s1)
 }
-
 func TestUserAgentLogging(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		t.Run(fmt.Sprintf("%d", i), testUserAgentLogging)
+	}
+}
+
+func testUserAgentLogging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -825,13 +824,8 @@ func TestWithBlocklistStreams(t *testing.T) {
 	expectPeersEventually(t, s2)
 	expectPeersEventually(t, s1)
 }
-func TestUserAgentLogging(t *testing.T) {
-	for i := 0; i < 20; i++ {
-		t.Run(fmt.Sprintf("%d", i), testUserAgentLogging)
-	}
-}
 
-func testUserAgentLogging(t *testing.T) {
+func TestUserAgentLogging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -437,10 +437,13 @@ func (s *Service) handleIncoming(stream network.Stream) {
 		return
 	}
 
-	peerUserAgent := appendSpace(s.peerUserAgent(peerID))
+	peerUserAgent, err := s.peerUserAgent(peerID)
+	if err != nil {
+		s.logger.Debugf("stream handler: inbound peer %s user agent: %w", err)
+	}
 
-	s.logger.Debugf("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.ShortString(), i.LightString(), peerUserAgent)
-	s.logger.Infof("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.Overlay, i.LightString(), peerUserAgent)
+	s.logger.Debugf("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.ShortString(), i.LightString(), appendSpace(peerUserAgent))
+	s.logger.Infof("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.Overlay, i.LightString(), appendSpace(peerUserAgent))
 }
 
 func (s *Service) SetPickyNotifier(n p2p.PickyNotifier) {
@@ -692,10 +695,13 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 
 	s.metrics.CreatedConnectionCount.Inc()
 
-	peerUserAgent := appendSpace(s.peerUserAgent(info.ID))
+	peerUserAgent, err := s.peerUserAgent(info.ID)
+	if err != nil {
+		return nil, fmt.Errorf("peer user agent: %w", err)
+	}
 
-	s.logger.Debugf("successfully connected to peer %s%s%s (outbound)", i.BzzAddress.ShortString(), i.LightString(), peerUserAgent)
-	s.logger.Infof("successfully connected to peer %s%s%s (outbound)", overlay, i.LightString(), peerUserAgent)
+	s.logger.Debugf("successfully connected to peer %s%s%s (outbound)", i.BzzAddress.ShortString(), i.LightString(), appendSpace(peerUserAgent))
+	s.logger.Infof("successfully connected to peer %s%s%s (outbound)", overlay, i.LightString(), appendSpace(peerUserAgent))
 	return i.BzzAddress, nil
 }
 
@@ -883,21 +889,21 @@ func (s *Service) Ping(ctx context.Context, addr ma.Multiaddr) (rtt time.Duratio
 // peerUserAgent returns User Agent string of the connected peer if the peer
 // provides it. It ignores the default libp2p user agent string
 // "github.com/libp2p/go-libp2p" and returns empty string in that case.
-func (s *Service) peerUserAgent(peerID libp2ppeer.ID) string {
+func (s *Service) peerUserAgent(peerID libp2ppeer.ID) (string, error) {
 	v, err := s.host.Peerstore().Get(peerID, "AgentVersion")
 	if err != nil {
 		// error is ignored as user agent is informative only
-		return ""
+		return "", fmt.Errorf("peerstore get AgentVersion: %w", err)
 	}
 	ua, ok := v.(string)
 	if !ok {
-		return ""
+		return "", fmt.Errorf("user agent %v is not a string", v)
 	}
 	// Ignore the default user agent.
-	if ua == "github.com/libp2p/go-libp2p" {
-		return ""
-	}
-	return ua
+	// if ua == "github.com/libp2p/go-libp2p" {
+	// 	return ""
+	// }
+	return ua, nil
 }
 
 // appendSpace adds a leading space character if the string is not empty.

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -52,7 +52,10 @@ var (
 	_ p2p.DebugService = (*Service)(nil)
 )
 
-const defaultLightNodeLimit = 100
+const (
+	defaultLightNodeLimit = 100
+	peerUserAgentTimeout  = time.Second
+)
 
 type Service struct {
 	ctx               context.Context
@@ -437,7 +440,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 		return
 	}
 
-	peerUserAgent := appendSpace(s.peerUserAgent(peerID))
+	peerUserAgent := appendSpace(s.peerUserAgent(s.ctx, peerID))
 
 	s.logger.Debugf("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.ShortString(), i.LightString(), peerUserAgent)
 	s.logger.Infof("stream handler: successfully connected to peer %s%s%s (inbound)", i.BzzAddress.Overlay, i.LightString(), peerUserAgent)
@@ -692,7 +695,7 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 
 	s.metrics.CreatedConnectionCount.Inc()
 
-	peerUserAgent := appendSpace(s.peerUserAgent(info.ID))
+	peerUserAgent := appendSpace(s.peerUserAgent(ctx, info.ID))
 
 	s.logger.Debugf("successfully connected to peer %s%s%s (outbound)", i.BzzAddress.ShortString(), i.LightString(), peerUserAgent)
 	s.logger.Infof("successfully connected to peer %s%s%s (outbound)", overlay, i.LightString(), peerUserAgent)
@@ -883,19 +886,25 @@ func (s *Service) Ping(ctx context.Context, addr ma.Multiaddr) (rtt time.Duratio
 // peerUserAgent returns User Agent string of the connected peer if the peer
 // provides it. It ignores the default libp2p user agent string
 // "github.com/libp2p/go-libp2p" and returns empty string in that case.
-func (s *Service) peerUserAgent(peerID libp2ppeer.ID) string {
+func (s *Service) peerUserAgent(ctx context.Context, peerID libp2ppeer.ID) string {
+	ctx, cancel := context.WithTimeout(ctx, peerUserAgentTimeout)
+	defer cancel()
 	var (
 		v   interface{}
 		err error
 	)
 	// Peerstore may not contain all keys and values right after the connections is created.
 	// This retry mechanism ensures more reliable user agent propagation.
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+	for iterate := true; iterate; {
 		v, err = s.host.Peerstore().Get(peerID, "AgentVersion")
 		if err == nil {
 			break
 		}
-		time.Sleep(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			iterate = false
+		case <-time.After(50 * time.Millisecond):
+		}
 	}
 	if err != nil {
 		// error is ignored as user agent is informative only

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -439,6 +439,8 @@ func (s *Service) handleIncoming(stream network.Stream) {
 
 	peerUserAgent, err := s.peerUserAgent(peerID)
 	if err != nil {
+		fmt.Println("got error getting user agent:")
+		fmt.Println(err)
 		s.logger.Debugf("stream handler: inbound peer %s user agent: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -892,7 +892,14 @@ func (s *Service) Ping(ctx context.Context, addr ma.Multiaddr) (rtt time.Duratio
 // provides it. It ignores the default libp2p user agent string
 // "github.com/libp2p/go-libp2p" and returns empty string in that case.
 func (s *Service) peerUserAgent(peerID libp2ppeer.ID) (string, error) {
-	v, err := s.host.Peerstore().Get(peerID, "AgentVersion")
+	var v interface{}
+	var err error
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		v, err = s.host.Peerstore().Get(peerID, "AgentVersion")
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		// error is ignored as user agent is informative only
 		return "", fmt.Errorf("peerstore get AgentVersion: %w", err)


### PR DESCRIPTION
This pr fixes the flaky test that checks for libp2p user agent in logs in high load environments like CI. It also ensures higher probability that the user agent is logged in high load environments.

The core problem is that the peerstore may not contain all keys and values right after the connections is created.
This retry mechanism ensures more reliable user agent propagation.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2482)
<!-- Reviewable:end -->
