### PR TITLE
fix(statestore): dont share iterator slice

### DIFF
--- a/pkg/statestore/leveldb/leveldb.go
+++ b/pkg/statestore/leveldb/leveldb.go
@@ -142,7 +142,7 @@ func (s *Store) Iterate(prefix string, iterFunc storage.StateIterFunc) (err erro
 	iter := s.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
 	defer iter.Release()
 	for iter.Next() {
-		stop, err := iterFunc(iter.Key(), iter.Value())
+		stop, err := iterFunc(append([]byte(nil), iter.Key()...), append([]byte(nil), iter.Value()...))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--Please include a summary of the change and which issue is fixed. -->
Fixes an abysmal bug where the underlying unsafe leveldb iterator slice address was leaked to callers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2747)
<!-- Reviewable:end -->
