### PR TITLE
fix: add missing error handling

### DIFF
--- a/pkg/debugapi/chequebook.go
+++ b/pkg/debugapi/chequebook.go
@@ -110,6 +110,12 @@ func (s *Service) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Reque
 
 	var lastSentResponse *chequebookLastChequePeerResponse
 	lastSent, err := s.swap.LastSentCheque(peer)
+	if errors.Is(err, postagecontract.ErrChainDisabled) {
+		jsonhttp.MethodNotAllowed(w, err)
+		s.logger.Debugf("debug api: chequebook cheque peer: %v", err)
+		s.logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
+		return
+	}
 	if err != nil && !errors.Is(err, chequebook.ErrNoCheque) && !errors.Is(err, swap.ErrNoChequebook) {
 		s.logger.Debugf("debug api: chequebook cheque peer: get peer %s last cheque: %v", peer.String(), err)
 		s.logger.Errorf("debug api: chequebook cheque peer: can't get peer %s last cheque", peer.String())
@@ -149,6 +155,12 @@ func (s *Service) chequebookLastPeerHandler(w http.ResponseWriter, r *http.Reque
 
 func (s *Service) chequebookAllLastHandler(w http.ResponseWriter, r *http.Request) {
 	lastchequessent, err := s.swap.LastSentCheques()
+	if errors.Is(err, postagecontract.ErrChainDisabled) {
+		jsonhttp.MethodNotAllowed(w, err)
+		s.logger.Debugf("debug api: chequebook cheque all: %v", err)
+		s.logger.Errorf("debug api: chequebook cheque all: can't get all last cheques")
+		return
+	}
 	if err != nil {
 		if !errors.Is(err, swap.ErrNoChequebook) {
 			s.logger.Debugf("debug api: chequebook cheque all: get all last cheques: %v", err)
@@ -255,6 +267,12 @@ func (s *Service) swapCashoutHandler(w http.ResponseWriter, r *http.Request) {
 	defer s.cashOutChequeSem.Release(1)
 
 	txHash, err := s.swap.CashCheque(ctx, peer)
+	if errors.Is(err, postagecontract.ErrChainDisabled) {
+		jsonhttp.MethodNotAllowed(w, err)
+		s.logger.Debugf("debug api: cashout peer: %v", err)
+		s.logger.Errorf("debug api: cashout peer: cannot cash %s", addr)
+		return
+	}
 	if err != nil {
 		s.logger.Debugf("debug api: cashout peer: cannot cash %s: %v", addr, err)
 		s.logger.Errorf("debug api: cashout peer: cannot cash %s", addr)
@@ -290,6 +308,12 @@ func (s *Service) swapCashoutStatusHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	status, err := s.swap.CashoutStatus(r.Context(), peer)
+	if errors.Is(err, postagecontract.ErrChainDisabled) {
+		jsonhttp.MethodNotAllowed(w, err)
+		s.logger.Debugf("debug api: cashout status peer: %v", err)
+		s.logger.Errorf("debug api: cashout status peer: %s", addr)
+		return
+	}
 	if err != nil {
 		if errors.Is(err, chequebook.ErrNoCheque) {
 			s.logger.Debugf("debug api: cashout status peer: %v, err: %v", addr, err)

--- a/pkg/debugapi/settlements.go
+++ b/pkg/debugapi/settlements.go
@@ -109,6 +109,12 @@ func (s *Service) peerSettlementsHandler(w http.ResponseWriter, r *http.Request)
 	peerexists := false
 
 	received, err := s.swap.TotalReceived(peer)
+	if errors.Is(err, postagecontract.ErrChainDisabled) {
+		jsonhttp.MethodNotAllowed(w, err)
+		s.logger.Debugf("debug api: settlements peer: %v", err)
+		s.logger.Errorf("debug api: settlements peer: can't get peer %s received settlement", peer.String())
+		return
+	}
 	if err != nil {
 		if !errors.Is(err, settlement.ErrPeerNoSettlements) {
 			s.logger.Debugf("debug api: settlements peer: get peer %s received settlement: %v", peer.String(), err)


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
It is possible to enable `swap` with a disabled chain backend.

In this case all calls to swap endpoint should return `405 Method Not Allowed`