### PR TITLE
fix: unblocking write to channel in retrieval

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -129,7 +129,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 		var (
 			peerAttempt  int
 			peersResults int
-			resultC      = make(chan retrievalResult, maxSelects)
+			resultC      = make(chan retrievalResult)
 		)
 
 		requestAttempt := 0

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -172,6 +172,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 				select {
 				case resultC <- retrievalResult{}:
 				case <-ctx.Done():
+				default:
 				}
 			}
 


### PR DESCRIPTION
This change improves a rare edge case where the channel for results would be filled by asynchronous retrieves, also removing the buffer for the channel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2729)
<!-- Reviewable:end -->
