### PR TITLE
feat: bootstraping node after batchstore migration

### DIFF
--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -317,3 +317,14 @@ func getLatestSnapshot(
 
 	return swarm.NewAddress(ref), nil
 }
+
+func batchStoreExists(s storage.StateStorer) (bool, error) {
+
+	hasOne := false
+	err := s.Iterate("batchstore_", func(key, value []byte) (stop bool, err error) {
+		hasOne = true
+		return true, err
+	})
+
+	return hasOne, err
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -218,8 +218,8 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 	}
 	b.stateStoreCloser = stateStore
 
-	// Check if the overlay is found in the statestore. If not, we can assume it has
-	// not been created yet and treat this as a fresh install.
+	// Check if the the batchstore exists. If not, we can assume it's missing
+	// due to a migration or it's a fresh install.
 	batchStoreExists, err := batchStoreExists(stateStore)
 	if err != nil {
 		return nil, err

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -218,11 +218,11 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 	}
 	b.stateStoreCloser = stateStore
 
-	newStateStore := false
 	// Check if the overlay is found in the statestore. If not, we can assume it has
 	// not been created yet and treat this as a fresh install.
-	if err := stateStore.Get(secureOverlayKey, new(swarm.Address)); errors.Is(err, storage.ErrNotFound) {
-		newStateStore = true
+	batchStoreExists, err := batchStoreExists(stateStore)
+	if err != nil {
+		return nil, err
 	}
 
 	addressbook := addressbook.New(stateStore)
@@ -455,7 +455,7 @@ func NewBee(addr string, publicKey *ecdsa.PublicKey, signer crypto.Signer, netwo
 	var initBatchState *postage.ChainSnapshot
 	// Bootstrap node with postage snapshot only if it is running on mainnet, is a fresh
 	// install or explicitly asked by user to resync
-	if networkID == mainnetNetworkID && o.UsePostageSnapshot && (newStateStore || o.Resync) {
+	if networkID == mainnetNetworkID && o.UsePostageSnapshot && (!batchStoreExists || o.Resync) {
 		start := time.Now()
 		logger.Info("cold postage start detected. fetching postage stamp snapshot from swarm")
 		initBatchState, err = bootstrapNode(


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.

### Description
Currently, the overlay check to see if the statestore exists for bootstrapping the node does not cover the case where only the batchstore is missing after a migration.

#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2895)
<!-- Reviewable:end -->
