### PR TITLE
fix: notifier setter race condition

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -865,7 +865,10 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 	if err := kad.Start(p2pCtx); err != nil {
 		return nil, err
 	}
-	p2ps.Ready()
+
+	if err := p2ps.Ready(); err != nil {
+		return nil, err
+	}
 
 	return b, nil
 }

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -106,22 +106,22 @@ func TestLightPeerLimit(t *testing.T) {
 	var (
 		limit     = 3
 		container = lightnode.NewContainer(test.RandomAddress())
+		notifier  = mockNotifier(noopCf, noopDf, true)
 		sf, _     = newService(t, 1, libp2pServiceOpts{
 			lightNodes: container,
 			libp2pOpts: libp2p.Options{
 				LightNodeLimit: limit,
 				FullNode:       true,
 			},
+			notifier: notifier,
 		})
-
-		notifier = mockNotifier(noopCf, noopDf, true)
 	)
-	sf.SetPickyNotifier(notifier)
 
 	addr := serviceUnderlayAddress(t, sf)
 
 	for i := 0; i < 5; i++ {
 		sl, _ := newService(t, 1, libp2pServiceOpts{
+			notifier: notifier,
 			libp2pOpts: libp2p.Options{
 				FullNode: false,
 			},

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -281,16 +281,18 @@ func TestDoubleConnectOnAllAddresses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s1, overlay1 := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{
-		FullNode: true,
-	}})
+	s1, overlay1 := newService(t, 1, libp2pServiceOpts{
+		notifier: mockNotifier(noopCf, noopDf, true),
+		libp2pOpts: libp2p.Options{
+			FullNode: true,
+		}})
 	addrs, err := s1.Addresses()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, addr := range addrs {
 		// creating new remote host for each address
-		s2, overlay2 := newService(t, 1, libp2pServiceOpts{})
+		s2, overlay2 := newService(t, 1, libp2pServiceOpts{notifier: mockNotifier(noopCf, noopDf, true)})
 
 		if _, err := s2.Connect(ctx, addr); err != nil {
 			t.Fatal(err)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -284,10 +284,6 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		return nil, fmt.Errorf("protocol version match %s: %w", id, err)
 	}
 
-	if err := s.reachabilityWorker(); err != nil {
-		return nil, err
-	}
-
 	s.host.SetStreamHandlerMatch(id, matcher, s.handleIncoming)
 
 	connMetricNotify := newConnMetricNotify(s.metrics)
@@ -897,6 +893,10 @@ func (s *Service) GetWelcomeMessage() string {
 }
 
 func (s *Service) Ready() {
+	if err := s.reachabilityWorker(); err != nil {
+		s.logger.Error("reachability worker", err)
+	}
+
 	close(s.ready)
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -892,12 +892,13 @@ func (s *Service) GetWelcomeMessage() string {
 	return s.handshakeService.GetWelcomeMessage()
 }
 
-func (s *Service) Ready() {
+func (s *Service) Ready() error {
 	if err := s.reachabilityWorker(); err != nil {
-		s.logger.Error("reachability worker", err)
+		return fmt.Errorf("reachability worker: %w", err)
 	}
 
 	close(s.ready)
+	return nil
 }
 
 func (s *Service) Halt() {

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -93,7 +93,7 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 		s.SetPickyNotifier(o.notifier)
 	}
 
-	s.Ready()
+	_ = s.Ready()
 
 	t.Cleanup(func() {
 		cancel()

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -32,6 +32,7 @@ type libp2pServiceOpts struct {
 	MockPeerKey *ecdsa.PrivateKey
 	libp2pOpts  libp2p.Options
 	lightNodes  *lightnode.Container
+	notifier    p2p.PickyNotifier
 }
 
 // newService constructs a new libp2p service.
@@ -87,6 +88,11 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if o.notifier != nil {
+		s.SetPickyNotifier(o.notifier)
+	}
+
 	s.Ready()
 
 	t.Cleanup(func() {


### PR DESCRIPTION
### Description
Starting the reacher worker in the `Ready` function to avoid a race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2757)
<!-- Reviewable:end -->
