### PR TITLE
Feat: Increase number of originator retries for chunk

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -38,7 +38,7 @@ const (
 )
 
 const (
-	maxPeers    = 3
+	maxPeers    = 8
 	maxAttempts = 16
 )
 


### PR DESCRIPTION
Increase number of peers tried for a chunk in push sync from 3 to 8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2629)
<!-- Reviewable:end -->
