### PR TITLE
feat: kademlia oversaturation based on an exponential decay formula

### DIFF
--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -5,13 +5,11 @@
 package kademlia
 
 var (
-	TimeToRetry                 = &timeToRetry
-	QuickSaturationPeers        = &quickSaturationPeers
-	SaturationPeers             = &saturationPeers
-	OverSaturationPeers         = &overSaturationPeers
-	BootnodeOverSaturationPeers = &bootNodeOverSaturationPeers
-	LowWaterMark                = &nnLowWatermark
-	PruneOversaturatedBinsFunc  = func(k *Kad) func(uint8) {
+	TimeToRetry                = &timeToRetry
+	QuickSaturationPeers       = &quickSaturationPeers
+	SaturationPeers            = &saturationPeers
+	LowWaterMark               = &nnLowWatermark
+	PruneOversaturatedBinsFunc = func(k *Kad) func(uint8) {
 		return k.pruneOversaturatedBins
 	}
 	GenerateCommonBinPrefixes = generateCommonBinPrefixes

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -14,6 +14,7 @@ var (
 	}
 	GenerateCommonBinPrefixes = generateCommonBinPrefixes
 	PeerPingPollTime          = &peerPingPollTime
+	DefaultOverSaturationCalc = defaultOverSaturationCalc
 )
 
 type PeerFilterFunc = peerFilterFunc

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -138,9 +138,7 @@ func New(
 ) (*Kad, error) {
 
 	if o.OverSaturationCalc == nil {
-		o.OverSaturationCalc = func(bin uint8) int {
-			return int(math.Exp(-float64(bin)/8.0)) * 50
-		}
+		o.OverSaturationCalc = defaultOverSaturationCalc
 	}
 
 	o.SaturationFunc = binSaturated(o.OverSaturationCalc, isStaticPeer(o.StaticNodes))
@@ -209,6 +207,12 @@ func New(
 
 	k.metrics.ReachabilityStatus.WithLabelValues(p2p.ReachabilityStatusUnknown.String()).Set(0)
 	return k, nil
+}
+
+// produces oversaturation values using an exponential decay formula, sequence is as follows:
+// bin 0 -> 50, 44, 39, 34, 30, 27
+func defaultOverSaturationCalc(bin uint8) int {
+	return int(math.Round(50 * math.Exp(-float64(bin)/8.0)))
 }
 
 type peerConnInfo struct {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -55,6 +55,7 @@ var (
 	timeToRetry          = 2 * shortRetry
 	broadcastBinSize     = 4
 	peerPingPollTime     = 10 * time.Second // how often to ping a peer
+	maxFirstbin          = float64(50)
 )
 
 var (
@@ -137,6 +138,8 @@ func New(
 	o Options,
 ) (*Kad, error) {
 
+	start := time.Now()
+
 	if o.OverSaturationCalc == nil {
 		o.OverSaturationCalc = defaultOverSaturationCalc
 	}
@@ -147,10 +150,6 @@ func New(
 		o.BitSuffixLength = defaultBitSuffixLength
 	}
 
-	for i := 0; i < int(swarm.MaxBins); i++ {
-	}
-
-	start := time.Now()
 	imc, err := im.NewCollector(metricsDB)
 	if err != nil {
 		return nil, err
@@ -212,7 +211,7 @@ func New(
 // produces oversaturation values using an exponential decay formula, sequence is as follows:
 // bin 0 -> 50, 44, 39, 34, 30, 27
 func defaultOverSaturationCalc(bin uint8) int {
-	return int(math.Round(50 * math.Exp(-float64(bin)/8.0)))
+	return int(math.Round(maxFirstbin * math.Exp(-float64(bin)/8.0)))
 }
 
 type peerConnInfo struct {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
 	"sync"
@@ -47,15 +48,13 @@ const (
 )
 
 var (
-	nnLowWatermark              = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
-	quickSaturationPeers        = 4
-	saturationPeers             = 8
-	overSaturationPeers         = 20
-	bootNodeOverSaturationPeers = 20
-	shortRetry                  = 30 * time.Second
-	timeToRetry                 = 2 * shortRetry
-	broadcastBinSize            = 4
-	peerPingPollTime            = 10 * time.Second // how often to ping a peer
+	nnLowWatermark       = 2 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
+	quickSaturationPeers = 4
+	saturationPeers      = 8
+	shortRetry           = 30 * time.Second
+	timeToRetry          = 2 * shortRetry
+	broadcastBinSize     = 4
+	peerPingPollTime     = 10 * time.Second // how often to ping a peer
 )
 
 var (
@@ -71,56 +70,59 @@ type (
 	pruneFunc          func(depth uint8)
 	staticPeerFunc     func(peer swarm.Address) bool
 	peerFilterFunc     func(peer swarm.Address) bool
+	overSaturationCalc func(depth uint8) int
 )
 
 var noopSanctionedPeerFn = func(_ swarm.Address) bool { return false }
 
 // Options for injecting services to Kademlia.
 type Options struct {
-	SaturationFunc   binSaturationFunc
-	Bootnodes        []ma.Multiaddr
-	BootnodeMode     bool
-	BitSuffixLength  int
-	PruneFunc        pruneFunc
-	StaticNodes      []swarm.Address
-	ReachabilityFunc peerFilterFunc
+	SaturationFunc     binSaturationFunc
+	Bootnodes          []ma.Multiaddr
+	BootnodeMode       bool
+	BitSuffixLength    int
+	PruneFunc          pruneFunc
+	StaticNodes        []swarm.Address
+	ReachabilityFunc   peerFilterFunc
+	OverSaturationCalc overSaturationCalc
 }
 
 // Kad is the Swarm forwarding kademlia implementation.
 type Kad struct {
-	base              swarm.Address         // this node's overlay address
-	discovery         discovery.Driver      // the discovery driver
-	addressBook       addressbook.Interface // address book to get underlays
-	p2p               p2p.Service           // p2p service to connect to nodes with
-	saturationFunc    binSaturationFunc     // pluggable saturation function
-	bitSuffixLength   int                   // additional depth of common prefix for bin
-	commonBinPrefixes [][]swarm.Address     // list of address prefixes for each bin
-	connectedPeers    *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
-	knownPeers        *pslice.PSlice        // both are po aware slice of addresses
-	bootnodes         []ma.Multiaddr
-	depth             uint8         // current neighborhood depth
-	radius            uint8         // storage area of responsibility
-	depthMu           sync.RWMutex  // protect depth changes
-	manageC           chan struct{} // trigger the manage forever loop to connect to new peers
-	peerSig           []chan struct{}
-	peerSigMtx        sync.Mutex
-	logger            logging.Logger // logger
-	bootnode          bool           // indicates whether the node is working in bootnode mode
-	collector         *im.Collector
-	quit              chan struct{} // quit channel
-	halt              chan struct{} // halt channel
-	done              chan struct{} // signal that `manage` has quit
-	wg                sync.WaitGroup
-	waitNext          *waitnext.WaitNext
-	metrics           metrics
-	pruneFunc         pruneFunc // pluggable prune function
-	pinger            pingpong.Interface
-	staticPeer        staticPeerFunc
-	bgBroadcastCtx    context.Context
-	bgBroadcastCancel context.CancelFunc
-	blocker           *blocker.Blocker
-	reachability      p2p.ReachabilityStatus
-	peerFilter        peerFilterFunc
+	base               swarm.Address         // this node's overlay address
+	discovery          discovery.Driver      // the discovery driver
+	addressBook        addressbook.Interface // address book to get underlays
+	p2p                p2p.Service           // p2p service to connect to nodes with
+	saturationFunc     binSaturationFunc     // pluggable saturation function
+	bitSuffixLength    int                   // additional depth of common prefix for bin
+	commonBinPrefixes  [][]swarm.Address     // list of address prefixes for each bin
+	connectedPeers     *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
+	knownPeers         *pslice.PSlice        // both are po aware slice of addresses
+	bootnodes          []ma.Multiaddr
+	depth              uint8         // current neighborhood depth
+	radius             uint8         // storage area of responsibility
+	depthMu            sync.RWMutex  // protect depth changes
+	manageC            chan struct{} // trigger the manage forever loop to connect to new peers
+	peerSig            []chan struct{}
+	peerSigMtx         sync.Mutex
+	logger             logging.Logger // logger
+	bootnode           bool           // indicates whether the node is working in bootnode mode
+	collector          *im.Collector
+	quit               chan struct{} // quit channel
+	halt               chan struct{} // halt channel
+	done               chan struct{} // signal that `manage` has quit
+	wg                 sync.WaitGroup
+	waitNext           *waitnext.WaitNext
+	metrics            metrics
+	pruneFunc          pruneFunc // pluggable prune function
+	pinger             pingpong.Interface
+	staticPeer         staticPeerFunc
+	bgBroadcastCtx     context.Context
+	bgBroadcastCancel  context.CancelFunc
+	blocker            *blocker.Blocker
+	reachability       p2p.ReachabilityStatus
+	peerFilter         peerFilterFunc
+	overSaturationCalc overSaturationCalc
 }
 
 // New returns a new Kademlia.
@@ -134,15 +136,20 @@ func New(
 	logger logging.Logger,
 	o Options,
 ) (*Kad, error) {
-	if o.SaturationFunc == nil {
-		os := overSaturationPeers
-		if o.BootnodeMode {
-			os = bootNodeOverSaturationPeers
+
+	if o.OverSaturationCalc == nil {
+		o.OverSaturationCalc = func(bin uint8) int {
+			return int(math.Exp(-float64(bin)/8.0)) * 50
 		}
-		o.SaturationFunc = binSaturated(os, isStaticPeer(o.StaticNodes))
 	}
+
+	o.SaturationFunc = binSaturated(o.OverSaturationCalc, isStaticPeer(o.StaticNodes))
+
 	if o.BitSuffixLength == 0 {
 		o.BitSuffixLength = defaultBitSuffixLength
+	}
+
+	for i := 0; i < int(swarm.MaxBins); i++ {
 	}
 
 	start := time.Now()
@@ -153,29 +160,30 @@ func New(
 	logger.Debugf("kademlia: NewCollector(...) took %v", time.Since(start))
 
 	k := &Kad{
-		base:              base,
-		discovery:         discovery,
-		addressBook:       addressbook,
-		p2p:               p2pSvc,
-		saturationFunc:    o.SaturationFunc,
-		bitSuffixLength:   o.BitSuffixLength,
-		commonBinPrefixes: make([][]swarm.Address, int(swarm.MaxBins)),
-		connectedPeers:    pslice.New(int(swarm.MaxBins), base),
-		knownPeers:        pslice.New(int(swarm.MaxBins), base),
-		bootnodes:         o.Bootnodes,
-		manageC:           make(chan struct{}, 1),
-		waitNext:          waitnext.New(),
-		logger:            logger,
-		bootnode:          o.BootnodeMode,
-		collector:         imc,
-		quit:              make(chan struct{}),
-		halt:              make(chan struct{}),
-		done:              make(chan struct{}),
-		metrics:           newMetrics(),
-		pruneFunc:         o.PruneFunc,
-		pinger:            pinger,
-		staticPeer:        isStaticPeer(o.StaticNodes),
-		peerFilter:        o.ReachabilityFunc,
+		base:               base,
+		discovery:          discovery,
+		addressBook:        addressbook,
+		p2p:                p2pSvc,
+		saturationFunc:     o.SaturationFunc,
+		bitSuffixLength:    o.BitSuffixLength,
+		commonBinPrefixes:  make([][]swarm.Address, int(swarm.MaxBins)),
+		connectedPeers:     pslice.New(int(swarm.MaxBins), base),
+		knownPeers:         pslice.New(int(swarm.MaxBins), base),
+		bootnodes:          o.Bootnodes,
+		manageC:            make(chan struct{}, 1),
+		waitNext:           waitnext.New(),
+		logger:             logger,
+		bootnode:           o.BootnodeMode,
+		collector:          imc,
+		quit:               make(chan struct{}),
+		halt:               make(chan struct{}),
+		done:               make(chan struct{}),
+		metrics:            newMetrics(),
+		pruneFunc:          o.PruneFunc,
+		pinger:             pinger,
+		staticPeer:         isStaticPeer(o.StaticNodes),
+		peerFilter:         o.ReachabilityFunc,
+		overSaturationCalc: o.OverSaturationCalc,
 	}
 
 	blocklistCallback := func(a swarm.Address) {
@@ -636,13 +644,13 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 		}
 
 		binPeersCount := k.connectedPeers.BinSize(uint8(i))
-		if binPeersCount < overSaturationPeers {
+		if binPeersCount < k.overSaturationCalc(uint8(i)) {
 			continue
 		}
 
 		binPeers := k.connectedPeers.BinPeers(uint8(i))
 
-		peersToRemove := binPeersCount - overSaturationPeers
+		peersToRemove := binPeersCount - k.overSaturationCalc(uint8(i))
 
 		for j := 0; peersToRemove > 0 && j < len(k.commonBinPrefixes[i]); j++ {
 
@@ -802,7 +810,7 @@ func (k *Kad) connectBootNodes(ctx context.Context) {
 // binSaturated indicates whether a certain bin is saturated or not.
 // when a bin is not saturated it means we would like to proactively
 // initiate connections to other peers in the bin.
-func binSaturated(oversaturationAmount int, staticNode staticPeerFunc) binSaturationFunc {
+func binSaturated(f overSaturationCalc, staticNode staticPeerFunc) binSaturationFunc {
 	return func(bin uint8, peers, connected *pslice.PSlice, filter peerFilterFunc) (bool, bool) {
 		potentialDepth := recalcDepth(peers, swarm.MaxPO, filter)
 
@@ -826,7 +834,7 @@ func binSaturated(oversaturationAmount int, staticNode staticPeerFunc) binSatura
 			return false, false, nil
 		})
 
-		return size >= saturationPeers, size >= oversaturationAmount
+		return size >= saturationPeers, size >= f(bin)
 	}
 }
 

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -213,7 +213,9 @@ func TestNeighborhoodDepthWithReachability(t *testing.T) {
 
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
-		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{})
+		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
+			OverSaturationCalc: func(uint8) int { return 20 },
+		})
 	)
 
 	kad.SetRadius(swarm.MaxPO) // initial tests do not check for radius
@@ -1726,6 +1728,15 @@ func TestIteratorOpts(t *testing.T) {
 	})
 }
 
+func TestDefaultOverSaturationCalc(t *testing.T) {
+	nums := []int{50, 44, 39, 34, 30, 27, 24, 21, 18, 16, 14, 13, 11, 10}
+	for i, n := range nums {
+		if got := kademlia.DefaultOverSaturationCalc(uint8(i)); got != n {
+			t.Fatalf("want %d, got %d", n, got)
+		}
+	}
+}
+
 type boolgen struct {
 	src       rand.Source
 	cache     int64
@@ -1742,15 +1753,6 @@ func (b *boolgen) Bool() bool {
 	b.remaining--
 
 	return result
-}
-
-func TestDefaultOverSaturationCalc(t *testing.T) {
-	nums := []int{50, 44, 39, 34, 30, 27, 24, 21, 18, 16, 14, 13, 11, 10}
-	for i, n := range nums {
-		if got := kademlia.DefaultOverSaturationCalc(uint8(i)); got != n {
-			t.Fatalf("want %d, got %d", n, got)
-		}
-	}
 }
 
 func mineBin(t *testing.T, base swarm.Address, bin, count int, isBalanced bool) []swarm.Address {

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1744,6 +1744,15 @@ func (b *boolgen) Bool() bool {
 	return result
 }
 
+func TestDefaultOverSaturationCalc(t *testing.T) {
+	nums := []int{50, 44, 39, 34, 30, 27, 24, 21, 18, 16, 14, 13, 11, 10}
+	for i, n := range nums {
+		if got := kademlia.DefaultOverSaturationCalc(uint8(i)); got != n {
+			t.Fatalf("want %d, got %d", n, got)
+		}
+	}
+}
+
 func mineBin(t *testing.T, base swarm.Address, bin, count int, isBalanced bool) []swarm.Address {
 
 	var rndAddrs = make([]swarm.Address, count)


### PR DESCRIPTION
Bin oversaturation count is calculated using an exponential decay formula.
The goal is to give more weight to shallower bins (relative to how they are now) as they make up the majority of known peers.
This should improve connectivity and decrease hops in syncing protocols.
 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2530)
<!-- Reviewable:end -->
