### PR TITLE
feat: enable darwin arm64 binary build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,6 +93,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
 
 snapshot:
   name_template: "{{.Tag}}-snapshot"


### PR DESCRIPTION
For now only enabling darwin arm64 build, later homebrew support will be enabled as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2740)
<!-- Reviewable:end -->
