### PR TITLE
feat: relax balancing

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -231,40 +231,24 @@ func (k *Kad) connectBalanced(wg *sync.WaitGroup, peerConnChan chan<- *peerConnI
 		}
 
 		binPeers := k.knownPeers.BinPeers(uint8(i))
+		binConnectedPeers := k.connectedPeers.BinPeers(uint8(i))
 
 		for j := range k.commonBinPrefixes[i] {
 			pseudoAddr := k.commonBinPrefixes[i][j]
 
-			closestConnectedPeer, err := closestPeer(k.connectedPeers, pseudoAddr, noopSanctionedPeerFn)
-			if err != nil {
-				if errors.Is(err, topology.ErrNotFound) {
-					break
-				}
-				k.logger.Errorf("closest connected peer: %v", err)
-				continue
-			}
-
-			closestConnectedPO := swarm.ExtendedProximity(closestConnectedPeer.Bytes(), pseudoAddr.Bytes())
-			if int(closestConnectedPO) >= i+k.bitSuffixLength+1 {
-				continue
-			}
-
 			// Connect to closest known peer which we haven't tried connecting to recently.
-			closestKnownPeer, err := closestPeerInSlice(binPeers, pseudoAddr, skipPeers)
-			if err != nil {
-				if errors.Is(err, topology.ErrNotFound) {
-					break
-				}
-				k.logger.Errorf("closest known peer: %v", err)
+
+			_, exists := nClosePeerInSlice(binConnectedPeers, pseudoAddr, noopSanctionedPeerFn, uint8(i+k.bitSuffixLength+1))
+			if exists {
+				continue
+			}
+
+			closestKnownPeer, exists := nClosePeerInSlice(binPeers, pseudoAddr, skipPeers, uint8(i+k.bitSuffixLength+1))
+			if !exists {
 				continue
 			}
 
 			if k.connectedPeers.Exists(closestKnownPeer) {
-				continue
-			}
-
-			closestKnownPeerPO := swarm.ExtendedProximity(closestKnownPeer.Bytes(), pseudoAddr.Bytes())
-			if int(closestKnownPeerPO) < i+k.bitSuffixLength+1 {
 				continue
 			}
 
@@ -1187,23 +1171,18 @@ func closestPeer(peers *pslice.PSlice, addr swarm.Address, spf sanctionedPeerFun
 	return closest, nil
 }
 
-func closestPeerInSlice(peers []swarm.Address, addr swarm.Address, spf sanctionedPeerFunc) (swarm.Address, error) {
-	closest := swarm.ZeroAddress
-	closestFunc := closestPeerFunc(&closest, addr, spf)
-
+func nClosePeerInSlice(peers []swarm.Address, addr swarm.Address, spf sanctionedPeerFunc, minPO uint8) (swarm.Address, bool) {
 	for _, peer := range peers {
-		_, _, err := closestFunc(peer, 0)
-		if err != nil {
-			return closest, err
+		if spf(peer) {
+			continue
+		}
+
+		if swarm.ExtendedProximity(peer.Bytes(), addr.Bytes()) >= minPO {
+			return peer, true
 		}
 	}
 
-	// check if found
-	if closest.IsZero() {
-		return closest, topology.ErrNotFound
-	}
-
-	return closest, nil
+	return swarm.ZeroAddress, false
 }
 
 func closestPeerFunc(closest *swarm.Address, addr swarm.Address, spf sanctionedPeerFunc) func(peer swarm.Address, po uint8) (bool, bool, error) {


### PR DESCRIPTION
### Description

This PR intends to change the selection of balanced connections by relaxing the criteria from selecting a closest peer to selecting a close-enough peer for a pseudo-address

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/2521

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2677)
<!-- Reviewable:end -->
