### PR TITLE
fix: Add chainsync rate limit tolerances

### DIFF
--- a/pkg/chainsyncer/chainsyncer.go
+++ b/pkg/chainsyncer/chainsyncer.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defaultFlagTimeout     = 20 * time.Minute
-	defaultPollEvery       = 1 * time.Minute
+	defaultPollEvery       = 2 * time.Minute
 	defaultBlockerPollTime = 10 * time.Second
 	blockDuration          = 1 * time.Hour
 

--- a/pkg/chainsyncer/metrics.go
+++ b/pkg/chainsyncer/metrics.go
@@ -15,6 +15,7 @@ type metrics struct {
 	PeerErrors       prometheus.Counter
 	InvalidProofs    prometheus.Counter
 	TotalTimeWaiting prometheus.Counter
+	OutLimitErrors   prometheus.Counter
 	PositiveProofs   prometheus.Gauge
 }
 
@@ -44,6 +45,12 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "invalid_proof_count",
+			Help:      "total number of invalid proofs we've received. duplicate increments are expected",
+		}),
+		OutLimitErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "out_limit_error_count",
 			Help:      "total number of invalid proofs we've received. duplicate increments are expected",
 		}),
 		TotalTimeWaiting: prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/chainsyncer/metrics.go
+++ b/pkg/chainsyncer/metrics.go
@@ -51,7 +51,7 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "out_limit_error_count",
-			Help:      "total number of invalid proofs we've received. duplicate increments are expected",
+			Help:      "total number of attempts blocked by the outer limiter",
 		}),
 		TotalTimeWaiting: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,


### PR DESCRIPTION
This PR introduces relaxed attempt intensity and increased tolerances in chainsync limiters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2768)
<!-- Reviewable:end -->
