### PR TITLE
fix(api, feeds): async feed get observes ctx, increase stream timeout

### DIFF
--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	writeDeadline   = 4 * time.Second // write deadline. should be smaller than the shutdown timeout on api close
-	readDeadline    = 4 * time.Second // read deadline. should be smaller than the shutdown timeout on api close
 	targetMaxLength = 3               // max target length in bytes, in order to prevent grieving by excess computation
 )
 

--- a/pkg/feeds/epochs/finder.go
+++ b/pkg/feeds/epochs/finder.go
@@ -197,7 +197,10 @@ LOOP:
 			case <-wgDone:
 				return nil, ctx.Err()
 			}
-		case r := <-c:
+		case r, more := <-c:
+			if !more {
+				return nil, nil
+			}
 			p := r.path
 			// ignore result from paths already  cancelled
 			select {
@@ -240,5 +243,4 @@ LOOP:
 			}
 		}
 	}
-	return nil, nil
 }


### PR DESCRIPTION
A couple of issues I found while working on my hackathon project. Not sure if I should open separate PRs for these.

- Fix `/chunks/stream` endpoint to use background context and not the HTTP request context. The websocket handler is being tracked by the api server wait group, but right now it uses the HTTP Request context. So if we dont get a message soon enough, the read loop terminates. Also to allow clients time to send and hold on to the connection for longer, we will also need to increase the read timeout.

- The async finder for epoch-based feed lookup doesn't observe context. Given that it accepts a context, it should observe the cancellation and stop all operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3033)
<!-- Reviewable:end -->
