### PR TITLE
docs: functional auth openapi spec

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -892,3 +892,14 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
           description: Default response
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: SecurityToken

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -618,6 +618,7 @@ components:
         expiry:
           type: integer
           nullable: false
+          description: Expiration time in seconds
 
     SecurityTokenResponse:
       type: object

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -612,17 +612,17 @@ components:
     SecurityTokenRequest:
       type: object
       properties:
-        Role:
+        role:
           type: string
           nullable: false
-        Expiry:
+        expiry:
           type: integer
           nullable: false
 
     SecurityTokenResponse:
       type: object
       properties:
-        Key:
+        key:
           type: string
           nullable: false
 

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -11,16 +11,6 @@ externalDocs:
 
 paths: {}
 components:
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
-
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: SecurityToken
-
   schemas:
     Address:
       type: object


### PR DESCRIPTION
The OpenAPI spec for the authentication modes was split between Swarm and SwarmCommon which did not work. Not sure if it is possible to have these split between two files or not, but it works in this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2755)
<!-- Reviewable:end -->
