### PR TITLE
fix: check for SOC while doing traversal operations

### DIFF
--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/loadsave"
 	"github.com/ethersphere/bee/pkg/manifest"
 	"github.com/ethersphere/bee/pkg/manifest/mantaray"
+	"github.com/ethersphere/bee/pkg/soc"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -54,6 +55,15 @@ func (s *service) Traverse(ctx context.Context, addr swarm.Address, iterFn swarm
 			return fmt.Errorf("traversal: iterate chunk address error for %q: %w", ref, err)
 		}
 		return nil
+	}
+
+	ch, err := s.store.Get(ctx, storage.ModeGetRequest, addr)
+	if err != nil {
+		return fmt.Errorf("traversal: failed to get root chunk %s: %w", addr.String(), err)
+	}
+	if soc.Valid(ch) {
+		// if this is a SOC, the traversal will be just be the single chunk
+		return iterFn(addr)
 	}
 
 	ls := loadsave.NewReadonly(s.store)


### PR DESCRIPTION
Fixes #2999 

Ideally, joiner and other file-related operations don't need to know about SOC. But the problem is we might call Traversal from the API layer with all kinds of chunks. We expect traversal to traverse any and all kinds. I feel this safeguard in Joiner would be the easiest way to understand and also prevent this type of use of Joiner in future.

The problem is when the problem occurs, we will see `storage: not found` errors which are false positives and we might end up wasting effort looking at all sorts of things, like I did here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3006)
<!-- Reviewable:end -->
