### PR TITLE
fix(transaction): use legacy tx for cancel operations

### DIFF
--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -412,7 +412,7 @@ func (t *transactionService) CancelTransaction(ctx context.Context, originalTxHa
 		return common.Hash{}, ErrGasPriceTooLow
 	}
 
-	signedTx, err := t.signer.SignTx(types.NewTx(&types.AccessListTx{
+	signedTx, err := t.signer.SignTx(types.NewTx(&types.LegacyTx{
 		Nonce:    storedTransaction.Nonce,
 		To:       &t.sender,
 		Value:    big.NewInt(0),

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -33,6 +33,9 @@ func nonceKey(sender common.Address) string {
 func signerMockForTransaction(signedTx *types.Transaction, sender common.Address, signerChainID *big.Int, t *testing.T) crypto.Signer {
 	return signermock.New(
 		signermock.WithSignTxFunc(func(transaction *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+			if transaction.Type() != 0 {
+				t.Fatalf("wrong transaction type. wanted 0, got %d", transaction.Type())
+			}
 			if signedTx.To() == nil {
 				if transaction.To() != nil {
 					t.Fatalf("signing transaction with recipient. wanted nil, got %x", transaction.To())


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [X] I have added tests to cover my changes.

### Description
<!--Please include a summary of the change and which issue is fixed. -->

Use legacy tx instead of access control tx which does not work with the configured signer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3018)
<!-- Reviewable:end -->
