### PR TITLE
fix: checks at time based refreshment

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/pricing"
+	"github.com/ethersphere/bee/pkg/settlement/pseudosettle"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -366,9 +367,13 @@ func (a *Accounting) settle(peer swarm.Address, balance *accountingPeer) error {
 
 		acceptedAmount, timestamp, err := a.refreshFunction(context.Background(), peer, paymentAmount, shadowBalance)
 		if err != nil {
-			a.metrics.AccountingDisconnectsEnforceRefreshCount.Inc()
-			_ = a.blocklist(peer, 1, "failed to refresh")
-			return fmt.Errorf("refresh failure: %w", err)
+			if !errors.Is(err, pseudosettle.ErrSettlementTooSoon) && !errors.Is(err, p2p.ErrPeerNotFound) {
+				a.metrics.AccountingDisconnectsEnforceRefreshCount.Inc()
+				_ = a.blocklist(peer, 1, "failed to refresh")
+				return fmt.Errorf("refresh failure: %w", err)
+			} else {
+				return fmt.Errorf("refresh failure: %w", err)
+			}
 		}
 
 		balance.refreshTimestamp = timestamp

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -378,6 +378,9 @@ func (a *Accounting) settle(peer swarm.Address, balance *accountingPeer) error {
 				// if we get settlement too soon from the peer timestamp being ahead of ours, block payment by returning early
 				// this is to disincentivize ahead of time timestamps resulting in more monetary settlements
 				// if err peer not found also fail
+				if errors.Is(err, pseudosettle.ErrSettlementTooSoon) {
+					a.metrics.AccountingNonFatalRefreshFailCount.Inc()
+				}
 				return fmt.Errorf("refresh failure: %w", err)
 			}
 		}

--- a/pkg/accounting/metrics.go
+++ b/pkg/accounting/metrics.go
@@ -18,6 +18,7 @@ type metrics struct {
 	DebitEventsCount                         prometheus.Counter
 	CreditEventsCount                        prometheus.Counter
 	AccountingDisconnectsEnforceRefreshCount prometheus.Counter
+	AccountingNonFatalRefreshFailCount       prometheus.Counter
 	AccountingDisconnectsOverdrawCount       prometheus.Counter
 	AccountingDisconnectsGhostOverdrawCount  prometheus.Counter
 	AccountingDisconnectsReconnectCount      prometheus.Counter
@@ -60,6 +61,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "disconnects_enforce_refresh_count",
 			Help:      "Number of occurrences of peers disconnected based on failed refreshment attempts",
+		}),
+		AccountingNonFatalRefreshFailCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "non_fatal_refresh_fail_count",
+			Help:      "Number of occurrences of refreshments failing for peers because of peer timestamp ahead of ours",
 		}),
 		AccountingDisconnectsOverdrawCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -272,7 +272,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 	}
 
 	currentTime := s.timeNow().Unix()
-	if currentTime == lastTime.CheckTimestamp {
+	if currentTime == lastTime.CheckTimestamp || currentTime == lastTime.Timestamp {
 		return nil, 0, ErrSettlementTooSoon
 	}
 
@@ -302,13 +302,13 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 		return nil, 0, err
 	}
 
-	checkTime := s.timeNow().Unix()
-
 	var paymentAck pb.PaymentAck
 	err = r.ReadMsgWithContext(ctx, &paymentAck)
 	if err != nil {
 		return nil, 0, err
 	}
+
+	checkTime := s.timeNow().Unix()
 
 	acceptedAmount := new(big.Int).SetBytes(paymentAck.Amount)
 	if acceptedAmount.Cmp(amount) > 0 {

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -272,7 +272,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 	}
 
 	currentTime := s.timeNow().Unix()
-	if currentTime == lastTime.CheckTimestamp || currentTime == lastTime.Timestamp {
+	if currentTime <= lastTime.CheckTimestamp || currentTime <= lastTime.Timestamp {
 		return nil, 0, ErrSettlementTooSoon
 	}
 

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -271,8 +271,12 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 		lastTime.Timestamp = 0
 	}
 
+	// check whether at least 1 second have passed since last refresh according to own timestamp and peers timestamp
 	currentTime := s.timeNow().Unix()
 	if currentTime <= lastTime.CheckTimestamp || currentTime <= lastTime.Timestamp {
+		// if not, return error too soon
+		// this is to avoid the peer receiving 2 refresh attempts from our node in the same second
+		// of which the second one would be refused and would lead to a disconnect from our node's enforcement of refreshments
 		return nil, 0, ErrSettlementTooSoon
 	}
 

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -257,7 +257,7 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount, checkAllo
 
 	defer func() {
 		if err != nil {
-			s.metrics.ReceivedPseudoSettlementsErrors.Inc()
+			s.metrics.SentPseudoSettlementsErrors.Inc()
 		}
 	}()
 


### PR DESCRIPTION
The aim of this PR is to make time based settlements more safe, by verifying timestamps from both sides to conclude whether 1 second passed since the last refreshment happened.

As an implication of this, the refreshments can be deintensified to once every two seconds in case there is an NTP difference observed on the two sides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2651)
<!-- Reviewable:end -->
