### PR TITLE
fix(api): streaming chunk upload for long running connections

### DIFF
--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	writeDeadline   = 4 * time.Second // write deadline. should be smaller than the shutdown timeout on api close
-	readDeadline    = 4 * time.Second // read deadline. should be smaller than the shutdown timeout on api close
 	targetMaxLength = 3               // max target length in bytes, in order to prevent grieving by excess computation
 )
 


### PR DESCRIPTION
Currently, the `/chunks/stream` endpoint uses the HTTP request context which expires once the API returns. However, the websocket connection is expected to be alive for a longer time. This change allows clients to maintain long-running connections to upload a stream of chunks. The websocket connection is tracked using the `wsWg` in the api handler, so by passing a background context we allow the server read loop to be alive till the client closes the connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3047)
<!-- Reviewable:end -->
