### PR TITLE
fix: use swap endpoint as chainless mode flag

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -60,7 +60,6 @@ const (
 	optionNameSwapInitialDeposit         = "swap-initial-deposit"
 	optionNameSwapEnable                 = "swap-enable"
 	optionNameChequebookEnable           = "chequebook-enable"
-	optionNameChainEnable                = "chain-enable"
 	optionNameTransactionHash            = "transaction"
 	optionNameBlockHash                  = "block-hash"
 	optionNameSwapDeploymentGasPrice     = "swap-deployment-gas-price"
@@ -251,13 +250,12 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
 	cmd.Flags().String(optionNameClefSignerEthereumAddress, "", "ethereum address to use from clef signer")
-	cmd.Flags().String(optionNameSwapEndpoint, "ws://localhost:8546", "swap ethereum blockchain endpoint")
+	cmd.Flags().String(optionNameSwapEndpoint, "", "swap ethereum blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory addresses")
 	cmd.Flags().StringSlice(optionNameSwapLegacyFactoryAddresses, nil, "legacy swap factory addresses")
 	cmd.Flags().String(optionNameSwapInitialDeposit, "10000000000000000", "initial deposit if deploying a new chequebook")
 	cmd.Flags().Bool(optionNameSwapEnable, true, "enable swap")
 	cmd.Flags().Bool(optionNameChequebookEnable, true, "enable chequebook")
-	cmd.Flags().Bool(optionNameChainEnable, true, "use a blockchain backend")
 	cmd.Flags().Bool(optionNameFullNode, false, "cause the node to start in full mode")
 	cmd.Flags().String(optionNamePostageContractAddress, "", "postage stamp contract address")
 	cmd.Flags().String(optionNamePriceOracleAddress, "", "price oracle contract address")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -186,7 +186,6 @@ func (c *command) initStartCmd() (err error) {
 				SwapInitialDeposit:         c.config.GetString(optionNameSwapInitialDeposit),
 				SwapEnable:                 c.config.GetBool(optionNameSwapEnable),
 				ChequebookEnable:           c.config.GetBool(optionNameChequebookEnable),
-				ChainEnable:                c.config.GetBool(optionNameChainEnable),
 				FullNodeMode:               fullNode,
 				Transaction:                c.config.GetString(optionNameTransactionHash),
 				BlockHash:                  c.config.GetString(optionNameBlockHash),

--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -60,8 +60,6 @@ password-file: /var/lib/bee/password
 # postage-stamp-address: ""
 ## ENS compatible API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url
 # resolver-options: []
-## use a blockchain backend (default true)
-# chain-enable: true
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "ws://localhost:8546")

--- a/packaging/homebrew-amd64/bee.yaml
+++ b/packaging/homebrew-amd64/bee.yaml
@@ -60,8 +60,6 @@ password-file: /usr/local/var/lib/swarm-bee/password
 # postage-stamp-address: ""
 ## ENS compatible API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url
 # resolver-options: []
-## use a blockchain backend (default true)
-# chain-enable: true
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "ws://localhost:8546")

--- a/packaging/homebrew-arm64/bee.yaml
+++ b/packaging/homebrew-arm64/bee.yaml
@@ -60,8 +60,6 @@ password-file: /opt/homebrew/var/lib/swarm-bee/password
 # postage-stamp-address: ""
 ## ENS compatible API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url
 # resolver-options: []
-## use a blockchain backend (default true)
-# chain-enable: true
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "ws://localhost:8546")

--- a/packaging/scoop/bee.yaml
+++ b/packaging/scoop/bee.yaml
@@ -50,8 +50,6 @@ password-file: ./password
 # postage-stamp-address: ""
 ## ENS compatible API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url
 # resolver-options: []
-## use a blockchain backend (default true)
-# chain-enable: true
 ## enable swap (default true)
 # swap-enable: true
 ## swap ethereum blockchain endpoint (default "ws://localhost:8546")

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -386,7 +386,7 @@ func (m noOpChainBackend) CodeAt(context.Context, common.Address, *big.Int) ([]b
 	return common.FromHex(sw3abi.SimpleSwapFactoryDeployedBinv0_4_0), nil
 }
 func (m noOpChainBackend) CallContract(context.Context, ethereum.CallMsg, *big.Int) ([]byte, error) {
-	panic("chain no op: CallContract")
+	return nil, errors.New("disabled chain backend")
 }
 func (m noOpChainBackend) HeaderByNumber(context.Context, *big.Int) (*types.Header, error) {
 	h := new(types.Header)


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] Documentation updated

### Description
Decommissions the `chain-enable` flag in favor of checking if `swap-endpoint` is provided.

Closes: #3062

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3066)
<!-- Reviewable:end -->
