### PR TITLE
fix: avoid connection attempts while blocklisting

### DIFF
--- a/pkg/p2p/error.go
+++ b/pkg/p2p/error.go
@@ -18,6 +18,8 @@ var (
 	ErrAlreadyConnected = errors.New("already connected")
 	// ErrDialLightNode is returned if connect was attempted to a light node.
 	ErrDialLightNode = errors.New("target peer is a light node")
+	// ErrPeerBlocklisted is returned if peer is on blocklist
+	ErrPeerBlocklisted = errors.New("peer blocklisted")
 )
 
 const (

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -672,14 +672,14 @@ func (s *Service) Connect(ctx context.Context, addr ma.Multiaddr) (address *bzz.
 		s.logger.Errorf("internal error while connecting with peer %s", info.ID)
 		_ = handshakeStream.Reset()
 		_ = s.host.Network().ClosePeer(info.ID)
-		return nil, fmt.Errorf("peer blocklisted")
+		return nil, err
 	}
 
 	if blocked {
 		s.logger.Errorf("blocked connection to blocklisted peer %s", info.ID)
 		_ = handshakeStream.Reset()
 		_ = s.host.Network().ClosePeer(info.ID)
-		return nil, fmt.Errorf("peer blocklisted")
+		return nil, p2p.ErrPeerBlocklisted
 	}
 
 	if exists := s.peers.addIfNotExists(stream.Conn(), overlay, i.FullNode); exists {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -357,6 +357,10 @@ func (k *Kad) connectionAttemptsHandler(ctx context.Context, wg *sync.WaitGroup,
 			k.logger.Debugf("kademlia: overlay mismatch has occurred to an overlay %q with underlay %q", peer.addr, bzzAddr.Underlay)
 			remove(peer)
 			return
+		case errors.Is(err, p2p.ErrPeerBlocklisted):
+			k.logger.Debugf("kademlia: peer still in blocklist: %q", bzzAddr)
+			k.logger.Warningf("peer still in blocklist")
+			return
 		case err != nil:
 			k.logger.Debugf("kademlia: peer not reachable from kademlia %q: %v", bzzAddr, err)
 			k.logger.Warningf("peer not reachable when attempting to connect")
@@ -910,6 +914,8 @@ func (k *Kad) connect(ctx context.Context, peer swarm.Address, ma ma.Multiaddr) 
 		}
 		return nil
 	case errors.Is(err, context.Canceled):
+		return err
+	case errors.Is(err, p2p.ErrPeerBlocklisted):
 		return err
 	case err != nil:
 		k.logger.Debugf("could not connect to peer %q: %v", peer, err)


### PR DESCRIPTION
This PR fixes a behaviour where blocklisted peers are removed from knownpeers because of reoccuring connection attempts