### PR TITLE
feat(kademlia): restrict peer quick pruning on net errors only

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1504,24 +1504,23 @@ func createMetricsSnapshotView(ss *im.Snapshot) *topology.MetricSnapshotView {
 
 // isNetworkError is checking various conditions that relate to network problems.
 func isNetworkError(err error) bool {
-	switch t := err.(type) {
-	case *net.OpError:
-		if t.Op == "dial" {
+	var netOpErr *net.OpError
+	if errors.As(err, &netOpErr) {
+		if netOpErr.Op == "dial" {
 			return true
 		}
-		if t.Op == "read" {
+		if netOpErr.Op == "read" {
 			return true
 		}
-	case syscall.Errno:
-		if t == syscall.ECONNREFUSED {
-			return true
-		}
-		if t == syscall.EPIPE {
-			return true
-		}
-		if t == syscall.ETIMEDOUT {
-			return true
-		}
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	if errors.Is(err, syscall.ETIMEDOUT) {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
This PR adds a very small addition to the quick pruning to prone only on network related errors. Thanks @acud for the idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2599)
<!-- Reviewable:end -->
