### PR TITLE
fix: chown all bee files to bee user

### DIFF
--- a/packaging/bee-get-addr
+++ b/packaging/bee-get-addr
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! `id -u` -eq 0 ] ; then
+if [ ! "$(id -u)" -eq 0 ] ; then
     echo "
 This script requires root priviledges, use sudo.
 "
@@ -34,3 +34,5 @@ See the docs for more at https://docs.ethswarm.org/docs/.
         "
         ;;
 esac
+
+chown -R bee:bee /var/lib/bee


### PR DESCRIPTION
At some moment `bee init` started creating files inside `statestore` folder, this fix makes sure that those files have correct ownership

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2573)
<!-- Reviewable:end -->
