### PR TITLE
fix: prepare credit context argument

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethersphere/bee/pkg/settlement/pseudosettle"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
@@ -36,10 +37,10 @@ var (
 
 // Interface is the Accounting interface.
 type Interface interface {
-	// Credit action to prevent overspending in case of concurrent requests.
-	PrepareCredit(peer swarm.Address, price uint64, originated bool) (Action, error)
+	// PrepareCredit action to prevent overspending in case of concurrent requests.
+	PrepareCredit(ctx context.Context, peer swarm.Address, price uint64, originated bool) (Action, error)
 	// PrepareDebit returns an accounting Action for the later debit to be executed on and to implement shadowing a possibly credited part of reserve on the other side.
-	PrepareDebit(peer swarm.Address, price uint64) (Action, error)
+	PrepareDebit(ctx context.Context, peer swarm.Address, price uint64) (Action, error)
 	// Balance returns the current balance for the given peer.
 	Balance(peer swarm.Address) (*big.Int, error)
 	// SurplusBalance returns the current surplus balance for the given peer.
@@ -85,13 +86,47 @@ type PayFunc func(context.Context, swarm.Address, *big.Int)
 // RefreshFunc is the function used for sync time-based settlement
 type RefreshFunc func(context.Context, swarm.Address, *big.Int, *big.Int) (*big.Int, int64, error)
 
+// SemMutex is a drop in replacement for the sync.Mutex
+// it will not lock if the context is expired
+type SemMutex struct {
+	sem *semaphore.Weighted
+}
+
+func NewMutex() SemMutex {
+	return SemMutex{
+		sem: semaphore.NewWeighted(1),
+	}
+}
+
+var ErrFailToLock = errors.New("failed to lock")
+
+func (m *SemMutex) Lock(ctx context.Context) error {
+	if err := m.sem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("%v: %w", ErrFailToLock, err)
+	}
+
+	return nil
+}
+
+func (m *SemMutex) TryLock() error {
+	if !m.sem.TryAcquire(1) {
+		return ErrFailToLock
+	}
+
+	return nil
+}
+
+func (m *SemMutex) Unlock() {
+	m.sem.Release(1)
+}
+
 // accountingPeer holds all in-memory accounting information for one peer.
 type accountingPeer struct {
-	lock                           sync.Mutex // lock to be held during any accounting action for this peer
-	reservedBalance                *big.Int   // amount currently reserved for active peer interaction
-	shadowReservedBalance          *big.Int   // amount potentially to be debited for active peer interaction
-	ghostBalance                   *big.Int   // amount potentially could have been debited for but was not
-	paymentThreshold               *big.Int   // the threshold at which the peer expects us to pay
+	SemMutex                                // lock to be held during any accounting action for this peer
+	reservedBalance                *big.Int // amount currently reserved for active peer interaction
+	shadowReservedBalance          *big.Int // amount potentially to be debited for active peer interaction
+	ghostBalance                   *big.Int // amount potentially could have been debited for but was not
+	paymentThreshold               *big.Int // the threshold at which the peer expects us to pay
 	earlyPayment                   *big.Int
 	refreshTimestamp               int64 // last time we attempted time-based settlement
 	paymentOngoing                 bool  // indicate if we are currently settling with the peer
@@ -195,11 +230,14 @@ func (a *Accounting) getIncreasedExpectedDebt(peer swarm.Address, accountingPeer
 	return new(big.Int).Add(expectedDebt, additionalDebt), currentBalance, nil
 }
 
-func (a *Accounting) PrepareCredit(peer swarm.Address, price uint64, originated bool) (Action, error) {
+func (a *Accounting) PrepareCredit(ctx context.Context, peer swarm.Address, price uint64, originated bool) (Action, error) {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.Lock(ctx); err != nil {
+		a.logger.Errorf("prepare credit: failed to acquire lock: %v", err)
+		return nil, err
+	}
+	defer accountingPeer.Unlock()
 
 	if !accountingPeer.connected {
 		return nil, errors.New("connection not initialized yet")
@@ -268,8 +306,10 @@ func (a *Accounting) PrepareCredit(peer swarm.Address, price uint64, originated 
 }
 
 func (c *creditAction) Apply() error {
-	c.accountingPeer.lock.Lock()
-	defer c.accountingPeer.lock.Unlock()
+	if err := c.accountingPeer.TryLock(); err != nil {
+		return err
+	}
+	defer c.accountingPeer.Unlock()
 
 	currentBalance, err := c.accounting.Balance(c.peer)
 	if err != nil {
@@ -341,8 +381,10 @@ func (c *creditAction) Cleanup() {
 		return
 	}
 
-	c.accountingPeer.lock.Lock()
-	defer c.accountingPeer.lock.Unlock()
+	if err := c.accountingPeer.TryLock(); err != nil {
+		return
+	}
+	defer c.accountingPeer.Unlock()
 
 	if c.price.Cmp(c.accountingPeer.reservedBalance) > 0 {
 		c.accounting.logger.Error("attempting to release more balance than was reserved for peer")
@@ -544,6 +586,7 @@ func (a *Accounting) getAccountingPeer(peer swarm.Address) *accountingPeer {
 	peerData, ok := a.accountingPeers[peer.String()]
 	if !ok {
 		peerData = &accountingPeer{
+			SemMutex:              NewMutex(),
 			reservedBalance:       big.NewInt(0),
 			shadowReservedBalance: big.NewInt(0),
 			ghostBalance:          big.NewInt(0),
@@ -672,10 +715,13 @@ func surplusBalanceKeyPeer(key []byte) (swarm.Address, error) {
 
 // PeerDebt returns the positive part of the sum of the outstanding balance and the shadow reserve
 func (a *Accounting) PeerDebt(peer swarm.Address) (*big.Int, error) {
-
 	accountingPeer := a.getAccountingPeer(peer)
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+
+	if err := accountingPeer.TryLock(); err != nil {
+		return nil, err
+	}
+
+	defer accountingPeer.Unlock()
 
 	balance := new(big.Int)
 	zero := big.NewInt(0)
@@ -769,8 +815,11 @@ func (a *Accounting) NotifyPaymentSent(peer swarm.Address, amount *big.Int, rece
 	defer a.wg.Done()
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("notify payment sent: failed to acquire lock: %v", err)
+		return
+	}
+	defer accountingPeer.Unlock()
 
 	accountingPeer.paymentOngoing = false
 	// decrease shadow reserve by payment value
@@ -813,8 +862,11 @@ func (a *Accounting) NotifyPaymentSent(peer swarm.Address, amount *big.Int, rece
 func (a *Accounting) NotifyPaymentThreshold(peer swarm.Address, paymentThreshold *big.Int) error {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("notify payment threashold: failed to acquire lock: %v", err)
+		return err
+	}
+	defer accountingPeer.Unlock()
 
 	accountingPeer.paymentThreshold.Set(paymentThreshold)
 	accountingPeer.earlyPayment.Set(new(big.Int).Div(new(big.Int).Mul(paymentThreshold, big.NewInt(100-a.earlyPayment)), big.NewInt(100)))
@@ -825,8 +877,12 @@ func (a *Accounting) NotifyPaymentThreshold(peer swarm.Address, paymentThreshold
 func (a *Accounting) NotifyPaymentReceived(peer swarm.Address, amount *big.Int) error {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("notify payment received: failed to acquire lock: %v", err)
+		return err
+	}
+
+	defer accountingPeer.Unlock()
 
 	currentBalance, err := a.Balance(peer)
 	if err != nil {
@@ -898,8 +954,12 @@ func (a *Accounting) NotifyPaymentReceived(peer swarm.Address, amount *big.Int) 
 func (a *Accounting) NotifyRefreshmentReceived(peer swarm.Address, amount *big.Int) error {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("notify refreshment received: failed to acquire lock: %v", err)
+		return err
+	}
+
+	defer accountingPeer.Unlock()
 
 	currentBalance, err := a.Balance(peer)
 	if err != nil {
@@ -923,11 +983,15 @@ func (a *Accounting) NotifyRefreshmentReceived(peer swarm.Address, amount *big.I
 }
 
 // PrepareDebit prepares a debit operation by increasing the shadowReservedBalance
-func (a *Accounting) PrepareDebit(peer swarm.Address, price uint64) (Action, error) {
+func (a *Accounting) PrepareDebit(ctx context.Context, peer swarm.Address, price uint64) (Action, error) {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.Lock(ctx); err != nil {
+		a.logger.Errorf("prepare debit: failed to acquire lock: %v", err)
+		return nil, err
+	}
+
+	defer accountingPeer.Unlock()
 
 	if !accountingPeer.connected {
 		return nil, errors.New("connection not initialized yet")
@@ -1017,8 +1081,10 @@ func (a *Accounting) increaseBalance(peer swarm.Address, accountingPeer *account
 
 // Apply applies the debit operation and decreases the shadowReservedBalance
 func (d *debitAction) Apply() error {
-	d.accountingPeer.lock.Lock()
-	defer d.accountingPeer.lock.Unlock()
+	if err := d.accountingPeer.TryLock(); err != nil {
+		return err
+	}
+	defer d.accountingPeer.Unlock()
 
 	a := d.accounting
 
@@ -1058,8 +1124,11 @@ func (d *debitAction) Cleanup() {
 		return
 	}
 
-	d.accountingPeer.lock.Lock()
-	defer d.accountingPeer.lock.Unlock()
+	if err := d.accountingPeer.TryLock(); err != nil {
+		return
+	}
+	defer d.accountingPeer.Unlock()
+
 	a := d.accounting
 	d.accountingPeer.shadowReservedBalance = new(big.Int).Sub(d.accountingPeer.shadowReservedBalance, d.price)
 	d.accountingPeer.ghostBalance = new(big.Int).Add(d.accountingPeer.ghostBalance, d.price)
@@ -1105,8 +1174,11 @@ func (a *Accounting) Connect(peer swarm.Address) {
 	accountingPeer := a.getAccountingPeer(peer)
 	zero := big.NewInt(0)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("connect: failed to acquire lock: %v", err)
+		return
+	}
+	defer accountingPeer.Unlock()
 
 	accountingPeer.connected = true
 	accountingPeer.shadowReservedBalance.Set(zero)
@@ -1175,8 +1247,11 @@ func (a *Accounting) decreaseOriginatedBalanceBy(peer swarm.Address, amount *big
 func (a *Accounting) Disconnect(peer swarm.Address) {
 	accountingPeer := a.getAccountingPeer(peer)
 
-	accountingPeer.lock.Lock()
-	defer accountingPeer.lock.Unlock()
+	if err := accountingPeer.TryLock(); err != nil {
+		a.logger.Errorf("disconnect: failed to acquire lock: %v", err)
+		return
+	}
+	defer accountingPeer.Unlock()
 
 	if accountingPeer.connected {
 		disconnectFor, err := a.blocklistUntil(peer, 1)

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -83,7 +83,7 @@ func TestAccountingAddBalance(t *testing.T) {
 
 	for i, booking := range bookings {
 		if booking.price < 0 {
-			creditAction, err := acc.PrepareCredit(booking.peer, uint64(-booking.price), true)
+			creditAction, err := acc.PrepareCredit(context.Background(), booking.peer, uint64(-booking.price), true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +93,7 @@ func TestAccountingAddBalance(t *testing.T) {
 			}
 			creditAction.Cleanup()
 		} else {
-			debitAction, err := acc.PrepareDebit(booking.peer, uint64(booking.price))
+			debitAction, err := acc.PrepareDebit(context.Background(), booking.peer, uint64(booking.price))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -165,7 +165,7 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 
 		pay := func(ctx context.Context, peer swarm.Address, amount *big.Int) {
 			if booking.overpay != 0 {
-				debitAction, err := acc.PrepareDebit(peer, booking.overpay)
+				debitAction, err := acc.PrepareDebit(context.Background(), peer, booking.overpay)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -179,7 +179,7 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 		acc.SetPayFunc(pay)
 
 		if booking.price < 0 {
-			creditAction, err := acc.PrepareCredit(booking.peer, uint64(-booking.price), booking.originatedCredit)
+			creditAction, err := acc.PrepareCredit(context.Background(), booking.peer, uint64(-booking.price), booking.originatedCredit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -198,7 +198,7 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 			}
 			creditAction.Cleanup()
 		} else {
-			debitAction, err := acc.PrepareDebit(booking.peer, uint64(booking.price))
+			debitAction, err := acc.PrepareDebit(context.Background(), booking.peer, uint64(booking.price))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,7 +257,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 	acc.Connect(peer2Addr)
 
 	peer1DebitAmount := testPrice
-	debitAction, err := acc.PrepareDebit(peer1Addr, peer1DebitAmount)
+	debitAction, err := acc.PrepareDebit(context.Background(), peer1Addr, peer1DebitAmount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 	debitAction.Cleanup()
 
 	peer2CreditAmount := 2 * testPrice
-	creditAction, err := acc.PrepareCredit(peer2Addr, peer2CreditAmount, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer2Addr, peer2CreditAmount, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestAccountingReserve(t *testing.T) {
 
 	acc.Connect(peer1Addr)
 
-	_, err = acc.PrepareCredit(peer1Addr, testPaymentThreshold.Uint64()+1, true)
+	_, err = acc.PrepareCredit(context.Background(), peer1Addr, testPaymentThreshold.Uint64()+1, true)
 	if err == nil {
 		t.Fatal("expected error from reserve")
 	}
@@ -350,7 +350,7 @@ func TestAccountingDisconnect(t *testing.T) {
 	acc.Connect(peer1Addr)
 
 	// put the peer 1 unit away from disconnect
-	debitAction, err := acc.PrepareDebit(peer1Addr, (testPaymentThreshold.Uint64()*(100+uint64(testPaymentTolerance))/100)-1)
+	debitAction, err := acc.PrepareDebit(context.Background(), peer1Addr, (testPaymentThreshold.Uint64()*(100+uint64(testPaymentTolerance))/100)-1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestAccountingDisconnect(t *testing.T) {
 	debitAction.Cleanup()
 
 	// put the peer over thee threshold
-	debitAction, err = acc.PrepareDebit(peer1Addr, 1)
+	debitAction, err = acc.PrepareDebit(context.Background(), peer1Addr, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,7 +411,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64() - 1000
 
-	creditAction, err := acc.PrepareCredit(peer1Addr, requestPrice, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, requestPrice, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +425,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 	creditAction.Cleanup()
 
 	// try another request
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,14 +457,14 @@ func TestAccountingCallSettlement(t *testing.T) {
 	}
 
 	// Assume 100 is reserved by some other request
-	creditActionLong, err := acc.PrepareCredit(peer1Addr, 100, true)
+	creditActionLong, err := acc.PrepareCredit(context.Background(), peer1Addr, 100, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Credit until the expected debt exceeds payment threshold
 	expectedAmount := testPaymentThreshold.Uint64() - 101
-	creditAction, err = acc.PrepareCredit(peer1Addr, expectedAmount, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, expectedAmount, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -477,7 +477,7 @@ func TestAccountingCallSettlement(t *testing.T) {
 	creditAction.Cleanup()
 
 	// try another request to trigger settlement
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +536,7 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64() - 1000
 
-	creditAction, err := acc.PrepareCredit(peer1Addr, requestPrice, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, requestPrice, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +550,7 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 	creditAction.Cleanup()
 
 	// try another request
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -597,7 +597,7 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 	// Credit until the expected debt exceeds payment threshold
 	expectedAmount := testPaymentThreshold.Uint64()
 
-	_, err = acc.PrepareCredit(peer1Addr, expectedAmount, true)
+	_, err = acc.PrepareCredit(context.Background(), peer1Addr, expectedAmount, true)
 	if !errors.Is(err, accounting.ErrOverdraft) {
 		t.Fatalf("expected overdraft, got %v", err)
 	}
@@ -655,7 +655,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64() - 1000
 
-	creditAction, err := acc.PrepareCredit(peer1Addr, requestPrice, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, requestPrice, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -669,7 +669,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 	creditAction.Cleanup()
 
 	// try another request
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +698,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 
 	acc.SetTime(ts)
 
-	creditAction, err = acc.PrepareCredit(peer1Addr, requestPrice, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, requestPrice, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -712,7 +712,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 	creditAction.Cleanup()
 
 	// try another request
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 	acc.SetTime(ts + 1)
 
 	// try another request
-	_, err = acc.PrepareCredit(peer1Addr, 1, true)
+	_, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -790,7 +790,7 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 
 	acc.Connect(peer1Addr)
 
-	creditAction, err := acc.PrepareCredit(peer1Addr, debt, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, debt, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -800,7 +800,7 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 	creditAction.Cleanup()
 
 	payment := testPaymentThreshold.Uint64() * (100 - uint64(earlyPayment)) / 100
-	creditAction, err = acc.PrepareCredit(peer1Addr, payment, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, payment, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,7 +845,7 @@ func TestAccountingSurplusBalance(t *testing.T) {
 	acc.Connect(peer1Addr)
 
 	// Try Debiting a large amount to peer so balance is large positive
-	debitAction, err := acc.PrepareDebit(peer1Addr, testPaymentThreshold.Uint64()-1)
+	debitAction, err := acc.PrepareDebit(context.Background(), peer1Addr, testPaymentThreshold.Uint64()-1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -897,7 +897,7 @@ func TestAccountingSurplusBalance(t *testing.T) {
 		t.Fatal("Not expected balance, expected 0")
 	}
 	// Debit for same peer, so balance stays 0 with surplusbalance decreasing to 2
-	debitAction, err = acc.PrepareDebit(peer1Addr, testPaymentThreshold.Uint64())
+	debitAction, err = acc.PrepareDebit(context.Background(), peer1Addr, testPaymentThreshold.Uint64())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -923,7 +923,7 @@ func TestAccountingSurplusBalance(t *testing.T) {
 		t.Fatal("Not expected balance, expected 0")
 	}
 	// Debit for same peer, so balance goes to 9998 (testpaymentthreshold - 2) with surplusbalance decreasing to 0
-	debitAction, err = acc.PrepareDebit(peer1Addr, testPaymentThreshold.Uint64())
+	debitAction, err = acc.PrepareDebit(context.Background(), peer1Addr, testPaymentThreshold.Uint64())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -970,7 +970,7 @@ func TestAccountingNotifyPaymentReceived(t *testing.T) {
 	acc.Connect(peer1Addr)
 
 	debtAmount := uint64(100)
-	debitAction, err := acc.PrepareDebit(peer1Addr, debtAmount)
+	debitAction, err := acc.PrepareDebit(context.Background(), peer1Addr, debtAmount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -985,7 +985,7 @@ func TestAccountingNotifyPaymentReceived(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	debitAction, err = acc.PrepareDebit(peer1Addr, debtAmount)
+	debitAction, err = acc.PrepareDebit(context.Background(), peer1Addr, debtAmount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1087,7 +1087,7 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	creditAction, err := acc.PrepareCredit(peer1Addr, debt, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, debt, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1096,7 +1096,7 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 	}
 	creditAction.Cleanup()
 
-	_, err = acc.PrepareCredit(peer1Addr, lowerThreshold, true)
+	_, err = acc.PrepareCredit(context.Background(), peer1Addr, lowerThreshold, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1131,7 +1131,7 @@ func TestAccountingPeerDebt(t *testing.T) {
 	acc.Connect(peer1Addr)
 
 	debt := uint64(1000)
-	debitAction, err := acc.PrepareDebit(peer1Addr, debt)
+	debitAction, err := acc.PrepareDebit(context.Background(), peer1Addr, debt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1150,7 +1150,7 @@ func TestAccountingPeerDebt(t *testing.T) {
 
 	peer2Addr := swarm.MustParseHexAddress("11112233")
 	acc.Connect(peer2Addr)
-	creditAction, err := acc.PrepareCredit(peer2Addr, 500, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer2Addr, 500, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1211,7 +1211,7 @@ func TestAccountingCallPaymentErrorRetries(t *testing.T) {
 	requestPrice := testPaymentThreshold.Uint64() - 100
 
 	// Credit until near payment threshold
-	creditAction, err := acc.PrepareCredit(peer1Addr, requestPrice, true)
+	creditAction, err := acc.PrepareCredit(context.Background(), peer1Addr, requestPrice, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1220,7 +1220,7 @@ func TestAccountingCallPaymentErrorRetries(t *testing.T) {
 	}
 	creditAction.Cleanup()
 
-	creditAction, err = acc.PrepareCredit(peer1Addr, 2, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 2, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1248,7 +1248,7 @@ func TestAccountingCallPaymentErrorRetries(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		ts++
 		acc.SetTime(ts)
-		creditAction, err = acc.PrepareCredit(peer1Addr, 2, true)
+		creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 2, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1270,7 +1270,7 @@ func TestAccountingCallPaymentErrorRetries(t *testing.T) {
 	acc.SetTime(ts)
 
 	// try another request
-	creditAction, err = acc.PrepareCredit(peer1Addr, 1, true)
+	creditAction, err = acc.PrepareCredit(context.Background(), peer1Addr, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1327,7 +1327,7 @@ func TestAccountingGhostOverdraft(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64()
 
-	debitActionNormal, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionNormal, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1338,14 +1338,14 @@ func TestAccountingGhostOverdraft(t *testing.T) {
 	debitActionNormal.Cleanup()
 
 	// debit ghost balance
-	debitActionGhost, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionGhost, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 	debitActionGhost.Cleanup()
 
 	// increase shadow reserve
-	debitActionShadow, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionShadow, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1356,7 +1356,7 @@ func TestAccountingGhostOverdraft(t *testing.T) {
 	}
 
 	// ghost overdraft triggering blocklist
-	debitAction4, err := acc.PrepareDebit(peer, requestPrice)
+	debitAction4, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1401,7 +1401,7 @@ func TestAccountingReconnectBeforeAllowed(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64()
 
-	debitActionNormal, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionNormal, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1412,14 +1412,14 @@ func TestAccountingReconnectBeforeAllowed(t *testing.T) {
 	debitActionNormal.Cleanup()
 
 	// debit ghost balance
-	debitActionGhost, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionGhost, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 	debitActionGhost.Cleanup()
 
 	// increase shadow reserve
-	debitActionShadow, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionShadow, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1471,7 +1471,7 @@ func TestAccountingResetBalanceAfterReconnect(t *testing.T) {
 
 	requestPrice := testPaymentThreshold.Uint64()
 
-	debitActionNormal, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionNormal, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1482,14 +1482,14 @@ func TestAccountingResetBalanceAfterReconnect(t *testing.T) {
 	debitActionNormal.Cleanup()
 
 	// debit ghost balance
-	debitActionGhost, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionGhost, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}
 	debitActionGhost.Cleanup()
 
 	// increase shadow reserve
-	debitActionShadow, err := acc.PrepareDebit(peer, requestPrice)
+	debitActionShadow, err := acc.PrepareDebit(context.Background(), peer, requestPrice)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/accounting/mock/accounting.go
+++ b/pkg/accounting/mock/accounting.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	"context"
 	"math/big"
 	"sync"
 
@@ -112,7 +113,7 @@ func (s *Service) MakeCreditAction(peer swarm.Address, price uint64) accounting.
 }
 
 // Debit is the mock function wrapper that calls the set implementation
-func (s *Service) PrepareDebit(peer swarm.Address, price uint64) (accounting.Action, error) {
+func (s *Service) PrepareDebit(_ context.Context, peer swarm.Address, price uint64) (accounting.Action, error) {
 	if s.prepareDebitFunc != nil {
 		return s.prepareDebitFunc(peer, price)
 	}
@@ -126,7 +127,7 @@ func (s *Service) PrepareDebit(peer swarm.Address, price uint64) (accounting.Act
 	}, nil
 }
 
-func (s *Service) PrepareCredit(peer swarm.Address, price uint64, originated bool) (accounting.Action, error) {
+func (s *Service) PrepareCredit(_ context.Context, peer swarm.Address, price uint64, originated bool) (accounting.Action, error) {
 	if s.prepareCreditFunc != nil {
 		return s.prepareCreditFunc(peer, price, originated)
 	}


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
In order to minimize lock contention for the accounting peer we will reject the goroutines that have an expired context as well as the goroutines that do not receive the lock within the context deadline.
This PR introduces a context aware mutex for that purpose.

Closes #2959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2961)
<!-- Reviewable:end -->
