### PR TITLE
fix: filter out filename path

### DIFF
--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -13,6 +13,7 @@ import (
 	"mime"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -412,10 +413,10 @@ func (s *server) serveManifestEntry(
 	manifestEntry manifest.Entry,
 	etag bool,
 ) {
-
 	additionalHeaders := http.Header{}
 	mtdt := manifestEntry.Metadata()
 	if fname, ok := mtdt[manifest.EntryMetadataFilenameKey]; ok {
+		fname = filepath.Base(fname) // only keep the file name
 		additionalHeaders["Content-Disposition"] =
 			[]string{fmt.Sprintf("inline; filename=\"%s\"", fname)}
 	}


### PR DESCRIPTION
**SWA-01-012 WP2: Potential directory traversal in download API** _(Medium)_

While reviewing the API implementation, it was found that the file download API possibly a directory traversal issue

It can be observed that the filename provided in the file’s metadata is directly returned in filename part of the Content-Disposition header. An attacker might, however, provide names   such   as  `../../../../etc/passwd`  or   similar,   which   could   subsequently   be accidentally used by client-code. In order to address this issue, it is recommended to already filter file names in the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2489)
<!-- Reviewable:end -->
