### PR TITLE
fix(pushsync): panic on invalid stamp

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -233,11 +233,12 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 	storedChunk := false
 	if ps.warmedUp() && ps.topologyDriver.IsWithinDepth(chunkAddress) {
 
-		chunk, err = ps.validStamp(chunk, ch.Stamp)
+		verifiedChunk, err := ps.validStamp(chunk, ch.Stamp)
 		if err != nil {
 			ps.metrics.InvalidStampErrors.Inc()
 			ps.logger.Warningf("pushsync: forwarder, invalid stamp for chunk %s", chunkAddress.String())
 		} else {
+			chunk = verifiedChunk
 			_, err = ps.storer.Put(ctx, storage.ModePutSync, chunk)
 			if err != nil {
 				ps.logger.Warningf("pushsync: within depth peer's attempt to store chunk failed: %v", err)


### PR DESCRIPTION
Fixes an edge case where an invalid stamp causes chunk data to be missing when continuing forwarding data to another peer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2608)
<!-- Reviewable:end -->

fixes #2607