### PR TITLE
fix: call reacher close

### DIFF
--- a/pkg/p2p/libp2p/internal/reacher/reacher_test.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher_test.go
@@ -63,7 +63,7 @@ func TestPingSuccess(t *testing.T) {
 
 			mock := newMock(tc.pingFunc, tc.reachableFunc)
 
-			r := reacher.New(mock, mock, &defaultOptions)
+			r := reacher.New(context.Background(), mock, mock, &defaultOptions)
 			defer r.Close()
 
 			overlay := test.RandomAddress()
@@ -108,7 +108,7 @@ func TestDisconnected(t *testing.T) {
 
 	mock := newMock(pingFunc, reachableFunc)
 
-	r := reacher.New(mock, mock, &defaultOptions)
+	r := reacher.New(context.Background(), mock, mock, &defaultOptions)
 	defer r.Close()
 
 	r.Connected(test.RandomAddress(), nil)

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -486,7 +486,7 @@ func (s *Service) handleIncoming(stream network.Stream) {
 
 func (s *Service) SetPickyNotifier(n p2p.PickyNotifier) {
 	s.handshakeService.SetPicker(n)
-	s.reacher = reacher.New(s, n, nil)
+	s.reacher = reacher.New(s.ctx, s, n, nil)
 	s.notifier = n
 }
 
@@ -909,6 +909,9 @@ func (s *Service) Close() error {
 		return err
 	}
 	if err := s.pingDialer.Close(); err != nil {
+		return err
+	}
+	if err := s.reacher.Close(); err != nil {
 		return err
 	}
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -911,8 +911,10 @@ func (s *Service) Close() error {
 	if err := s.pingDialer.Close(); err != nil {
 		return err
 	}
-	if err := s.reacher.Close(); err != nil {
-		return err
+	if s.reacher != nil {
+		if err := s.reacher.Close(); err != nil {
+			return err
+		}
 	}
 
 	return s.host.Close()

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -119,6 +119,7 @@ type ReachableNotifier interface {
 type Reacher interface {
 	Connected(swarm.Address, ma.Multiaddr)
 	Disconnected(swarm.Address)
+	Close() error
 }
 
 type ReachabilityUpdater interface {


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
off the back of the infamous #2902 it seems that upon shutdown a bunch of `reacher` go routines are left hanging so added the call to `reacher` Close to the chain; also added check for context on peer iteration in `ping`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3014)
<!-- Reviewable:end -->
