### PR TITLE
fix(chainsyncer): switch to ticker

### DIFF
--- a/pkg/chainsyncer/chainsyncer.go
+++ b/pkg/chainsyncer/chainsyncer.go
@@ -101,21 +101,21 @@ func (c *ChainSyncer) manage() {
 		o           sync.Once
 		positives   int32
 		items       int
-		timer       = time.NewTimer(0)
+		ticker      = time.NewTicker(1 * time.Nanosecond)
 	)
 	go func() {
 		<-c.quit
 		cancel()
-		_ = timer.Stop()
+		ticker.Stop()
 	}()
 
 	for {
 		select {
 		case <-c.quit:
 			return
-		case <-timer.C:
+		case <-ticker.C:
 			o.Do(func() {
-				timer.Reset(c.pollEvery)
+				ticker.Reset(c.pollEvery)
 			})
 		}
 		// go through every peer we are connected to


### PR DESCRIPTION
Changes a mistakenly used `timer` to a `ticker`. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2622)
<!-- Reviewable:end -->
