### PR TITLE
fix: replace PAT with GITHUB_TOKEN for ghcr.io login

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -53,7 +53,7 @@ jobs:
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare local cluster
         run: |
-          printf ${{ secrets.CR_PAT }} | docker login ghcr.io -u bee-worker --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -174,7 +174,7 @@ jobs:
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare testing cluster (Node connection and clef enabled)
         run: |
-          printf ${{ secrets.CR_PAT }} | docker login ghcr.io -u bee-worker --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -260,7 +260,7 @@ jobs:
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve_gc.patch
       - name: Prepare testing cluster (storage incentives setup)
         run: |
-          printf ${{ secrets.CR_PAT }} | docker login ghcr.io -u bee-worker --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -331,7 +331,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
       - name: Build image
         run: |
-          printf ${{ secrets.CR_PAT }} | docker login ghcr.io -u bee-worker --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           timeout ${TIMEOUT} make beelocal ACTION=build OPTS='ci skip-vet skip-push'
       - name: Retag Docker image and push for cache
         if: success()

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -53,7 +53,7 @@ jobs:
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare local cluster
         run: |
-          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $ --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -174,7 +174,7 @@ jobs:
           patch pkg/postage/service.go .github/patches/postageservice.patch
       - name: Prepare testing cluster (Node connection and clef enabled)
         run: |
-          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $ --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -260,7 +260,7 @@ jobs:
           patch pkg/postage/batchstore/reserve.go .github/patches/postagereserve_gc.patch
       - name: Prepare testing cluster (storage incentives setup)
         run: |
-          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $ --password-stdin
           timeout ${TIMEOUT} make beekeeper BEEKEEPER_INSTALL_DIR=/usr/local/bin BEEKEEPER_USE_SUDO=true
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet'
       - name: Set kube config
@@ -331,7 +331,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
       - name: Build image
         run: |
-          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $ --password-stdin
           timeout ${TIMEOUT} make beelocal ACTION=build OPTS='ci skip-vet skip-push'
       - name: Retag Docker image and push for cache
         if: success()


### PR DESCRIPTION
It's no longer needed to use PAT (personal access token) to push to github's container registry. Using GITHUB_TOKEN it's much more secure because it allows access only for current pipeline run.

### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
GIthub has changed the way how to authenticate to their container registry that we use as image cache

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/2987)
<!-- Reviewable:end -->
