### PR TITLE
fix: ignore greylist for self verification

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -388,7 +388,7 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 
 	senderMatcher := transaction.NewMatcher(swapBackend, types.NewLondonSigner(big.NewInt(chainID)), stateStore)
 
-	_, err = senderMatcher.Matches(p2pCtx, txHash, networkID, swarmAddress)
+	_, err = senderMatcher.Matches(p2pCtx, txHash, networkID, swarmAddress, true)
 	if err != nil {
 		return nil, fmt.Errorf("identity transaction verification failed: %w", err)
 	}

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -63,7 +63,7 @@ type AdvertisableAddressResolver interface {
 }
 
 type SenderMatcher interface {
-	Matches(ctx context.Context, tx []byte, networkID uint64, senderOverlay swarm.Address) ([]byte, error)
+	Matches(ctx context.Context, tx []byte, networkID uint64, senderOverlay swarm.Address, ignoreGreylist bool) ([]byte, error)
 }
 
 // Service can perform initiate or handle a handshake between peers.
@@ -191,7 +191,7 @@ func (s *Service) Handshake(ctx context.Context, stream p2p.Stream, peerMultiadd
 		return nil, ErrNetworkIDIncompatible
 	}
 
-	blockHash, err := s.senderMatcher.Matches(ctx, resp.Ack.Transaction, s.networkID, overlay)
+	blockHash, err := s.senderMatcher.Matches(ctx, resp.Ack.Transaction, s.networkID, overlay, false)
 	if err != nil {
 		return nil, fmt.Errorf("overlay %v verification failed: %w", overlay, err)
 	}
@@ -321,7 +321,7 @@ func (s *Service) Handle(ctx context.Context, stream p2p.Stream, remoteMultiaddr
 		}
 	}
 
-	blockHash, err := s.senderMatcher.Matches(ctx, ack.Transaction, s.networkID, overlay)
+	blockHash, err := s.senderMatcher.Matches(ctx, ack.Transaction, s.networkID, overlay, false)
 	if err != nil {
 		return nil, fmt.Errorf("overlay %v verification failed: %w", overlay, err)
 	}

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -812,7 +812,7 @@ type MockSenderMatcher struct {
 	blockHash []byte
 }
 
-func (m MockSenderMatcher) Matches(context.Context, []byte, uint64, swarm.Address) ([]byte, error) {
+func (m MockSenderMatcher) Matches(context.Context, []byte, uint64, swarm.Address, bool) ([]byte, error) {
 
 	if m.v {
 		return m.blockHash, nil

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -169,6 +169,6 @@ type MockSenderMatcher struct {
 	BlockHash []byte
 }
 
-func (m MockSenderMatcher) Matches(context.Context, []byte, uint64, swarm.Address) ([]byte, error) {
+func (m MockSenderMatcher) Matches(context.Context, []byte, uint64, swarm.Address, bool) ([]byte, error) {
 	return m.BlockHash, nil
 }

--- a/pkg/transaction/sender_matcher.go
+++ b/pkg/transaction/sender_matcher.go
@@ -54,7 +54,7 @@ func NewMatcher(backend Backend, signer types.Signer, storage storage.StateStore
 	}
 }
 
-func (m *Matcher) Matches(ctx context.Context, tx []byte, networkID uint64, senderOverlay swarm.Address) ([]byte, error) {
+func (m *Matcher) Matches(ctx context.Context, tx []byte, networkID uint64, senderOverlay swarm.Address, ignoreGreylist bool) ([]byte, error) {
 
 	incomingTx := common.BytesToHash(tx)
 
@@ -67,7 +67,7 @@ func (m *Matcher) Matches(ctx context.Context, tx []byte, networkID uint64, send
 	} else if val.Verified {
 		// add cache invalidation
 		return val.NextBlockHash, nil
-	} else if val.TimeStamp.Add(5 * time.Minute).After(m.timeNow()) {
+	} else if val.TimeStamp.Add(5*time.Minute).After(m.timeNow()) && !ignoreGreylist {
 		return nil, ErrGreylisted
 	}
 

--- a/pkg/transaction/sender_matcher_test.go
+++ b/pkg/transaction/sender_matcher_test.go
@@ -40,7 +40,7 @@ func TestMatchesSender(t *testing.T) {
 
 		matcher := transaction.NewMatcher(backendmock.New(txByHash), nil, statestore.NewStateStore())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if !errors.Is(err, transaction.ErrTransactionNotFound) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionNotFound, err)
 		}
@@ -53,7 +53,7 @@ func TestMatchesSender(t *testing.T) {
 
 		matcher := transaction.NewMatcher(backendmock.New(txByHash), nil, statestore.NewStateStore())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if !errors.Is(err, transaction.ErrTransactionPending) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionPending, err)
 		}
@@ -69,7 +69,7 @@ func TestMatchesSender(t *testing.T) {
 		}
 		matcher := transaction.NewMatcher(backendmock.New(txByHash), signer, statestore.NewStateStore())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if !errors.Is(err, transaction.ErrTransactionSenderInvalid) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionSenderInvalid, err)
 		}
@@ -103,7 +103,7 @@ func TestMatchesSender(t *testing.T) {
 
 		matcher := transaction.NewMatcher(backendmock.New(txByHash, trxReceipt, headerByNum), signer, statestore.NewStateStore())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if err == nil {
 			t.Fatalf("expected no match")
 		}
@@ -139,7 +139,7 @@ func TestMatchesSender(t *testing.T) {
 
 		senderOverlay := crypto.NewOverlayFromEthereumAddress(signer.addr.Bytes(), 0, nextBlockHeader.Hash().Bytes())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay, false)
 		if err != nil {
 			t.Fatalf("expected match")
 		}
@@ -178,14 +178,14 @@ func TestMatchesSender(t *testing.T) {
 
 		senderOverlay := crypto.NewOverlayFromEthereumAddress(overlayEth.Bytes(), 0, nextBlockHeader.Hash().Bytes())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay, false)
 		if err != nil {
 			t.Fatalf("expected match. got %v", err)
 		}
 
 		senderOverlay = crypto.NewOverlayFromEthereumAddress(signer.addr.Bytes(), 0, nextBlockHeader.Hash().Bytes())
 
-		_, err = matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		_, err = matcher.Matches(context.Background(), trx, 0, senderOverlay, false)
 		if err == nil {
 			t.Fatalf("matched signer for data tx")
 		}
@@ -226,12 +226,12 @@ func TestMatchesSender(t *testing.T) {
 
 		senderOverlay := crypto.NewOverlayFromEthereumAddress(signer.addr.Bytes(), 0, nextBlockHeader.Hash().Bytes())
 
-		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		_, err := matcher.Matches(context.Background(), trx, 0, senderOverlay, false)
 		if err != nil {
 			t.Fatalf("expected match")
 		}
 
-		_, err = matcher.Matches(context.Background(), trx, 0, senderOverlay)
+		_, err = matcher.Matches(context.Background(), trx, 0, senderOverlay, false)
 		if err != nil {
 			t.Fatalf("expected match")
 		}
@@ -249,12 +249,12 @@ func TestMatchesSender(t *testing.T) {
 		matcher := transaction.NewMatcher(backendmock.New(txByHash), nil, statestore.NewStateStore())
 		matcher.SetTime(0)
 
-		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if !errors.Is(err, transaction.ErrTransactionNotFound) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionNotFound, err)
 		}
 
-		_, err = matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err = matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
 		if !errors.Is(err, transaction.ErrGreylisted) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrGreylisted, err)
 		}
@@ -262,7 +262,26 @@ func TestMatchesSender(t *testing.T) {
 		// greylist expires
 		matcher.SetTime(5 * 60)
 
-		_, err = matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}))
+		_, err = matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
+		if !errors.Is(err, transaction.ErrTransactionNotFound) {
+			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionNotFound, err)
+		}
+	})
+
+	t.Run("greylisted but ignored", func(t *testing.T) {
+		txByHash := backendmock.WithTransactionByHashFunc(func(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+			return nil, false, errors.New("transaction not found by hash")
+		})
+
+		matcher := transaction.NewMatcher(backendmock.New(txByHash), nil, statestore.NewStateStore())
+		matcher.SetTime(0)
+
+		_, err := matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), false)
+		if !errors.Is(err, transaction.ErrTransactionNotFound) {
+			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionNotFound, err)
+		}
+
+		_, err = matcher.Matches(context.Background(), trx, 0, swarm.NewAddress([]byte{}), true)
 		if !errors.Is(err, transaction.ErrTransactionNotFound) {
 			t.Fatalf("bad error type, want %v, got %v", transaction.ErrTransactionNotFound, err)
 		}


### PR DESCRIPTION
Currently we greylist our own address if the node is started before the transaction has been included and one block on top (which can happen if you use a transaction from outside bee). Which means we cannot attempt to start the node for another 5 minutes. This adds an exception for this check.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2688)
<!-- Reviewable:end -->
