### PR TITLE
fix: cashout to overlay address if no chequebook

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -242,6 +242,11 @@ func InitSwap(
 	swapProtocol := swapprotocol.New(p2ps, logger, overlayEthAddress, priceOracle)
 	swapAddressBook := swap.NewAddressbook(stateStore)
 
+	cashoutAddress := overlayEthAddress
+	if chequebookService != nil {
+		cashoutAddress = chequebookService.Address()
+	}
+
 	swapService := swap.New(
 		swapProtocol,
 		logger,
@@ -252,6 +257,7 @@ func InitSwap(
 		networkID,
 		cashoutService,
 		accounting,
+		cashoutAddress,
 	)
 
 	swapProtocol.SetSwap(swapService)

--- a/pkg/settlement/swap/swap.go
+++ b/pkg/settlement/swap/swap.go
@@ -47,31 +47,33 @@ type Interface interface {
 
 // Service is the implementation of the swap settlement layer.
 type Service struct {
-	proto       swapprotocol.Interface
-	logger      logging.Logger
-	store       storage.StateStorer
-	accounting  settlement.Accounting
-	metrics     metrics
-	chequebook  chequebook.Service
-	chequeStore chequebook.ChequeStore
-	cashout     chequebook.CashoutService
-	addressbook Addressbook
-	networkID   uint64
+	proto          swapprotocol.Interface
+	logger         logging.Logger
+	store          storage.StateStorer
+	accounting     settlement.Accounting
+	metrics        metrics
+	chequebook     chequebook.Service
+	chequeStore    chequebook.ChequeStore
+	cashout        chequebook.CashoutService
+	addressbook    Addressbook
+	networkID      uint64
+	cashoutAddress common.Address
 }
 
 // New creates a new swap Service.
-func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64, cashout chequebook.CashoutService, accounting settlement.Accounting) *Service {
+func New(proto swapprotocol.Interface, logger logging.Logger, store storage.StateStorer, chequebook chequebook.Service, chequeStore chequebook.ChequeStore, addressbook Addressbook, networkID uint64, cashout chequebook.CashoutService, accounting settlement.Accounting, cashoutAddress common.Address) *Service {
 	return &Service{
-		proto:       proto,
-		logger:      logger,
-		store:       store,
-		metrics:     newMetrics(),
-		chequebook:  chequebook,
-		chequeStore: chequeStore,
-		addressbook: addressbook,
-		networkID:   networkID,
-		cashout:     cashout,
-		accounting:  accounting,
+		proto:          proto,
+		logger:         logger,
+		store:          store,
+		metrics:        newMetrics(),
+		chequebook:     chequebook,
+		chequeStore:    chequeStore,
+		addressbook:    addressbook,
+		networkID:      networkID,
+		cashout:        cashout,
+		accounting:     accounting,
+		cashoutAddress: cashoutAddress,
 	}
 }
 
@@ -352,7 +354,7 @@ func (s *Service) CashCheque(ctx context.Context, peer swarm.Address) (common.Ha
 	if !known {
 		return common.Hash{}, chequebook.ErrNoCheque
 	}
-	return s.cashout.CashCheque(ctx, chequebookAddress, s.chequebook.Address())
+	return s.cashout.CashCheque(ctx, chequebookAddress, s.cashoutAddress)
 }
 
 // CashoutStatus gets the status of the latest cashout transaction for the peers chequebook

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -224,6 +224,7 @@ func TestReceiveCheque(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		observer,
+		common.Address{},
 	)
 
 	err := swap.ReceiveCheque(context.Background(), peer, cheque, exchangeRate, deduction)
@@ -297,6 +298,7 @@ func TestReceiveChequeReject(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		observer,
+		common.Address{},
 	)
 
 	err := swap.ReceiveCheque(context.Background(), peer, cheque, exchangeRate, deduction)
@@ -352,6 +354,7 @@ func TestReceiveChequeWrongChequebook(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		observer,
+		common.Address{},
 	)
 
 	err := swapService.ReceiveCheque(context.Background(), peer, cheque, exchangeRate, deduction)
@@ -415,6 +418,7 @@ func TestPay(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		observer,
+		common.Address{},
 	)
 
 	swap.Pay(context.Background(), peer, amount)
@@ -457,6 +461,7 @@ func TestPayIssueError(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		nil,
+		common.Address{},
 	)
 
 	observer := newTestObserver()
@@ -507,6 +512,7 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		observer,
+		common.Address{},
 	)
 
 	swapService.Pay(context.Background(), peer, amount)
@@ -560,6 +566,7 @@ func TestHandshake(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		nil,
+		common.Address{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)
@@ -606,6 +613,7 @@ func TestHandshakeNewPeer(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		nil,
+		common.Address{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)
@@ -644,6 +652,7 @@ func TestMigratePeer(t *testing.T) {
 		networkID,
 		&cashoutMock{},
 		nil,
+		common.Address{},
 	)
 
 	err := swapService.Handshake(peer, beneficiary)
@@ -673,11 +682,7 @@ func TestCashout(t *testing.T) {
 		&swapProtocolMock{},
 		logger,
 		store,
-		mockchequebook.NewChequebook(
-			mockchequebook.WithChequebookAddressFunc(func() common.Address {
-				return ourChequebookAddress
-			}),
-		),
+		mockchequebook.NewChequebook(),
 		mockchequestore.NewChequeStore(),
 		addressbook,
 		uint64(1),
@@ -693,6 +698,7 @@ func TestCashout(t *testing.T) {
 			},
 		},
 		nil,
+		ourChequebookAddress,
 	)
 
 	returnedHash, err := swapService.CashCheque(context.Background(), peer)
@@ -739,6 +745,7 @@ func TestCashoutStatus(t *testing.T) {
 			},
 		},
 		nil,
+		common.Address{},
 	)
 
 	returnedStatus, err := swapService.CashoutStatus(context.Background(), peer)


### PR DESCRIPTION
the last PR did not handle cashouts correctly if running without a chequebook. this prevents a go panic and uses the nodes overlay eth address as a destination instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2732)
<!-- Reviewable:end -->
