### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -7,7 +7,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,7 +268,7 @@ func newLogger(cmd *cobra.Command, verbosity string) (logging.Logger, error) {
 	var logger logging.Logger
 	switch verbosity {
 	case "0", "silent":
-		logger = logging.New(ioutil.Discard, 0)
+		logger = logging.New(io.Discard, 0)
 	case "1", "error":
 		logger = logging.New(cmd.OutOrStdout(), logrus.ErrorLevel)
 	case "2", "warn":

--- a/cmd/bee/cmd/cmd_test.go
+++ b/cmd/bee/cmd/cmd_test.go
@@ -6,7 +6,6 @@ package cmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 var homeDir string
 
 func TestMain(m *testing.M) {
-	dir, err := ioutil.TempDir("", "bee-cmd-")
+	dir, err := os.MkdirTemp("", "bee-cmd-")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -11,7 +11,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -325,7 +324,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger logging.Logger) (co
 	if p := c.config.GetString(optionNamePassword); p != "" {
 		password = p
 	} else if pf := c.config.GetString(optionNamePasswordFile); pf != "" {
-		b, err := ioutil.ReadFile(pf)
+		b, err := os.ReadFile(pf)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -7,7 +7,7 @@ package accounting_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 	"time"
@@ -50,7 +50,7 @@ type booking struct {
 
 // TestAccountingAddBalance does several accounting actions and verifies the balance after each steep
 func TestAccountingAddBalance(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -117,7 +117,7 @@ func TestAccountingAddBalance(t *testing.T) {
 
 // TestAccountingAddBalance does several accounting actions and verifies the balance after each steep
 func TestAccountingAddOriginatedBalance(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -233,7 +233,7 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 // It creates an accounting instance, does some accounting
 // Then it creates a new accounting instance with the same store and verifies the balances
 func TestAccountingAdd_persistentBalances(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -299,7 +299,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 
 // TestAccountingReserve tests that reserve returns an error if the payment threshold would be exceeded
 func TestAccountingReserve(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -329,7 +329,7 @@ func TestAccountingReserve(t *testing.T) {
 
 // TestAccountingDisconnect tests that exceeding the disconnect threshold with Debit returns a p2p.DisconnectError
 func TestAccountingDisconnect(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -376,7 +376,7 @@ func TestAccountingDisconnect(t *testing.T) {
 
 // TestAccountingCallSettlement tests that settlement is called correctly if the payment threshold is hit
 func TestAccountingCallSettlement(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -501,7 +501,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 }
 
 func TestAccountingCallSettlementMonetary(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -620,7 +620,7 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 }
 
 func TestAccountingCallSettlementTooSoon(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -759,7 +759,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 
 // TestAccountingCallSettlementEarly tests that settlement is called correctly if the payment threshold minus early payment is hit
 func TestAccountingCallSettlementEarly(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -823,7 +823,7 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 }
 
 func TestAccountingSurplusBalance(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -946,7 +946,7 @@ func TestAccountingSurplusBalance(t *testing.T) {
 
 // TestAccountingNotifyPayment tests that payments adjust the balance and payment which put us into debt are rejected
 func TestAccountingNotifyPaymentReceived(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1009,7 +1009,7 @@ func (p *pricingMock) AnnouncePaymentThreshold(ctx context.Context, peer swarm.A
 }
 
 func TestAccountingConnected(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1045,7 +1045,7 @@ func TestAccountingConnected(t *testing.T) {
 }
 
 func TestAccountingNotifyPaymentThreshold(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1105,7 +1105,7 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 }
 
 func TestAccountingPeerDebt(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1163,7 +1163,7 @@ func TestAccountingPeerDebt(t *testing.T) {
 }
 
 func TestAccountingCallPaymentFailureRetries(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1276,7 +1276,7 @@ func TestAccountingCallPaymentFailureRetries(t *testing.T) {
 var errInvalidReason = errors.New("invalid blocklist reason")
 
 func TestAccountingGhostOverdraft(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1350,7 +1350,7 @@ func TestAccountingGhostOverdraft(t *testing.T) {
 }
 
 func TestAccountingReconnectBeforeAllowed(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -1420,7 +1420,7 @@ func TestAccountingReconnectBeforeAllowed(t *testing.T) {
 }
 
 func TestAccountingResetBalanceAfterReconnect(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	store := mock.NewStateStore()
 	defer store.Close()

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -83,7 +82,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 	signer := crypto.NewDefaultSigner(pk)
 
 	if o.Logger == nil {
-		o.Logger = logging.New(ioutil.Discard, 0)
+		o.Logger = logging.New(io.Discard, 0)
 	}
 	if o.Resolver == nil {
 		o.Resolver = resolverMock.NewResolver()
@@ -159,7 +158,7 @@ func pipelineFactory(s storage.Putter, mode storage.ModePut, encrypt bool) func(
 
 func TestParseName(t *testing.T) {
 	const bzzHash = "89c17d0d8018a19057314aa035e61c9d23c47581a61dd3a79a7839692c617e4d"
-	log := logging.New(ioutil.Discard, 0)
+	log := logging.New(io.Discard, 0)
 
 	testCases := []struct {
 		desc       string
@@ -277,7 +276,7 @@ func TestPostageHeaderError(t *testing.T) {
 	var (
 		mockStorer     = mock.NewStorer()
 		mockStatestore = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 5)
+		logger         = logging.New(io.Discard, 5)
 		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, big.NewInt(3), 11, 10, 1000, true)))
 		client, _, _   = newTestServer(t, testServerOptions{
 			Storer: mockStorer,

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -7,7 +7,7 @@ package api_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -36,10 +36,10 @@ func TestBytes(t *testing.T) {
 	var (
 		storerMock   = mock.NewStorer()
 		pinningMock  = pinning.NewServiceMock()
-		logger       = logging.New(ioutil.Discard, 0)
+		logger       = logging.New(io.Discard, 0)
 		client, _, _ = newTestServer(t, testServerOptions{
 			Storer:  storerMock,
-			Tags:    tags.NewTags(statestore.NewStateStore(), logging.New(ioutil.Discard, 0)),
+			Tags:    tags.NewTags(statestore.NewStateStore(), logging.New(io.Discard, 0)),
 			Pinning: pinningMock,
 			Logger:  logger,
 			Post:    mockpost.New(mockpost.WithAcceptAll()),
@@ -111,7 +111,7 @@ func TestBytes(t *testing.T) {
 
 	t.Run("download", func(t *testing.T) {
 		resp := request(t, client, http.MethodGet, resource+"/"+expHash, nil, http.StatusOK)
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -41,7 +40,7 @@ func TestBzzFiles(t *testing.T) {
 		storerMock           = smock.NewStorer()
 		statestoreMock       = statestore.NewStateStore()
 		pinningMock          = pinning.NewServiceMock()
-		logger               = logging.New(ioutil.Discard, 0)
+		logger               = logging.New(io.Discard, 0)
 		client, _, _         = newTestServer(t, testServerOptions{
 			Storer:  storerMock,
 			Pinning: pinningMock,
@@ -444,7 +443,7 @@ func TestBzzFilesRangeRequests(t *testing.T) {
 	for _, upload := range uploads {
 		t.Run(upload.name, func(t *testing.T) {
 			mockStatestore := statestore.NewStateStore()
-			logger := logging.New(ioutil.Discard, 0)
+			logger := logging.New(io.Discard, 0)
 			client, _, _ := newTestServer(t, testServerOptions{
 				Storer: smock.NewStorer(),
 				Tags:   tags.NewTags(mockStatestore, logger),
@@ -546,7 +545,7 @@ func parseRangeParts(t *testing.T, contentType string, body []byte) (parts [][]b
 	}
 	mr := multipart.NewReader(bytes.NewReader(body), params["boundary"])
 	for part, err := mr.NextPart(); err == nil; part, err = mr.NextPart() {
-		value, err := ioutil.ReadAll(part)
+		value, err := io.ReadAll(part)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -560,7 +559,7 @@ func TestFeedIndirection(t *testing.T) {
 	var (
 		updateData     = []byte("<h1>Swarm Feeds Hello World!</h1>")
 		mockStatestore = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		storer         = smock.NewStorer()
 		client, _, _   = newTestServer(t, testServerOptions{
 			Storer: storer,
@@ -649,7 +648,7 @@ func TestFeedIndirection(t *testing.T) {
 
 func TestBzzReupload(t *testing.T) {
 	var (
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		mockStatestore = statestore.NewStateStore()
 		m              = &mockSteward{}
 		storer         = smock.NewStorer()

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -88,7 +87,7 @@ func (s *server) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return

--- a/pkg/api/chunk_stream_test.go
+++ b/pkg/api/chunk_stream_test.go
@@ -7,7 +7,7 @@ package api_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -33,7 +33,7 @@ func TestChunkUploadStream(t *testing.T) {
 
 	var (
 		statestoreMock = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		tag            = tags.NewTags(statestoreMock, logger)
 		storerMock     = mock.NewStorer()
 		pinningMock    = pinning.NewServiceMock()

--- a/pkg/api/chunk_test.go
+++ b/pkg/api/chunk_test.go
@@ -7,7 +7,7 @@ package api_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestChunkUploadDownload(t *testing.T) {
 		resourceTargets = func(addr swarm.Address) string { return "/chunks/" + addr.String() + "?targets=" + targets }
 		chunk           = testingc.GenerateTestRandomChunk()
 		statestoreMock  = statestore.NewStateStore()
-		logger          = logging.New(ioutil.Discard, 0)
+		logger          = logging.New(io.Discard, 0)
 		tag             = tags.NewTags(statestoreMock, logger)
 		storerMock      = mock.NewStorer()
 		pinningMock     = pinning.NewServiceMock()
@@ -69,7 +69,7 @@ func TestChunkUploadDownload(t *testing.T) {
 
 		// try to fetch the same chunk
 		resp := request(t, client, http.MethodGet, chunksResource(chunk.Address()), nil, http.StatusOK)
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -38,7 +37,7 @@ func TestDirs(t *testing.T) {
 		ctx                 = context.Background()
 		storer              = mock.NewStorer()
 		mockStatestore      = statestore.NewStateStore()
-		logger              = logging.New(ioutil.Discard, 0)
+		logger              = logging.New(io.Discard, 0)
 		client, _, _        = newTestServer(t, testServerOptions{
 			Storer:          storer,
 			Tags:            tags.NewTags(mockStatestore, logger),

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"testing"
@@ -45,7 +45,7 @@ func TestFeed_Get(t *testing.T) {
 			return fmt.Sprintf("/feeds/%s/%s", owner, topic)
 		}
 		mockStatestore = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
 		mockStorer     = mock.NewStorer()
 		client, _, _   = newTestServer(t, testServerOptions{
@@ -151,7 +151,7 @@ func TestFeed_Post(t *testing.T) {
 	// manifest entry and make sure all metadata correct
 	var (
 		mockStatestore = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
 		topic          = "aabbcc"
 		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, big.NewInt(3), 11, 10, 1000, true)))

--- a/pkg/api/gatewaymode_test.go
+++ b/pkg/api/gatewaymode_test.go
@@ -6,7 +6,7 @@ package api_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -22,7 +22,7 @@ import (
 )
 
 func TestGatewayMode(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	chunk := testingc.GenerateTestRandomChunk()
 	client, _, _ := newTestServer(t, testServerOptions{
 		Storer:      mock.NewStorer(),

--- a/pkg/api/pin_test.go
+++ b/pkg/api/pin_test.go
@@ -6,7 +6,7 @@ package api_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -86,9 +86,9 @@ func TestPinHandlers(t *testing.T) {
 		client, _, _ = newTestServer(t, testServerOptions{
 			Storer:    storerMock,
 			Traversal: traversal.New(storerMock),
-			Tags:      tags.NewTags(statestore.NewStateStore(), logging.New(ioutil.Discard, 0)),
+			Tags:      tags.NewTags(statestore.NewStateStore(), logging.New(io.Discard, 0)),
 			Pinning:   pinning.NewServiceMock(),
-			Logger:    logging.New(ioutil.Discard, 5),
+			Logger:    logging.New(io.Discard, 5),
 			Post:      mockpost.New(mockpost.WithAcceptAll()),
 		})
 	)

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -72,7 +72,7 @@ func (s *server) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		s.logger.Debugf("pss read payload: %v", err)
 		s.logger.Error("pss read payload")

--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -10,7 +10,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -165,7 +165,7 @@ func TestPssWebsocketMultiHandler(t *testing.T) {
 // TestPssSend tests that the pss message sending over http works correctly.
 func TestPssSend(t *testing.T) {
 	var (
-		logger = logging.New(ioutil.Discard, 0)
+		logger = logging.New(io.Discard, 0)
 
 		mtx             sync.Mutex
 		receivedTopic   pss.Topic
@@ -409,7 +409,7 @@ func newPssTest(t *testing.T, o opts) (pss.Interface, *ecdsa.PublicKey, *websock
 		t.Fatal(err)
 	}
 	var (
-		logger = logging.New(ioutil.Discard, 0)
+		logger = logging.New(io.Discard, 0)
 		pss    = pss.New(privkey, logger)
 	)
 	if o.pingPeriod == 0 {

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -7,7 +7,7 @@ package api
 import (
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -57,7 +57,7 @@ func (s *server) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"testing"
@@ -31,7 +31,7 @@ func TestSOC(t *testing.T) {
 		testData       = []byte("foo")
 		socResource    = func(owner, id, sig string) string { return fmt.Sprintf("/soc/%s/%s?sig=%s", owner, id, sig) }
 		mockStatestore = statestore.NewStateStore()
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		tag            = tags.NewTags(mockStatestore, logger)
 		mp             = mockpost.New(mockpost.WithIssuer(postage.NewStampIssuer("", "", batchOk, big.NewInt(3), 11, 10, 1000, true)))
 		mockStorer     = mock.NewStorer()
@@ -109,7 +109,7 @@ func TestSOC(t *testing.T) {
 		// try to fetch the same chunk
 		rsrc := fmt.Sprintf("/chunks/" + s.Address().String())
 		resp := request(t, client, http.MethodGet, rsrc, nil, http.StatusOK)
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/api/stewardship_test.go
+++ b/pkg/api/stewardship_test.go
@@ -7,7 +7,7 @@ package api_test
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ import (
 
 func TestStewardship(t *testing.T) {
 	var (
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		mockStatestore = statestore.NewStateStore()
 		m              = &mockSteward{}
 		storer         = smock.NewStorer()

--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -7,7 +7,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -45,7 +45,7 @@ func newTagResponse(tag *tags.Tag) tagResponse {
 }
 
 func (s *server) createTagHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return
@@ -147,7 +147,7 @@ func (s *server) doneSplitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, w) {
 			return

--- a/pkg/api/tag_test.go
+++ b/pkg/api/tag_test.go
@@ -7,7 +7,7 @@ package api_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -46,7 +46,7 @@ func TestTags(t *testing.T) {
 		tagsResource          = "/tags"
 		chunk                 = testingc.GenerateTestRandomChunk()
 		mockStatestore        = statestore.NewStateStore()
-		logger                = logging.New(ioutil.Discard, 0)
+		logger                = logging.New(io.Discard, 0)
 		tag                   = tags.NewTags(mockStatestore, logger)
 		client, _, listenAddr = newTestServer(t, testServerOptions{
 			Storer: mock.NewStorer(),

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +89,7 @@ func newTestServer(t *testing.T, o testServerOptions) *testServer {
 	swapserv := swapmock.New(o.SwapOpts...)
 	transaction := transactionmock.New(o.TransactionOpts...)
 	ln := lightnode.NewContainer(o.Overlay)
-	s := debugapi.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(ioutil.Discard, 0), nil, o.CORSAllowedOrigins, big.NewInt(2), transaction)
+	s := debugapi.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(io.Discard, 0), nil, o.CORSAllowedOrigins, big.NewInt(2), transaction)
 	s.Configure(o.Overlay, o.P2P, o.Pingpong, topologyDriver, ln, o.Storer, o.Tags, acc, settlement, true, swapserv, chequebook, o.BatchStore, o.Post, o.PostageContract, o.Traverser)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
@@ -157,7 +157,7 @@ func TestServer_Configure(t *testing.T) {
 	swapserv := swapmock.New(o.SwapOpts...)
 	ln := lightnode.NewContainer(o.Overlay)
 	transaction := transactionmock.New(o.TransactionOpts...)
-	s := debugapi.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(ioutil.Discard, 0), nil, nil, big.NewInt(2), transaction)
+	s := debugapi.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, logging.New(io.Discard, 0), nil, nil, big.NewInt(2), transaction)
 	ts := httptest.NewServer(s)
 	t.Cleanup(ts.Close)
 

--- a/pkg/debugapi/tag_test.go
+++ b/pkg/debugapi/tag_test.go
@@ -7,7 +7,7 @@ package debugapi_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -26,7 +26,7 @@ func tagsWithIdResource(id uint32) string { return fmt.Sprintf("/tags/%d", id) }
 
 func TestTags(t *testing.T) {
 	var (
-		logger         = logging.New(ioutil.Discard, 0)
+		logger         = logging.New(io.Discard, 0)
 		chunk          = testingc.GenerateTestRandomChunk()
 		mockStorer     = mock.NewStorer()
 		mockStatestore = statestore.NewStateStore()

--- a/pkg/file/addresses/addresses_getter_test.go
+++ b/pkg/file/addresses/addresses_getter_test.go
@@ -6,7 +6,7 @@ package addresses_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -67,7 +67,7 @@ func TestAddressesGetterIterateChunkAddresses(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = file.JoinReadAll(ctx, j, ioutil.Discard)
+	_, err = file.JoinReadAll(ctx, j, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"sync"
 	"testing"
@@ -67,7 +66,7 @@ func TestJoinerSingleChunk(t *testing.T) {
 	if l != int64(len(mockData)) {
 		t.Fatalf("expected join data length %d, got %d", len(mockData), l)
 	}
-	joinData, err := ioutil.ReadAll(joinReader)
+	joinData, err := io.ReadAll(joinReader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +104,7 @@ func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 	if l != int64(len(mockData)) {
 		t.Fatalf("expected join data length %d, got %d", len(mockData), l)
 	}
-	joinData, err := ioutil.ReadAll(joinReader)
+	joinData, err := io.ReadAll(joinReader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,13 +315,13 @@ func TestSeek(t *testing.T) {
 			store := mock.NewStorer()
 			defer store.Close()
 
-			data, err := ioutil.ReadAll(io.LimitReader(r, tc.size))
+			data, err := io.ReadAll(io.LimitReader(r, tc.size))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
-			addr, err := s.Split(ctx, ioutil.NopCloser(bytes.NewReader(data)), tc.size, false)
+			addr, err := s.Split(ctx, io.NopCloser(bytes.NewReader(data)), tc.size, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -594,13 +593,13 @@ func TestPrefetch(t *testing.T) {
 			store := mock.NewStorer()
 			defer store.Close()
 
-			data, err := ioutil.ReadAll(io.LimitReader(r, tc.size))
+			data, err := io.ReadAll(io.LimitReader(r, tc.size))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
-			addr, err := s.Split(ctx, ioutil.NopCloser(bytes.NewReader(data)), tc.size, false)
+			addr, err := s.Split(ctx, io.NopCloser(bytes.NewReader(data)), tc.size, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"runtime/debug"
 	"strconv"
@@ -39,7 +39,7 @@ var (
 
 func TestHandlerRateLimit(t *testing.T) {
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	statestore := mock.NewStateStore()
 	addressbook := ab.New(statestore)
 	networkID := uint64(1)
@@ -108,7 +108,7 @@ func TestHandlerRateLimit(t *testing.T) {
 
 func TestBroadcastPeers(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	statestore := mock.NewStateStore()
 	addressbook := ab.New(statestore)
 	networkID := uint64(1)

--- a/pkg/intervalstore/store_test.go
+++ b/pkg/intervalstore/store_test.go
@@ -17,7 +17,6 @@
 package intervalstore
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestInmemoryStore(t *testing.T) {
 
 // TestDBStore tests basic functionality of DBStore.
 func TestDBStore(t *testing.T) {
-	dir, err := ioutil.TempDir("", "intervals_test_db_store")
+	dir, err := os.MkdirTemp("", "intervals_test_db_store")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/jsonhttp/handlers_test.go
+++ b/pkg/jsonhttp/handlers_test.go
@@ -7,7 +7,7 @@ package jsonhttp_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +21,7 @@ func TestMethodHandler(t *testing.T) {
 
 	h := jsonhttp.MethodHandler{
 		"POST": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got, err := ioutil.ReadAll(r.Body)
+			got, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -119,7 +119,7 @@ func TestNewMaxBodyBytesHandler(t *testing.T) {
 	var limit int64 = 10
 
 	h := jsonhttp.NewMaxBodyBytesHandler(limit)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		if err != nil {
 			if jsonhttp.HandleBodyReadError(err, w) {
 				return

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -54,7 +53,7 @@ func Request(t testing.TB, client *http.Client, method, url string, responseCode
 	}
 
 	if o.expectedResponse != nil {
-		got, err := ioutil.ReadAll(resp.Body)
+		got, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -69,7 +68,7 @@ func Request(t testing.TB, client *http.Client, method, url string, responseCode
 		if v := resp.Header.Get("Content-Type"); v != jsonhttp.DefaultContentTypeHeader {
 			t.Errorf("got content type %q, want %q", v, jsonhttp.DefaultContentTypeHeader)
 		}
-		got, err := ioutil.ReadAll(resp.Body)
+		got, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,14 +92,14 @@ func Request(t testing.TB, client *http.Client, method, url string, responseCode
 		return resp.Header
 	}
 	if o.responseBody != nil {
-		got, err := ioutil.ReadAll(resp.Body)
+		got, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
 		*o.responseBody = got
 	}
 	if o.noResponseBody {
-		got, err := ioutil.ReadAll(resp.Body)
+		got, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -104,7 +103,7 @@ func TestWithRequestBody(t *testing.T) {
 	var gotBody []byte
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
-		gotBody, err = ioutil.ReadAll(r.Body)
+		gotBody, err = io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -131,7 +130,7 @@ func TestWithJSONRequestBody(t *testing.T) {
 	}
 	var gotBody response
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		v, err := ioutil.ReadAll(r.Body)
+		v, err := io.ReadAll(r.Body)
 		if err != nil {
 			jsonhttp.InternalServerError(w, err)
 			return
@@ -177,7 +176,7 @@ func TestWithMultipartRequest(t *testing.T) {
 			}
 			gotContentDisposition = p.Header.Get("Content-Disposition")
 			gotContentType = p.Header.Get("Content-Type")
-			gotBody, err = ioutil.ReadAll(p)
+			gotBody, err = io.ReadAll(p)
 			if err != nil {
 				jsonhttp.BadRequest(w, err)
 				return

--- a/pkg/keystore/file/service.go
+++ b/pkg/keystore/file/service.go
@@ -7,7 +7,6 @@ package file
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ func New(dir string) *Service {
 func (s *Service) Exists(name string) (bool, error) {
 	filename := s.keyFilename(name)
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil && !os.IsNotExist(err) {
 		return false, fmt.Errorf("read private key: %w", err)
 	}
@@ -44,7 +43,7 @@ func (s *Service) Exists(name string) (bool, error) {
 func (s *Service) Key(name, password string) (pk *ecdsa.PrivateKey, created bool, err error) {
 	filename := s.keyFilename(name)
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, false, fmt.Errorf("read private key: %w", err)
 	}
@@ -63,7 +62,7 @@ func (s *Service) Key(name, password string) (pk *ecdsa.PrivateKey, created bool
 		if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
 			return nil, false, err
 		}
-		if err := ioutil.WriteFile(filename, d, 0600); err != nil {
+		if err := os.WriteFile(filename, d, 0600); err != nil {
 			return nil, false, err
 		}
 		return pk, true, nil

--- a/pkg/keystore/file/service_test.go
+++ b/pkg/keystore/file/service_test.go
@@ -5,7 +5,6 @@
 package file_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func TestService(t *testing.T) {
-	dir, err := ioutil.TempDir("", "bzz-keystore-file-")
+	dir, err := os.MkdirTemp("", "bzz-keystore-file-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/localstore/export.go
+++ b/pkg/localstore/export.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/postage"
@@ -122,7 +121,7 @@ func (db *DB) Import(ctx context.Context, r io.Reader) (count int64, err error) 
 			if firstFile {
 				firstFile = false
 				if hdr.Name == exportVersionFilename {
-					data, err := ioutil.ReadAll(tr)
+					data, err := io.ReadAll(tr)
 					if err != nil {
 						select {
 						case errC <- err:
@@ -145,7 +144,7 @@ func (db *DB) Import(ctx context.Context, r io.Reader) (count int64, err error) 
 				continue
 			}
 
-			rawdata, err := ioutil.ReadAll(tr)
+			rawdata, err := io.ReadAll(tr)
 			if err != nil {
 				select {
 				case errC <- err:

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"sync"
@@ -478,7 +478,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 // TestDB_gcSize checks if gcSize has a correct value after
 // database is initialized with existing data.
 func TestDB_gcSize(t *testing.T) {
-	dir, err := ioutil.TempDir("", "localstore-stored-gc-size")
+	dir, err := os.MkdirTemp("", "localstore-stored-gc-size")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestDB_gcSize(t *testing.T) {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	db, err := New(dir, baseKey, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"runtime"
 	"sort"
@@ -157,7 +157,7 @@ func newTestDB(t testing.TB, o *Options) *DB {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	db, err := New("", baseKey, nil, o, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/localstore/migration_test.go
+++ b/pkg/localstore/migration_test.go
@@ -17,7 +17,7 @@
 package localstore
 
 import (
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"strings"
@@ -48,7 +48,7 @@ func TestOneMigration(t *testing.T) {
 		}},
 	}
 
-	dir, err := ioutil.TempDir("", "localstore-test")
+	dir, err := os.MkdirTemp("", "localstore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestOneMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh localstore with the sanctuary schema name
 	db, err := New(dir, baseKey, nil, nil, logger)
@@ -136,7 +136,7 @@ func TestManyMigrations(t *testing.T) {
 		}},
 	}
 
-	dir, err := ioutil.TempDir("", "localstore-test")
+	dir, err := os.MkdirTemp("", "localstore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestManyMigrations(t *testing.T) {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh localstore with the sanctuary schema name
 	db, err := New(dir, baseKey, nil, nil, logger)
@@ -216,7 +216,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 		}},
 	}
 
-	dir, err := ioutil.TempDir("", "localstore-test")
+	dir, err := os.MkdirTemp("", "localstore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 	if _, err := rand.Read(baseKey); err != nil {
 		t.Fatal(err)
 	}
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh localstore with the sanctuary schema name
 	db, err := New(dir, baseKey, nil, nil, logger)
@@ -276,7 +276,7 @@ func TestMigrationErrorTo(t *testing.T) {
 		}},
 	}
 
-	dir, err := ioutil.TempDir("", "localstore-test")
+	dir, err := os.MkdirTemp("", "localstore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestMigrationErrorTo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh localstore with the sanctuary schema name
 	db, err := New(dir, baseKey, nil, nil, logger)

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -190,7 +190,7 @@ func TestInvalidPostageStamp(t *testing.T) {
 func newRetrievingNetstore(rec recovery.Callback, validStamp postage.ValidStampFn) (ret *retrievalMock, mockStore *mock.MockStorer, ns storage.Storer) {
 	retrieve := &retrievalMock{}
 	store := mock.NewStorer()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	return retrieve, store, netstore.New(store, validStamp, rec, retrieve, logger)
 }
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,7 +32,7 @@ func TestHandshake(t *testing.T) {
 		testWelcomeMessage = "HelloWorld"
 	)
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	networkID := uint64(3)
 
 	node1ma, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1634/p2p/16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA")

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 	"time"
@@ -54,7 +54,7 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 	addr := ":0"
 
 	if o.Logger == nil {
-		o.Logger = logging.New(ioutil.Discard, 0)
+		o.Logger = logging.New(io.Discard, 0)
 	}
 
 	statestore := mock.NewStateStore()

--- a/pkg/p2p/streamtest/streamtest_test.go
+++ b/pkg/p2p/streamtest/streamtest_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -500,7 +499,7 @@ func TestRecorder_withMiddlewares(t *testing.T) {
 		if err := rw.Flush(); err != nil {
 			return err
 		}
-		_, err = ioutil.ReadAll(rw)
+		_, err = io.ReadAll(rw)
 		return err
 	}
 
@@ -558,7 +557,7 @@ func TestRecorder_recordErr(t *testing.T) {
 			return err
 		}
 
-		_, err = ioutil.ReadAll(stream)
+		_, err = io.ReadAll(stream)
 		return err
 	}
 

--- a/pkg/pingpong/pingpong_test.go
+++ b/pkg/pingpong/pingpong_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"runtime"
 	"testing"
 	"time"
@@ -24,7 +24,7 @@ import (
 )
 
 func TestPing(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// create a pingpong server that handles the incoming stream
 	server := pingpong.New(nil, logger, nil)

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"hash"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	testLog    = logging.New(ioutil.Discard, 0)
+	testLog    = logging.New(io.Discard, 0)
 	errTest    = errors.New("fails")
 	testTxHash = make([]byte, 32)
 )

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"math/rand"
 	"os"
@@ -27,7 +27,7 @@ func setupBatchStore(t *testing.T) (postage.Storer, map[string]uint8) {
 	t.Helper()
 	// we cannot  use the mock statestore here since the iterator is not giving the right order
 	// must use the leveldb statestore
-	dir, err := ioutil.TempDir("", "batchstore_test")
+	dir, err := os.MkdirTemp("", "batchstore_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func setupBatchStore(t *testing.T) (postage.Storer, map[string]uint8) {
 			t.Fatal(err)
 		}
 	})
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	stateStore, err := leveldb.NewStateStore(dir, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -738,7 +738,7 @@ func TestUnreserveItemSequence(t *testing.T) {
 	batchstore.Capacity = batchstore.Exp2(5) // 32 chunks
 	initBatchDepth := uint8(8)
 
-	dir, err := ioutil.TempDir("", "batchstore_test")
+	dir, err := os.MkdirTemp("", "batchstore_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,7 +747,7 @@ func TestUnreserveItemSequence(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	stateStore, err := leveldb.NewStateStore(dir, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -5,7 +5,7 @@
 package batchstore_test
 
 import (
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 
@@ -25,7 +25,7 @@ func TestBatchStoreGet(t *testing.T) {
 	key := batchstore.BatchKey(testBatch.ID)
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, logging.New(ioutil.Discard, 0))
+	batchStore, _ := batchstore.New(stateStore, nil, logging.New(io.Discard, 0))
 
 	stateStorePut(t, stateStore, key, testBatch)
 	got := batchStoreGetBatch(t, batchStore, testBatch.ID)
@@ -37,7 +37,7 @@ func TestBatchStorePut(t *testing.T) {
 	key := batchstore.BatchKey(testBatch.ID)
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, logging.New(ioutil.Discard, 0))
+	batchStore, _ := batchstore.New(stateStore, nil, logging.New(io.Discard, 0))
 	batchStore.SetRadiusSetter(noopRadiusSetter{})
 	batchStorePutBatch(t, batchStore, testBatch)
 
@@ -50,7 +50,7 @@ func TestBatchStoreGetChainState(t *testing.T) {
 	testChainState := postagetest.NewChainState()
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, logging.New(ioutil.Discard, 0))
+	batchStore, _ := batchstore.New(stateStore, nil, logging.New(io.Discard, 0))
 	batchStore.SetRadiusSetter(noopRadiusSetter{})
 
 	err := batchStore.PutChainState(testChainState)
@@ -65,7 +65,7 @@ func TestBatchStorePutChainState(t *testing.T) {
 	testChainState := postagetest.NewChainState()
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, logging.New(ioutil.Discard, 0))
+	batchStore, _ := batchstore.New(stateStore, nil, logging.New(io.Discard, 0))
 	batchStore.SetRadiusSetter(noopRadiusSetter{})
 
 	batchStorePutChainState(t, batchStore, testChainState)
@@ -79,7 +79,7 @@ func TestBatchStoreReset(t *testing.T) {
 	testBatch := postagetest.MustNewBatch()
 
 	path := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// we use the real statestore since the mock uses a mutex,
 	// therefore deleting while iterating (in Reset() implementation)

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"sync"
 	"testing"
@@ -27,7 +27,7 @@ var addr common.Address = common.HexToAddress("abcdef")
 var postageStampAddress common.Address = common.HexToAddress("eeee")
 
 func TestListener(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	blockNumber := uint64(500)
 	timeout := 5 * time.Second
 	// test that when the listener gets a certain event

--- a/pkg/pricing/pricing_test.go
+++ b/pkg/pricing/pricing_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 
@@ -35,7 +35,7 @@ func (t *testThresholdObserver) NotifyPaymentThreshold(peerAddr swarm.Address, p
 }
 
 func TestAnnouncePaymentThreshold(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	testThreshold := big.NewInt(100000)
 	observer := &testThresholdObserver{}
 
@@ -100,7 +100,7 @@ func TestAnnouncePaymentThreshold(t *testing.T) {
 }
 
 func TestAnnouncePaymentWithInsufficientThreshold(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	testThreshold := big.NewInt(100_000)
 	observer := &testThresholdObserver{}
 

--- a/pkg/pss/pss_test.go
+++ b/pkg/pss/pss_test.go
@@ -7,7 +7,7 @@ package pss_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -32,7 +32,7 @@ func TestSend(t *testing.T) {
 		storedChunk = chunk
 		return nil, nil
 	})
-	p := pss.New(nil, logging.New(ioutil.Discard, 0))
+	p := pss.New(nil, logging.New(io.Discard, 0))
 	p.SetPushSyncer(pushSyncService)
 
 	target := pss.Target([]byte{1}) // arbitrary test target
@@ -81,7 +81,7 @@ func TestDeliver(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p := pss.New(privkey, logging.New(ioutil.Discard, 0))
+	p := pss.New(privkey, logging.New(io.Discard, 0))
 
 	target := pss.Target([]byte{1}) // arbitrary test target
 	targets := pss.Targets([]pss.Target{target})
@@ -136,7 +136,7 @@ func TestRegister(t *testing.T) {
 	}
 	recipient := &privkey.PublicKey
 	var (
-		p       = pss.New(privkey, logging.New(ioutil.Discard, 0))
+		p       = pss.New(privkey, logging.New(io.Discard, 0))
 		h1Calls = 0
 		h2Calls = 0
 		h3Calls = 0

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -6,7 +6,7 @@ package puller_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"math"
 	"testing"
 	"time"
@@ -592,7 +592,7 @@ func newPuller(ops opts) (*puller.Puller, storage.StateStorer, *mockk.Mock, *moc
 	s := mock.NewStateStore()
 	ps := mockps.NewPullSync(ops.pullSync...)
 	kad := mockk.NewMockKademlia(ops.kad...)
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	o := puller.Options{
 		Bins: ops.bins,

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"runtime/pprof"
 	"strings"
@@ -561,7 +561,7 @@ func newTestDB(t testing.TB, o *localstore.Options) (baseKey []byte, db *localst
 		t.Fatal(err)
 	}
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	db, err := localstore.New("", baseKey, nil, o, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -214,7 +213,7 @@ func haveChunks(t *testing.T, s *mock.PullStorage, addrs ...swarm.Address) {
 
 func newPullSync(s p2p.Streamer, o ...mock.Option) (*pullsync.Syncer, *mock.PullStorage) {
 	storage := mock.NewPullStorage(o...)
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	unwrap := func(swarm.Chunk) {}
 	validStamp := func(ch swarm.Chunk, _ []byte) (swarm.Chunk, error) { return ch, nil }
 	return pullsync.New(s, storage, unwrap, validStamp, logger), storage

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -7,7 +7,7 @@ package pusher_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -479,7 +479,7 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 
 func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
 	t.Helper()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	storer, err := localstore.New("", addr.Bytes(), nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -807,7 +807,7 @@ func createPushSyncNode(t *testing.T, addr swarm.Address, prices pricerParameter
 
 func createPushSyncNodeWithAccounting(t *testing.T, addr swarm.Address, prices pricerParameters, recorder *streamtest.Recorder, unwrap func(swarm.Chunk), signer crypto.Signer, acct accounting.Interface, mockOpts ...mock.Option) (*pushsync.PushSync, *mocks.MockStorer, *tags.Tags) {
 	t.Helper()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	storer := mocks.NewStorer()
 
 	mockTopology := mock.NewTopologyDriver(mockOpts...)

--- a/pkg/recovery/repair_test.go
+++ b/pkg/recovery/repair_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -115,7 +115,7 @@ func TestCallbackCalls(t *testing.T) {
 
 // TestNewRepairHandler tests the function of repairing a chunk when a request for chunk repair is received.
 func TestNewRepairHandler(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	t.Run("repair-chunk", func(t *testing.T) {
 		// generate test chunk, store and publisher
@@ -216,7 +216,7 @@ func TestNewRepairHandler(t *testing.T) {
 func newTestNetStore(t *testing.T, recoveryFunc recovery.Callback) storage.Storer {
 	t.Helper()
 	storer := mock.NewStorer()
-	logger := logging.New(ioutil.Discard, 5)
+	logger := logging.New(io.Discard, 5)
 
 	mockStorer := storemock.NewStorer()
 	serverMockAccounting := accountingmock.NewAccounting()

--- a/pkg/resolver/multiresolver/multiresolver.go
+++ b/pkg/resolver/multiresolver/multiresolver.go
@@ -7,7 +7,7 @@ package multiresolver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"strings"
 
@@ -62,7 +62,7 @@ func NewMultiResolver(opts ...Option) *MultiResolver {
 
 	// Discard log output by default.
 	if mr.logger == nil {
-		mr.logger = logging.New(ioutil.Discard, 0)
+		mr.logger = logging.New(io.Discard, 0)
 	}
 	log := mr.logger
 

--- a/pkg/resolver/multiresolver/multiresolver_test.go
+++ b/pkg/resolver/multiresolver/multiresolver_test.go
@@ -7,7 +7,7 @@ package multiresolver_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -25,7 +25,7 @@ func newAddr(s string) Address {
 }
 
 func TestMultiresolverOpts(t *testing.T) {
-	wantLog := logging.New(ioutil.Discard, 1)
+	wantLog := logging.New(io.Discard, 1)
 	wantCfgs := []multiresolver.ConnectionConfig{
 		{
 			Address:  "testadr1",

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +40,7 @@ var (
 func TestDelivery(t *testing.T) {
 	var (
 		chunk                = testingc.FixtureChunk("0033")
-		logger               = logging.New(ioutil.Discard, 0)
+		logger               = logging.New(io.Discard, 0)
 		mockStorer           = storemock.NewStorer()
 		clientMockAccounting = accountingmock.NewAccounting()
 		serverMockAccounting = accountingmock.NewAccounting()
@@ -151,7 +151,7 @@ func TestDelivery(t *testing.T) {
 func TestRetrieveChunk(t *testing.T) {
 
 	var (
-		logger = logging.New(ioutil.Discard, 0)
+		logger = logging.New(io.Discard, 0)
 		pricer = pricermock.NewMockService(defaultPrice, defaultPrice)
 	)
 
@@ -270,7 +270,7 @@ func TestRetrieveChunk(t *testing.T) {
 }
 
 func TestRetrievePreemptiveRetry(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	chunk := testingc.FixtureChunk("0025")
 	someOtherChunk := testingc.FixtureChunk("0033")

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 	"time"
@@ -99,7 +99,7 @@ func (t *testObserver) Release(peer swarm.Address, amount uint64) {
 var testRefreshRate = int64(10000)
 
 func TestPayment(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	storeRecipient := mock.NewStateStore()
 	defer storeRecipient.Close()
@@ -219,7 +219,7 @@ func TestPayment(t *testing.T) {
 }
 
 func TestTimeLimitedPayment(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	storeRecipient := mock.NewStateStore()
 	defer storeRecipient.Close()

--- a/pkg/settlement/swap/priceoracle/priceoracle_test.go
+++ b/pkg/settlement/swap/priceoracle/priceoracle_test.go
@@ -6,7 +6,7 @@ package priceoracle_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestExchangeGetPrice(t *testing.T) {
 	expectedDeduce.FillBytes(result[32:64])
 
 	ex := priceoracle.New(
-		logging.New(ioutil.Discard, 0),
+		logging.New(io.Discard, 0),
 		priceOracleAddress,
 		transactionmock.New(
 			transactionmock.WithABICall(

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -7,7 +7,7 @@ package swap_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 	"time"
@@ -151,7 +151,7 @@ func (m *cashoutMock) CashoutStatus(ctx context.Context, chequebookAddress commo
 }
 
 func TestReceiveCheque(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
 	amount := big.NewInt(50)
@@ -254,7 +254,7 @@ func TestReceiveCheque(t *testing.T) {
 }
 
 func TestReceiveChequeReject(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
 	chequebookAddress := common.HexToAddress("0xcd")
@@ -316,7 +316,7 @@ func TestReceiveChequeReject(t *testing.T) {
 }
 
 func TestReceiveChequeWrongChequebook(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
 	chequebookAddress := common.HexToAddress("0xcd")
@@ -371,7 +371,7 @@ func TestReceiveChequeWrongChequebook(t *testing.T) {
 }
 
 func TestPay(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	amount := big.NewInt(50)
@@ -425,7 +425,7 @@ func TestPay(t *testing.T) {
 }
 
 func TestPayIssueError(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	amount := big.NewInt(50)
@@ -480,7 +480,7 @@ func TestPayIssueError(t *testing.T) {
 }
 
 func TestPayUnknownBeneficiary(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	amount := big.NewInt(50)
@@ -526,7 +526,7 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 }
 
 func TestHandshake(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	beneficiary := common.HexToAddress("0xcd")
@@ -573,7 +573,7 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestHandshakeNewPeer(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	beneficiary := common.HexToAddress("0xcd")
@@ -619,7 +619,7 @@ func TestHandshakeNewPeer(t *testing.T) {
 }
 
 func TestMigratePeer(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	beneficiary := common.HexToAddress("0xcd")
@@ -653,7 +653,7 @@ func TestMigratePeer(t *testing.T) {
 }
 
 func TestCashout(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	theirChequebookAddress := common.HexToAddress("ffff")
@@ -706,7 +706,7 @@ func TestCashout(t *testing.T) {
 }
 
 func TestCashoutStatus(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	store := mockstore.NewStateStore()
 
 	theirChequebookAddress := common.HexToAddress("ffff")

--- a/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
+++ b/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"math/big"
 
-	"io/ioutil"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,7 +32,7 @@ func TestEmitCheques(t *testing.T) {
 
 	// Test negotiating / sending cheques
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")
 	swapReceiver := swapmock.NewSwap()
@@ -147,7 +147,7 @@ func TestEmitCheques(t *testing.T) {
 }
 
 func TestCantEmitChequeRateMismatch(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")
 	swapReceiver := swapmock.NewSwap()
@@ -211,7 +211,7 @@ func TestCantEmitChequeRateMismatch(t *testing.T) {
 
 func TestCantEmitChequeDeductionMismatch(t *testing.T) {
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")
 	swapReceiver := swapmock.NewSwap()
@@ -274,7 +274,7 @@ func TestCantEmitChequeDeductionMismatch(t *testing.T) {
 }
 
 func TestCantEmitChequeIneligibleDeduction(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")
 	swapReceiver := swapmock.NewSwap()

--- a/pkg/shed/db_test.go
+++ b/pkg/shed/db_test.go
@@ -17,7 +17,6 @@
 package shed
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -48,7 +47,7 @@ func TestNewDB(t *testing.T) {
 // TestDB_persistence creates one DB, saves a field and closes that DB.
 // Then, it constructs another DB and trues to retrieve the saved value.
 func TestDB_persistence(t *testing.T) {
-	dir, err := ioutil.TempDir("", "shed-test-persistence")
+	dir, err := os.MkdirTemp("", "shed-test-persistence")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/statestore/leveldb/leveldb_test.go
+++ b/pkg/statestore/leveldb/leveldb_test.go
@@ -5,7 +5,6 @@
 package leveldb_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 
 func TestPersistentStateStore(t *testing.T) {
 	test.Run(t, func(t *testing.T) storage.StateStorer {
-		dir, err := ioutil.TempDir("", "statestore_test")
+		dir, err := os.MkdirTemp("", "statestore_test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -50,7 +49,7 @@ func TestPersistentStateStore(t *testing.T) {
 }
 
 func TestGetSchemaName(t *testing.T) {
-	dir, err := ioutil.TempDir("", "statestore_test")
+	dir, err := os.MkdirTemp("", "statestore_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/statestore/leveldb/migration_test.go
+++ b/pkg/statestore/leveldb/migration_test.go
@@ -19,7 +19,7 @@ package leveldb
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -51,7 +51,7 @@ func TestOneMigration(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh statestore with the sanctuary schema name
 	db, err := NewStateStore(dir, logger)
@@ -134,7 +134,7 @@ func TestManyMigrations(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh statestore with the sanctuary schema name
 	db, err := NewStateStore(dir, logger)
@@ -209,7 +209,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 		}},
 	}
 	dir := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh statestore with the sanctuary schema name
 	db, err := NewStateStore(dir, logger)
@@ -260,7 +260,7 @@ func TestMigrationErrorTo(t *testing.T) {
 		}},
 	}
 	dir := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh statestore with the sanctuary schema name
 	db, err := NewStateStore(dir, logger)
@@ -288,7 +288,7 @@ func TestMigrationErrorTo(t *testing.T) {
 
 func TestMigrationSwap(t *testing.T) {
 	dir := t.TempDir()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	// start the fresh statestore with the sanctuary schema name
 	db, err := NewStateStore(dir, logger)

--- a/pkg/statestore/test/store.go
+++ b/pkg/statestore/test/store.go
@@ -6,7 +6,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -47,7 +46,7 @@ func (st *Serializing) UnmarshalBinary(data []byte) (err error) {
 // It tests that values persist across sessions.
 func RunPersist(t *testing.T, f func(t *testing.T, dir string) storage.StateStorer) {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "statestore_test")
+	dir, err := os.MkdirTemp("", "statestore_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tags/tag_test.go
+++ b/pkg/tags/tag_test.go
@@ -18,7 +18,7 @@ package tags
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -35,7 +35,7 @@ var (
 // TestTagSingleIncrements tests if Inc increments the tag state value
 func TestTagSingleIncrements(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	tg := &Tag{Total: 10, stateStore: mockStatestore, logger: logger}
 
 	tc := []struct {
@@ -140,7 +140,7 @@ func TestTagETA(t *testing.T) {
 // TestTagConcurrentIncrements tests Inc calls concurrently
 func TestTagConcurrentIncrements(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	tg := &Tag{stateStore: mockStatestore, logger: logger}
 	n := 10
 	wg := sync.WaitGroup{}
@@ -170,7 +170,7 @@ func TestTagConcurrentIncrements(t *testing.T) {
 // TestTagsMultipleConcurrentIncrements tests Inc calls concurrently
 func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	ts := NewTags(mockStatestore, logger)
 	n := 100
 	wg := sync.WaitGroup{}
@@ -221,7 +221,7 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 // tag Address (byte slice) contains some arbitrary value
 func TestMarshallingWithAddr(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)
 	tg.Address = swarm.NewAddress([]byte{0, 1, 2, 3, 4, 5, 6})
 
@@ -270,7 +270,7 @@ func TestMarshallingWithAddr(t *testing.T) {
 // TestMarshallingNoAddress tests that marshalling and unmarshalling is done correctly
 func TestMarshallingNoAddr(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)
 	for _, f := range allStates {
 		err := tg.Inc(f)

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -19,7 +19,7 @@ package tags
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 	"time"
@@ -31,7 +31,7 @@ import (
 
 func TestAll(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	ts := NewTags(mockStatestore, logger)
 	if _, err := ts.Create(1); err != nil {
 		t.Fatal(err)
@@ -66,7 +66,7 @@ func TestAll(t *testing.T) {
 
 func TestListAll(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 
 	ts1 := NewTags(mockStatestore, logger)
 
@@ -144,7 +144,7 @@ func TestListAll(t *testing.T) {
 
 func TestPersistence(t *testing.T) {
 	mockStatestore := statestore.NewStateStore()
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	ts := NewTags(mockStatestore, logger)
 	ta, err := ts.Create(1)
 	if err != nil {

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -876,7 +876,7 @@ func TestClosestPeer(t *testing.T) {
 	_ = waitPeers
 	t.Skip("disabled due to kademlia inconsistencies hotfix")
 
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	base := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 	connectedPeers := []p2p.Peer{
 		{
@@ -1288,7 +1288,7 @@ func TestOutofDepthPrune(t *testing.T) {
 // TestLatency tests that kademlia polls peers for latency.
 func TestLatency(t *testing.T) {
 	var (
-		logger = logging.New(ioutil.Discard, 0)
+		logger = logging.New(io.Discard, 0)
 		base   = swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
 		p1     = test.RandomAddress()
 
@@ -1567,7 +1567,7 @@ func newTestKademliaWithAddrDiscovery(
 		signer = beeCrypto.NewDefaultSigner(pk)                      // signer
 		ab     = addressbook.New(mockstate.NewStateStore())          // address book
 		p2p    = p2pMock(ab, signer, connCounter, failedConnCounter) // p2p mock
-		logger = logging.New(ioutil.Discard, 0)                      // logger
+		logger = logging.New(io.Discard, 0)                          // logger
 		ppm    = pingpongmock.New(func(_ context.Context, _ swarm.Address, _ ...string) (time.Duration, error) {
 			return 0, nil
 		})

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/logging"
@@ -130,7 +129,7 @@ func TestStartSpanFromContext_logger(t *testing.T) {
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
-	span, logger, _ := tracer.StartSpanFromContext(context.Background(), "some-operation", logging.New(ioutil.Discard, 0))
+	span, logger, _ := tracer.StartSpanFromContext(context.Background(), "some-operation", logging.New(io.Discard, 0))
 	defer span.Finish()
 
 	wantTraceID := span.Context().(jaeger.SpanContext).TraceID()
@@ -169,7 +168,7 @@ func TestNewLoggerWithTraceID(t *testing.T) {
 	span, _, ctx := tracer.StartSpanFromContext(context.Background(), "some-operation", nil)
 	defer span.Finish()
 
-	logger := tracing.NewLoggerWithTraceID(ctx, logging.New(ioutil.Discard, 0))
+	logger := tracing.NewLoggerWithTraceID(ctx, logging.New(io.Discard, 0))
 
 	wantTraceID := span.Context().(jaeger.SpanContext).TraceID()
 

--- a/pkg/transaction/monitor_test.go
+++ b/pkg/transaction/monitor_test.go
@@ -6,7 +6,7 @@ package transaction_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMonitorWatchTransaction(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	txHash := common.HexToHash("0xabcd")
 	nonce := uint64(10)
 	sender := common.HexToAddress("0xffee")

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"testing"
 
@@ -71,7 +71,7 @@ func signerMockForTransaction(signedTx *types.Transaction, sender common.Address
 }
 
 func TestTransactionSend(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	sender := common.HexToAddress("0xddff")
 	recipient := common.HexToAddress("0xabcd")
 	txData := common.Hex2Bytes("0xabcdee")
@@ -343,7 +343,7 @@ func TestTransactionSend(t *testing.T) {
 }
 
 func TestTransactionWaitForReceipt(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	txHash := common.HexToHash("0xabcdee")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)
@@ -401,7 +401,7 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 }
 
 func TestTransactionResend(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)
@@ -460,7 +460,7 @@ func TestTransactionResend(t *testing.T) {
 }
 
 func TestTransactionCancel(t *testing.T) {
-	logger := logging.New(ioutil.Discard, 0)
+	logger := logging.New(io.Discard, 0)
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2545)
<!-- Reviewable:end -->
