### PR TITLE
fix: continue forwarding if replication fails

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -218,14 +218,13 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 		chunk, err = ps.validStamp(chunk, ch.Stamp)
 		if err != nil {
 			ps.metrics.InvalidStampErrors.Inc()
-			return fmt.Errorf("pushsync valid stamp: %w", err)
-		}
-
-		_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
-		if err != nil {
-			ps.logger.Warningf("pushsync: within depth peer's attempt to store chunk failed: %v", err)
 		} else {
-			storedChunk = true
+			_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
+			if err != nil {
+				ps.logger.Warningf("pushsync: within depth peer's attempt to store chunk failed: %v", err)
+			} else {
+				storedChunk = true
+			}
 		}
 	}
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -213,7 +213,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 
 	// forwarding replication
 	storedChunk := false
-	if ps.topologyDriver.IsWithinDepth(chunkAddress) {
+	if ps.warmedUp() && ps.topologyDriver.IsWithinDepth(chunkAddress) {
 
 		chunk, err = ps.validStamp(chunk, ch.Stamp)
 		if err != nil {


### PR DESCRIPTION
Forwarding nodes that replicate should be warmed up and, in the case of a replication error, should continue forwarding it.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2524)
<!-- Reviewable:end -->
