### PR TITLE
feat: async writes to store for netstore retrieval

### DIFF
--- a/pkg/netstore/netstore.go
+++ b/pkg/netstore/netstore.go
@@ -30,7 +30,6 @@ type store struct {
 	logger           logging.Logger
 	validStamp       postage.ValidStampFn
 	recoveryCallback recovery.Callback // this is the callback to be executed when a chunk fails to be retrieved
-	opChan           chan putOp
 	bgWorkers        chan struct{}
 	sCtx             context.Context
 	sCancel          context.CancelFunc
@@ -44,7 +43,8 @@ var (
 // New returns a new NetStore that wraps a given Storer.
 func New(s storage.Storer, validStamp postage.ValidStampFn, rcb recovery.Callback, r retrieval.Interface, logger logging.Logger) storage.Storer {
 	ns := &store{Storer: s, validStamp: validStamp, recoveryCallback: rcb, retrieval: r, logger: logger}
-	ns.backgroundPutter()
+	ns.sCtx, ns.sCancel = context.WithCancel(context.Background())
+	ns.bgWorkers = make(chan struct{}, 16)
 	return ns
 }
 
@@ -66,10 +66,44 @@ func (s *store) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addres
 				go s.recoveryCallback(addr, targets)
 				return nil, ErrRecoveryAttempt
 			}
-			select {
-			case <-ctx.Done():
-			case s.opChan <- putOp{ch: ch, mode: mode}:
-			}
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+
+				select {
+				case <-s.sCtx.Done():
+					s.logger.Debug("netstore: stopping netstore")
+					return
+				case s.bgWorkers <- struct{}{}:
+				}
+				defer func() {
+					<-s.bgWorkers
+				}()
+
+				stamp, err := ch.Stamp().MarshalBinary()
+				if err != nil {
+					s.logger.Errorf("netstore: failed to marshal stamp from chunk %s Err:%s", ch.Address(), err.Error())
+					return
+				}
+
+				putMode := storage.ModePutRequest
+				if mode == storage.ModeGetRequestPin {
+					putMode = storage.ModePutRequestPin
+				}
+
+				cch, err := s.validStamp(ch, stamp)
+				if err != nil {
+					// if a chunk with an invalid postage stamp was received
+					// we force it into the cache.
+					putMode = storage.ModePutRequestCache
+					cch = ch
+				}
+
+				_, err = s.Storer.Put(s.sCtx, putMode, cch)
+				if err != nil {
+					s.logger.Errorf("netstore: failed to put chunk %s Err: %s", cch.Address(), err.Error())
+				}
+			}()
 			return ch, nil
 		}
 		return nil, fmt.Errorf("netstore get: %w", err)
@@ -98,67 +132,4 @@ func (s *store) Close() error {
 	case <-time.After(time.Second * 5):
 		return errors.New("netstore: waited 5 seconds to close active goroutines")
 	}
-}
-
-type putOp struct {
-	ch   swarm.Chunk
-	mode storage.ModeGet
-}
-
-func (s *store) backgroundPutter() {
-	s.sCtx, s.sCancel = context.WithCancel(context.Background())
-	s.bgWorkers = make(chan struct{}, 16)
-	s.opChan = make(chan putOp)
-
-	s.wg.Add(1)
-	go func() {
-		defer close(s.bgWorkers)
-		defer s.wg.Done()
-
-		for {
-			select {
-			case <-s.sCtx.Done():
-				s.logger.Debug("netstore: stopping netstore background putter")
-				return
-			case op := <-s.opChan:
-				select {
-				case <-s.sCtx.Done():
-					s.logger.Debug("netstore: stopping netstore background putter")
-					return
-				case s.bgWorkers <- struct{}{}:
-					s.wg.Add(1)
-					go func(op putOp) {
-						defer func() {
-							<-s.bgWorkers
-							s.wg.Done()
-						}()
-
-						stamp, err := op.ch.Stamp().MarshalBinary()
-						if err != nil {
-							s.logger.Errorf("netstore: failed to marshal stamp from chunk %s Err:%s", op.ch.Address(), err.Error())
-							return
-						}
-
-						putMode := storage.ModePutRequest
-						if op.mode == storage.ModeGetRequestPin {
-							putMode = storage.ModePutRequestPin
-						}
-
-						cch, err := s.validStamp(op.ch, stamp)
-						if err != nil {
-							// if a chunk with an invalid postage stamp was received
-							// we force it into the cache.
-							putMode = storage.ModePutRequestCache
-							cch = op.ch
-						}
-
-						_, err = s.Storer.Put(s.sCtx, putMode, cch)
-						if err != nil {
-							s.logger.Errorf("netstore: failed to put chunk %s Err: %s", cch.Address(), err.Error())
-						}
-					}(op)
-				}
-			}
-		}
-	}()
 }

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -49,20 +49,7 @@ func TestNetstoreRetrieval(t *testing.T) {
 	}
 
 	// store should have the chunk once the background PUT is complete
-	var d swarm.Chunk
-	start := time.Now()
-	for {
-		time.Sleep(time.Millisecond * 10)
-
-		d, err = store.Get(context.Background(), storage.ModeGetRequest, addr)
-		if err != nil {
-			if time.Since(start) > time.Second*3 {
-				t.Fatal("waited 3 secs for background put operation", err)
-			}
-		} else {
-			break
-		}
-	}
+	d := waitAndGetChunk(t, store, addr, storage.ModeGetRequest)
 
 	if !bytes.Equal(d.Data(), chunkData) {
 		t.Fatal("chunk data not equal to expected data")
@@ -169,20 +156,7 @@ func TestInvalidPostageStamp(t *testing.T) {
 	}
 
 	// store should have the chunk once the background PUT is complete
-	var d swarm.Chunk
-	start := time.Now()
-	for {
-		time.Sleep(time.Millisecond * 10)
-
-		d, err = store.Get(context.Background(), storage.ModeGetRequest, addr)
-		if err != nil {
-			if time.Since(start) > time.Second*3 {
-				t.Fatal("waited 3 secs for background put operation", err)
-			}
-		} else {
-			break
-		}
-	}
+	d := waitAndGetChunk(t, store, addr, storage.ModeGetRequest)
 
 	if !bytes.Equal(d.Data(), chunkData) {
 		t.Fatal("chunk data not equal to expected data")
@@ -203,6 +177,24 @@ func TestInvalidPostageStamp(t *testing.T) {
 	}
 	if !bytes.Equal(d.Data(), chunkData) {
 		t.Fatal("chunk data not equal to expected data")
+	}
+}
+
+func waitAndGetChunk(t *testing.T, store storage.Storer, addr swarm.Address, mode storage.ModeGet) swarm.Chunk {
+	t.Helper()
+
+	start := time.Now()
+	for {
+		time.Sleep(time.Millisecond * 10)
+
+		d, err := store.Get(context.Background(), mode, addr)
+		if err != nil {
+			if time.Since(start) > time.Second*3 {
+				t.Fatal("waited 3 secs for background put operation", err)
+			}
+		} else {
+			return d, nil
+		}
 	}
 }
 

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -193,7 +193,7 @@ func waitAndGetChunk(t *testing.T, store storage.Storer, addr swarm.Address, mod
 				t.Fatal("waited 3 secs for background put operation", err)
 			}
 		} else {
-			return d, nil
+			return d
 		}
 	}
 }

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -189,7 +189,7 @@ func waitAndGetChunk(t *testing.T, store storage.Storer, addr swarm.Address, mod
 
 		d, err := store.Get(context.Background(), mode, addr)
 		if err != nil {
-			if time.Since(start) > time.Second*3 {
+			if time.Since(start) > 3*time.Second {
 				t.Fatal("waited 3 secs for background put operation", err)
 			}
 		} else {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -96,6 +96,7 @@ type Bee struct {
 	tagsCloser               io.Closer
 	stateStoreCloser         io.Closer
 	localstoreCloser         io.Closer
+	nsCloser                 io.Closer
 	topologyCloser           io.Closer
 	topologyHalter           topology.Halter
 	pusherCloser             io.Closer
@@ -671,6 +672,7 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 	} else {
 		ns = netstore.New(storer, validStamp, nil, retrieve, logger)
 	}
+	b.nsCloser = ns
 
 	traversalService := traversal.New(ns)
 
@@ -966,6 +968,7 @@ func (b *Bee) Shutdown(ctx context.Context) error {
 	tryClose(b.tracerCloser, "tracer")
 	tryClose(b.tagsCloser, "tag persistence")
 	tryClose(b.topologyCloser, "topology driver")
+	tryClose(b.nsCloser, "netstore")
 	tryClose(b.stateStoreCloser, "statestore")
 	tryClose(b.localstoreCloser, "localstore")
 	tryClose(b.errorLogWriter, "error log writer")


### PR DESCRIPTION
This PR aims to optimize the `netstore` Get operation by doing the store Put operation in the background. This allows the chunk to be returned early for processing and unblock the client to request more chunks.

TODO:
- [ ] post measurements of download rates before+after this change cherry-picked over `v1.3.0` on production

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2665)
<!-- Reviewable:end -->
