### PR TITLE
docs: update chunk endpoint info

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -198,6 +198,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmDeferredUpload"
       requestBody:
+        description: Chunk binary data that has to have at least 8 bytes.
         content:
           application/octet-stream:
             schema:
@@ -208,7 +209,9 @@ paths:
           description: Ok
           headers:
             "swarm-tag":
-              $ref: "SwarmCommon.yaml#/components/headers/SwarmTag"
+              description: Tag UID if it was passed to the request `swarm-tag` header.
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/Uid"
           content:
             application/json:
               schema:


### PR DESCRIPTION
The promise was that `tag` is created and returned for every uploading action, which is not true for `/chunks` upload as it only returns it if the user himself put tag already into the request. This documents this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2717)
<!-- Reviewable:end -->
