### PR TITLE
fix: pushsync perpetual loop when all peers are unavailable

### DIFF
--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -701,12 +701,28 @@ func TestPeerSkipList(t *testing.T) {
 		t.Fatal("peer should be skipped")
 	}
 
+	want := 3
+	skipList.SetSaturated(addr1, want)
+	have := skipList.Saturated(addr1)
+	if want != have {
+		t.Errorf("set/get saturated: want: %d; have: %d", want, have)
+	}
+
 	time.Sleep(time.Millisecond * 11)
 
 	skipList.PruneExpired()
-
 	if len(skipList.ChunkSkipPeers(addr1)) != 0 {
 		t.Fatal("entry should be pruned")
+	}
+
+	skipList.Add(addr1, addr2, time.Minute)
+	skipList.FlushExpirations(addr1)
+	skipList.SetSaturated(addr1, 3)
+	if len(skipList.ChunkSkipPeers(addr1)) != 0 {
+		t.Errorf("entry should be pruned")
+	}
+	if have, want := skipList.Saturated(addr1), 3; have != want {
+		t.Errorf("set/get saturated: want: %d; have: %d", want, have)
 	}
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
This PR fixes the perpetual pushsync loop when all peers are unavailable, in which case it will attempt to contact the peers a predefined number of times with a predefined wait time between attempts and terminate when it fails.

#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
Closes #2946 

### Screenshots (if appropriate):

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3036)
<!-- Reviewable:end -->
