### PR TITLE
feat: retrieval attempt persistently tried on originator

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -182,9 +182,11 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 			case res := <-resultC:
 				if errors.Is(res.err, topology.ErrNotFound) {
 					if sp.Saturated() {
+						// if no peer is available, and none skipped temporarily
 						s.logger.Tracef("retrieval: failed to get chunk %s", addr)
 						return nil, storage.ErrNotFound
 					} else {
+						// skip to next request round if any peers are only skipped temporarily
 						peerAttempt = maxSelects
 					}
 				}

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -181,8 +181,12 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 				// break
 			case res := <-resultC:
 				if errors.Is(res.err, topology.ErrNotFound) {
-					s.logger.Tracef("retrieval: failed to get chunk %s", addr)
-					return nil, storage.ErrNotFound
+					if sp.Saturated() {
+						s.logger.Tracef("retrieval: failed to get chunk %s", addr)
+						return nil, storage.ErrNotFound
+					} else {
+						peerAttempt = maxSelects
+					}
 				}
 				if res.retrieved {
 					if res.err != nil {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -100,7 +100,8 @@ func (s *Service) Protocol() p2p.ProtocolSpec {
 const (
 	retrieveChunkTimeout          = 10 * time.Second
 	retrieveRetryIntervalDuration = 5 * time.Second
-	maxRequestRounds              = 5
+	originMaxRequestRounds        = 256
+	forwardMaxRequestRounds       = 5
 	maxSelects                    = 8
 	originSuffix                  = "_origin"
 )
@@ -118,8 +119,10 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 	v, _, err := s.singleflight.Do(ctx, flightRoute, func(ctx context.Context) (interface{}, error) {
 		maxPeers := 1
+		requestRounds := forwardMaxRequestRounds
 		if origin {
 			maxPeers = maxSelects
+			requestRounds = originMaxRequestRounds
 		}
 
 		sp := newSkipPeers()
@@ -137,7 +140,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 		lastTime := time.Now().Unix()
 
-		for requestAttempt < maxRequestRounds {
+		for requestAttempt < requestRounds {
 
 			if peerAttempt < maxSelects {
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -182,7 +182,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 			case res := <-resultC:
 				if errors.Is(res.err, topology.ErrNotFound) {
 					s.logger.Tracef("retrieval: failed to get chunk %s", addr)
-					return nil, res.err
+					return nil, storage.ErrNotFound
 				}
 				if res.retrieved {
 					if res.err != nil {

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -59,6 +59,8 @@ func (s *skipPeers) AddOverdraft(address swarm.Address) {
 	s.overdraftAddresses = append(s.overdraftAddresses, address)
 }
 
+// Saturated function returns whether all skipped entries a permanently skipped for this skiplist
+// Temporary entries are stored in the overdraftAddresses slice of the skiplist, so if that is empty, the function returns true
 func (s *skipPeers) Saturated() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -62,10 +62,5 @@ func (s *skipPeers) AddOverdraft(address swarm.Address) {
 func (s *skipPeers) Saturated() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	if len(s.overdraftAddresses) > 0 {
-		return false
-	}
-
-	return true
+	return len(s.overdraftAddresses) <= 0
 }

--- a/pkg/retrieval/skip_peers.go
+++ b/pkg/retrieval/skip_peers.go
@@ -58,3 +58,14 @@ func (s *skipPeers) AddOverdraft(address swarm.Address) {
 
 	s.overdraftAddresses = append(s.overdraftAddresses, address)
 }
+
+func (s *skipPeers) Saturated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.overdraftAddresses) > 0 {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
The aim of this PR is to make originated retrieval attempts more persistent in trying to find a peer with free accounting balance by increasing the number of times reserving (PrepareCredit) is attempted. 

This change does not effect the maximum number of actual requests made to retrieve a chunk. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2650)
<!-- Reviewable:end -->
