### PR TITLE
fix: retry when overdraft peer might be closest

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -358,11 +358,12 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 
-	nextPeer := func() (swarm.Address, bool, error) {
+	// nextPeer attempts to lookup the next peer to push the chunk to, if there are overdrafted peers the boolean would signal a re-attempt
+	nextPeer := func() (peer swarm.Address, retry bool, err error) {
 
 		fullSkipList := append(ps.skipList.ChunkSkipPeers(ch.Address()), skipPeers.All()...)
 
-		peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), includeSelf, topology.Filter{Reachable: true}, fullSkipList...)
+		peer, err = ps.topologyDriver.ClosestPeer(ch.Address(), includeSelf, topology.Filter{Reachable: true}, fullSkipList...)
 		if err != nil {
 			// ClosestPeer can return ErrNotFound in case we are not connected to any peers
 			// in which case we should return immediately.

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -377,14 +377,14 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 					return swarm.ZeroAddress, ErrOutOfDepthStoring
 				}
 
-				if skipPeers.OverdraftListEmpty() {
+				if skipPeers.OverdraftListEmpty() { // no peers in skip list means we can be confident that we are the closest peer
 					ps.pushToNeighbourhood(ctx, fullSkipList, ch, origin, originAddr)
 					return swarm.ZeroAddress, err
 				}
 
 				ps.logger.Debug("pushsync: continue iteration and reset overdraft skiplist")
 
-				skipPeers.ResetOverdraft()
+				skipPeers.ResetOverdraft() // reset the overdraft list and retry (in case the closest peer was there)
 				return swarm.ZeroAddress, errContinue
 			}
 

--- a/pkg/skippeers/skip_peers.go
+++ b/pkg/skippeers/skip_peers.go
@@ -20,7 +20,7 @@ func (s *List) All() []swarm.Address {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return append(append(s.addresses[:0:0], s.addresses...), s.overdraftAddresses...)
+	return append(s.addresses, s.overdraftAddresses...)
 }
 
 func (s *List) ResetOverdraft() {

--- a/pkg/skippeers/skip_peers.go
+++ b/pkg/skippeers/skip_peers.go
@@ -11,9 +11,9 @@ import (
 )
 
 type List struct {
+	mu                 sync.Mutex
 	overdraftAddresses []swarm.Address
 	addresses          []swarm.Address
-	mu                 sync.Mutex
 }
 
 func (s *List) All() []swarm.Address {
@@ -67,5 +67,5 @@ func (s *List) AddOverdraft(address swarm.Address) {
 func (s *List) OverdraftListEmpty() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.overdraftAddresses) <= 0
+	return len(s.overdraftAddresses) == 0
 }

--- a/pkg/skippeers/skip_peers.go
+++ b/pkg/skippeers/skip_peers.go
@@ -20,7 +20,11 @@ func (s *List) All() []swarm.Address {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return append(s.addresses, s.overdraftAddresses...)
+	all := make([]swarm.Address, 0, len(s.addresses)+len(s.overdraftAddresses))
+	all = append(all, s.addresses...)
+	all = append(all, s.overdraftAddresses...)
+
+	return all
 }
 
 func (s *List) ResetOverdraft() {

--- a/pkg/skippeers/skip_peers.go
+++ b/pkg/skippeers/skip_peers.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package retrieval
+package skippeers
 
 import (
 	"sync"
@@ -10,30 +10,26 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-type skipPeers struct {
+type List struct {
 	overdraftAddresses []swarm.Address
 	addresses          []swarm.Address
 	mu                 sync.Mutex
 }
 
-func newSkipPeers() *skipPeers {
-	return &skipPeers{}
-}
-
-func (s *skipPeers) All() []swarm.Address {
+func (s *List) All() []swarm.Address {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	return append(append(s.addresses[:0:0], s.addresses...), s.overdraftAddresses...)
 }
 
-func (s *skipPeers) Reset() {
+func (s *List) ResetOverdraft() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.overdraftAddresses = []swarm.Address{}
+	s.overdraftAddresses = nil
 }
 
-func (s *skipPeers) Add(address swarm.Address) {
+func (s *List) Add(address swarm.Address) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -46,7 +42,7 @@ func (s *skipPeers) Add(address swarm.Address) {
 	s.addresses = append(s.addresses, address)
 }
 
-func (s *skipPeers) AddOverdraft(address swarm.Address) {
+func (s *List) AddOverdraft(address swarm.Address) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -56,12 +52,19 @@ func (s *skipPeers) AddOverdraft(address swarm.Address) {
 		}
 	}
 
+	for i, a := range s.addresses {
+		if a.Equal(address) {
+			s.addresses = append(s.addresses[:i], s.addresses[i+1:]...)
+			break
+		}
+	}
+
 	s.overdraftAddresses = append(s.overdraftAddresses, address)
 }
 
-// Saturated function returns whether all skipped entries a permanently skipped for this skiplist
+// OverdraftListEmpty function returns whether all skipped entries a permanently skipped for this skiplist
 // Temporary entries are stored in the overdraftAddresses slice of the skiplist, so if that is empty, the function returns true
-func (s *skipPeers) Saturated() bool {
+func (s *List) OverdraftListEmpty() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.overdraftAddresses) <= 0

--- a/pkg/skippeers/skip_peers_test.go
+++ b/pkg/skippeers/skip_peers_test.go
@@ -37,4 +37,10 @@ func TestAddOverdraft(t *testing.T) {
 	if len(sp.All()) != 2 {
 		t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
 	}
+
+	sp.ResetOverdraft()
+
+	if !sp.OverdraftListEmpty() {
+		t.Errorf("expected empty list, got %s", sp.All())
+	}
 }

--- a/pkg/skippeers/skip_peers_test.go
+++ b/pkg/skippeers/skip_peers_test.go
@@ -20,25 +20,21 @@ func TestAddOverdraft(t *testing.T) {
 	sp := new(skippeers.List)
 	sp.Add(p1)
 
-	t.Run("duplicate entries are ignored", func(t *testing.T) {
-		sp.Add(p1)
-		if len(sp.All()) != 1 {
-			t.Errorf("expected len: %d, got %d", 1, len(sp.All()))
-		}
-	})
+	// duplicate entries are ignored
+	sp.Add(p1)
+	if len(sp.All()) != 1 {
+		t.Errorf("expected len: %d, got %d", 1, len(sp.All()))
+	}
 
-	t.Run("add peer", func(t *testing.T) {
-		sp.Add(p2)
-		if len(sp.All()) != 2 {
-			t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
-		}
-	})
+	// add peer
+	sp.Add(p2)
+	if len(sp.All()) != 2 {
+		t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
+	}
 
-	t.Run("add overdraft removes from addresses", func(t *testing.T) {
-		sp.AddOverdraft(p2)
-
-		if len(sp.All()) != 2 {
-			t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
-		}
-	})
+	// add overdraft removes from addresses
+	sp.AddOverdraft(p2)
+	if len(sp.All()) != 2 {
+		t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
+	}
 }

--- a/pkg/skippeers/skip_peers_test.go
+++ b/pkg/skippeers/skip_peers_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package skippeers_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/skippeers"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func TestAddOverdraft(t *testing.T) {
+	var (
+		p1 = swarm.NewAddress([]byte("0xab"))
+		p2 = swarm.NewAddress([]byte("0xbc"))
+	)
+
+	sp := new(skippeers.List)
+	sp.Add(p1)
+
+	t.Run("duplicate entries are ignored", func(t *testing.T) {
+		sp.Add(p1)
+		if len(sp.All()) != 1 {
+			t.Errorf("expected len: %d, got %d", 1, len(sp.All()))
+		}
+	})
+
+	t.Run("add peer", func(t *testing.T) {
+		sp.Add(p2)
+		if len(sp.All()) != 2 {
+			t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
+		}
+	})
+
+	t.Run("add overdraft removes from addresses", func(t *testing.T) {
+		sp.AddOverdraft(p2)
+
+		if len(sp.All()) != 2 {
+			t.Errorf("expected len: %d, got %d", 2, len(sp.All()))
+		}
+	})
+}


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
[Push Sync closestPeer overdraft case](https://hackmd.io/oZTAHIZjRdm6PUcimWY20Q)

Closes: #3048 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3052)
<!-- Reviewable:end -->
