### PR TITLE
ci: trigger bee-factory builds on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,16 +52,3 @@ jobs:
           SCOOP_PAT: ${{ secrets.SCOOP_PAT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
-
-      - name: Get the released tags version
-        id: get-version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Trigger Bee Factory image build
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_PAT }}
-          repository: ethersphere/bee-factory
-          event-type: build-images
-          client-payload: '{"tag": "${{ steps.get-version.outputs.VERSION }}"}'
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,3 +52,16 @@ jobs:
           SCOOP_PAT: ${{ secrets.SCOOP_PAT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+
+      - name: Get the released tags version
+        id: get-version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Trigger Bee Factory image build
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_PAT }}
+          repository: ethersphere/bee-factory
+          event-type: build-images
+          client-payload: '{"tag": "${{ steps.get-version.outputs.VERSION }}"}'
+

--- a/.github/workflows/release_triggers.yaml
+++ b/.github/workflows/release_triggers.yaml
@@ -1,0 +1,27 @@
+name: Workflow that triggers after-release actions
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get the released tags version
+        id: get-version
+        run: |
+          REF="${{ github.event.workflow_run.head_branch }}"
+          echo ::set-output name=VERSION::${REF/refs\/tags\//}
+
+      - name: Trigger Bee Factory image build
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_PAT }}
+          repository: ethersphere/bee-factory
+          event-type: build-images
+          client-payload: '{"tag": "${{ steps.get-version.outputs.VERSION }}"}'
+


### PR DESCRIPTION
This PR is part of an automatization initiative to stream-line updating Bee versions across our JS land. This action triggers automatically build of Bee Factory images that will be then propagated to our JS repos with PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2654)
<!-- Reviewable:end -->
