### PR TITLE
fix(p2p): handle header stream reset explicitly

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -35,6 +35,7 @@ import (
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/network"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
@@ -840,6 +841,9 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
 		_ = stream.Reset()
+		if errors.Is(err, mux.ErrReset) {
+			_ = s.Disconnect(overlay, fmt.Sprintf("headers reset for peer %q", overlay))
+		}
 		return nil, fmt.Errorf("send headers: %w", err)
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -841,6 +841,9 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 	// exchange headers
 	if err := sendHeaders(ctx, headers, stream); err != nil {
 		_ = stream.Reset()
+
+		// kludge: this is meant to catch the edge case where we think we are
+		// connected to a peer but they don't share the same view.
 		if errors.Is(err, mux.ErrReset) {
 			_ = s.Disconnect(overlay, fmt.Sprintf("headers reset for peer %q", overlay))
 		}


### PR DESCRIPTION
This PR adds explicit handling to a stream reset on the header exchange with the peer. We've found that this is caused by an inconsistent state of the peerstore, in which apparently disconnections do no propagate correctly to our abstraction, so we seem to be connected to a peer, while the other peer does not seem to accept the same assumption. This results in an immediate stream reset from the other side, resolving the long mystery under which we were operating.

Note that this is a stopgap solution and creates an unnecessary dependency in the headers exchange in order to determine connectivity status. Not exactly textbook solution, but allows for a clear disambiguation of the case since this error should definitely _never ever_ happen in this code block, and will give us a bit of leeway to rectify the situation by inspecting this in depth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2796)
<!-- Reviewable:end -->
