### PR TITLE
fix: fix swap migraton state store corruption

### DIFF
--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/pkg/storage"
 )
 
 var (
@@ -143,6 +144,9 @@ func migrateSwap(s *store) error {
 					return err
 				}
 				continue
+			}
+			if !errors.Is(err, storage.ErrNotFound) {
+				return err
 			}
 
 			if err = s.Get(key, &val); err != nil {

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -129,7 +129,7 @@ func migrateSwap(s *store) error {
 			}
 
 			if len(split[1]) != 20 {
-				s.logger.Debugf("skipping already migrated key %s", string(key))
+				s.logger.Debugf("skipping already migrated key %s", key)
 				continue
 			}
 
@@ -138,7 +138,7 @@ func migrateSwap(s *store) error {
 
 			var val string
 			if err = s.Get(fixed, &val); err == nil {
-				s.logger.Debugf("skipping duplicate key %s", string(key))
+				s.logger.Debugf("skipping duplicate key %s", key)
 				if err = s.Delete(key); err != nil {
 					return err
 				}

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -136,7 +136,7 @@ func migrateSwap(s *store) error {
 				return err
 			}
 
-			if err = s.Put(fixed, common.HexToAddress(val)); err != nil {
+			if err = s.Put(fixed, val); err != nil {
 				return err
 			}
 

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -128,10 +128,23 @@ func migrateSwap(s *store) error {
 				return errors.New("no peer in key")
 			}
 
+			if len(split[1]) != 20 {
+				s.logger.Debugf("skipping already migrated key %s", string(key))
+				continue
+			}
+
 			addr := common.BytesToAddress([]byte(split[1]))
 			fixed := fmt.Sprintf("%s%x", prefix, addr)
 
 			var val string
+			if err = s.Get(fixed, &val); err == nil {
+				s.logger.Debugf("skipping duplicate key %s", string(key))
+				if err = s.Delete(key); err != nil {
+					return err
+				}
+				continue
+			}
+
 			if err = s.Get(key, &val); err != nil {
 				return err
 			}


### PR DESCRIPTION
prevents the corruption of the swarm peer address and already migrated keys during the migration. Note that this does not help nodes which already ran the migration.

* both `swarm.Address` and `common.Address` are treated as string in their state store representation, so just loading and storing preserves the correct value.
* addresses which are not length 20 strings are assumed to be already migrated
* in case of a conflict, the newer value takes precedence

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2537)
<!-- Reviewable:end -->
