### PR TITLE
chore: downgrade mingw-w64 version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,11 @@ jobs:
           ${{ runner.OS }}-build-${{ env.cache-name }}-
           ${{ runner.OS }}-build-
           ${{ runner.OS }}-
+    - name: Setup MinGW-w64
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco uninstall mingw
+        choco install mingw --version 8.1.0
     - name: Build
       run: make build
     - name: Lint


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.

### Description
Mingw version is downgraded to 8.1.0

#### Motivation and context (Optional)
We had issue in build process with [Test with race detector](https://beehive.ethswarm.org/swarm/pl/x7dcc5jtq3rndnmoupy4jj91oy) due to newer mingw version in github runner.
