### PR TITLE
fix: correct postage batch page size

### DIFF
--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -207,6 +207,9 @@ func (svc *batchService) UpdateBlockNumber(blockNumber uint64) error {
 	if blockNumber == cs.Block {
 		return nil
 	}
+	if blockNumber < cs.Block {
+		return fmt.Errorf("batch service: block number moved backwards from %d to %d", cs.Block, blockNumber)
+	}
 	diff := big.NewInt(0).SetUint64(blockNumber - cs.Block)
 
 	cs.TotalAmount.Add(cs.TotalAmount, diff.Mul(diff, cs.CurrentPrice))

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -210,9 +210,9 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 			}
 
 			// do some paging (sub-optimal)
-			if to-from > blockPage {
+			if to-from >= blockPage {
 				paged <- struct{}{}
-				to = from + blockPage
+				to = from + blockPage - 1
 			} else {
 				closeOnce.Do(func() { close(synced) })
 			}


### PR DESCRIPTION
* pages were actually 1 block larger than they should be
* add a sanity check to ensure block number does not move backwards
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2625)
<!-- Reviewable:end -->
