### PR TITLE
feat: multiple retries at each hop

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -38,7 +38,7 @@ const (
 )
 
 const (
-	maxAttemps             = 3
+	maxAttempts            = 3
 	maxAttemptsWithoutPush = 16
 )
 
@@ -329,7 +329,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, isOrigin 
 	defer ps.skipList.PruneExpired()
 
 	var (
-		allowedRetries = maxAttemps
+		allowedRetries = maxAttempts
 		includeSelf    = ps.isFullNode
 		skipPeers      []swarm.Address
 	)


### PR DESCRIPTION
PR introduces retries at each hop for the pushsync protocol.

Peer-chunk skip-listing by @acud prevents repeating network traversals so we can have this feature again.

One benefit, which is counterintuitive, is that this change theoretically **reduces** the total number of hops to the closest peer.

The reason is the protocol allows for multiple deeper depth-first searches at each hop where a successful traversal may be discovered at some second or third attempt starting from a node far away from the origin node.

Without retries after the origin node, if a traversal returns with error, the next traversal has to start beginning at the origin which means all the previous traversal progress has been lost.

This was proved to be theoretically true using the bee-sync-sim tool.

![image](https://user-images.githubusercontent.com/14264581/134402869-c1551ca9-fc1e-49c6-934d-59fe5f990b3e.png)

In the example above, without retries, reaching the destination node would've required three full traversals starting from the origin. Instead, the node '1b944a' retries with his own peers and finds the destination node. '1b91da' is also aware of closer nodes but because those retries fail, he becomes the storer node.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2535)
<!-- Reviewable:end -->
