### PR TITLE
feat: set default admin password in restricted dev

### DIFF
--- a/cmd/bee/cmd/start_dev.go
+++ b/cmd/bee/cmd/start_dev.go
@@ -150,6 +150,9 @@ func (c *command) initStartDevCmd() (err error) {
 		},
 	}
 
+	// bcrypt-ed 'hello', or 'OmhlbGxv' in base64
+	const defaultDevPassword = "E6Gr5TfcJQHSya4OG2Cf0Z6RVtH0E2tQVNAP3+majDBYuJcyhPB4MvD6vbYV96Bk95KaUmLdhD7kbEWMGk48BIkfucGSWU9+xGFMUu3feOUBzcFlg5iDUQ=="
+
 	cmd.Flags().Bool(optionNameDebugAPIEnable, true, "enable debug HTTP API")
 	cmd.Flags().String(optionNameAPIAddr, ":1633", "HTTP API listen address")
 	cmd.Flags().String(optionNameDebugAPIAddr, ":1635", "debug HTTP API listen address")
@@ -162,7 +165,7 @@ func (c *command) initStartDevCmd() (err error) {
 	cmd.Flags().Bool(optionNameDBDisableSeeksCompaction, false, "disables db compactions triggered by seeks")
 	cmd.Flags().Bool(optionNameRestrictedAPI, false, "enable permission check on the http APIs")
 	cmd.Flags().String(optionNameTokenEncryptionKey, "", "security token encryption hash")
-	cmd.Flags().String(optionNameAdminPasswordHash, "", "bcrypt hash of the admin password to get the security token")
+	cmd.Flags().String(optionNameAdminPasswordHash, defaultDevPassword, "bcrypt hash of the admin password to get the security token")
 
 	c.root.AddCommand(cmd)
 	return nil


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
To improve the developer's experience the `dev` mode has a default admin password when ran in `restricted` mode.

To be used like so:

```http
POST localhost:1633/auth
Content-Type: application/json
Authorization: Basic OmhlbGxv
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2947)
<!-- Reviewable:end -->
