### PR TITLE
fix: open listener after syncing is done

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -130,8 +130,7 @@ type Service struct {
 	Options
 
 	http.Handler
-	handlerMu sync.RWMutex
-	router    *mux.Router
+	router *mux.Router
 
 	metrics metrics
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -28,9 +28,6 @@ const (
 )
 
 func (s *Service) MountTechnicalDebug() {
-	s.handlerMu.Lock()
-	defer s.handlerMu.Unlock()
-
 	router := mux.NewRouter()
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
 	s.router = router
@@ -47,9 +44,6 @@ func (s *Service) MountTechnicalDebug() {
 }
 
 func (s *Service) MountDebug(restricted bool) {
-	s.handlerMu.Lock()
-	defer s.handlerMu.Unlock()
-
 	s.mountBusinessDebug(restricted)
 
 	s.Handler = web.ChainHandlers(
@@ -62,9 +56,6 @@ func (s *Service) MountDebug(restricted bool) {
 }
 
 func (s *Service) MountAPI() {
-	s.handlerMu.Lock()
-	defer s.handlerMu.Unlock()
-
 	if s.router == nil {
 		s.router = mux.NewRouter()
 		s.router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -344,11 +344,6 @@ func NewBee(interrupt chan os.Signal, addr string, publicKey *ecdsa.PublicKey, s
 		b.debugAPIServer = debugAPIServer
 	}
 
-	apiListener, err := net.Listen("tcp", o.APIAddr)
-	if err != nil {
-		return nil, fmt.Errorf("api listener: %w", err)
-	}
-
 	var apiService *api.Service
 
 	if o.Restricted {
@@ -360,6 +355,11 @@ func NewBee(interrupt chan os.Signal, addr string, publicKey *ecdsa.PublicKey, s
 			ReadHeaderTimeout: 3 * time.Second,
 			Handler:           apiService,
 			ErrorLog:          log.New(b.errorLogWriter, "", 0),
+		}
+
+		apiListener, err := net.Listen("tcp", o.APIAddr)
+		if err != nil {
+			return nil, fmt.Errorf("api listener: %w", err)
 		}
 
 		go func() {
@@ -919,6 +919,12 @@ func NewBee(interrupt chan os.Signal, addr string, publicKey *ecdsa.PublicKey, s
 				Handler:           apiService,
 				ErrorLog:          log.New(b.errorLogWriter, "", 0),
 			}
+
+			apiListener, err := net.Listen("tcp", o.APIAddr)
+			if err != nil {
+				return nil, fmt.Errorf("api listener: %w", err)
+			}
+
 			go func() {
 				logger.Infof("api address: %s", apiListener.Addr())
 				if err := apiServer.Serve(apiListener); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
After merging the APIs we open the listener before the postage syncing begins, this PR makes the listener to start only once the syncing is done.

Closes: #3060 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3065)
<!-- Reviewable:end -->
