### PR TITLE
chore(ci): adjust block threshold for ci

### DIFF
--- a/.github/patches/postageservice.patch
+++ b/.github/patches/postageservice.patch
@@ -1,4 +1,4 @@
 21c21
 < 	blockThreshold = 10
 ---
-> 	blockThreshold = 0
+> 	blockThreshold = 6


### PR DESCRIPTION
block threshold in ci is too too low leading to unnecessary push sync fails due to unsynced batch stores. it might take up to 5 blocks for a batch to become valid (4 tail size, 2 batch factor), so I used 6 as threshold here. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2714)
<!-- Reviewable:end -->
