### PR TITLE
refactor: remove broadcast wg

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -114,7 +114,6 @@ type Kad struct {
 	staticPeer        staticPeerFunc
 	bgBroadcastCtx    context.Context
 	bgBroadcastCancel context.CancelFunc
-	bgBroadcastWg     sync.WaitGroup
 	blocker           *blocker.Blocker
 }
 
@@ -909,9 +908,7 @@ func (k *Kad) Announce(ctx context.Context, peer swarm.Address, fullnode bool) e
 				continue
 			default:
 			}
-			k.bgBroadcastWg.Add(1)
 			go func(connectedPeer swarm.Address) {
-				defer k.bgBroadcastWg.Done()
 
 				// Create a new deadline ctx to prevent goroutine pile up
 				cCtx, cCancel := context.WithTimeout(k.bgBroadcastCtx, time.Minute)
@@ -1400,11 +1397,6 @@ func (k *Kad) Close() error {
 	go func() {
 		k.wg.Wait()
 		close(cc)
-	}()
-
-	go func() {
-		k.bgBroadcastWg.Wait()
-		close(bgBroadcastDone)
 	}()
 
 	eg := errgroup.Group{}


### PR DESCRIPTION
Due to a race condition it could be that after the broadcast context cancellation an additional goroutine may be added to the waitgroup. The race detector is therefore complaining on the shutdown sequence. The worst case condition is that the goroutine is added after the `Wait` call returned, however, due to the fact that the context is cancelled, the subsequent call to `hive` to actually communicate the peer will return with a `context.Cancelled` error.