### PR TITLE
opt: handshake handle checks with kademlia pick before overlay verification

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -54,7 +54,7 @@ var (
 	ErrWelcomeMessageLength = fmt.Errorf("handshake welcome message longer than maximum of %d characters", MaxWelcomeMessageLength)
 
 	// ErrPicker is returned if the picker (kademlia) rejects the peer
-	ErrPickyNotifier = fmt.Errorf("picky notifier")
+	ErrPicker = fmt.Errorf("picker rejection")
 )
 
 // AdvertisableAddressResolver can Resolve a Multiaddress.
@@ -317,8 +317,7 @@ func (s *Service) Handle(ctx context.Context, stream p2p.Stream, remoteMultiaddr
 
 	if s.picker != nil {
 		if !s.picker.Pick(p2p.Peer{Address: overlay, FullNode: ack.FullNode}) {
-			s.logger.Warningf("handshake handler: don't want incoming peer %s", overlay)
-			return nil, ErrPickyNotifier
+			return nil, ErrPicker
 		}
 	}
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -52,6 +52,9 @@ var (
 
 	// ErrWelcomeMessageLength is returned if the welcome message is longer than the maximum length
 	ErrWelcomeMessageLength = fmt.Errorf("handshake welcome message longer than maximum of %d characters", MaxWelcomeMessageLength)
+
+	// ErrWelcomeMessageLength is returned if the welcome message is longer than the maximum length
+	ErrPickyNotifier = fmt.Errorf("picky notifier")
 )
 
 // AdvertisableAddressResolver can Resolve a Multiaddress.
@@ -79,6 +82,7 @@ type Service struct {
 	libp2pID              libp2ppeer.ID
 	metrics               metrics
 	network.Notifiee      // handshake service can be the receiver for network.Notify
+	notifier              p2p.PickyNotifier
 }
 
 // Info contains the information received from the handshake.
@@ -118,6 +122,10 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 	svc.welcomeMessage.Store(welcomeMessage)
 
 	return svc, nil
+}
+
+func (s *Service) SetPickyNotifier(n p2p.PickyNotifier) {
+	s.notifier = n
 }
 
 // Handshake initiates a handshake with a peer.
@@ -306,6 +314,13 @@ func (s *Service) Handle(ctx context.Context, stream p2p.Stream, remoteMultiaddr
 	}
 
 	overlay := swarm.NewAddress(ack.Address.Overlay)
+
+	if s.notifier != nil {
+		if !s.notifier.Pick(p2p.Peer{Address: overlay, FullNode: ack.FullNode}) {
+			s.logger.Warningf("handshake handler: don't want incoming peer %s", overlay)
+			return nil, ErrPickyNotifier
+		}
+	}
 
 	blockHash, err := s.senderMatcher.Matches(ctx, ack.Transaction, s.networkID, overlay)
 	if err != nil {

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethersphere/bee/pkg/bzz"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake/mock"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/handshake/pb"
@@ -173,6 +174,47 @@ func TestHandshake(t *testing.T) {
 
 		if ack.WelcomeMessage != testWelcomeMessage {
 			t.Fatalf("Bad ack welcome message: want %s, got %s", testWelcomeMessage, ack.WelcomeMessage)
+		}
+	})
+
+	t.Run("Handshake - picker error", func(t *testing.T) {
+
+		handshakeService, err := handshake.New(signer1, aaddresser, senderMatcher, node1Info.BzzAddress.Overlay, networkID, true, trxHash, "", node1AddrInfo.ID, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handshakeService.SetPicker(mockPicker(func(p p2p.Peer) bool { return false }))
+
+		var buffer1 bytes.Buffer
+		var buffer2 bytes.Buffer
+		stream1 := mock.NewStream(&buffer1, &buffer2)
+		stream2 := mock.NewStream(&buffer2, &buffer1)
+
+		w := protobuf.NewWriter(stream2)
+		if err := w.WriteMsg(&pb.Syn{
+			ObservedUnderlay: node1maBinary,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := w.WriteMsg(&pb.Ack{
+			Address: &pb.BzzAddress{
+				Underlay:  node2maBinary,
+				Overlay:   node2BzzAddress.Overlay.Bytes(),
+				Signature: node2BzzAddress.Signature,
+			},
+			NetworkID:   networkID,
+			Transaction: trxHash,
+			FullNode:    true,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = handshakeService.Handle(context.Background(), stream1, node2AddrInfo.Addrs[0], node2AddrInfo.ID)
+		expectedErr := handshake.ErrPicker
+		if err == nil || !errors.Is(err, expectedErr) {
+			t.Fatal("expected:", expectedErr, "got:", err)
 		}
 	})
 
@@ -726,6 +768,18 @@ func TestHandshake(t *testing.T) {
 			t.Fatal("expected nil res")
 		}
 	})
+}
+
+func mockPicker(f func(p2p.Peer) bool) p2p.Picker {
+	return &picker{pickerFunc: f}
+}
+
+type picker struct {
+	pickerFunc func(p2p.Peer) bool
+}
+
+func (p *picker) Pick(peer p2p.Peer) bool {
+	return p.pickerFunc(peer)
 }
 
 // testInfo validates if two Info instances are equal.

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -213,7 +213,7 @@ func TestHandshake(t *testing.T) {
 
 		_, err = handshakeService.Handle(context.Background(), stream1, node2AddrInfo.Addrs[0], node2AddrInfo.ID)
 		expectedErr := handshake.ErrPicker
-		if err == nil || !errors.Is(err, expectedErr) {
+		if !errors.Is(err, expectedErr) {
 			t.Fatal("expected:", expectedErr, "got:", err)
 		}
 	})

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -331,15 +331,6 @@ func (s *Service) handleIncoming(stream network.Stream) {
 		return
 	}
 
-	if s.notifier != nil {
-		if !s.notifier.Pick(p2p.Peer{Address: overlay, FullNode: i.FullNode}) {
-			s.logger.Warningf("stream handler: don't want incoming peer %s. disconnecting", overlay)
-			_ = handshakeStream.Reset()
-			_ = s.host.Network().ClosePeer(peerID)
-			return
-		}
-	}
-
 	if exists := s.peers.addIfNotExists(stream.Conn(), overlay, i.FullNode); exists {
 		s.logger.Debugf("stream handler: peer %s already exists", overlay)
 		if err = handshakeStream.FullClose(); err != nil {
@@ -447,6 +438,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 }
 
 func (s *Service) SetPickyNotifier(n p2p.PickyNotifier) {
+	s.handshakeService.SetPickyNotifier(n)
 	s.notifier = n
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -438,7 +438,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 }
 
 func (s *Service) SetPickyNotifier(n p2p.PickyNotifier) {
-	s.handshakeService.SetPickyNotifier(n)
+	s.handshakeService.SetPicker(n)
 	s.notifier = n
 }
 

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -43,8 +43,12 @@ type Halter interface {
 
 // PickyNotifier can decide whether a peer should be picked
 type PickyNotifier interface {
-	Pick(Peer) bool
+	Picker
 	Notifier
+}
+
+type Picker interface {
+	Pick(Peer) bool
 }
 
 type Notifier interface {


### PR DESCRIPTION
Oversaturated bins reject new incoming peers, so in the life time of a node, after the warmup period, almost all of connection attempts are rejected. 
The PR moves the Pick check before the overlay verification step. As a result, the number of eth backend calls are drastically reduced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2541)
<!-- Reviewable:end -->
