### PR TITLE
feat: prune extra peers from oversaturated, out of depth bins 

### DIFF
--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -11,7 +11,7 @@ var (
 	OverSaturationPeers         = &overSaturationPeers
 	BootnodeOverSaturationPeers = &bootNodeOverSaturationPeers
 	LowWaterMark                = &nnLowWatermark
-	PruneOversaturatedBinsFunc  = func(k *Kad) func(uint8) {
+	PruneOversaturatedBinsFunc  = func(k *Kad) func(uint8, int) {
 		return k.pruneOversaturatedBins
 	}
 	GenerateCommonBinPrefixes = generateCommonBinPrefixes

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -15,4 +15,5 @@ var (
 		return k.pruneOversaturatedBins
 	}
 	GenerateCommonBinPrefixes = generateCommonBinPrefixes
+	ExtraPeersToPrune         = &extraPeersToPrune
 )

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -584,7 +584,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8, extraCap int) {
 
 		binPeers := k.connectedPeers.BinPeers(uint8(i))
 
-		peersToRemove := binPeersCount - (overSaturationPeers + extraCap)
+		peersToRemove := (binPeersCount - overSaturationPeers) + extraCap
 
 		for j := 0; peersToRemove > 0 && j < len(k.commonBinPrefixes[i]); j++ {
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -476,7 +476,7 @@ func (k *Kad) manage() {
 					return
 				case <-k.quit:
 					return
-				case <-time.After(15 * time.Minute):
+				case <-time.After(5 * time.Minute):
 					k.pruneFunc(k.NeighborhoodDepth(), extraPeersToPrune)
 				}
 			}

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -466,20 +466,22 @@ func (k *Kad) manage() {
 		}
 	}()
 
-	k.wg.Add(1)
-	go func() {
-		defer k.wg.Done()
-		for {
-			select {
-			case <-k.halt:
-				return
-			case <-k.quit:
-				return
-			case <-time.After(15 * time.Minute):
-				k.pruneFunc(k.NeighborhoodDepth(), extraPeersToPrune)
+	if !k.bootnode {
+		k.wg.Add(1)
+		go func() {
+			defer k.wg.Done()
+			for {
+				select {
+				case <-k.halt:
+					return
+				case <-k.quit:
+					return
+				case <-time.After(15 * time.Minute):
+					k.pruneFunc(k.NeighborhoodDepth(), extraPeersToPrune)
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	for {
 		select {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -47,6 +47,7 @@ var (
 	shortRetry                  = 30 * time.Second
 	timeToRetry                 = 2 * shortRetry
 	broadcastBinSize            = 4
+	extraPeersToPrune           = 5
 )
 
 var (
@@ -566,7 +567,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 
 		binPeers := k.connectedPeers.BinPeers(uint8(i))
 
-		peersToRemove := binPeersCount - overSaturationPeers
+		peersToRemove := binPeersCount - (overSaturationPeers + extraPeersToPrune)
 
 		for j := 0; peersToRemove > 0 && j < len(k.commonBinPrefixes[i]); j++ {
 

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1202,13 +1202,13 @@ func TestOutofDepthPrune(t *testing.T) {
 	var (
 		conns, failedConns int32 // how many connect calls were made to the p2p mock
 
-		pruneFuncImpl *func(uint8)
+		pruneFuncImpl *func(uint8, int)
 		pruneMux      = sync.Mutex{}
-		pruneFunc     = func(depth uint8) {
+		pruneFunc     = func(depth uint8, cap int) {
 			pruneMux.Lock()
 			defer pruneMux.Unlock()
 			f := *pruneFuncImpl
-			f(depth)
+			f(depth, cap)
 		}
 
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, &failedConns, kademlia.Options{
@@ -1220,7 +1220,7 @@ func TestOutofDepthPrune(t *testing.T) {
 
 	// implement empty prune func
 	pruneMux.Lock()
-	pruneImpl := func(uint8) {}
+	pruneImpl := func(uint8, int) {}
 	pruneFuncImpl = &(pruneImpl)
 	pruneMux.Unlock()
 
@@ -1264,8 +1264,8 @@ func TestOutofDepthPrune(t *testing.T) {
 
 	// set prune func to the default
 	pruneMux.Lock()
-	pruneImpl = func(depth uint8) {
-		kademlia.PruneOversaturatedBinsFunc(kad)(depth)
+	pruneImpl = func(depth uint8, cap int) {
+		kademlia.PruneOversaturatedBinsFunc(kad)(depth, cap)
 	}
 	pruneFuncImpl = &(pruneImpl)
 	pruneMux.Unlock()

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1194,6 +1194,11 @@ func TestOutofDepthPrune(t *testing.T) {
 	}(*kademlia.OverSaturationPeers)
 	*kademlia.OverSaturationPeers = 8
 
+	defer func(p int) {
+		*kademlia.ExtraPeersToPrune = p
+	}(*kademlia.ExtraPeersToPrune)
+	*kademlia.ExtraPeersToPrune = 0
+
 	var (
 		conns, failedConns int32 // how many connect calls were made to the p2p mock
 


### PR DESCRIPTION
Oversaturated, out of depth bins are pruned to a higher degree based on a timer to increase overall network discoverability. 

Theatrically, this should have positive cascading effects on the push and retrieval protocols. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2536)
<!-- Reviewable:end -->
