### PR TITLE
feat: support loading ethereum key files

### DIFF
--- a/pkg/keystore/file/key.go
+++ b/pkg/keystore/file/key.go
@@ -151,7 +151,14 @@ func decryptData(v keyCripto, password string) ([]byte, error) {
 	}
 	calculatedMAC := sha3.Sum256(append(derivedKey[16:32], cipherText...))
 	if !bytes.Equal(calculatedMAC[:], mac) {
-		return nil, keystore.ErrInvalidPassword
+		// if this fails we might be trying to load an ethereum V3 keyfile
+		calculatedMACEth, err := crypto.LegacyKeccak256(append(derivedKey[16:32], cipherText...))
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(calculatedMACEth[:], mac) {
+			return nil, keystore.ErrInvalidPassword
+		}
 	}
 
 	iv, err := hex.DecodeString(v.CipherParams.IV)


### PR DESCRIPTION
turns out the reason we cannot load ethereum key files is because we compute the mac differently. with this change bee can load its own key format as well as the one from geth and clef.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2710)
<!-- Reviewable:end -->
