### PR TITLE
chore: reduce batchstore logging

### DIFF
--- a/pkg/postage/batchstore/reserve.go
+++ b/pkg/postage/batchstore/reserve.go
@@ -160,7 +160,6 @@ func (s *store) computeRadius() error {
 	}
 
 	s.metrics.Radius.Set(float64(s.rs.Radius))
-	s.logger.Debugf("batchstore: computed radius %d", s.rs.Radius)
 
 	// Unreserve calls increase the global storage radius, but in the edge case that the new radius
 	// is lower because total commitment has decreased, the global storage radius has to be readjusted
@@ -180,7 +179,6 @@ func (s *store) computeRadius() error {
 		}
 
 		s.metrics.StorageRadius.Set(float64(s.rs.StorageRadius))
-		s.logger.Debugf("batchstore: computed storage radius %d", s.rs.StorageRadius)
 
 		// lower batches' storage radius if new value is lower
 		if s.rs.StorageRadius < oldStorageRadius {


### PR DESCRIPTION
recent changes to the batchstore have increased the amount of logging we do on every batch insertion. this PR reduces the number of loglines we do per operation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2897)
<!-- Reviewable:end -->
