### PR TITLE
fix: remove unnecessary labels from pushsync metric

### DIFF
--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -141,7 +141,7 @@ func newMetrics() metrics {
 				Name:      "push_peer_time",
 				Help:      "Histogram for time taken to push a chunk to a peer.",
 				Buckets:   []float64{.5, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20},
-			}, []string{"bin", "attempted", "status"},
+			}, []string{"status"},
 		),
 		TotalReplicationFromDistantPeer: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -370,7 +370,13 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 
 		now := time.Now()
 		r, attempted, err := ps.pushPeer(ctxd, peer, ch, origin)
-		ps.measurePushPeer(now, peer, attempted, err)
+		var status string
+		if err != nil {
+			status = "failure"
+		} else {
+			status = "success"
+		}
+		ps.metrics.PushToPeerTime.WithLabelValues(status).Observe(time.Since(now).Seconds())
 
 		// attempted is true if we get past accounting and actually attempt
 		// to send the request to the peer. If we dont get past accounting, we
@@ -406,18 +412,6 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 	}
 
 	return nil, ErrNoPush
-}
-
-func (ps *PushSync) measurePushPeer(t time.Time, peer swarm.Address, attempted bool, err error) {
-	po := swarm.Proximity(ps.address.Bytes(), peer.Bytes())
-	var errStr string
-	if err != nil {
-		errStr = "failure"
-	} else {
-		errStr = "success"
-	}
-	ps.metrics.PushToPeerTime.WithLabelValues(fmt.Sprintf("%d", po), fmt.Sprintf("%v", attempted), errStr).
-		Observe(time.Since(t).Seconds())
 }
 
 func (ps *PushSync) pushPeer(ctx context.Context, peer swarm.Address, ch swarm.Chunk, origin bool) (*pb.Receipt, bool, error) {


### PR DESCRIPTION
removes attempted and bin labels from the pushsync metric as we haven't gotten value from it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2674)
<!-- Reviewable:end -->
