### PR TITLE
refactor: allow duplicate handshakes

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -489,7 +489,6 @@ func TestConnectWithEnabledWSTransports(t *testing.T) {
 
 // TestConnectRepeatHandshake tests if handshake was attempted more then once by the same peer
 func TestConnectRepeatHandshake(t *testing.T) {
-	t.Skip("test flaking")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -518,12 +517,12 @@ func TestConnectRepeatHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := s2.HandshakeService().Handshake(ctx, libp2p.NewStream(stream), info.Addrs[0], info.ID); err == nil {
-		t.Fatalf("expected stream error")
+	if _, err := s2.HandshakeService().Handshake(ctx, libp2p.NewStream(stream), info.Addrs[0], info.ID); err != nil {
+		t.Fatal(err)
 	}
 
-	expectPeersEventually(t, s2)
-	expectPeersEventually(t, s1)
+	expectPeersEventually(t, s2, overlay1)
+	expectPeersEventually(t, s1, overlay2)
 }
 
 func TestBlocklisting(t *testing.T) {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -293,8 +293,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	s.host.SetStreamHandlerMatch(id, matcher, s.handleIncoming)
 
 	connMetricNotify := newConnMetricNotify(s.metrics)
-	h.Network().Notify(peerRegistry)       // update peer registry on network events
-	h.Network().Notify(s.handshakeService) // update handshake service on network events
+	h.Network().Notify(peerRegistry) // update peer registry on network events
 	h.Network().Notify(connMetricNotify)
 	return s, nil
 }


### PR DESCRIPTION
As discussed while looking into various errors we've been running into on the libp2p abstraction level, it has been concluded that removing the duplicate handshake constraint is not beneficial and should be removed. It does not guard against anything, and duplicate handshakes are allowed even _with_ this code section (since we can dial to a node and a node can dial back and there's no keeping track of the bidirectional connections). Furthermore, libp2p allows for multiple underlying connections and will use the best one when sending a message according to its internal heuristics of connection selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2794)
<!-- Reviewable:end -->
