### PR TITLE
refactor: introduce structural logging

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -42,7 +42,6 @@ const (
 var beeWelcomeMessage string
 
 func (c *command) initStartCmd() (err error) {
-
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start a Swarm node",

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -8,7 +8,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
@@ -39,6 +38,10 @@ func createWindowsEventLogger(svcName string, logger logging.Logger) (logging.Lo
 type windowsEventLogger struct {
 	logger logging.Logger
 	winlog debug.Log
+}
+
+func (l *windowsEventLogger) Log(verbosity logrus.Level, args ...interface{}) {
+	// ignore
 }
 
 func (l *windowsEventLogger) Tracef(format string, args ...interface{}) {
@@ -81,18 +84,6 @@ func (l *windowsEventLogger) Error(args ...interface{}) {
 	_ = l.winlog.Error(1633, fmt.Sprint(args...))
 }
 
-func (l *windowsEventLogger) WithField(key string, value interface{}) *logrus.Entry {
-	return l.logger.WithField(key, value)
-}
-
-func (l *windowsEventLogger) WithFields(fields logrus.Fields) *logrus.Entry {
-	return l.logger.WithFields(fields)
-}
-
-func (l *windowsEventLogger) WriterLevel(level logrus.Level) *io.PipeWriter {
-	return l.NewEntry().WriterLevel(level)
-}
-
-func (l *windowsEventLogger) NewEntry() *logrus.Entry {
-	return l.logger.NewEntry()
+func (l *windowsEventLogger) WithValues(keysAndValues ...interface{}) logging.Logger {
+	return l.logger.WithValues(keysAndValues...)
 }

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -677,6 +677,52 @@ components:
           type: string
           nullable: false
 
+    LoggerExp:
+      type: string
+      description: Base 64 encoded regular expression or subsystem string.
+      pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+      example: "b25lL25hbWU="
+
+    LoggerTreeData:
+      type: object
+      nullable: true
+      properties:
+        /:
+          $ref: "#/components/schemas/LoggerTreeNode"
+        +:
+          type: array
+          items:
+            type: string
+          description: The combination of the logger verbosity and its subsystem separated by |.
+          example: "warning|one/name[0][]>>824634860360"
+
+    LoggerTreeNode:
+      type: object
+      additionalProperties:
+          $ref: "#/components/schemas/LoggerTreeData"
+
+    Logger:
+      type: object
+      properties:
+        logger:
+          type: string
+        verbosity:
+          type: string
+        subsystem:
+          type: string
+        id:
+          type: string
+
+    LoggerResponse:
+      type: object
+      properties:
+        tree:
+            $ref: "#/components/schemas/LoggerTreeNode"
+        loggers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Logger"
+
   headers:
     SwarmTag:
       description: "Tag UID"

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -997,3 +997,62 @@ paths:
 
         default:
           description: Default response
+
+  "/loggers":
+    get:
+      summary: Get all available loggers.
+      tags:
+        - Logging
+      responses:
+        "200":
+          description: Returns an array of all available loggers, also represented in short form in a tree.
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/LoggerResponse"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        default:
+            description: Default response
+
+  "/loggers/{exp}":
+    get:
+      summary: Get all available loggers that match the specified expression.
+      parameters:
+        - in: path
+          name: exp
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/LoggerExp"
+          required: true
+          description: Regular expression or a subsystem that matches the logger(s).
+      tags:
+        - Logging
+      responses:
+        "200":
+          description: Returns an array of all available loggers that matches given expression, also represented in short form in a tree.
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/LoggerResponse"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        default:
+          description: Default response
+    put:
+      summary: Set logger(s) verbosity level.
+      parameters:
+        - in: path
+          name: exp
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/LoggerExp"
+          required: true
+          description: Regular expression or a subsystem that matches the logger(s).
+      tags:
+        - Logging
+      responses:
+        "200":
+          description: The verbosity was changed successfully.
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        default:
+          description: Default response

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -125,7 +125,7 @@ func (s *Service) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 // bytesGetHandler handles retrieval of raw binary data of arbitrary length.
 func (s *Service) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger).Logger
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
 	nameOrHex := mux.Vars(r)["address"]
 
 	address, err := s.resolveNameOrAddress(nameOrHex)
@@ -144,7 +144,7 @@ func (s *Service) bytesGetHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
-	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger).Logger
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger)
 	nameOrHex := mux.Vars(r)["address"]
 
 	address, err := s.resolveNameOrAddress(nameOrHex)

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -4,7 +4,10 @@
 
 package api
 
-import "github.com/ethersphere/bee/pkg/swarm"
+import (
+	"github.com/ethersphere/bee/pkg/log"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
 
 type (
 	BytesPostResponse     = bytesPostResponse
@@ -108,3 +111,16 @@ var (
 	ErrCantResendTransaction = errCantResendTransaction
 	ErrAlreadyImported       = errAlreadyImported
 )
+
+type (
+	LogRegistryIterateFn   func(fn func(string, string, log.Level, uint) bool)
+	LogSetVerbosityByExpFn func(e string, v log.Level) error
+)
+
+var (
+	LogRegistryIterate   = logRegistryIterate
+	LogSetVerbosityByExp = logSetVerbosityByExp
+)
+
+func ReplaceLogRegistryIterateFn(fn LogRegistryIterateFn)   { logRegistryIterate = fn }
+func ReplaceLogSetVerbosityByExp(fn LogSetVerbosityByExpFn) { logSetVerbosityByExp = fn }

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -112,6 +112,7 @@ func (s *Service) loggerSetVerbosityHandler(w http.ResponseWriter, r *http.Reque
 		s.logger.Debugf("loggers set verbosity: parse verbosity level failed: %v", err)
 		s.logger.Error("loggers set verbosity: parse verbosity level failed")
 		jsonhttp.BadRequest(w, err)
+		return
 	}
 
 	exp, err := base64.URLEncoding.DecodeString(mux.Vars(r)["exp"])
@@ -119,6 +120,7 @@ func (s *Service) loggerSetVerbosityHandler(w http.ResponseWriter, r *http.Reque
 		s.logger.Debugf("loggers set verbosity: query parameter decoding failed: %v", err)
 		s.logger.Error("loggers set verbosity: query parameter decoding failed")
 		jsonhttp.BadRequest(w, err)
+		return
 	}
 
 	if err := logSetVerbosityByExp(string(exp), verbosity); err != nil {

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/log"
+	"github.com/gorilla/mux"
+)
+
+// The following variables exist only to be mocked in tests.
+var (
+	logRegistryIterate   = log.RegistryIterate
+	logSetVerbosityByExp = log.SetVerbosityByExp
+)
+
+type (
+	data struct {
+		Next  node     `json:"/,omitempty"`
+		Names []string `json:"+,omitempty"`
+	}
+
+	node map[string]*data
+
+	logger struct {
+		Logger    string `json:"logger"`
+		Verbosity string `json:"verbosity"`
+		Subsystem string `json:"subsystem"`
+		ID        string `json:"id"`
+	}
+
+	loggerResult struct {
+		Tree    node     `json:"tree"`
+		Loggers []logger `json:"loggers"`
+	}
+)
+
+// loggerGetHandler returns all available loggers that match the specified expression.
+func (s *Service) loggerGetHandler(w http.ResponseWriter, r *http.Request) {
+	var (
+		exp string
+		err error
+	)
+
+	if val, ok := mux.Vars(r)["exp"]; ok {
+		buf, err := base64.URLEncoding.DecodeString(val)
+		if err != nil {
+			s.logger.Debugf("loggers get: query parameter decoding failed: %v", err)
+			s.logger.Error("loggers get: query parameter decoding failed")
+			jsonhttp.BadRequest(w, err)
+		}
+		exp = string(buf)
+	}
+
+	rex, err := regexp.Compile(exp)
+
+	result := loggerResult{Tree: make(node)}
+	logRegistryIterate(func(id, name string, verbosity log.Level, v uint) bool {
+		if exp == "" || exp == id || (rex != nil && rex.MatchString(id)) {
+			if int(verbosity) == int(v) {
+				verbosity = log.VerbosityAll
+			}
+
+			// Tree structure.
+			curr := result.Tree
+			path := strings.Split(name, "/")
+			last := len(path) - 1
+			for i, n := range path {
+				if curr[n] == nil {
+					curr[n] = &data{Next: make(node)}
+				}
+				if i == last {
+					name := fmt.Sprintf("%s|%s", verbosity, id)
+					curr[n].Names = append(curr[n].Names, name)
+				}
+				curr = curr[n].Next
+			}
+
+			// Flat structure.
+			result.Loggers = append(result.Loggers, logger{
+				Logger:    name,
+				Verbosity: verbosity.String(),
+				Subsystem: id,
+				ID:        base64.URLEncoding.EncodeToString([]byte(id)),
+			})
+		}
+		return true
+	})
+
+	if len(result.Loggers) == 0 && err != nil {
+		s.logger.Debugf("loggers get: regexp compilation failed: %v", err)
+		s.logger.Error("loggers get: regexp compilation failed")
+		jsonhttp.BadRequest(w, err)
+	} else {
+		jsonhttp.OK(w, result)
+	}
+}
+
+// loggerSetVerbosityHandler sets logger(s) verbosity level based on
+// the specified expression or subsystem that matches the logger(s).
+func (s *Service) loggerSetVerbosityHandler(w http.ResponseWriter, r *http.Request) {
+	verbosity, err := log.ParseVerbosityLevel(mux.Vars(r)["verbosity"])
+	if err != nil {
+		s.logger.Debugf("loggers set verbosity: parse verbosity level failed: %v", err)
+		s.logger.Error("loggers set verbosity: parse verbosity level failed")
+		jsonhttp.BadRequest(w, err)
+	}
+
+	exp, err := base64.URLEncoding.DecodeString(mux.Vars(r)["exp"])
+	if err != nil {
+		s.logger.Debugf("loggers set verbosity: query parameter decoding failed: %v", err)
+		s.logger.Error("loggers set verbosity: query parameter decoding failed")
+		jsonhttp.BadRequest(w, err)
+	}
+
+	if err := logSetVerbosityByExp(string(exp), verbosity); err != nil {
+		jsonhttp.BadRequest(w, err)
+	} else {
+		jsonhttp.OK(w, nil)
+	}
+}

--- a/pkg/api/logger_test.go
+++ b/pkg/api/logger_test.go
@@ -1,0 +1,139 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/api"
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/log"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetLoggers(t *testing.T) {
+	defer func(fn api.LogRegistryIterateFn) {
+		api.ReplaceLogRegistryIterateFn(fn)
+	}(api.LogRegistryIterate)
+
+	fn := func(fn func(id, path string, verbosity log.Level, v uint) bool) {
+		data := []struct {
+			id        string
+			path      string
+			verbosity log.Level
+			v         uint
+		}{{
+			id:        `one[0][]>>824634860360`,
+			path:      "one",
+			verbosity: log.VerbosityAll,
+			v:         0,
+		}, {
+			id:        `one/name[0][]>>824634860360`,
+			path:      "one/name",
+			verbosity: log.VerbosityWarning,
+			v:         0,
+		}, {
+			id:        `one/name[0][\"val\"=1]>>824634860360`,
+			path:      "one/name",
+			verbosity: log.VerbosityWarning,
+			v:         0,
+		}, {
+			id:        `one/name[1][]>>824634860360`,
+			path:      "one/name",
+			verbosity: log.VerbosityInfo,
+			v:         1,
+		}, {
+			id:        `one/name[2][]>>824634860360`,
+			path:      "one/name",
+			verbosity: log.VerbosityInfo,
+			v:         2,
+		}}
+
+		for _, d := range data {
+			if !fn(d.id, d.path, d.verbosity, d.v) {
+				return
+			}
+		}
+	}
+	api.ReplaceLogRegistryIterateFn(fn)
+
+	have := make(map[string]interface{})
+	want := make(map[string]interface{})
+	data := `{"loggers":[{"id":"b25lWzBdW10-PjgyNDYzNDg2MDM2MA==","logger":"one","subsystem":"one[0][]\u003e\u003e824634860360","verbosity":"all"},{"id":"b25lL25hbWVbMF1bXT4-ODI0NjM0ODYwMzYw","logger":"one/name","subsystem":"one/name[0][]\u003e\u003e824634860360","verbosity":"warning"},{"id":"b25lL25hbWVbMF1bXCJ2YWxcIj0xXT4-ODI0NjM0ODYwMzYw","logger":"one/name","subsystem":"one/name[0][\\\"val\\\"=1]\u003e\u003e824634860360","verbosity":"warning"},{"id":"b25lL25hbWVbMV1bXT4-ODI0NjM0ODYwMzYw","logger":"one/name","subsystem":"one/name[1][]\u003e\u003e824634860360","verbosity":"info"},{"id":"b25lL25hbWVbMl1bXT4-ODI0NjM0ODYwMzYw","logger":"one/name","subsystem":"one/name[2][]\u003e\u003e824634860360","verbosity":"info"}],"tree":{"one":{"+":["all|one[0][]\u003e\u003e824634860360"],"/":{"name":{"+":["warning|one/name[0][]\u003e\u003e824634860360","warning|one/name[0][\\\"val\\\"=1]\u003e\u003e824634860360","info|one/name[1][]\u003e\u003e824634860360","info|one/name[2][]\u003e\u003e824634860360"]}}}}}`
+	if err := json.Unmarshal([]byte(data), &want); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	client, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true})
+	jsonhttptest.Request(t, client, http.MethodGet, "/loggers", http.StatusOK,
+		jsonhttptest.WithUnmarshalJSONResponse(&have),
+	)
+
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Errorf("response body mismatch (-want +have):\n%s", diff)
+	}
+}
+
+func TestSetLoggerVerbosity(t *testing.T) {
+	defer func(fn api.LogSetVerbosityByExpFn) {
+		api.ReplaceLogSetVerbosityByExp(fn)
+	}(api.LogSetVerbosityByExp)
+
+	client, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true})
+
+	type data struct {
+		exp string
+		ver log.Level
+	}
+
+	have := new(data)
+	api.ReplaceLogSetVerbosityByExp(func(e string, v log.Level) error {
+		have.exp = e
+		have.ver = v
+		return nil
+	})
+
+	tests := []struct {
+		want data
+	}{{
+		want: data{exp: `name`, ver: log.VerbosityWarning},
+	}, {
+		want: data{exp: `^name$`, ver: log.VerbosityWarning},
+	}, {
+		want: data{exp: `^name/\[0`, ver: log.VerbosityWarning},
+	}, {
+		want: data{exp: `^name/\[0\]\[`, ver: log.VerbosityWarning},
+	}, {
+		want: data{exp: `^name/\[0\]\[\"val\"=1\]`, ver: log.VerbosityWarning},
+	}, {
+		want: data{exp: `^name/\[0\]\[\"val\"=1\]>>824634860360`, ver: log.VerbosityWarning},
+	}}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("to=%s,exp=%s", tc.want.ver, tc.want.exp), func(t *testing.T) {
+			exp := base64.URLEncoding.EncodeToString([]byte(tc.want.exp))
+			url := fmt.Sprintf("/loggers/%s/%s", exp, tc.want.ver)
+			jsonhttptest.Request(t, client, http.MethodPut, url, http.StatusOK,
+				jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+					Message: http.StatusText(http.StatusOK),
+					Code:    http.StatusOK,
+				}),
+			)
+
+			if have.exp != tc.want.exp {
+				t.Errorf("exp missmatch: want: %q; have: %q", tc.want.exp, have.exp)
+			}
+
+			if have.ver != tc.want.ver {
+				t.Errorf("verbosity missmatch: want: %q; have: %q", tc.want.ver, have.ver)
+			}
+		})
+	}
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -144,6 +144,25 @@ func (s *Service) mountTechnicalDebug() {
 		httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
 		web.FinalHandlerFunc(statusHandler),
 	))
+
+	s.router.Handle("/loggers", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
+			web.FinalHandlerFunc(s.loggerGetHandler),
+		),
+	})
+	s.router.Handle("/loggers/{exp}", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
+			web.FinalHandlerFunc(s.loggerGetHandler),
+		),
+	})
+	s.router.Handle("/loggers/{exp}/{verbosity}", jsonhttp.MethodHandler{
+		"PUT": web.ChainHandlers(
+			httpaccess.SetAccessLogLevelHandler(0), // suppress access log messages
+			web.FinalHandlerFunc(s.loggerSetVerbosityHandler),
+		),
+	})
 }
 
 func (s *Service) mountAPI() {

--- a/pkg/log/example_test.go
+++ b/pkg/log/example_test.go
@@ -48,20 +48,20 @@ func Example() {
 	loggerV1WithName.Debug("v1 with name debug should work")
 
 	// Output:
-	// "level"="error" "logger"="example" "msg"="error should work" "error"=null "k"=1 "k"=2
+	// "level"="error" "logger"="example" "msg"="error should work" "k"=1 "k"=2
 	// "level"="warning" "logger"="example" "msg"="warning should work" "address"=12345
 	// "level"="info" "logger"="example" "msg"="info should work" "k"=3 "k"=4
 	// "level"="debug" "logger"="example" "msg"="debug should work" "error"="failed"
 	//
-	// "level"="error" "logger"="example" "msg"="v1 error should work" "error"=null
+	// "level"="error" "logger"="example" "msg"="v1 error should work"
 	// "level"="warning" "logger"="example" "msg"="v1 warning should work"
 	// "level"="info" "logger"="example" "msg"="v1 info should work"
 	// "level"="debug" "logger"="example" "v"=1 "msg"="v1 debug should work"
 	//
-	// "level"="error" "logger"="example" "msg"="v1 error should work" "error"=null
+	// "level"="error" "logger"="example" "msg"="v1 error should work"
 	// "level"="warning" "logger"="example" "msg"="v1 warning should work"
 	//
-	// "level"="error" "logger"="example/example_name" "msg"="v1 with name error should work" "error"=null
+	// "level"="error" "logger"="example/example_name" "msg"="v1 with name error should work"
 	// "level"="warning" "logger"="example/example_name" "msg"="v1 with name warning should work"
 	// "level"="info" "logger"="example/example_name" "msg"="v1 with name info should work"
 	// "level"="debug" "logger"="example/example_name" "v"=1 "msg"="v1 with name debug should work"

--- a/pkg/log/example_test.go
+++ b/pkg/log/example_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ethersphere/bee/pkg/log"
+)
+
+func Example() {
+	log.ModifyDefaults(
+		log.WithSink(os.Stdout),
+		log.WithVerbosity(log.VerbosityAll),
+	)
+
+	logger := log.NewLogger("example").Build()
+	logger.Error(nil, "error should work", "k", 1, "k", 2)
+	logger.Warning("warning should work", "address", 12345)
+	logger.Info("info should work", "k", 3, "k", 4)
+	logger.Debug("debug should work", "error", errors.New("failed"))
+	fmt.Println()
+
+	loggerV1 := logger.V(1).Build()
+	loggerV1.Error(nil, "v1 error should work")
+	loggerV1.Warning("v1 warning should work")
+	loggerV1.Info("v1 info should work")
+	loggerV1.Debug("v1 debug should work")
+	fmt.Println()
+
+	_ = log.SetVerbosity(loggerV1, log.VerbosityWarning)
+	loggerV1.Error(nil, "v1 error should work")
+	loggerV1.Warning("v1 warning should work")
+	loggerV1.Info("v1 info shouldn't work")
+	loggerV1.Debug("v1 debug shouldn't work")
+	fmt.Println()
+
+	loggerV1WithName := loggerV1.WithName("example_name").Build()
+	// The verbosity was inherited from loggerV1 so we have to change it.
+	_ = log.SetVerbosity(loggerV1WithName, log.VerbosityAll)
+	loggerV1WithName.Error(nil, "v1 with name error should work")
+	loggerV1WithName.Warning("v1 with name warning should work")
+	loggerV1WithName.Info("v1 with name info should work")
+	loggerV1WithName.Debug("v1 with name debug should work")
+
+	// Output:
+	// "level"="error" "logger"="example" "msg"="error should work" "error"=null "k"=1 "k"=2
+	// "level"="warning" "logger"="example" "msg"="warning should work" "address"=12345
+	// "level"="info" "logger"="example" "msg"="info should work" "k"=3 "k"=4
+	// "level"="debug" "logger"="example" "msg"="debug should work" "error"="failed"
+	//
+	// "level"="error" "logger"="example" "msg"="v1 error should work" "error"=null
+	// "level"="warning" "logger"="example" "msg"="v1 warning should work"
+	// "level"="info" "logger"="example" "msg"="v1 info should work"
+	// "level"="debug" "logger"="example" "v"=1 "msg"="v1 debug should work"
+	//
+	// "level"="error" "logger"="example" "msg"="v1 error should work" "error"=null
+	// "level"="warning" "logger"="example" "msg"="v1 warning should work"
+	//
+	// "level"="error" "logger"="example/example_name" "msg"="v1 with name error should work" "error"=null
+	// "level"="warning" "logger"="example/example_name" "msg"="v1 with name warning should work"
+	// "level"="info" "logger"="example/example_name" "msg"="v1 with name info should work"
+	// "level"="debug" "logger"="example/example_name" "v"=1 "msg"="v1 with name debug should work"
+}

--- a/pkg/log/formatter.go
+++ b/pkg/log/formatter.go
@@ -66,6 +66,10 @@ type fmtOptions struct {
 const (
 	null    = "null"       // null is a placeholder for nil values.
 	noValue = "<no-value>" // noValue is a placeholder for missing values.
+
+	// maxLogDepthExceeded is printed as the last value in
+	// the recursive chain when the depth limit is exceeded.
+	maxLogDepthExceeded = `"<max-log-depth-exceeded>"`
 )
 
 // caller represents the original call site for a log line. The File and
@@ -159,7 +163,7 @@ func (f *formatter) prettyWithFlags(value interface{}, flags uint32, depth int) 
 	const flagRawStruct = 0x1 // Do not print braces on structs.
 
 	if depth > f.opts.maxLogDepth {
-		return `"<max-log-depth-exceeded>"`
+		return maxLogDepthExceeded
 	}
 
 	// Handle types that take full control of logging.

--- a/pkg/log/formatter.go
+++ b/pkg/log/formatter.go
@@ -1,0 +1,492 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Note: the following code is derived (borrows) from: github.com/go-logr/logr
+
+package log
+
+import (
+	"bytes"
+	"encoding"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// MessageCategory indicates which category or categories
+// of messages should include the caller in the log lines.
+type MessageCategory int
+
+const (
+	CategoryNone MessageCategory = iota
+	CategoryAll
+	CategoryError
+	CategoryWarning
+	CategoryInfo
+	CategoryDebug
+)
+
+// Marshaler is an optional interface that logged values may choose to
+// implement. Loggers with structured output, such as JSON, should
+// log the object return by the MarshalLog method instead of the
+// original value.
+type Marshaler interface {
+	// MarshalLog can be used to:
+	//   - ensure that structs are not logged as strings when the original
+	//     value has a String method: return a different type without a
+	//     String method
+	//   - select which fields of a complex type should get logged:
+	//     return a simpler struct with fewer fields
+	//   - log unexported fields: return a different struct
+	//     with exported fields
+	//
+	// It may return any value of any type.
+	MarshalLog() interface{}
+}
+
+// PseudoStruct is a list of key-value pairs that gets logged as a struct.
+// E.g.: PseudoStruct{"f1", 1, "f2", true, "f3", []int{}}.
+type PseudoStruct []interface{}
+
+// fmtOptions carries parameters which influence the way logs are generated/formatted.
+type fmtOptions struct {
+	caller          MessageCategory
+	logCallerFunc   bool
+	logTimestamp    bool
+	timestampLayout string
+	maxLogDepth     int
+	jsonOutput      bool
+	callerDepth     int
+}
+
+const (
+	null    = "null"       // null is a placeholder for nil values.
+	noValue = "<no-value>" // noValue is a placeholder for missing values.
+)
+
+// caller represents the original call site for a log line. The File and
+// Line fields will always be provided, while the Func field is optional.
+type caller struct {
+	// File is the basename of the file for this call site.
+	File string `json:"file"`
+	// Line is the line number in the file for this call site.
+	Line int `json:"line"`
+	// Func is the function name for this call site, or empty if
+	// fmtOptions.logCallerFunc is not enabled.
+	Func string `json:"function,omitempty"`
+}
+
+// newFormatter constructs a formatter which
+// behavior is influenced by the given options.
+func newFormatter(opts fmtOptions) *formatter {
+	return &formatter{opts: opts}
+}
+
+// formatter is responsible for formatting the output of the log messages.
+type formatter struct {
+	opts fmtOptions
+}
+
+// render produces a log line where the base is
+// never escaped; the opposite is true for args.
+func (f *formatter) render(base, args []interface{}) []byte {
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+	if f.opts.jsonOutput {
+		buf.WriteByte('{')
+	}
+	f.flatten(buf, base, false, false)
+	f.flatten(buf, args, len(base) > 0, true)
+	if f.opts.jsonOutput {
+		buf.WriteByte('}')
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// flatten renders a list of key-value pairs into a buffer. If continuing is
+// true, it assumes that the buffer has previous values and will emit a
+// separator (which depends on the output format) before the first pair is
+// written. If escapeKeys is true, the keys are assumed to have
+// non-JSON-compatible characters in them and must be evaluated for escapes.
+func (f *formatter) flatten(buf *bytes.Buffer, kvList []interface{}, continuing bool, escapeKeys bool) {
+	// This logic overlaps with sanitize() but saves one type-cast per key,
+	// which can be measurable.
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		k, ok := kvList[i].(string)
+		if !ok {
+			k = f.nonStringKey(kvList[i])
+			kvList[i] = k
+		}
+		v := kvList[i+1]
+
+		if i > 0 || continuing {
+			if f.opts.jsonOutput {
+				buf.WriteByte(',')
+			} else {
+				// In theory the format could be something we don't understand.
+				// In practice, we control it, so it won't be.
+				buf.WriteByte(' ')
+			}
+		}
+
+		if escapeKeys {
+			buf.WriteString(prettyString(k))
+		} else {
+			// The following is faster.
+			buf.WriteByte('"')
+			buf.WriteString(k)
+			buf.WriteByte('"')
+		}
+		if f.opts.jsonOutput {
+			buf.WriteByte(':')
+		} else {
+			buf.WriteByte('=')
+		}
+		buf.WriteString(f.prettyWithFlags(v, 0, 0))
+	}
+}
+
+// prettyWithFlags prettifies the given value.
+// TODO: This is not fast. Most of the overhead goes here.
+func (f *formatter) prettyWithFlags(value interface{}, flags uint32, depth int) string {
+	const flagRawStruct = 0x1 // Do not print braces on structs.
+
+	if depth > f.opts.maxLogDepth {
+		return `"<max-log-depth-exceeded>"`
+	}
+
+	// Handle types that take full control of logging.
+	if v, ok := value.(Marshaler); ok {
+		// Replace the value with what the type wants to get logged.
+		// That then gets handled below via reflection.
+		value = invokeMarshaler(v)
+	}
+
+	// Handle types that want to format themselves.
+	switch v := value.(type) {
+	case fmt.Stringer:
+		value = invokeStringer(v)
+	case error:
+		value = invokeError(v)
+	}
+
+	// Handling the most common types without reflect is a small perf win.
+	switch v := value.(type) {
+	case bool:
+		return strconv.FormatBool(v)
+	case string:
+		return prettyString(v)
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uintptr:
+		return strconv.FormatUint(uint64(v), 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case complex64:
+		return `"` + strconv.FormatComplex(complex128(v), 'f', -1, 64) + `"`
+	case complex128:
+		return `"` + strconv.FormatComplex(v, 'f', -1, 128) + `"`
+	case PseudoStruct:
+		buf := bytes.NewBuffer(make([]byte, 0, 1024))
+		v = f.sanitize(v)
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < len(v); i += 2 {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			k, _ := v[i].(string) // sanitize() above means no need to check success arbitrary keys might need escaping.
+			buf.WriteString(prettyString(k))
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v[i+1], 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	t := reflect.TypeOf(value)
+	if t == nil {
+		return null
+	}
+	v := reflect.ValueOf(value)
+	switch t.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.String:
+		return prettyString(v.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.Float32:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 32)
+	case reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.Complex64:
+		return `"` + strconv.FormatComplex(v.Complex(), 'f', -1, 64) + `"`
+	case reflect.Complex128:
+		return `"` + strconv.FormatComplex(v.Complex(), 'f', -1, 128) + `"`
+	case reflect.Struct:
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < t.NumField(); i++ {
+			fld := t.Field(i)
+			if fld.PkgPath != "" {
+				// Reflect says this field is only defined for non-exported fields.
+				continue
+			}
+			if !v.Field(i).CanInterface() {
+				// Reflect isn't clear exactly what this means, but we can't use it.
+				continue
+			}
+			name := ""
+			omitempty := false
+			if tag, found := fld.Tag.Lookup("json"); found {
+				if tag == "-" {
+					continue
+				}
+				if comma := strings.Index(tag, ","); comma != -1 {
+					if n := tag[:comma]; n != "" {
+						name = n
+					}
+					rest := tag[comma:]
+					if strings.Contains(rest, ",omitempty,") || strings.HasSuffix(rest, ",omitempty") {
+						omitempty = true
+					}
+				} else {
+					name = tag
+				}
+			}
+			if omitempty && isEmpty(v.Field(i)) {
+				continue
+			}
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if fld.Anonymous && fld.Type.Kind() == reflect.Struct && name == "" {
+				buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), flags|flagRawStruct, depth+1))
+				continue
+			}
+			if name == "" {
+				name = fld.Name
+			}
+			// Field names can't contain characters which need escaping.
+			buf.WriteByte('"')
+			buf.WriteString(name)
+			buf.WriteByte('"')
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	case reflect.Slice, reflect.Array:
+		buf.WriteByte('[')
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			e := v.Index(i)
+			buf.WriteString(f.prettyWithFlags(e.Interface(), 0, depth+1))
+		}
+		buf.WriteByte(']')
+		return buf.String()
+	case reflect.Map:
+		buf.WriteByte('{')
+		// This does not sort the map keys, for best perf.
+		it := v.MapRange()
+		i := 0
+		for it.Next() {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			// If a map key supports TextMarshaler, use it.
+			keystr := ""
+			if m, ok := it.Key().Interface().(encoding.TextMarshaler); ok {
+				txt, err := m.MarshalText()
+				if err != nil {
+					keystr = fmt.Sprintf("<error-MarshalText: %s>", err.Error())
+				} else {
+					keystr = string(txt)
+				}
+				keystr = prettyString(keystr)
+			} else {
+				// prettyWithFlags will produce already-escaped values.
+				keystr = f.prettyWithFlags(it.Key().Interface(), 0, depth+1)
+				if t.Key().Kind() != reflect.String {
+					// JSON only does string keys. Unlike Go's standard JSON, we'll convert just about anything to a string.
+					keystr = prettyString(keystr)
+				}
+			}
+			buf.WriteString(keystr)
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(it.Value().Interface(), 0, depth+1))
+			i++
+		}
+		buf.WriteByte('}')
+		return buf.String()
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return null
+		}
+		return f.prettyWithFlags(v.Elem().Interface(), 0, depth)
+	}
+	return fmt.Sprintf(`"<unhandled-%s>"`, t.Kind().String())
+}
+
+// caller captures basic information about the caller (filename, line, function).
+func (f *formatter) caller() caller {
+	pc, file, line, ok := runtime.Caller(f.opts.callerDepth + 3)
+	if !ok {
+		return caller{"<unknown>", 0, ""}
+	}
+	caller := caller{File: filepath.Base(file), Line: line}
+	if f.opts.logCallerFunc {
+		if fp := runtime.FuncForPC(pc); fp != nil {
+			caller.Func = fp.Name()
+		}
+	}
+	return caller
+}
+
+// nonStringKey converts non-string value v to string.
+func (f *formatter) nonStringKey(v interface{}) string {
+	return fmt.Sprintf("<non-string-key: %s>", f.snippet(v))
+}
+
+// snippet produces a short snippet string of an arbitrary value.
+func (f *formatter) snippet(v interface{}) string {
+	const snipLen = 16
+
+	snip := f.prettyWithFlags(v, 0, 0)
+	if len(snip) > snipLen {
+		snip = snip[:snipLen]
+	}
+	return snip
+}
+
+// sanitize ensures that a list of key-value pairs has a value for every key
+// (adding a value if needed) and that each key is a string (substituting a key
+// if needed).
+func (f *formatter) sanitize(kvList []interface{}) []interface{} {
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		_, ok := kvList[i].(string)
+		if !ok {
+			kvList[i] = f.nonStringKey(kvList[i])
+		}
+	}
+	return kvList
+}
+
+// isEmpty is similar to the IsZero() reflect.Value method, except that
+// in the case of Array and Struct it does not go into depth.
+func isEmpty(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+// prettyString prettify the given string.
+// TODO: try to avoid allocations.
+func prettyString(s string) string {
+	// Avoid escaping (which does allocations) if we can.
+	if needsEscape(s) {
+		return strconv.Quote(s)
+	}
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b.WriteByte('"')
+	b.WriteString(s)
+	b.WriteByte('"')
+	return b.String()
+}
+
+// needsEscape determines whether the input string needs
+// to be escaped or not, without doing any allocations.
+func needsEscape(s string) bool {
+	for _, r := range s {
+		if !strconv.IsPrint(r) || r == '\\' || r == '"' {
+			return true
+		}
+	}
+	return false
+}
+
+// invokeMarshaler returns panic-safe output from the Marshaler.MarshalLog() method.
+func invokeMarshaler(m Marshaler) (ret interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return m.MarshalLog()
+}
+
+// invokeStringer returns panic-safe output from the fmt.Stringer.String() method.
+func invokeStringer(s fmt.Stringer) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return s.String()
+}
+
+// invokeError returns panic-safe output from the error. Error() method.
+func invokeError(e error) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return e.Error()
+}

--- a/pkg/log/formatter_test.go
+++ b/pkg/log/formatter_test.go
@@ -1,0 +1,773 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Note: the following code is derived (borrows) from: github.com/go-logr/logr
+
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// substr is handled via reflection instead of type assertions.
+type substr string
+
+// point implements encoding.TextMarshaller and can be used as a map key.
+type point struct{ x, y int }
+
+func (p point) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("(%d, %d)", p.x, p.y)), nil
+}
+
+// pointErr implements encoding.TextMarshaler but returns an error.
+type pointErr struct{ x, y int }
+
+func (p pointErr) MarshalText() ([]byte, error) {
+	return nil, fmt.Errorf("uh oh: %d, %d", p.x, p.y)
+}
+
+// marshalerTest expect to result in the MarshalLog() value when logged.
+type marshalerTest struct{ val string }
+
+func (_ marshalerTest) MarshalLog() interface{} {
+	return struct{ Inner string }{"I am a log.Marshaler"}
+}
+func (_ marshalerTest) String() string {
+	return "String(): you should not see this"
+}
+func (_ marshalerTest) Error() string {
+	return "Error(): you should not see this"
+}
+
+// marshalerPanicTest expect this to result in a panic when logged.
+type marshalerPanicTest struct{ val string }
+
+func (_ marshalerPanicTest) MarshalLog() interface{} {
+	panic("marshalerPanicTest")
+}
+
+// stringerTest expect this to result in the String() value when logged.
+type stringerTest struct{ val string }
+
+func (_ stringerTest) String() string {
+	return "I am a fmt.Stringer"
+}
+func (_ stringerTest) Error() string {
+	return "Error(): you should not see this"
+}
+
+// stringerPanicTest expect this to result in a panic when logged.
+type stringerPanicTest struct{ val string }
+
+func (_ stringerPanicTest) String() string {
+	panic("stringerPanicTest")
+}
+
+// errorTest expect this to result in the Error() value when logged.
+type errorTest struct{ val string }
+
+func (_ errorTest) Error() string {
+	return "I am an error"
+}
+
+// errorPanicTest expect this to result in a panic when logged.
+type errorPanicTest struct{ val string }
+
+func (_ errorPanicTest) Error() string {
+	panic("errorPanicTest")
+}
+
+type (
+	jsonTagsStringTest struct {
+		String1 string `json:"string1"`           // renamed
+		String2 string `json:"-"`                 // ignored
+		String3 string `json:"-,"`                // named "-"
+		String4 string `json:"string4,omitempty"` // renamed, ignore if empty
+		String5 string `json:","`                 // no-op
+		String6 string `json:",omitempty"`        // ignore if empty
+	}
+
+	jsonTagsBoolTest struct {
+		Bool1 bool `json:"bool1"`           // renamed
+		Bool2 bool `json:"-"`               // ignored
+		Bool3 bool `json:"-,"`              // named "-"
+		Bool4 bool `json:"bool4,omitempty"` // renamed, ignore if empty
+		Bool5 bool `json:","`               // no-op
+		Bool6 bool `json:",omitempty"`      // ignore if empty
+	}
+
+	jsonTagsIntTest struct {
+		Int1 int `json:"int1"`           // renamed
+		Int2 int `json:"-"`              // ignored
+		Int3 int `json:"-,"`             // named "-"
+		Int4 int `json:"int4,omitempty"` // renamed, ignore if empty
+		Int5 int `json:","`              // no-op
+		Int6 int `json:",omitempty"`     // ignore if empty
+	}
+
+	jsonTagsUintTest struct {
+		Uint1 uint `json:"uint1"`           // renamed
+		Uint2 uint `json:"-"`               // ignored
+		Uint3 uint `json:"-,"`              // named "-"
+		Uint4 uint `json:"uint4,omitempty"` // renamed, ignore if empty
+		Uint5 uint `json:","`               // no-op
+		Uint6 uint `json:",omitempty"`      // ignore if empty
+	}
+
+	jsonTagsFloatTest struct {
+		Float1 float64 `json:"float1"`           // renamed
+		Float2 float64 `json:"-"`                // ignored
+		Float3 float64 `json:"-,"`               // named "-"
+		Float4 float64 `json:"float4,omitempty"` // renamed, ignore if empty
+		Float5 float64 `json:","`                // no-op
+		Float6 float64 `json:",omitempty"`       // ignore if empty
+	}
+
+	jsonTagsComplexTest struct {
+		Complex1 complex128 `json:"complex1"`           // renamed
+		Complex2 complex128 `json:"-"`                  // ignored
+		Complex3 complex128 `json:"-,"`                 // named "-"
+		Complex4 complex128 `json:"complex4,omitempty"` // renamed, ignore if empty
+		Complex5 complex128 `json:","`                  // no-op
+		Complex6 complex128 `json:",omitempty"`         // ignore if empty
+	}
+
+	jsonTagsPtrTest struct {
+		Ptr1 *string `json:"ptr1"`           // renamed
+		Ptr2 *string `json:"-"`              // ignored
+		Ptr3 *string `json:"-,"`             // named "-"
+		Ptr4 *string `json:"ptr4,omitempty"` // renamed, ignore if empty
+		Ptr5 *string `json:","`              // no-op
+		Ptr6 *string `json:",omitempty"`     // ignore if empty
+	}
+
+	jsonTagsArrayTest struct {
+		Array1 [2]string `json:"array1"`           // renamed
+		Array2 [2]string `json:"-"`                // ignored
+		Array3 [2]string `json:"-,"`               // named "-"
+		Array4 [2]string `json:"array4,omitempty"` // renamed, ignore if empty
+		Array5 [2]string `json:","`                // no-op
+		Array6 [2]string `json:",omitempty"`       // ignore if empty
+	}
+
+	jsonTagsSliceTest struct {
+		Slice1 []string `json:"slice1"`           // renamed
+		Slice2 []string `json:"-"`                // ignored
+		Slice3 []string `json:"-,"`               // named "-"
+		Slice4 []string `json:"slice4,omitempty"` // renamed, ignore if empty
+		Slice5 []string `json:","`                // no-op
+		Slice6 []string `json:",omitempty"`       // ignore if empty
+	}
+
+	jsonTagsMapTest struct {
+		Map1 map[string]string `json:"map1"`           // renamed
+		Map2 map[string]string `json:"-"`              // ignored
+		Map3 map[string]string `json:"-,"`             // named "-"
+		Map4 map[string]string `json:"map4,omitempty"` // renamed, ignore if empty
+		Map5 map[string]string `json:","`              // no-op
+		Map6 map[string]string `json:",omitempty"`     // ignore if empty
+	}
+
+	InnerStructTest struct{ Inner string }
+	InnerIntTest    int
+	InnerMapTest    map[string]string
+	InnerSliceTest  []string
+
+	embedStructTest struct {
+		InnerStructTest
+		Outer string
+	}
+
+	embedNonStructTest struct {
+		InnerIntTest
+		InnerMapTest
+		InnerSliceTest
+	}
+
+	Inner1Test InnerStructTest
+	Inner2Test InnerStructTest
+	Inner3Test InnerStructTest
+	Inner4Test InnerStructTest
+	Inner5Test InnerStructTest
+	Inner6Test InnerStructTest
+
+	embedJSONTagsTest struct {
+		Outer      string
+		Inner1Test `json:"inner1"`
+		Inner2Test `json:"-"`
+		Inner3Test `json:"-,"`
+		Inner4Test `json:"inner4,omitempty"`
+		Inner5Test `json:","`
+		Inner6Test `json:"inner6,omitempty"`
+	}
+)
+
+func TestPretty(t *testing.T) {
+	intPtr := func(i int) *int { return &i }
+	strPtr := func(s string) *string { return &s }
+
+	testCases := []struct {
+		val interface{}
+		exp string // used in testCases where JSON can't handle it
+	}{{
+		val: "strval",
+	}, {
+		val: "strval\nwith\t\"escapes\"",
+	}, {
+		val: substr("substrval"),
+	}, {
+		val: substr("substrval\nwith\t\"escapes\""),
+	}, {
+		val: true,
+	}, {
+		val: false,
+	}, {
+		val: 93,
+	}, {
+		val: int8(93),
+	}, {
+		val: int16(93),
+	}, {
+		val: int32(93),
+	}, {
+		val: int64(93),
+	}, {
+		val: -93,
+	}, {
+		val: int8(-93),
+	}, {
+		val: int16(-93),
+	}, {
+		val: int32(-93),
+	}, {
+		val: int64(-93),
+	}, {
+		val: uint(93),
+	}, {
+		val: uint8(93),
+	}, {
+		val: uint16(93),
+	}, {
+		val: uint32(93),
+	}, {
+		val: uint64(93),
+	}, {
+		val: uintptr(93),
+	}, {
+		val: float32(93.76),
+	}, {
+		val: 93.76,
+	}, {
+		val: complex64(93i),
+		exp: `"(0+93i)"`,
+	}, {
+		val: 93i,
+		exp: `"(0+93i)"`,
+	}, {
+		val: intPtr(93),
+	}, {
+		val: strPtr("pstrval"),
+	}, {
+		val: []int{},
+	}, {
+		val: []int(nil),
+		exp: `[]`,
+	}, {
+		val: []int{9, 3, 7, 6},
+	}, {
+		val: []string{"str", "with\tescape"},
+	}, {
+		val: []substr{"substr", "with\tescape"},
+	}, {
+		val: [4]int{9, 3, 7, 6},
+	}, {
+		val: [2]string{"str", "with\tescape"},
+	}, {
+		val: [2]substr{"substr", "with\tescape"},
+	}, {
+		val: struct {
+			Int         int
+			notExported string
+			String      string
+		}{
+			93, "you should not see this", "seventy-six",
+		},
+	}, {
+		val: map[string]int{},
+	}, {
+		val: map[string]int(nil),
+		exp: `{}`,
+	}, {
+		val: map[string]int{
+			"nine": 3,
+		},
+	}, {
+		val: map[string]int{
+			"with\tescape": 76,
+		},
+	}, {
+		val: map[substr]int{
+			"nine": 3,
+		},
+	}, {
+		val: map[substr]int{
+			"with\tescape": 76,
+		},
+	}, {
+		val: map[int]int{
+			9: 3,
+		},
+	}, {
+		val: map[float64]int{
+			9.5: 3,
+		},
+		exp: `{"9.5":3}`,
+	}, {
+		val: map[point]int{
+			{x: 1, y: 2}: 3,
+		},
+	}, {
+		val: map[pointErr]int{
+			{x: 1, y: 2}: 3,
+		},
+		exp: `{"<error-MarshalText: uh oh: 1, 2>":3}`,
+	}, {
+		val: struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+		}{
+			93, 76,
+		},
+	}, {
+		val: struct {
+			X []int
+			Y map[int]int
+			Z struct{ P, Q int }
+		}{
+			[]int{9, 3, 7, 6},
+			map[int]int{9: 3},
+			struct{ P, Q int }{9, 3},
+		},
+	}, {
+		val: []struct{ X, Y string }{
+			{"nine", "three"},
+			{"seven", "six"},
+			{"with\t", "\tescapes"},
+		},
+	}, {
+		val: struct {
+			A *int
+			B *int
+			C interface{}
+			D interface{}
+		}{
+			B: intPtr(1),
+			D: interface{}(2),
+		},
+	}, {
+		val: marshalerTest{"foobar"},
+		exp: `{"Inner":"I am a log.Marshaler"}`,
+	}, {
+		val: &marshalerTest{"foobar"},
+		exp: `{"Inner":"I am a log.Marshaler"}`,
+	}, {
+		val: (*marshalerTest)(nil),
+		exp: `"<panic: value method github.com/ethersphere/bee/pkg/log.marshalerTest.MarshalLog called using nil *marshalerTest pointer>"`,
+	}, {
+		val: marshalerPanicTest{"foobar"},
+		exp: `"<panic: marshalerPanicTest>"`,
+	}, {
+		val: stringerTest{"foobar"},
+		exp: `"I am a fmt.Stringer"`,
+	}, {
+		val: &stringerTest{"foobar"},
+		exp: `"I am a fmt.Stringer"`,
+	}, {
+		val: (*stringerTest)(nil),
+		exp: `"<panic: value method github.com/ethersphere/bee/pkg/log.stringerTest.String called using nil *stringerTest pointer>"`,
+	}, {
+		val: stringerPanicTest{"foobar"},
+		exp: `"<panic: stringerPanicTest>"`,
+	}, {
+		val: errorTest{"foobar"},
+		exp: `"I am an error"`,
+	}, {
+		val: &errorTest{"foobar"},
+		exp: `"I am an error"`,
+	}, {
+		val: (*errorTest)(nil),
+		exp: `"<panic: value method github.com/ethersphere/bee/pkg/log.errorTest.Error called using nil *errorTest pointer>"`,
+	}, {
+		val: errorPanicTest{"foobar"},
+		exp: `"<panic: errorPanicTest>"`,
+	}, {
+		val: jsonTagsStringTest{
+			String1: "v1",
+			String2: "v2",
+			String3: "v3",
+			String4: "v4",
+			String5: "v5",
+			String6: "v6",
+		},
+	}, {
+		val: jsonTagsStringTest{},
+	}, {
+		val: jsonTagsBoolTest{
+			Bool1: true,
+			Bool2: true,
+			Bool3: true,
+			Bool4: true,
+			Bool5: true,
+			Bool6: true,
+		},
+	}, {
+		val: jsonTagsBoolTest{},
+	}, {
+		val: jsonTagsIntTest{
+			Int1: 1,
+			Int2: 2,
+			Int3: 3,
+			Int4: 4,
+			Int5: 5,
+			Int6: 6,
+		},
+	}, {
+		val: jsonTagsIntTest{},
+	}, {
+		val: jsonTagsUintTest{
+			Uint1: 1,
+			Uint2: 2,
+			Uint3: 3,
+			Uint4: 4,
+			Uint5: 5,
+			Uint6: 6,
+		},
+	}, {
+		val: jsonTagsUintTest{},
+	}, {
+		val: jsonTagsFloatTest{
+			Float1: 1.1,
+			Float2: 2.2,
+			Float3: 3.3,
+			Float4: 4.4,
+			Float5: 5.5,
+			Float6: 6.6,
+		},
+	}, {
+		val: jsonTagsFloatTest{},
+	}, {
+		val: jsonTagsComplexTest{
+			Complex1: 1i,
+			Complex2: 2i,
+			Complex3: 3i,
+			Complex4: 4i,
+			Complex5: 5i,
+			Complex6: 6i,
+		},
+		exp: `{"complex1":"(0+1i)","-":"(0+3i)","complex4":"(0+4i)","Complex5":"(0+5i)","Complex6":"(0+6i)"}`,
+	}, {
+		val: jsonTagsComplexTest{},
+		exp: `{"complex1":"(0+0i)","-":"(0+0i)","Complex5":"(0+0i)"}`,
+	}, {
+		val: jsonTagsPtrTest{
+			Ptr1: strPtr("1"),
+			Ptr2: strPtr("2"),
+			Ptr3: strPtr("3"),
+			Ptr4: strPtr("4"),
+			Ptr5: strPtr("5"),
+			Ptr6: strPtr("6"),
+		},
+	}, {
+		val: jsonTagsPtrTest{},
+	}, {
+		val: jsonTagsArrayTest{
+			Array1: [2]string{"v1", "v1"},
+			Array2: [2]string{"v2", "v2"},
+			Array3: [2]string{"v3", "v3"},
+			Array4: [2]string{"v4", "v4"},
+			Array5: [2]string{"v5", "v5"},
+			Array6: [2]string{"v6", "v6"},
+		},
+	}, {
+		val: jsonTagsArrayTest{},
+	}, {
+		val: jsonTagsSliceTest{
+			Slice1: []string{"v1", "v1"},
+			Slice2: []string{"v2", "v2"},
+			Slice3: []string{"v3", "v3"},
+			Slice4: []string{"v4", "v4"},
+			Slice5: []string{"v5", "v5"},
+			Slice6: []string{"v6", "v6"},
+		},
+	}, {
+		val: jsonTagsSliceTest{},
+		exp: `{"slice1":[],"-":[],"Slice5":[]}`,
+	}, {
+		val: jsonTagsMapTest{
+			Map1: map[string]string{"k1": "v1"},
+			Map2: map[string]string{"k2": "v2"},
+			Map3: map[string]string{"k3": "v3"},
+			Map4: map[string]string{"k4": "v4"},
+			Map5: map[string]string{"k5": "v5"},
+			Map6: map[string]string{"k6": "v6"},
+		},
+	}, {
+		val: jsonTagsMapTest{},
+		exp: `{"map1":{},"-":{},"Map5":{}}`,
+	}, {
+		val: embedStructTest{},
+	}, {
+		val: embedNonStructTest{},
+		exp: `{"InnerIntTest":0,"InnerMapTest":{},"InnerSliceTest":[]}`,
+	}, {
+		val: embedJSONTagsTest{},
+	}, {
+		val: PseudoStruct(makeKV("f1", 1, "f2", true, "f3", []int{})),
+		exp: `{"f1":1,"f2":true,"f3":[]}`,
+	}, {
+		val: map[jsonTagsStringTest]int{
+			{String1: `"quoted"`, String4: `unquoted`}: 1,
+		},
+		exp: `{"{\"string1\":\"\\\"quoted\\\"\",\"-\":\"\",\"string4\":\"unquoted\",\"String5\":\"\"}":1}`,
+	}, {
+		val: map[jsonTagsIntTest]int{
+			{Int1: 1, Int2: 2}: 3,
+		},
+		exp: `{"{\"int1\":1,\"-\":0,\"Int5\":0}":3}`,
+	}, {
+		val: map[[2]struct{ S string }]int{
+			{{S: `"quoted"`}, {S: "unquoted"}}: 1,
+		},
+		exp: `{"[{\"S\":\"\\\"quoted\\\"\"},{\"S\":\"unquoted\"}]":1}`,
+	}, {
+		val: jsonTagsComplexTest{},
+		exp: `{"complex1":"(0+0i)","-":"(0+0i)","Complex5":"(0+0i)"}`,
+	}, {
+		val: jsonTagsPtrTest{
+			Ptr1: strPtr("1"),
+			Ptr2: strPtr("2"),
+			Ptr3: strPtr("3"),
+			Ptr4: strPtr("4"),
+			Ptr5: strPtr("5"),
+			Ptr6: strPtr("6"),
+		},
+	}, {
+		val: jsonTagsPtrTest{},
+	}, {
+		val: jsonTagsArrayTest{
+			Array1: [2]string{"v1", "v1"},
+			Array2: [2]string{"v2", "v2"},
+			Array3: [2]string{"v3", "v3"},
+			Array4: [2]string{"v4", "v4"},
+			Array5: [2]string{"v5", "v5"},
+			Array6: [2]string{"v6", "v6"},
+		},
+	}, {
+		val: jsonTagsArrayTest{},
+	}, {
+		val: jsonTagsSliceTest{
+			Slice1: []string{"v1", "v1"},
+			Slice2: []string{"v2", "v2"},
+			Slice3: []string{"v3", "v3"},
+			Slice4: []string{"v4", "v4"},
+			Slice5: []string{"v5", "v5"},
+			Slice6: []string{"v6", "v6"},
+		},
+	}, {
+		val: jsonTagsSliceTest{},
+		exp: `{"slice1":[],"-":[],"Slice5":[]}`,
+	}, {
+		val: jsonTagsMapTest{
+			Map1: map[string]string{"k1": "v1"},
+			Map2: map[string]string{"k2": "v2"},
+			Map3: map[string]string{"k3": "v3"},
+			Map4: map[string]string{"k4": "v4"},
+			Map5: map[string]string{"k5": "v5"},
+			Map6: map[string]string{"k6": "v6"},
+		},
+	}, {
+		val: jsonTagsMapTest{},
+		exp: `{"map1":{},"-":{},"Map5":{}}`,
+	}, {
+		val: embedStructTest{},
+	}, {
+		val: embedNonStructTest{},
+		exp: `{"InnerIntTest":0,"InnerMapTest":{},"InnerSliceTest":[]}`,
+	}, {
+		val: embedJSONTagsTest{},
+	}, {
+		val: PseudoStruct(makeKV("f1", 1, "f2", true, "f3", []int{})),
+		exp: `{"f1":1,"f2":true,"f3":[]}`,
+	}, {
+		val: map[jsonTagsStringTest]int{
+			{String1: `"quoted"`, String4: `unquoted`}: 1,
+		},
+		exp: `{"{\"string1\":\"\\\"quoted\\\"\",\"-\":\"\",\"string4\":\"unquoted\",\"String5\":\"\"}":1}`,
+	}, {
+		val: map[jsonTagsIntTest]int{
+			{Int1: 1, Int2: 2}: 3,
+		},
+		exp: `{"{\"int1\":1,\"-\":0,\"Int5\":0}":3}`,
+	}, {
+		val: map[[2]struct{ S string }]int{
+			{{S: `"quoted"`}, {S: "unquoted"}}: 1,
+		},
+		exp: `{"[{\"S\":\"\\\"quoted\\\"\"},{\"S\":\"unquoted\"}]":1}`,
+	}}
+
+	o := *defaults.options
+	f := newFormatter(o.fmtOptions)
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			want := ""
+			have := f.prettyWithFlags(tc.val, 0, 0)
+
+			if tc.exp != "" {
+				want = tc.exp
+			} else {
+				jb, err := json.Marshal(tc.val)
+				if err != nil {
+					t.Fatalf("unexpected error: %v\nhave: %q", err, have)
+				}
+				want = string(jb)
+			}
+
+			if have != want {
+				t.Errorf("prettyWithFlags(...):\n\twant %q\n\thave %q", want, have)
+			}
+		})
+	}
+}
+
+func makeKV(args ...interface{}) []interface{} { return args }
+
+func TestRender(t *testing.T) {
+	testCases := []struct {
+		name     string
+		builtins []interface{}
+		args     []interface{}
+		wantKV   string
+		wantJSON string
+	}{{
+		name:     "nil",
+		wantKV:   "",
+		wantJSON: "{}",
+	}, {
+		name:     "empty",
+		builtins: []interface{}{},
+		args:     []interface{}{},
+		wantKV:   "",
+		wantJSON: "{}",
+	}, {
+		name:     "primitives",
+		builtins: makeKV("int1", 1, "int2", 2),
+		args:     makeKV("bool1", true, "bool2", false),
+		wantKV:   `"int1"=1 "int2"=2 "bool1"=true "bool2"=false`,
+		wantJSON: `{"int1":1,"int2":2,"bool1":true,"bool2":false}`,
+	}, {
+		name:     "pseudo structs",
+		builtins: makeKV("int", PseudoStruct(makeKV("intsub", 1))),
+		args:     makeKV("bool", PseudoStruct(makeKV("boolsub", true))),
+		wantKV:   `"int"={"intsub":1} "bool"={"boolsub":true}`,
+		wantJSON: `{"int":{"intsub":1},"bool":{"boolsub":true}}`,
+	}, {
+		name:     "escapes",
+		builtins: makeKV("\"1\"", 1),     // will not be escaped, but should never happen
+		args:     makeKV("bool\n", true), // escaped
+		wantKV:   `""1""=1 "bool\n"=true`,
+		wantJSON: `{""1"":1,"bool\n":true}`,
+	}, {
+		name:     "missing value",
+		builtins: makeKV("builtin"),
+		args:     makeKV("arg"),
+		wantKV:   `"builtin"="<no-value>" "arg"="<no-value>"`,
+		wantJSON: `{"builtin":"<no-value>","arg":"<no-value>"}`,
+	}, {
+		name:     "non-string key int",
+		builtins: makeKV(123, "val"), // should never happen
+		args:     makeKV(456, "val"),
+		wantKV:   `"<non-string-key: 123>"="val" "<non-string-key: 456>"="val"`,
+		wantJSON: `{"<non-string-key: 123>":"val","<non-string-key: 456>":"val"}`,
+	}, {
+		name: "non-string key struct",
+		builtins: makeKV(struct { // will not be escaped, but should never happen
+			F1 string
+			F2 int
+		}{"builtin", 123}, "val"),
+		args: makeKV(struct {
+			F1 string
+			F2 int
+		}{"arg", 456}, "val"),
+		wantKV:   `"<non-string-key: {"F1":"builtin",>"="val" "<non-string-key: {\"F1\":\"arg\",\"F2\">"="val"`,
+		wantJSON: `{"<non-string-key: {"F1":"builtin",>":"val","<non-string-key: {\"F1\":\"arg\",\"F2\">":"val"}`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			test := func(t *testing.T, formatter *formatter, want string) {
+				have := string(bytes.TrimRight(formatter.render(tc.builtins, tc.args), "\n"))
+				if have != want {
+					t.Errorf("render(...):\nwant %q\nhave %q", want, have)
+				}
+			}
+			t.Run("KV", func(t *testing.T) {
+				o := *defaults.options
+				test(t, newFormatter(o.fmtOptions), tc.wantKV)
+			})
+			t.Run("JSON", func(t *testing.T) {
+				o := *defaults.options
+				WithJSONOutput()(&o)
+				test(t, newFormatter(o.fmtOptions), tc.wantJSON)
+			})
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	testCases := []struct {
+		name string
+		kv   []interface{}
+		want []interface{}
+	}{{
+		name: "empty",
+		kv:   []interface{}{},
+		want: []interface{}{},
+	}, {
+		name: "already sane",
+		kv:   makeKV("int", 1, "str", "ABC", "bool", true),
+		want: makeKV("int", 1, "str", "ABC", "bool", true),
+	}, {
+		name: "missing value",
+		kv:   makeKV("key"),
+		want: makeKV("key", "<no-value>"),
+	}, {
+		name: "non-string key int",
+		kv:   makeKV(123, "val"),
+		want: makeKV("<non-string-key: 123>", "val"),
+	}, {
+		name: "non-string key struct",
+		kv: makeKV(struct {
+			F1 string
+			F2 int
+		}{"f1", 8675309}, "val"),
+		want: makeKV(`<non-string-key: {"F1":"f1","F2":>`, "val"),
+	}}
+
+	o := *defaults.options
+	WithJSONOutput()(&o)
+	f := newFormatter(o.fmtOptions)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			have := f.sanitize(tc.kv)
+			if diff := cmp.Diff(have, tc.want); diff != "" {
+				t.Errorf("sanitize(...) mismatch (-want +have):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -263,6 +263,5 @@ func WithLevelHooks(l Level, hooks ...Hook) Option {
 		default:
 			opts.levelHooks[l] = append(opts.levelHooks[l], hooks...)
 		}
-
 	}
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -108,9 +108,17 @@ type Builder interface {
 	// to be logged with each log line.
 	WithValues(keysAndValues ...interface{}) Builder
 
-	// Build returns new or existing Logger
+	// Build returns a new or existing Logger
 	// instance, if such instance already exists.
+	// The new instance is not registered in the
+	// logger registry.
 	Build() Logger
+
+	// Register returns new or existing Logger
+	// instance, if such instance already exists.
+	// If a new instance is created, it is also
+	// registered in the logger registry.
+	Register() Logger
 }
 
 // Logger provides a set of methods that define the behavior of the logger.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,268 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"io"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// Level specifies a level of verbosity for logger.
+// Level should be modified only through its set method.
+// Level is treated as a sync/atomic int32.
+type Level int32
+
+// get returns the value of the Level.
+func (l *Level) get() Level {
+	return Level(atomic.LoadInt32((*int32)(l)))
+}
+
+// set updates the value of the Level.
+func (l *Level) set(v Level) {
+	atomic.StoreInt32((*int32)(l), int32(v))
+}
+
+// String implements the fmt.Stringer interface.
+func (l Level) String() string {
+	switch l.get() {
+	case VerbosityNone:
+		return "none"
+	case VerbosityError:
+		return "error"
+	case VerbosityWarning:
+		return "warning"
+	case VerbosityInfo:
+		return "info"
+	case VerbosityDebug:
+		return "debug"
+	case VerbosityAll:
+		return "all"
+	}
+	return strconv.FormatInt(int64(l), 10) // Covers all in the range [VerbosityDebug ... VerbosityAll>.
+}
+
+// ParseVerbosityLevel returns a verbosity Level parsed from the given s.
+func ParseVerbosityLevel(s string) (Level, error) {
+	switch s {
+	case "none":
+		return VerbosityNone, nil
+	case "error":
+		return VerbosityError, nil
+	case "warning":
+		return VerbosityWarning, nil
+	case "info":
+		return VerbosityInfo, nil
+	case "debug":
+		return VerbosityDebug, nil
+	case "all":
+		return VerbosityAll, nil
+	}
+	i, err := strconv.ParseInt(s, 10, 32)
+	return Level(i), err
+}
+
+const (
+	// VerbosityNone will silence the logger.
+	VerbosityNone = Level(iota - 4)
+	// VerbosityError allows only error messages to be printed.
+	VerbosityError
+	// VerbosityWarning allows only error and warning messages to be printed.
+	VerbosityWarning
+	// VerbosityInfo allows only error, warning and info messages to be printed.
+	VerbosityInfo
+	// VerbosityDebug allows only error, warning, info and debug messages to be printed.
+	VerbosityDebug
+	// VerbosityAll allows to print all messages up to and including level V.
+	// It is a placeholder for the maximum possible V level verbosity within the logger.
+	VerbosityAll = Level(1<<31 - 1)
+)
+
+// Hook that is fired when logging
+// on the associated severity log level.
+// Note, the call must be non-blocking.
+type Hook interface {
+	Fire(Level) error
+}
+
+// Builder specifies a set of methods that can be used to
+// modify the behavior of the logger before it is created.
+type Builder interface {
+	// V specifies verbosity level added to the debug verbosity, relative to
+	// the parent Logger. In other words, V-levels are additive. A higher
+	// verbosity level means a log message is less important.
+	V(v uint) Builder
+
+	// WithName specifies a name element added to the Logger's name.
+	// Successive calls with WithName append additional suffixes to the
+	// Logger's name. It's strongly recommended that name segments contain
+	// only letters, digits, and hyphens (see the package documentation for
+	// more information). Formatter uses '/' characters to separate name
+	// elements. Callers should not pass '/' in the provided name string.
+	WithName(name string) Builder
+
+	// WithValues specifies additional key/value pairs
+	// to be logged with each log line.
+	WithValues(keysAndValues ...interface{}) Builder
+
+	// Build returns new or existing Logger
+	// instance, if such instance already exists.
+	Build() Logger
+}
+
+// Logger provides a set of methods that define the behavior of the logger.
+type Logger interface {
+	Builder
+
+	// Debug logs a debug message with the given key/value pairs as context.
+	// The msg argument should be used to add some constant description to
+	// the log line. The key/value pairs can then be used to add additional
+	// variable information. The key/value pairs must alternate string keys
+	// and arbitrary values.
+	Debug(msg string, keysAndValues ...interface{})
+
+	// Info logs an info message with the given key/value pairs as context.
+	// The msg argument should be used to add some constant description to
+	// the log line. The key/value pairs can then be used to add additional
+	// variable information. The key/value pairs must alternate string keys
+	// and arbitrary values.
+	Info(msg string, keysAndValues ...interface{})
+
+	// Warning logs a warning message with the given key/value pairs as context.
+	// The msg argument should be used to add some constant description to
+	// the log line. The key/value pairs can then be used to add additional
+	// variable information. The key/value pairs must alternate string keys
+	// and arbitrary values.
+	Warning(msg string, keysAndValues ...interface{})
+
+	// Error logs an error, with the given message and key/value pairs as context.
+	// The msg argument should be used to add context to any underlying error,
+	// while the err argument should be used to attach the actual error that
+	// triggered this log line, if present. The err parameter is optional
+	// and nil may be passed instead of an error instance.
+	Error(err error, msg string, keysAndValues ...interface{})
+}
+
+// Lock wraps io.Writer in a mutex to make it safe for concurrent use.
+// In particular, *os.Files must be locked before use.
+func Lock(w io.Writer) io.Writer {
+	if _, ok := w.(*lockWriter); ok {
+		return w // No need to layer on another lock.
+	}
+	return &lockWriter{w: w}
+}
+
+// lockWriter attaches mutex to io.Writer for convince of usage.
+type lockWriter struct {
+	sync.Mutex
+	w io.Writer
+}
+
+// Write implements the io.Writer interface.
+func (ls *lockWriter) Write(bs []byte) (int, error) {
+	ls.Lock()
+	n, err := ls.w.Write(bs)
+	ls.Unlock()
+	return n, err
+}
+
+// Options specifies parameters that affect logger behavior.
+type Options struct {
+	sink       io.Writer
+	verbosity  Level
+	levelHooks levelHooks
+	fmtOptions fmtOptions
+}
+
+// Option represent Options parameters modifier.
+type Option func(*Options)
+
+// WithSink tells the logger to log to the given sync.
+// The provided sync should be safe for concurrent use,
+// if it is not then it should be wrapped with Lock helper.
+func WithSink(sink io.Writer) Option {
+	return func(opts *Options) { opts.sink = sink }
+}
+
+// WithVerbosity tells the logger which verbosity level should be logged by default.
+func WithVerbosity(verbosity Level) Option {
+	return func(opts *Options) { opts.verbosity = verbosity }
+}
+
+// WithCaller tells the logger to add a "caller" key to some or all log lines.
+// This has some overhead, so some users might not want it.
+func WithCaller(category MessageCategory) Option {
+	return func(opts *Options) { opts.fmtOptions.caller = category }
+}
+
+// WithCallerFunc tells the logger to also log the calling function name.
+// This has no effect if caller logging is not enabled (see WithCaller).
+func WithCallerFunc() Option {
+	return func(opts *Options) { opts.fmtOptions.logCallerFunc = true }
+}
+
+// WithTimestamp tells the logger to add a "timestamp" key to log lines.
+// This has some overhead, so some users might not want it.
+func WithTimestamp() Option {
+	return func(opts *Options) { opts.fmtOptions.logTimestamp = true }
+}
+
+// WithTimestampLayout tells the logger how to render timestamps when
+// WithTimestamp is enabled. If not specified, a default format will
+// be used. For more details, see docs for Go's time.Layout.
+func WithTimestampLayout(layout string) Option {
+	return func(opts *Options) { opts.fmtOptions.timestampLayout = layout }
+}
+
+// WithMaxDepth tells the logger how many levels of nested fields
+// (e.g. a struct that contains a struct, etc.) it may log. Every time
+// it finds a struct, slice, array, or map the depth is increased by one.
+// When the maximum is reached, the value will be converted to a string
+// indicating that the max depth has been exceeded. If this field is not
+// specified, a default value will be used.
+func WithMaxDepth(depth int) Option {
+	return func(opts *Options) { opts.fmtOptions.maxLogDepth = depth }
+}
+
+// WithJSONOutput tells the logger if the output should be formatted as JSON.
+func WithJSONOutput() Option {
+	return func(opts *Options) { opts.fmtOptions.jsonOutput = true }
+}
+
+// WithCallerDepth tells the logger the number of stack-frames
+// to skip when attributing the log line to a file and line.
+func WithCallerDepth(depth int) Option {
+	return func(opts *Options) { opts.fmtOptions.callerDepth = depth }
+}
+
+// WithLevelHooks tells the logger to register and execute hooks at
+// related severity log levels. If VerbosityAll is given, then the
+// given hooks will be registered with each severity log level.
+// On the other hand, if VerbosityNone is given, hooks will
+// not be registered with any severity log level.
+func WithLevelHooks(l Level, hooks ...Hook) Option {
+	return func(opts *Options) {
+		if opts.levelHooks == nil {
+			opts.levelHooks = make(map[Level][]Hook)
+		}
+		switch l {
+		case VerbosityNone:
+			return
+		case VerbosityAll:
+			for _, ml := range []Level{
+				VerbosityError,
+				VerbosityWarning,
+				VerbosityInfo,
+				VerbosityDebug,
+			} {
+				opts.levelHooks[ml] = append(opts.levelHooks[ml], hooks...)
+			}
+		default:
+			opts.levelHooks[l] = append(opts.levelHooks[l], hooks...)
+		}
+
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -246,9 +246,9 @@ func WithCallerDepth(depth int) Option {
 	return func(opts *Options) { opts.fmtOptions.callerDepth = depth }
 }
 
-// WithLevelHooks tells the logger to register and execute hooks at
-// related severity log levels. If VerbosityAll is given, then the
-// given hooks will be registered with each severity log level.
+// WithLevelHooks tells the logger to register and execute hooks at related
+// severity log levels. If VerbosityAll is given, then the given hooks will
+// be registered with each severity log level, including the debug V levels.
 // On the other hand, if VerbosityNone is given, hooks will
 // not be registered with any severity log level.
 func WithLevelHooks(l Level, hooks ...Hook) Option {
@@ -265,6 +265,7 @@ func WithLevelHooks(l Level, hooks ...Hook) Option {
 				VerbosityWarning,
 				VerbosityInfo,
 				VerbosityDebug,
+				VerbosityAll, // V levels.
 			} {
 				opts.levelHooks[ml] = append(opts.levelHooks[ml], hooks...)
 			}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -231,11 +231,9 @@ func (l *logger) log(vl Level, mc MessageCategory, err error, msg string, keysAn
 	}
 	base = append(base, "msg", msg)
 	if vl == VerbosityError {
-		var loggableErr interface{}
 		if err != nil {
-			loggableErr = err.Error()
+			base = append(base, "error", err.Error())
 		}
-		base = append(base, "error", loggableErr)
 	}
 	if len(l.values) > 0 {
 		base = append(base, l.values...)

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -89,7 +90,7 @@ type logger struct {
 func (l *logger) Debug(msg string, keysAndValues ...interface{}) {
 	if int(l.verbosity.get()) >= int(l.v) {
 		if err := l.log(VerbosityDebug, CategoryDebug, nil, msg, keysAndValues...); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }
@@ -98,7 +99,7 @@ func (l *logger) Debug(msg string, keysAndValues ...interface{}) {
 func (l *logger) Info(msg string, keysAndValues ...interface{}) {
 	if l.verbosity.get() >= VerbosityInfo {
 		if err := l.log(VerbosityInfo, CategoryInfo, nil, msg, keysAndValues...); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }
@@ -107,7 +108,7 @@ func (l *logger) Info(msg string, keysAndValues ...interface{}) {
 func (l *logger) Warning(msg string, keysAndValues ...interface{}) {
 	if l.verbosity.get() >= VerbosityWarning {
 		if err := l.log(VerbosityWarning, CategoryWarning, nil, msg, keysAndValues...); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }
@@ -116,7 +117,7 @@ func (l *logger) Warning(msg string, keysAndValues ...interface{}) {
 func (l *logger) Error(err error, msg string, keysAndValues ...interface{}) {
 	if l.verbosity.get() >= VerbosityError {
 		if err := l.log(VerbosityError, CategoryError, err, msg, keysAndValues...); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,287 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+var _ Logger = (*logger)(nil)
+
+// levelHooks is a helper type for storing and
+// help triggering the hooks on a logger instance.
+type levelHooks map[Level][]Hook
+
+// fire triggers all the hooks for the given level.
+func (lh levelHooks) fire(level Level) error {
+	for _, hook := range lh[level] {
+		if err := hook.Fire(level); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// logger implements the Logger interface.
+type logger struct {
+	// id is the unique identifier of a logger.
+	// It identifies the instance of a logger in the logger registry.
+	id string
+
+	// v level represents the granularity of debug calls.
+	v uint
+
+	// vc captures the original value of v before it is modified,
+	// which can happen during the build of the logger.
+	vc *uint
+
+	// names represents a path in the tree,
+	// element 0 is the root of the tree.
+	names []string
+
+	// namesStr is a cache of render names slice, so
+	// we don't have to render them on each Build call.
+	namesStr string
+
+	// namesLen captures the original length of the names slice before new
+	// elements are added, which can happen during the build of the logger.
+	namesLen int
+
+	// values holds additional key/value pairs
+	// that are included on every log call.
+	values []interface{}
+
+	// valuesStr is a cache of render values slice, so
+	// we don't have to render them on each Build call.
+	valuesStr string
+
+	// valuesLen captures the original length of the values slice before new
+	// elements are added, which can happen during the build of the logger.
+	valuesLen int
+
+	// formatter formats log messages before they are written to the sink.
+	formatter *formatter
+
+	// verbosity represents the current verbosity level.
+	// This variable is used to modify the verbosity of the logger instance.
+	// Higher values enable more logs. Logs at or below this level
+	// will be written, while logs above this level will be discarded.
+	verbosity Level
+
+	// sink represents the stream where the logs are written.
+	sink io.Writer
+
+	// levelHooks allow triggering of registered hooks
+	// on their associated severity log levels.
+	levelHooks levelHooks
+}
+
+// Debug implements the Logger interface Debug method.
+func (l *logger) Debug(msg string, keysAndValues ...interface{}) {
+	if int(l.verbosity.get()) >= int(l.v) {
+		if err := l.log(VerbosityDebug, CategoryDebug, nil, msg, keysAndValues...); err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+// Info implements the Logger interface Info method.
+func (l *logger) Info(msg string, keysAndValues ...interface{}) {
+	if l.verbosity.get() >= VerbosityInfo {
+		if err := l.log(VerbosityInfo, CategoryInfo, nil, msg, keysAndValues...); err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+// Warning implements the Logger interface Warning method.
+func (l *logger) Warning(msg string, keysAndValues ...interface{}) {
+	if l.verbosity.get() >= VerbosityWarning {
+		if err := l.log(VerbosityWarning, CategoryWarning, nil, msg, keysAndValues...); err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+// Error implements the Logger interface Error method.
+func (l *logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if l.verbosity.get() >= VerbosityError {
+		if err := l.log(VerbosityError, CategoryError, err, msg, keysAndValues...); err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+// V implements the Builder interface V method.
+func (l *logger) V(level uint) Builder {
+	if level > 0 {
+		if l.vc == nil {
+			v := l.v
+			l.vc = &v
+		}
+		*l.vc += level
+	}
+	return l
+}
+
+// WithName implements the Builder interface WithName method.
+func (l *logger) WithName(name string) Builder {
+	l.names = append(l.names, name)
+	return l
+}
+
+// WithValues implements the Builder interface WithValues method.
+func (l *logger) WithValues(keysAndValues ...interface{}) Builder {
+	l.values = append(l.values, keysAndValues...)
+	return l
+}
+
+// Build implements the Builder interface Build method.
+func (l *logger) Build() Logger {
+	if l.id != "" &&
+		l.vc == nil &&
+		l.namesLen == len(l.names) &&
+		l.valuesLen == len(l.values) {
+		return l // Ignore subsequent chained calls to the Build method.
+	}
+
+	v := l.v
+	if l.vc != nil {
+		v = *l.vc
+	}
+
+	namesStr := l.namesStr
+	if l.namesLen < len(l.names) {
+		namesStr = strings.Join(l.names, "/")
+	}
+
+	valuesStr := l.valuesStr
+	if l.valuesLen < len(l.values) {
+		// ~5 is the average length of an English word; 4 is the rune size.
+		len := nextPowOf2(uint64(5 * 4 * len(l.values)))
+		buf := bytes.NewBuffer(make([]byte, 0, len))
+		l.formatter.flatten(buf, l.values, false, false)
+		valuesStr = buf.String()
+	}
+
+	// Basic builder invariants must be restored to the root
+	// instance from which other instances are created.
+	defer func() {
+		l.vc = nil
+		l.names = l.names[:l.namesLen]
+		l.values = l.values[:l.valuesLen]
+	}()
+
+	key, val := hash(namesStr, v, valuesStr, l.sink), (*logger)(nil)
+	switch i, ok := loggers.Load(key); {
+	case ok: // Nothing to build, the instance exists.
+		return i.(*logger)
+	case l.id == "": // Build a root instance.
+		val = l
+		val.id = key
+		val.v = v
+		val.namesStr = namesStr
+		val.namesLen = len(val.names)
+		val.valuesStr = valuesStr
+		val.valuesLen = len(val.values)
+	default: // Build a new child instance.
+		c := *l
+		val = &c
+		val.id = key
+		val.v = v
+		val.namesStr = namesStr
+		val.namesLen = len(val.names)
+		val.names = append(make([]string, 0, val.namesLen), val.names...)
+		val.valuesStr = valuesStr
+		val.valuesLen = len(val.values)
+		val.values = append(make([]interface{}, 0, val.valuesLen), val.values...)
+	}
+	res, _ := loggers.LoadOrStore(key, val)
+	return res.(*logger)
+}
+
+// setVerbosity changes the verbosity level or the logger.
+func (l *logger) setVerbosity(v Level) {
+	l.verbosity.set(v)
+}
+
+// log logs the given msg and key-value pairs with the given level
+// and the given message category caller (if enabled) to the sink.
+func (l *logger) log(vl Level, mc MessageCategory, err error, msg string, keysAndValues ...interface{}) error {
+	base := make([]interface{}, 0, 14+len(keysAndValues))
+	if l.formatter.opts.logTimestamp {
+		base = append(base, "time", time.Now().Format(l.formatter.opts.timestampLayout))
+	}
+	base = append(base, "level", vl.String(), "logger", l.namesStr)
+	if vl == VerbosityDebug && l.v > 0 {
+		base = append(base, "v", l.v)
+	}
+	if policy := l.formatter.opts.caller; policy == CategoryAll || policy == mc {
+		base = append(base, "caller", l.formatter.caller())
+	}
+	base = append(base, "msg", msg)
+	if vl == VerbosityError {
+		var loggableErr interface{}
+		if err != nil {
+			loggableErr = err.Error()
+		}
+		base = append(base, "error", loggableErr)
+	}
+	if len(l.values) > 0 {
+		base = append(base, l.values...)
+	}
+	buf := l.formatter.render(base, keysAndValues)
+
+	var merr *multierror.Error
+	if _, err = l.sink.Write(buf); err != nil {
+		merr = multierror.Append(
+			merr,
+			fmt.Errorf("log %s: failed to write message: %v\n", vl, err),
+		)
+	}
+	if err := l.levelHooks.fire(vl); err != nil {
+		merr = multierror.Append(
+			merr,
+			fmt.Errorf("log %s: failed to fire hooks: %v\n", vl, err),
+		)
+	}
+	return merr.ErrorOrNil()
+}
+
+// hash is a hashing function for creating unique identifiers.
+func hash(prefix string, v uint, values string, w io.Writer) string {
+	var sink uintptr
+	if reflect.ValueOf(w).Kind() == reflect.Ptr {
+		sink = reflect.ValueOf(w).Pointer()
+	} else {
+		sink = reflect.ValueOf(&w).Pointer()
+	}
+	return fmt.Sprintf("%s[%d][%s]>>%d", prefix, v, values, sink)
+}
+
+// nextPowOf2 rounds up n to the next highest power of 2.
+// See: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+func nextPowOf2(n uint64) uint64 {
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n |= n >> 32
+	n++
+	return n
+}
+
+// TODO:
+// - Implement the HTTP log middleware
+// - Write benchmarks and do optimizations; consider `func (l *VLogger) getBuffer() *buffer` from glog

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -186,7 +186,7 @@ func (l *logger) Build() Logger {
 	switch i, ok := loggers.Load(key); {
 	case ok: // Nothing to build, the instance exists.
 		return i.(*logger)
-	case l.id == "": // Build a root instance.
+	case l.id == "": // A new root instance.
 		val = l
 		val.id = key
 		val.v = v
@@ -194,7 +194,7 @@ func (l *logger) Build() Logger {
 		val.namesLen = len(val.names)
 		val.valuesStr = valuesStr
 		val.valuesLen = len(val.values)
-	default: // Build a new child instance.
+	default: // A new child instance.
 		c := *l
 		val = &c
 		val.id = key
@@ -206,6 +206,13 @@ func (l *logger) Build() Logger {
 		val.valuesLen = len(val.values)
 		val.values = append(make([]interface{}, 0, val.valuesLen), val.values...)
 	}
+	return val
+}
+
+// Register implements the Builder interface Register method.
+func (l *logger) Register() Logger {
+	val := l.Build()
+	key := hash(l.namesStr, l.v, l.valuesStr, l.sink)
 	res, _ := loggers.LoadOrStore(key, val)
 	return res.(*logger)
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -23,7 +23,12 @@ var _ Logger = (*logger)(nil)
 type levelHooks map[Level][]Hook
 
 // fire triggers all the hooks for the given level.
+// If level V is enabled in debug verbosity, then
+// the VerbosityAll hooks are triggered.
 func (lh levelHooks) fire(level Level) error {
+	if level > VerbosityDebug {
+		level = VerbosityAll
+	}
 	for _, hook := range lh[level] {
 		if err := hook.Fire(level); err != nil {
 			return err

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -228,7 +228,7 @@ func (l *logger) log(vl Level, mc MessageCategory, err error, msg string, keysAn
 			fmt.Errorf("log %s: failed to write message: %v\n", vl, err),
 		)
 	}
-	if err := l.levelHooks.fire(vl); err != nil {
+	if err := l.levelHooks.fire(vl + Level(l.v)); err != nil {
 		merr = multierror.Append(
 			merr,
 			fmt.Errorf("log %s: failed to fire hooks: %v\n", vl, err),

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -191,69 +191,6 @@ func (l *logger) Error(err error, msg string, keysAndValues ...interface{}) {
 	}
 }
 
-// Build implements the Builder interface Build method.
-//func (l *logger) Build() Logger {
-//	if l.id != "" &&
-//		l.vc == nil &&
-//		l.namesLen == len(l.names) &&
-//		l.valuesLen == len(l.values) {
-//		return l // Ignore subsequent chained calls to the Build method.
-//	}
-//
-//	v := l.v
-//	if l.vc != nil {
-//		v = *l.vc
-//	}
-//
-//	namesStr := l.namesStr
-//	if l.namesLen < len(l.names) {
-//		namesStr = strings.Join(l.names, "/")
-//	}
-//
-//	valuesStr := l.valuesStr
-//	if l.valuesLen < len(l.values) {
-//		// ~5 is the average length of an English word; 4 is the rune size.
-//		len := nextPowOf2(uint64(5 * 4 * len(l.values)))
-//		buf := bytes.NewBuffer(make([]byte, 0, len))
-//		l.formatter.flatten(buf, l.values, false, false)
-//		valuesStr = buf.String()
-//	}
-//
-//	// Basic builder invariants must be restored to the root
-//	// instance from which other instances are created.
-//	defer func() { // TODO: create a copy instead of restoring invariants!
-//		l.vc = nil
-//		l.names = l.names[:l.namesLen]
-//		l.values = l.values[:l.valuesLen]
-//	}()
-//
-//	key, val := hash(namesStr, v, valuesStr, l.sink), (*logger)(nil)
-//	switch i, ok := loggers.Load(key); {
-//	case ok: // Nothing to build, the instance exists.
-//		return i.(*logger)
-//	case l.id == "": // A new root instance.
-//		val = l
-//		val.id = key
-//		val.v = v
-//		val.namesStr = namesStr
-//		val.namesLen = len(val.names)
-//		val.valuesStr = valuesStr
-//		val.valuesLen = len(val.values)
-//	default: // A new child instance.
-//		c := *l
-//		val = &c
-//		val.id = key
-//		val.v = v
-//		val.namesStr = namesStr
-//		val.namesLen = len(val.names)
-//		val.names = append(make([]string, 0, val.namesLen), val.names...)
-//		val.valuesStr = valuesStr
-//		val.valuesLen = len(val.values)
-//		val.values = append(make([]interface{}, 0, val.valuesLen), val.values...)
-//	}
-//	return val
-//}
-
 // setVerbosity changes the verbosity level or the logger.
 func (l *logger) setVerbosity(v Level) {
 	l.verbosity.set(v)

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -1,0 +1,1050 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// hook is a helper type for recording
+// if Hook.Fire method has been triggered.
+type hook bool
+
+// reset resets this hook as if it were never fired.
+func (h *hook) reset() {
+	*h = false
+}
+
+// Fire implements Hook.Fire method.
+func (h *hook) Fire(Level) error {
+	*h = true
+	return nil
+}
+
+// applyError is a higher order function that returns the given fn with an applied err.
+func applyError(fn func(error, string, ...interface{}), err error) func(string, ...interface{}) {
+	return func(msg string, kvs ...interface{}) {
+		fn(err, msg, kvs...)
+	}
+}
+
+// newLogger is a convenient constructor for creating
+// new instances of Logger without pinning the defaults.
+func newLogger(modifications ...Option) (Builder, *bytes.Buffer) {
+	const name = "root"
+
+	opts := *defaults.options
+	for _, modify := range modifications {
+		modify(&opts)
+	}
+
+	bb := new(bytes.Buffer)
+	return &logger{
+		names:      []string{name},
+		namesStr:   name,
+		namesLen:   1,
+		formatter:  newFormatter(opts.fmtOptions),
+		verbosity:  opts.verbosity,
+		sink:       bb,
+		levelHooks: opts.levelHooks,
+	}, bb
+}
+
+func TestLoggerOptionsLevelHooks(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	t.Run("verbosity=none", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityNone, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: false,
+		}, {
+			fn:   logger.Build().Info,
+			want: false,
+		}, {
+			fn:   logger.Build().Warning,
+			want: false,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: false,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+	t.Run("verbosity=debug", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityDebug, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: true,
+		}, {
+			fn:   logger.Build().Info,
+			want: false,
+		}, {
+			fn:   logger.Build().Warning,
+			want: false,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: false,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+	t.Run("verbosity=info", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityInfo, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: false,
+		}, {
+			fn:   logger.Build().Info,
+			want: true,
+		}, {
+			fn:   logger.Build().Warning,
+			want: false,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: false,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+	t.Run("verbosity=warning", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityWarning, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: false,
+		}, {
+			fn:   logger.Build().Info,
+			want: false,
+		}, {
+			fn:   logger.Build().Warning,
+			want: true,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: false,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+	t.Run("verbosity=error", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityError, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: false,
+		}, {
+			fn:   logger.Build().Info,
+			want: false,
+		}, {
+			fn:   logger.Build().Warning,
+			want: false,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: true,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+	t.Run("verbosity=all", func(t *testing.T) {
+		have := hook(false)
+		logger, _ := newLogger(WithLevelHooks(VerbosityAll, &have))
+
+		tests := []struct {
+			fn   func(string, ...interface{})
+			want bool
+		}{{
+			fn:   logger.Build().Debug,
+			want: true,
+		}, {
+			fn:   logger.Build().Info,
+			want: true,
+		}, {
+			fn:   logger.Build().Warning,
+			want: true,
+		}, {
+			fn:   applyError(logger.Build().Error, nil),
+			want: true,
+		}}
+
+		for _, tc := range tests {
+			tc.fn("")
+			if tc.want != bool(have) {
+				t.Errorf("hook: want fired %t; have %t", tc.want, have)
+			}
+			have.reset()
+		}
+	})
+}
+
+func TestLoggerOptionsTimestampFormat(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	logger, bb := newLogger(
+		WithTimestamp(),
+		WithTimestampLayout("TIMESTAMP"),
+		WithCallerDepth(1),
+	)
+	logger.Build().Info("msg")
+	have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+	want := `"time"="TIMESTAMP" "level"="info" "logger"="root" "msg"="msg"`
+	if have != want {
+		t.Errorf("\nwant %q\nhave %q", want, have)
+	}
+}
+
+func TestLogger(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	logger, bb := newLogger()
+
+	testCases := []struct {
+		name  string
+		logFn func(string, ...interface{})
+		args  []interface{}
+		want  string
+	}{{
+		name:  "just msg",
+		logFn: logger.Build().Debug,
+		args:  makeKV(),
+		want:  `"level"="debug" "logger"="root" "msg"="msg"`,
+	}, {
+		name:  "primitives",
+		logFn: logger.Build().Debug,
+		args:  makeKV("int", 1, "str", "ABC", "bool", true),
+		want:  `"level"="debug" "logger"="root" "msg"="msg" "int"=1 "str"="ABC" "bool"=true`,
+	}, {
+		name:  "just msg",
+		logFn: logger.Build().Info,
+		args:  makeKV(),
+		want:  `"level"="info" "logger"="root" "msg"="msg"`,
+	}, {
+		name:  "primitives",
+		logFn: logger.Build().Info,
+		args:  makeKV("int", 1, "str", "ABC", "bool", true),
+		want:  `"level"="info" "logger"="root" "msg"="msg" "int"=1 "str"="ABC" "bool"=true`,
+	}, {
+		name:  "just msg",
+		logFn: logger.Build().Warning,
+		args:  makeKV(),
+		want:  `"level"="warning" "logger"="root" "msg"="msg"`,
+	}, {
+		name:  "primitives",
+		logFn: logger.Build().Warning,
+		args:  makeKV("int", 1, "str", "ABC", "bool", true),
+		want:  `"level"="warning" "logger"="root" "msg"="msg" "int"=1 "str"="ABC" "bool"=true`,
+	}, {
+		name:  "just msg",
+		logFn: applyError(logger.Build().Error, errors.New("err")),
+		args:  makeKV(),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err"`,
+	}, {
+		name:  "primitives",
+		logFn: applyError(logger.Build().Error, errors.New("err")),
+		args:  makeKV("int", 1, "str", "ABC", "bool", true),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err" "int"=1 "str"="ABC" "bool"=true`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bb.Reset()
+			tc.logFn("msg", tc.args...)
+			t.Logf("%p:%#v", &logger, logger)
+			have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+			if have != tc.want {
+				t.Errorf("\nwant %q\nhave %q", tc.want, have)
+			}
+		})
+	}
+}
+
+func TestLoggerWithCaller(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	t.Run("caller=CategoryAll", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryAll))
+
+		logger.Build().Debug("msg")
+		_, file, line, _ := runtime.Caller(0)
+		want := fmt.Sprintf(`"level"="debug" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		_, file, line, _ = runtime.Caller(0)
+		want = fmt.Sprintf(`"level"="info" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		_, file, line, _ = runtime.Caller(0)
+		want = fmt.Sprintf(`"level"="warning" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		_, file, line, _ = runtime.Caller(0)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = fmt.Sprintf(`"level"="error" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryAll, logCallerFunc=true", func(t *testing.T) {
+		const thisFunc = "github.com/ethersphere/bee/pkg/log.TestLoggerWithCaller.func3"
+
+		logger, bb := newLogger(WithCaller(CategoryAll), WithCallerFunc())
+
+		logger.Build().Debug("msg")
+		_, file, line, _ := runtime.Caller(0)
+		want := fmt.Sprintf(`"level"="debug" "logger"="root" "caller"={"file":%q,"line":%d,"function":%q} "msg"="msg"`, filepath.Base(file), line-1, thisFunc)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		_, file, line, _ = runtime.Caller(0)
+		want = fmt.Sprintf(`"level"="info" "logger"="root" "caller"={"file":%q,"line":%d,"function":%q} "msg"="msg"`, filepath.Base(file), line-1, thisFunc)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		_, file, line, _ = runtime.Caller(0)
+		want = fmt.Sprintf(`"level"="warning" "logger"="root" "caller"={"file":%q,"line":%d,"function":%q} "msg"="msg"`, filepath.Base(file), line-1, thisFunc)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		_, file, line, _ = runtime.Caller(0)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = fmt.Sprintf(`"level"="error" "logger"="root" "caller"={"file":%q,"line":%d,"function":%q} "msg"="msg" "error"="err"`, filepath.Base(file), line-1, thisFunc)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryDebug", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryDebug))
+
+		logger.Build().Debug("msg")
+		_, file, line, _ := runtime.Caller(0)
+		want := fmt.Sprintf(`"level"="debug" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"="err"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryInfo", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryInfo))
+
+		logger.Build().Debug("msg")
+		want := `"level"="debug" "logger"="root" "msg"="msg"`
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		_, file, line, _ := runtime.Caller(0)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = fmt.Sprintf(`"level"="info" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"="err"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryWarning", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryWarning))
+
+		logger.Build().Debug("msg")
+		want := `"level"="debug" "logger"="root" "msg"="msg"`
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		_, file, line, _ := runtime.Caller(0)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = fmt.Sprintf(`"level"="warning" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line-1)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"="err"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryError", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryError))
+
+		logger.Build().Debug("msg")
+		want := `"level"="debug" "logger"="root" "msg"="msg"`
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		_, file, line, _ := runtime.Caller(0)
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = fmt.Sprintf(`"level"="error" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("caller=CategoryNone", func(t *testing.T) {
+		logger, bb := newLogger(WithCaller(CategoryNone))
+
+		logger.Build().Debug("msg")
+		want := `"level"="debug" "logger"="root" "msg"="msg"`
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(errors.New("err"), "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"="err"`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+}
+
+func TestLoggerWithName(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	logger, bb := newLogger()
+	logger.Build()
+
+	testCases := []struct {
+		name  string
+		logFn func(string, ...interface{})
+		args  []interface{}
+		want  string
+	}{{
+		name:  "one",
+		logFn: logger.WithName("pfx1").Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root/pfx1" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithName("pfx1").WithName("pfx2").Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root/pfx1/pfx2" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: logger.WithName("pfx1").Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root/pfx1" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithName("pfx1").WithName("pfx2").Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root/pfx1/pfx2" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: logger.WithName("pfx1").Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root/pfx1" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithName("pfx1").WithName("pfx2").Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root/pfx1/pfx2" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: applyError(logger.WithName("pfx1").Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root/pfx1" "msg"="msg" "error"="err" "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: applyError(logger.WithName("pfx1").WithName("pfx2").Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root/pfx1/pfx2" "msg"="msg" "error"="err" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bb.Reset()
+			tc.logFn("msg", tc.args...)
+			have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+			if have != tc.want {
+				t.Errorf("\nwant %q\nhave %q", tc.want, have)
+			}
+		})
+	}
+}
+
+func TestLoggerWithValues(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	logger, bb := newLogger()
+
+	testCases := []struct {
+		name  string
+		logFn func(string, ...interface{})
+		args  []interface{}
+		want  string
+	}{{
+		name:  "zero",
+		logFn: logger.Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: logger.WithValues("one", 1).Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root" "msg"="msg" "one"=1 "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithValues("one", 1, "two", 2).Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root" "msg"="msg" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:  "dangling",
+		logFn: logger.WithValues("dangling").Build().Debug,
+		args:  makeKV("k", "v"),
+		want:  `"level"="debug" "logger"="root" "msg"="msg" "dangling"="<no-value>" "k"="v"`,
+	}, {
+		name:  "zero",
+		logFn: logger.Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: logger.WithValues("one", 1).Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root" "msg"="msg" "one"=1 "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithValues("one", 1, "two", 2).Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root" "msg"="msg" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:  "dangling",
+		logFn: logger.WithValues("dangling").Build().Info,
+		args:  makeKV("k", "v"),
+		want:  `"level"="info" "logger"="root" "msg"="msg" "dangling"="<no-value>" "k"="v"`,
+	}, {
+		name:  "zero",
+		logFn: logger.Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root" "msg"="msg" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: logger.WithValues("one", 1).Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root" "msg"="msg" "one"=1 "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: logger.WithValues("one", 1, "two", 2).Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root" "msg"="msg" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:  "dangling",
+		logFn: logger.WithValues("dangling").Build().Warning,
+		args:  makeKV("k", "v"),
+		want:  `"level"="warning" "logger"="root" "msg"="msg" "dangling"="<no-value>" "k"="v"`,
+	}, {
+		name:  "zero",
+		logFn: applyError(logger.Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err" "k"="v"`,
+	}, {
+		name:  "one",
+		logFn: applyError(logger.WithValues("one", 1).Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err" "one"=1 "k"="v"`,
+	}, {
+		name:  "two",
+		logFn: applyError(logger.WithValues("one", 1, "two", 2).Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:  "dangling",
+		logFn: applyError(logger.WithValues("dangling").Build().Error, errors.New("err")),
+		args:  makeKV("k", "v"),
+		want:  `"level"="error" "logger"="root" "msg"="msg" "error"="err" "dangling"="<no-value>" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bb.Reset()
+			tc.logFn("msg", tc.args...)
+			have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+			if have != tc.want {
+				t.Errorf("\nwant %q\nhave %q", tc.want, have)
+			}
+		})
+	}
+}
+
+func TestLoggerWithCallDepth(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	t.Run("verbosity=debug, callerDepth=1", func(t *testing.T) {
+		logger, bb := newLogger(WithCallerDepth(1), WithCaller(CategoryAll))
+		logger.Build().Debug("msg")
+		_, file, line, _ := runtime.Caller(1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want := fmt.Sprintf(`"level"="debug" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=info, callerDepth=1", func(t *testing.T) {
+		logger, bb := newLogger(WithCallerDepth(1), WithCaller(CategoryAll))
+		logger.Build().Info("msg")
+		_, file, line, _ := runtime.Caller(1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want := fmt.Sprintf(`"level"="info" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=warning, callerDepth=1", func(t *testing.T) {
+		logger, bb := newLogger(WithCallerDepth(1), WithCaller(CategoryAll))
+		logger.Build().Warning("msg")
+		_, file, line, _ := runtime.Caller(1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want := fmt.Sprintf(`"level"="warning" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg"`, filepath.Base(file), line)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=error, callerDepth=1", func(t *testing.T) {
+		logger, bb := newLogger(WithCallerDepth(1), WithCaller(CategoryAll))
+		logger.Build().Error(errors.New("err"), "msg")
+		_, file, line, _ := runtime.Caller(1)
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want := fmt.Sprintf(`"level"="error" "logger"="root" "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line)
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+}
+
+func TestLoggerVerbosity(t *testing.T) {
+	l := loggers
+	t.Cleanup(func() {
+		loggers = l
+	})
+	loggers = new(sync.Map)
+
+	t.Run("verbosity=all", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityAll))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		want := `"level"="debug" "logger"="root" "v"=1 "msg"="msg"`
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Debug("msg")
+		want = `"level"="debug" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(nil, "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=debug", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityDebug))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		want := ""
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Debug("msg")
+		want = `"level"="debug" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(nil, "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=info", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityInfo))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		logger.Build().Debug("msg")
+		want := ""
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Info("msg")
+		want = `"level"="info" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(nil, "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=warning", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityWarning))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		logger.Build().Debug("msg")
+		logger.Build().Info("msg")
+		want := ""
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Warning("msg")
+		want = `"level"="warning" "logger"="root" "msg"="msg"`
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(nil, "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=error", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityError))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		logger.Build().Debug("msg")
+		logger.Build().Info("msg")
+		logger.Build().Warning("msg")
+		want := ""
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+
+		bb.Reset()
+
+		logger.Build().Error(nil, "msg")
+		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
+		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+	t.Run("verbosity=none", func(t *testing.T) {
+		logger, bb := newLogger(WithVerbosity(VerbosityNone))
+		logger.Build()
+
+		logger.V(1).Build().Debug("msg")
+		logger.Build().Debug("msg")
+		logger.Build().Info("msg")
+		logger.Build().Warning("msg")
+		logger.Build().Error(nil, "msg")
+		want := ""
+		have := string(bytes.TrimRight(bb.Bytes(), "\n"))
+		if have != want {
+			t.Errorf("\nwant %q\nhave %q", want, have)
+		}
+	})
+}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -887,7 +887,7 @@ func TestLoggerVerbosity(t *testing.T) {
 
 		logger.Build().Error(nil, "msg")
 		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
-		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		want = `"level"="error" "logger"="root" "msg"="msg"`
 		if have != want {
 			t.Errorf("\nwant %q\nhave %q", want, have)
 		}
@@ -934,7 +934,7 @@ func TestLoggerVerbosity(t *testing.T) {
 
 		logger.Build().Error(nil, "msg")
 		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
-		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		want = `"level"="error" "logger"="root" "msg"="msg"`
 		if have != want {
 			t.Errorf("\nwant %q\nhave %q", want, have)
 		}
@@ -973,7 +973,7 @@ func TestLoggerVerbosity(t *testing.T) {
 
 		logger.Build().Error(nil, "msg")
 		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
-		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		want = `"level"="error" "logger"="root" "msg"="msg"`
 		if have != want {
 			t.Errorf("\nwant %q\nhave %q", want, have)
 		}
@@ -1004,7 +1004,7 @@ func TestLoggerVerbosity(t *testing.T) {
 
 		logger.Build().Error(nil, "msg")
 		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
-		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		want = `"level"="error" "logger"="root" "msg"="msg"`
 		if have != want {
 			t.Errorf("\nwant %q\nhave %q", want, have)
 		}
@@ -1027,7 +1027,7 @@ func TestLoggerVerbosity(t *testing.T) {
 
 		logger.Build().Error(nil, "msg")
 		have = string(bytes.TrimRight(bb.Bytes(), "\n"))
-		want = `"level"="error" "logger"="root" "msg"="msg" "error"=null`
+		want = `"level"="error" "logger"="root" "msg"="msg"`
 		if have != want {
 			t.Errorf("\nwant %q\nhave %q", want, have)
 		}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -46,16 +46,19 @@ func newLogger(modifications ...Option) (Builder, *bytes.Buffer) {
 		modify(&opts)
 	}
 
-	bb := new(bytes.Buffer)
-	return &logger{
-		names:      []string{name},
-		namesStr:   name,
-		namesLen:   1,
+	b := new(bytes.Buffer)
+	l := &logger{
 		formatter:  newFormatter(opts.fmtOptions),
 		verbosity:  opts.verbosity,
-		sink:       bb,
+		sink:       b,
 		levelHooks: opts.levelHooks,
-	}, bb
+	}
+	l.builder = &builder{
+		l:        l,
+		names:    []string{name},
+		namesStr: name,
+	}
+	return l, b
 }
 
 func TestLoggerOptionsLevelHooks(t *testing.T) {
@@ -321,7 +324,6 @@ func TestLogger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bb.Reset()
 			tc.logFn("msg", tc.args...)
-			t.Logf("%p:%#v", &logger, logger)
 			have := string(bytes.TrimRight(bb.Bytes(), "\n"))
 			if have != tc.want {
 				t.Errorf("\nwant %q\nhave %q", tc.want, have)

--- a/pkg/log/noop_logger.go
+++ b/pkg/log/noop_logger.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+// noop is an implementation of a logger that does not log.
+var noop Logger = new(noopLogger)
+
+type noopLogger struct{}
+
+func (nl noopLogger) V(_ uint) Builder                    { return nl }
+func (nl noopLogger) WithName(_ string) Builder           { return nl }
+func (nl noopLogger) WithValues(_ ...interface{}) Builder { return nl }
+func (nl noopLogger) Build() Logger                       { return nl }
+func (nl noopLogger) Register() Logger                    { return nl }
+
+func (nl noopLogger) Debug(_ string, _ ...interface{})          {}
+func (nl noopLogger) Info(_ string, _ ...interface{})           {}
+func (nl noopLogger) Warning(_ string, _ ...interface{})        {}
+func (nl noopLogger) Error(_ error, _ string, _ ...interface{}) {}

--- a/pkg/log/registry.go
+++ b/pkg/log/registry.go
@@ -1,0 +1,121 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// defaults specifies the default global options for log
+// package which every new logger will inherit on its creation.
+var defaults = struct {
+	pin       sync.Once // pin pins the options and formatter settings.
+	options   *Options
+	formatter *formatter
+}{
+	options: &Options{
+		sink:      Lock(os.Stderr),
+		verbosity: VerbosityDebug,
+		fmtOptions: fmtOptions{
+			timestampLayout: "2006-01-02 15:04:05.000000",
+			maxLogDepth:     16,
+		},
+	},
+}
+
+// ModifyDefaults modifies the global default options for this log package
+// that each new logger inherits when it is created. The default values can
+// be modified only once, so further calls to this function will be ignored.
+// This function should be called before the first call to the NewLogger
+// factory constructor, otherwise it will have no effect.
+func ModifyDefaults(opts ...Option) {
+	defaults.pin.Do(func() {
+		for _, modify := range opts {
+			modify(defaults.options)
+		}
+		defaults.formatter = newFormatter(defaults.options.fmtOptions)
+	})
+}
+
+// loggers is the central register for Logger instances.
+var loggers = new(sync.Map)
+
+// NewLogger is a factory constructor which returns a new logger instance
+// based on the given name. If such an instance already exists in the
+// logger registry, then this existing instance is returned instead.
+func NewLogger(name string) Logger {
+	// Pin the default settings if
+	// they are not already pinned.
+	ModifyDefaults()
+
+	val, ok := loggers.Load(hash(name, 0, "", defaults.options.sink))
+	if ok {
+		return val.(*logger)
+	}
+
+	return &logger{
+		names:      []string{name},
+		namesStr:   name,
+		namesLen:   1,
+		formatter:  defaults.formatter,
+		verbosity:  defaults.options.verbosity,
+		sink:       defaults.options.sink,
+		levelHooks: defaults.options.levelHooks,
+	}
+}
+
+// SetVerbosity sets the level
+// of verbosity of the given logger.
+func SetVerbosity(l Logger, v Level) error {
+	bl := l.(*logger)
+	switch new, max := v.get(), Level(bl.v); {
+	case new == VerbosityAll:
+		bl.setVerbosity(max)
+	case new > max:
+		return fmt.Errorf("maximum verbosity %d exceeded for logger: %s", bl.v, bl.id)
+	default:
+		bl.setVerbosity(new)
+	}
+	return nil
+}
+
+// SetVerbosityByExp sets all loggers to the given
+// verbosity level v that match the given expression
+// e, which can be a logger id or a regular expression.
+// An error is returned if e fails to compile.
+func SetVerbosityByExp(e string, v Level) error {
+	val, ok := loggers.Load(e)
+	if ok {
+		val.(*logger).setVerbosity(v)
+		return nil
+	}
+
+	rex, err := regexp.Compile(e)
+	if err != nil {
+		return err
+	}
+
+	var merr *multierror.Error
+	loggers.Range(func(key, val interface{}) bool {
+		if rex.MatchString(key.(string)) {
+			merr = multierror.Append(merr, SetVerbosity(val.(*logger), v))
+		}
+		return true
+	})
+	return merr.ErrorOrNil()
+}
+
+// RegistryIterate iterates through all registered loggers.
+func RegistryIterate(fn func(id, path string, verbosity Level, v uint) (next bool)) {
+	loggers.Range(func(_, val interface{}) bool {
+		l := val.(*logger)
+		return fn(l.id, l.namesStr, l.verbosity.get(), l.v)
+	})
+}

--- a/pkg/log/registry.go
+++ b/pkg/log/registry.go
@@ -22,7 +22,7 @@ var defaults = struct {
 	formatter *formatter
 }{
 	options: &Options{
-		sink:      Lock(os.Stderr),
+		sink:      os.Stderr,
 		verbosity: VerbosityDebug,
 		fmtOptions: fmtOptions{
 			timestampLayout: "2006-01-02 15:04:05.000000",

--- a/pkg/log/registry.go
+++ b/pkg/log/registry.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"sync"
@@ -60,6 +61,10 @@ func NewLogger(name string, opts ...Option) Logger {
 	options := *defaults.options
 	for _, modify := range opts {
 		modify(&options)
+	}
+
+	if options.sink == io.Discard {
+		return noop
 	}
 
 	formatter := defaults.formatter

--- a/pkg/log/registry.go
+++ b/pkg/log/registry.go
@@ -60,15 +60,18 @@ func NewLogger(name string) Logger {
 		return val.(*logger)
 	}
 
-	return &logger{
-		names:      []string{name},
-		namesStr:   name,
-		namesLen:   1,
+	l := &logger{
 		formatter:  defaults.formatter,
 		verbosity:  defaults.options.verbosity,
 		sink:       defaults.options.sink,
 		levelHooks: defaults.options.levelHooks,
 	}
+	l.builder = &builder{
+		l:        l,
+		names:    []string{name},
+		namesStr: name,
+	}
+	return l
 }
 
 // SetVerbosity sets the level

--- a/pkg/log/registry_test.go
+++ b/pkg/log/registry_test.go
@@ -1,0 +1,215 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// allVerbosityLevels enumerates all possible verbosity levels.
+var allVerbosityLevels = []Level{
+	VerbosityNone,
+	VerbosityError,
+	VerbosityWarning,
+	VerbosityInfo,
+	VerbosityDebug,
+	VerbosityAll,
+}
+
+// opts specifies different set options for testing.
+var opts = []Option{
+	WithSink(new(bytes.Buffer)),
+	WithVerbosity(1),
+	WithCaller(CategoryError),
+	WithCallerFunc(),
+	WithTimestamp(),
+	WithTimestampLayout("0123456789"),
+	WithMaxDepth(2),
+	WithJSONOutput(),
+	WithCallerDepth(3),
+}
+
+func TestModifyDefaults(t *testing.T) {
+	o := defaults.options
+	t.Cleanup(func() {
+		defaults.pin = sync.Once{}
+		defaults.options = o
+	})
+
+	want := new(Options)
+	have := new(Options)
+	for _, o := range opts {
+		o(want)
+	}
+	defaults.options = have
+	ModifyDefaults(opts...)
+
+	diff := cmp.Diff(have, want, cmp.AllowUnexported(
+		Options{},
+		fmtOptions{},
+		bytes.Buffer{},
+	))
+	if diff != "" {
+		t.Errorf("ModifyDefaults(...) mismatch (-want +have):\n%s", diff)
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	l, o := loggers, defaults.options
+	t.Cleanup(func() {
+		loggers = l
+		defaults.pin = sync.Once{}
+		defaults.options = o
+	})
+
+	loggers = new(sync.Map)
+	defaults.options = new(Options)
+	ModifyDefaults(opts...)
+
+	var (
+		cnt int
+		val interface{}
+	)
+	NewLogger("root").Build()
+	loggers.Range(func(k, v interface{}) bool {
+		cnt++
+		val = v
+		return true
+	})
+	if cnt != 1 {
+		t.Fatalf("NewLogger(...) instance(s) count mismatch: want: 1; have: %d", cnt)
+	}
+	want := val.(*logger)
+	have := NewLogger("root").Build()
+
+	diff := cmp.Diff(have, want, cmp.AllowUnexported(
+		logger{},
+		caller{},
+		formatter{},
+		fmtOptions{},
+		bytes.Buffer{},
+	))
+	if diff != "" {
+		t.Errorf("NewLogger(...) mismatch (-want +have):\n%s", diff)
+	}
+}
+
+func TestSetVerbosity(t *testing.T) {
+	l, o := loggers, defaults.options
+	t.Cleanup(func() {
+		loggers = l
+		defaults.pin = sync.Once{}
+		defaults.options = o
+	})
+
+	loggers = new(sync.Map)
+	defaults.options = new(Options)
+	ModifyDefaults(opts...)
+
+	NewLogger("root").Build()
+	NewLogger("root").WithName("child1").Build()
+	NewLogger("root").WithName("child1").WithValues("abc", 123).Build()
+
+	registered := make(map[string]*logger)
+	loggers.Range(func(k, v interface{}) bool {
+		registered[k.(string)] = v.(*logger)
+		return true
+	})
+
+	for _, verbosity := range allVerbosityLevels {
+		t.Run(fmt.Sprintf("to=%s/by logger", verbosity), func(t *testing.T) {
+			for _, logger := range registered {
+				if err := SetVerbosity(logger, verbosity); err != nil {
+					t.Errorf("SetVerbosity(...) unexpected error %v", err)
+				}
+
+				// On VerbosityAll, the maximum verbosity will
+				// be set instead (VerbosityDebug in our case).
+				if verbosity == VerbosityAll {
+					verbosity = VerbosityDebug
+				}
+
+				want, have := verbosity, registered[logger.id].verbosity.get()
+				if want != have {
+					t.Errorf("SetVerbosity(...) want verbosity: %q; have: %q", want, have)
+				}
+
+			}
+		})
+	}
+
+	for _, verbosity := range allVerbosityLevels {
+		t.Run(fmt.Sprintf("to=%s/by exp", verbosity), func(t *testing.T) {
+			if err := SetVerbosityByExp("^root", verbosity); err != nil {
+				t.Errorf("SetVerbosityByExp(...) unexpected error %v", err)
+			}
+
+			// On VerbosityAll, the maximum verbosity will
+			// be set instead (VerbosityDebug in our case).
+			if verbosity == VerbosityAll {
+				verbosity = VerbosityDebug
+			}
+
+			for _, logger := range registered {
+				want, have := verbosity, logger.verbosity.get()
+				if want != have {
+					t.Errorf("SetVerbosityByExp(...) want verbosity: %q; have: %q", want, have)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistryRange(t *testing.T) {
+	l, o := loggers, defaults.options
+	t.Cleanup(func() {
+		loggers = l
+		defaults.pin = sync.Once{}
+		defaults.options = o
+	})
+
+	loggers = new(sync.Map)
+	defaults.options = new(Options)
+	ModifyDefaults(opts...)
+
+	NewLogger("root").Build()
+	NewLogger("root").WithName("child1").Build()
+	NewLogger("root").WithName("child1").WithValues("abc", 123).Build()
+
+	registered := make(map[string]*logger)
+	loggers.Range(func(k, v interface{}) bool {
+		registered[k.(string)] = v.(*logger)
+		return true
+	})
+
+	var cnt int
+	RegistryIterate(func(id, path string, verbosity Level, v uint) (next bool) {
+		cnt++
+
+		have := registered[id]
+		if have.id != id {
+			t.Errorf("RegistryIterate(...) want id: %q; have: %q", id, have.id)
+		}
+		if have.namesStr != path {
+			t.Errorf("RegistryIterate(...) want namesStr: %q; have: %q", path, have.namesStr)
+		}
+		if have.verbosity.get() != verbosity {
+			t.Errorf("RegistryIterate(...) want verbosity: %q; have: %q", verbosity, have.verbosity)
+		}
+		if have.v != v {
+			t.Errorf("RegistryIterate(...) want: v %d; have: %d", v, have.v)
+		}
+		return true
+	})
+
+	if have, want := cnt, len(registered); have != want {
+		t.Fatalf("RegistryIterate(...) instance(s) count mismatch: want: %d; have: %d", want, have)
+	}
+}

--- a/pkg/log/registry_test.go
+++ b/pkg/log/registry_test.go
@@ -77,7 +77,7 @@ func TestNewLogger(t *testing.T) {
 		cnt int
 		val interface{}
 	)
-	NewLogger("root").Build()
+	NewLogger("root").Register()
 	loggers.Range(func(k, v interface{}) bool {
 		cnt++
 		val = v
@@ -87,7 +87,7 @@ func TestNewLogger(t *testing.T) {
 		t.Fatalf("NewLogger(...) instance(s) count mismatch: want: 1; have: %d", cnt)
 	}
 	want := val.(*logger)
-	have := NewLogger("root").Build()
+	have := NewLogger("root").Register()
 
 	diff := cmp.Diff(have, want, cmp.AllowUnexported(
 		logger{},
@@ -113,9 +113,9 @@ func TestSetVerbosity(t *testing.T) {
 	defaults.options = new(Options)
 	ModifyDefaults(opts...)
 
-	NewLogger("root").Build()
-	NewLogger("root").WithName("child1").Build()
-	NewLogger("root").WithName("child1").WithValues("abc", 123).Build()
+	NewLogger("root").Register()
+	NewLogger("root").WithName("child1").Register()
+	NewLogger("root").WithName("child1").WithValues("abc", 123).Register()
 
 	registered := make(map[string]*logger)
 	loggers.Range(func(k, v interface{}) bool {
@@ -179,9 +179,9 @@ func TestRegistryRange(t *testing.T) {
 	defaults.options = new(Options)
 	ModifyDefaults(opts...)
 
-	NewLogger("root").Build()
-	NewLogger("root").WithName("child1").Build()
-	NewLogger("root").WithName("child1").WithValues("abc", 123).Build()
+	NewLogger("root").Register()
+	NewLogger("root").WithName("child1").Register()
+	NewLogger("root").WithName("child1").WithValues("abc", 123).Register()
 
 	registered := make(map[string]*logger)
 	loggers.Range(func(k, v interface{}) bool {

--- a/pkg/log/registry_test.go
+++ b/pkg/log/registry_test.go
@@ -90,6 +90,7 @@ func TestNewLogger(t *testing.T) {
 	have := NewLogger("root").Register()
 
 	diff := cmp.Diff(have, want, cmp.AllowUnexported(
+		builder{},
 		logger{},
 		caller{},
 		formatter{},

--- a/pkg/logging/httpaccess/http_access.go
+++ b/pkg/logging/httpaccess/http_access.go
@@ -42,30 +42,30 @@ func NewHTTPAccessLogHandler(logger logging.Logger, level logrus.Level, tracer *
 			if err != nil {
 				ip = r.RemoteAddr
 			}
-			fields := logrus.Fields{
-				"ip":       ip,
-				"method":   r.Method,
-				"host":     r.Host,
-				"uri":      r.RequestURI,
-				"proto":    r.Proto,
-				"status":   status,
-				"size":     rl.size,
-				"duration": time.Since(startTime).Seconds(),
+			fields := []interface{}{
+				"ip", ip,
+				"method", r.Method,
+				"host", r.Host,
+				"uri", r.RequestURI,
+				"proto", r.Proto,
+				"status", status,
+				"size", rl.size,
+				"duration", time.Since(startTime).Seconds(),
 			}
 			if v := r.Referer(); v != "" {
-				fields["referrer"] = v
+				fields = append(fields, "referrer", v)
 			}
 			if v := r.UserAgent(); v != "" {
-				fields["user-agent"] = v
+				fields = append(fields, "user-agent", v)
 			}
 			if v := r.Header.Get("X-Forwarded-For"); v != "" {
-				fields["x-forwarded-for"] = v
+				fields = append(fields, "x-forwarded-for", v)
 			}
 			if v := r.Header.Get("X-Real-Ip"); v != "" {
-				fields["x-real-ip"] = v
+				fields = append(fields, "x-real-ip", v)
 			}
 
-			logger.WithFields(fields).Log(rl.level, message)
+			logger.WithValues(fields...).Log(rl.level, message)
 		})
 	}
 }

--- a/pkg/logging/metrics.go
+++ b/pkg/logging/metrics.go
@@ -5,9 +5,9 @@
 package logging
 
 import (
+	"github.com/ethersphere/bee/pkg/log"
 	m "github.com/ethersphere/bee/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 type metrics struct {
@@ -58,32 +58,22 @@ func newMetrics() metrics {
 	}
 }
 
-func (l *logger) Metrics() []prometheus.Collector {
-	return m.PrometheusCollectorsFromFields(l.metrics)
-}
-
-func (m metrics) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
-		logrus.TraceLevel,
-	}
-}
-
-func (m metrics) Fire(e *logrus.Entry) error {
-	switch e.Level {
-	case logrus.ErrorLevel:
+func (m metrics) Fire(v log.Level) error {
+	switch v {
+	case log.VerbosityError:
 		m.ErrorCount.Inc()
-	case logrus.WarnLevel:
+	case log.VerbosityWarning:
 		m.WarnCount.Inc()
-	case logrus.InfoLevel:
+	case log.VerbosityInfo:
 		m.InfoCount.Inc()
-	case logrus.DebugLevel:
+	case log.VerbosityDebug:
 		m.DebugCount.Inc()
-	case logrus.TraceLevel:
+	default:
 		m.TraceCount.Inc()
 	}
 	return nil
+}
+
+func (w *wrapper) Metrics() []prometheus.Collector {
+	return m.PrometheusCollectorsFromFields(w.metrics)
 }

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -47,7 +47,6 @@ import (
 	"github.com/ethersphere/bee/pkg/transaction"
 	"github.com/hashicorp/go-multierror"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -95,9 +94,8 @@ func bootstrapNode(
 	p2pCtx, p2pCancel := context.WithCancel(context.Background())
 
 	b := &Bee{
-		p2pCancel:      p2pCancel,
-		errorLogWriter: logger.WriterLevel(logrus.ErrorLevel),
-		tracerCloser:   tracerCloser,
+		p2pCancel:    p2pCancel,
+		tracerCloser: tracerCloser,
 	}
 
 	defer func() {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -25,8 +25,6 @@ import (
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/tracing"
-
-	"github.com/sirupsen/logrus"
 )
 
 type Op struct {
@@ -120,7 +118,7 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 		}
 	}()
 
-	ctxLogger := func() (context.Context, *logrus.Entry) {
+	ctxLogger := func() (context.Context, logging.Logger) {
 		mtx.Lock()
 		defer mtx.Unlock()
 		return ctx, logger
@@ -228,7 +226,7 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 	}
 }
 
-func (s *Service) pushChunk(ctx context.Context, ch swarm.Chunk, logger *logrus.Entry, directUpload bool) error {
+func (s *Service) pushChunk(ctx context.Context, ch swarm.Chunk, logger logging.Logger, directUpload bool) error {
 	defer s.inflight.delete(ch)
 	var wantSelf bool
 	// Later when we process receipt, get the receipt and process it

--- a/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
+++ b/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"io"
 	"math/big"
-
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -5,7 +5,9 @@
 package tracing_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"testing"
@@ -129,12 +131,20 @@ func TestStartSpanFromContext_logger(t *testing.T) {
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
-	span, logger, _ := tracer.StartSpanFromContext(context.Background(), "some-operation", logging.New(io.Discard, 0))
+	buf := new(bytes.Buffer)
+
+	span, logger, _ := tracer.StartSpanFromContext(context.Background(), "some-operation", logging.New(buf, 0))
 	defer span.Finish()
 
 	wantTraceID := span.Context().(jaeger.SpanContext).TraceID()
 
-	v, ok := logger.Data[tracing.LogField]
+	logger.Info(nil)
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	v, ok := data[tracing.LogField]
 	if !ok {
 		t.Fatalf("log field %q not found", tracing.LogField)
 	}
@@ -168,11 +178,19 @@ func TestNewLoggerWithTraceID(t *testing.T) {
 	span, _, ctx := tracer.StartSpanFromContext(context.Background(), "some-operation", nil)
 	defer span.Finish()
 
-	logger := tracing.NewLoggerWithTraceID(ctx, logging.New(io.Discard, 0))
+	buf := new(bytes.Buffer)
+
+	logger := tracing.NewLoggerWithTraceID(ctx, logging.New(buf, 0))
 
 	wantTraceID := span.Context().(jaeger.SpanContext).TraceID()
 
-	v, ok := logger.Data[tracing.LogField]
+	logger.Info(nil)
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	v, ok := data[tracing.LogField]
 	if !ok {
 		t.Fatalf("log field %q not found", tracing.LogField)
 	}

--- a/pkg/util/ioutil/ioutil.go
+++ b/pkg/util/ioutil/ioutil.go
@@ -68,3 +68,14 @@ func TimeoutReader(ctx context.Context, r io.Reader, timeout time.Duration, canc
 
 	return pr
 }
+
+// The WriterFunc type is an adapter to allow the use of
+// ordinary functions as io.Writer Write method. If f is
+// a function with the appropriate signature, WriterFunc(f)
+// is an io.Writer that calls f.
+type WriterFunc func([]byte) (int, error)
+
+// WriterFunc calls f(p).
+func (f WriterFunc) Write(p []byte) (n int, err error) {
+	return f(p)
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [x] I have added tests to cover my changes.

### Description
This new logger borrows some of the ideas described here: https://github.com/go-logr/logr#background
with the exception of excluding warning and debug log levels, for compatibility reasons. In addition, it adds V levels to the debug log level, so that messages with larger V levels can be logged if needed. The status of loggers can be queried via the HTTP endpoint, and verbosity can also be set for single or multiple loggers (based on regex matching) via the HTTP endpoint at runtime.

#### Motivation and context (Optional)
During debugging sessions, it is often necessary to reduce or increase/decrease the range of log messages for individual packages (or groups) in order to efficiently focus on the relevant log messages. It is also very important to have this ability to turn on/off/change the verbosity of the logs at runtime without restarting individual nodes. Finally, log messages that have structure (structural logging) are a crucial component in parsing logs efficiently and in automated log processing.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2975)
<!-- Reviewable:end -->
