### PR TITLE
build: support m1 macs install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ run_as_root() {
 }
 
 supported() {
-  local supported="darwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm64\nlinux-armv6"
+  local supported="darwin-arm64\ndarwin-amd64\nlinux-386\nlinux-amd64\nlinux-arm64\nlinux-armv6"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     if [ $OS == "windows" ]; then
       echo "Auto install not supported for Windows."


### PR DESCRIPTION
Noticed you are missing `darwin-arm64` from supported list.

Btw. a funny thing is if you run an M1 non-native terminal application then the `uname -m` incorrectly reports `x86_64` as it runs in the emulation software (Rossetta). I am using [Hyper](https://hyper.is/) which for example is not yet compatible (I am running old version).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2789)
<!-- Reviewable:end -->
