### PR TITLE
fix: sharky read deadlock on context cancelled

### DIFF
--- a/pkg/sharky/shard.go
+++ b/pkg/sharky/shard.go
@@ -73,6 +73,7 @@ type entry struct {
 
 // read models the input to read operation (the output is an error)
 type read struct {
+	ctx  context.Context
 	buf  []byte // variable size read buffer
 	slot uint32 // slot to read from
 }
@@ -114,6 +115,7 @@ LOOP:
 			for {
 				select {
 				case sh.errc <- sh.read(op):
+				case <-op.ctx.Done():
 				case <-sh.quit:
 					return
 				}

--- a/pkg/sharky/shard_slots_test.go
+++ b/pkg/sharky/shard_slots_test.go
@@ -82,7 +82,7 @@ func readFromLocation(t *testing.T, shard *shard, loc Location) []byte {
 	buf := make([]byte, loc.Length)
 
 	select {
-	case shard.reads <- read{buf[:loc.Length], loc.Slot}:
+	case shard.reads <- read{ctx: context.Background(), buf: buf[:loc.Length], slot: loc.Slot}:
 		if err := <-shard.errc; err != nil {
 			t.Fatal("read", err)
 		}

--- a/pkg/sharky/store.go
+++ b/pkg/sharky/store.go
@@ -119,7 +119,7 @@ func (s *Store) create(index uint8, maxDataSize int, basedir fs.FS) (*shard, err
 func (s *Store) Read(ctx context.Context, loc Location, buf []byte) (err error) {
 	sh := s.shards[loc.Shard]
 	select {
-	case sh.reads <- read{buf[:loc.Length], loc.Slot}:
+	case sh.reads <- read{ctx: ctx, buf: buf[:loc.Length], slot: loc.Slot}:
 		s.metrics.TotalReadCalls.Inc()
 	case <-ctx.Done():
 		return ctx.Err()
@@ -133,8 +133,6 @@ func (s *Store) Read(ctx context.Context, loc Location, buf []byte) (err error) 
 		return err
 	case <-s.quit:
 		return ErrQuitting
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 

--- a/pkg/sharky/store.go
+++ b/pkg/sharky/store.go
@@ -125,6 +125,10 @@ func (s *Store) Read(ctx context.Context, loc Location, buf []byte) (err error) 
 		return ctx.Err()
 	}
 
+	// it is important that this select would NEVER respect the context
+	// cancellation. this would result in a deadlock on the shard, since
+	// the result of the operation must be drained from errc, allowing the
+	// shard to be able to handle new operations (#2932).
 	select {
 	case err = <-sh.errc:
 		if err != nil {


### PR DESCRIPTION
### Description
<!--Please include a summary of the change and which issue is fixed. -->
Fixes a bug where a cancelled context would result in a deadlock on the sharky read which tries to write the error back to the `sh.errc` channel

Caught in a goroutine dump from @tmm360 on #2909.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2932)
<!-- Reviewable:end -->
