### PR TITLE
fix: add fallback content length check in middleware

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -414,15 +414,18 @@ func (s *server) contentLengthMetricMiddleware() func(h http.Handler) http.Handl
 			switch r.Method {
 			case http.MethodGet:
 				hdr := w.Header().Get("Decompressed-Content-Length")
-				contentLength, err := strconv.Atoi(hdr)
-				if err != nil {
-					s.logger.Debugf("api: decompressed content length: '%s', int conversion failed: %v", hdr, err)
+				if hdr == "" {
+					s.logger.Debug("api: decompressed content length header not found")
 					hdr = w.Header().Get("Content-Length")
-					contentLength, err = strconv.Atoi(hdr)
-					if err != nil {
-						s.logger.Debugf("api: content length: '%s', int conversion failed: %v", hdr, err)
+					if hdr == "" {
+						s.logger.Debug("api: content length header not found")
 						return
 					}
+				}
+				contentLength, err := strconv.Atoi(hdr)
+				if err != nil {
+					s.logger.Debugf("api: content length: '%s', int conversion failed: %v", hdr, err)
+					return
 				}
 				if contentLength > 0 {
 					s.metrics.ContentApiDuration.WithLabelValues(fmt.Sprintf("%d", toFileSizeBucket(int64(contentLength))), r.Method).Observe(time.Since(now).Seconds())

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -417,7 +417,12 @@ func (s *server) contentLengthMetricMiddleware() func(h http.Handler) http.Handl
 				contentLength, err := strconv.Atoi(hdr)
 				if err != nil {
 					s.logger.Debugf("api: decompressed content length: '%s', int conversion failed: %v", hdr, err)
-					return
+					hdr = w.Header().Get("Content-Length")
+					contentLength, err = strconv.Atoi(hdr)
+					if err != nil {
+						s.logger.Debugf("api: content length: '%s', int conversion failed: %v", hdr, err)
+						return
+					}
 				}
 				if contentLength > 0 {
 					s.metrics.ContentApiDuration.WithLabelValues(fmt.Sprintf("%d", toFileSizeBucket(int64(contentLength))), r.Method).Observe(time.Since(now).Seconds())


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
If `decompressed-content-length` fails try the normal one before stopping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2907)
<!-- Reviewable:end -->
