### PR TITLE
chore(localstore): add reserve size to debug

### DIFF
--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -616,6 +616,12 @@ func (db *DB) DebugIndices() (indexInfo map[string]int, err error) {
 	}
 	indexInfo["gcSize"] = int(val)
 
+	val, err = db.reserveSize.Get()
+	if err != nil {
+		return indexInfo, err
+	}
+	indexInfo["reserveSize"] = int(val)
+
 	return indexInfo, err
 }
 


### PR DESCRIPTION
adds the missing scalar field to the debug indices method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2750)
<!-- Reviewable:end -->
