### PR TITLE
fix: catch eth error

### DIFF
--- a/pkg/transaction/backend.go
+++ b/pkg/transaction/backend.go
@@ -50,6 +50,9 @@ func IsSynced(ctx context.Context, backend Backend, maxDelay time.Duration) (boo
 	}
 
 	header, err := backend.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	if errors.Is(err, ethereum.NotFound) {
+		return false, time.Time{}, nil
+	}
 	if err != nil {
 		return false, time.Time{}, err
 	}


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
we get inconsistent behavior when checking for synced status, this change will discriminate ethereum errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2844)
<!-- Reviewable:end -->
