### PR TITLE
feat: sync postage stamps in batches

### DIFF
--- a/.github/patches/listener.patch
+++ b/.github/patches/listener.patch
@@ -1,4 +1,4 @@
-168c168
-< 	chainUpdateInterval := (time.Duration(l.blockTime) * time.Second) / 2
+31c31
+< 	batchFactor = uint64(5) // minimal number of blocks to sync at once
 ---
-> 	chainUpdateInterval := (time.Duration(l.blockTime) * time.Second) / 5
+> 	batchFactor = uint64(1) // minimal number of blocks to sync at once

--- a/.github/patches/listener.patch
+++ b/.github/patches/listener.patch
@@ -1,4 +1,0 @@
-31c31
-< 	batchFactor = uint64(5) // minimal number of blocks to sync at once
----
-> 	batchFactor = uint64(1) // minimal number of blocks to sync at once

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve.patch
           patch pkg/postage/postagecontract/contract.go .github/patches/postagecontract.patch
-          patch pkg/postage/listener/listener.go .github/patches/listener.patch
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare local cluster
         run: |
@@ -170,7 +169,6 @@ jobs:
         run: |
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve.patch
           patch pkg/postage/postagecontract/contract.go .github/patches/postagecontract.patch
-          patch pkg/postage/listener/listener.go .github/patches/listener.patch
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare testing cluster (Node connection and clef enabled)
         run: |
@@ -255,7 +253,6 @@ jobs:
         run: |
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve.patch
           patch pkg/postage/postagecontract/contract.go .github/patches/postagecontract.patch
-          patch pkg/postage/listener/listener.go .github/patches/listener.patch
           patch pkg/postage/service.go .github/patches/postageservice.patch
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve_gc.patch
       - name: Prepare testing cluster (storage incentives setup)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -171,6 +171,7 @@ const (
 	refreshRate                   = int64(4500000)
 	basePrice                     = 10000
 	postageSyncingStallingTimeout = 10 * time.Minute
+	postageSyncingBackoffTimeout  = 5 * time.Second
 )
 
 func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, networkID uint64, logger logging.Logger, libp2pPrivateKey, pssPrivateKey *ecdsa.PrivateKey, o *Options) (b *Bee, err error) {
@@ -467,7 +468,7 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 		postageSyncStart = startBlock
 	}
 
-	eventListener = listener.New(logger, swapBackend, postageContractAddress, o.BlockTime, &pidKiller{node: b}, postageSyncingStallingTimeout)
+	eventListener = listener.New(logger, swapBackend, postageContractAddress, o.BlockTime, &pidKiller{node: b}, postageSyncingStallingTimeout, postageSyncingBackoffTimeout)
 	b.listenerCloser = eventListener
 
 	batchSvc, err = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, o.Resync)

--- a/pkg/postage/listener/export_test.go
+++ b/pkg/postage/listener/export_test.go
@@ -12,5 +12,6 @@ var (
 	BatchDepthIncreaseTopic = batchDepthIncreaseTopic
 	PriceUpdateTopic        = priceUpdateTopic
 
-	TailSize = tailSize
+	TailSize    = tailSize
+	BatchFactor = batchFactor
 )

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -26,8 +26,11 @@ import (
 )
 
 const (
-	blockPage = 5000 // how many blocks to sync every time we page
-	tailSize  = 4    // how many blocks to tail from the tip of the chain
+	blockPage   = 5000      // how many blocks to sync every time we page
+	tailSize    = 4         // how many blocks to tail from the tip of the chain
+	batchFactor = uint64(5) // minimal number of blocks to sync at once
+
+	backoffTime = 5 * time.Second
 )
 
 var (
@@ -174,14 +177,13 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 		cancel()
 	}()
 
-	chainUpdateInterval := (time.Duration(l.blockTime) * time.Second) / 2
-
 	synced := make(chan struct{})
 	closeOnce := new(sync.Once)
 	paged := make(chan struct{}, 1)
 	paged <- struct{}{}
 
 	lastProgress := time.Now()
+	lastConfirmedBlock := uint64(0)
 
 	l.wg.Add(1)
 	listenf := func() error {
@@ -194,10 +196,21 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 				return ErrPostageSyncingStalled
 			}
 
+			// if we have a last blocknumber from the backend we can make a good estimate on when we need to requery
+			// otherwise we just use the backoff time
+			var expectedWaitTime time.Duration
+			if lastConfirmedBlock != 0 {
+				nextExpectedBatchBlock := (lastConfirmedBlock/batchFactor + 1) * batchFactor
+				remainingBlocks := nextExpectedBatchBlock - lastConfirmedBlock
+				expectedWaitTime = time.Duration(l.blockTime*remainingBlocks) * time.Second
+			} else {
+				expectedWaitTime = backoffTime
+			}
+
 			select {
 			case <-paged:
 				// if we paged then it means there's more things to sync on
-			case <-time.After(chainUpdateInterval):
+			case <-time.After(expectedWaitTime):
 			case <-l.quit:
 				return nil
 			}
@@ -208,6 +221,7 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 			if err != nil {
 				l.metrics.BackendErrors.Inc()
 				l.logger.Warningf("listener: could not get block number: %v", err)
+				lastConfirmedBlock = 0
 				continue
 			}
 
@@ -218,6 +232,10 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 
 			// consider to-tailSize as the "latest" block we need to sync to
 			to = to - tailSize
+			lastConfirmedBlock = to
+
+			// round down to the largest multiple of batchFactor
+			to = (to / batchFactor) * batchFactor
 
 			if to < from {
 				// if the blockNumber is actually less than what we already, it might mean the backend is not synced or some reorg scenario
@@ -237,6 +255,7 @@ func (l *listener) Listen(from uint64, updater postage.EventUpdater) <-chan stru
 			if err != nil {
 				l.metrics.BackendErrors.Inc()
 				l.logger.Warningf("listener: could not get logs: %v", err)
+				lastConfirmedBlock = 0
 				continue
 			}
 


### PR DESCRIPTION
always process at least 5 blocks at once to drastically reduce our number of backend requests. (note this means it might take up to 4.5 block times longer until a postage batch is accepted). this change is necessary as otherwise the listener of one node alone already exhausts the free budget from some api providers.

Syning before:
```
200 201 202 203 204 205 206 207 208 209 210 (block height)
196 197 198 199 200 201 202 203 204 205 206 (last synced block)
```

Syning after:
```
200 201 202 203 204 205 206 207 208 209 210 (block height)
195 195 195 195 200 200 200 200 200 205 205 (last synced block)
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2641)
<!-- Reviewable:end -->
