### PR TITLE
fix: retry transaction receipt with delay

### DIFF
--- a/pkg/transaction/backend.go
+++ b/pkg/transaction/backend.go
@@ -90,6 +90,11 @@ func WaitBlockAfterTransaction(ctx context.Context, backend Backend, pollingInte
 			if !errors.Is(err, ethereum.NotFound) {
 				return nil, err
 			}
+			select {
+			case <-time.After(pollingInterval):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 			continue
 		}
 


### PR DESCRIPTION
It was observed that in case of an error the retry loop is very tight. This adds a polling delay to every iteration.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2667)
<!-- Reviewable:end -->
