### PR TITLE
feat: keep known peers list on network outage

### DIFF
--- a/pkg/topology/kademlia/metrics.go
+++ b/pkg/topology/kademlia/metrics.go
@@ -33,6 +33,7 @@ type metrics struct {
 	Blocklist                             prometheus.Counter
 	ReachabilityStatus                    *prometheus.GaugeVec
 	PeersReachabilityStatus               *prometheus.GaugeVec
+	NetworkUnreachableErrors              prometheus.Counter
 }
 
 // newMetrics is a convenient constructor for creating new metrics.
@@ -178,6 +179,12 @@ func newMetrics() metrics {
 			},
 			[]string{"peers_reachability_status"},
 		),
+		NetworkUnreachableErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "network_unreachable_total_errors",
+			Help:      "Number of total network unreachable errors returned during the connection attempt.",
+		}),
 	}
 }
 

--- a/pkg/topology/kademlia/unreachable_unix.go
+++ b/pkg/topology/kademlia/unreachable_unix.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package kademlia
+
+import "golang.org/x/sys/unix"
+
+// Collection of errors returned by the libp2p library when the
+// underlying operating system considers the network unreachable.
+var (
+	errHostUnreachable    error = unix.EHOSTUNREACH
+	errNetworkUnreachable error = unix.ENETUNREACH
+)

--- a/pkg/topology/kademlia/unreachable_windows.go
+++ b/pkg/topology/kademlia/unreachable_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
+
+package kademlia
+
+import "golang.org/x/sys/windows"
+
+// Collection of errors returned by the libp2p library when the
+// underlying operating system considers the network unreachable.
+var (
+	errHostUnreachable    error = windows.WSAEHOSTUNREACH
+	errNetworkUnreachable error = windows.WSAENETUNREACH
+)


### PR DESCRIPTION
Allows keeping the number of known peers in the kademlia topology unchanged during the network outage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2853)
<!-- Reviewable:end -->
