### PR TITLE
docs(openapi): add array of swarm addresses to topology bins

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -102,15 +102,15 @@ components:
               connected:
                 type: integer
               disconnectedPeers:
-                type: object
-                additionalProperties:
+                type: array
+                items:
                   type: object
                   properties:
                     address:
                       $ref: "#/components/schemas/SwarmAddress"
               connectedPeers:
-                type: object
-                additionalProperties:
+                type: array
+                items:
                   type: object
                   properties:
                     address:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -103,8 +103,18 @@ components:
                 type: integer
               disconnectedPeers:
                 type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    address:
+                      $ref: "#/components/schemas/SwarmAddress"
               connectedPeers:
                 type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    address:
+                      $ref: "#/components/schemas/SwarmAddress"
 
     Cheque:
       type: object

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -108,6 +108,8 @@ components:
                   properties:
                     address:
                       $ref: "#/components/schemas/SwarmAddress"
+                    metrics:
+                      $ref: "#/components/schemas/PeerMetricsView"
               connectedPeers:
                 type: array
                 items:
@@ -115,6 +117,9 @@ components:
                   properties:
                     address:
                       $ref: "#/components/schemas/SwarmAddress"
+                    metrics:
+                      $ref: "#/components/schemas/PeerMetricsView"
+
 
     Cheque:
       type: object
@@ -254,6 +259,28 @@ components:
     P2PUnderlay:
       type: string
       example: "/ip4/127.0.0.1/tcp/1634/p2p/16Uiu2HAmTm17toLDaPYzRyjKn27iCB76yjKnJ5DjQXneFmifFvaX"
+
+    PeerMetricsView:
+      type: object
+      properties:
+        lastSeenTimestamp:
+          type: integer
+          nullable: false
+        sessionConnectionRetry:
+          type: integer
+          nullable: false
+        connectionTotalDuration:
+          type: number
+          nullable: false
+        sessionConnectionDuration:
+          type: number
+          nullable: false
+        sessionConnectionDirection:
+          type: string
+          nullable: false
+        latencyEWMA:
+          type: integer
+          nullable: false
 
     Peers:
       type: object


### PR DESCRIPTION
adding missing connectedPeers and disconnectedPeers definitions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2523)
<!-- Reviewable:end -->
