### PR TITLE
fix: remove old overlay delete

### DIFF
--- a/pkg/node/statestore.go
+++ b/pkg/node/statestore.go
@@ -28,20 +28,13 @@ func InitStateStore(log logging.Logger, dataDir string) (ret storage.StateStorer
 	return leveldb.NewStateStore(filepath.Join(dataDir, "statestore"), log)
 }
 
-const overlayKey = "overlay"
 const secureOverlayKey = "non-mineable-overlay"
 
 // CheckOverlayWithStore checks the overlay is the same as stored in the statestore
 func CheckOverlayWithStore(overlay swarm.Address, storer storage.StateStorer) error {
 
-	// migrate overlay key to new key
-	err := storer.Delete(overlayKey)
-	if err != nil && !errors.Is(err, storage.ErrNotFound) {
-		return err
-	}
-
 	var storedOverlay swarm.Address
-	err = storer.Get(secureOverlayKey, &storedOverlay)
+	err := storer.Get(secureOverlayKey, &storedOverlay)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound) {
 			return err


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2751)
<!-- Reviewable:end -->

Now that all nodes in the network are using > 1.0.0, we can remove this bit of old code.