### PR TITLE
fix: error instead of panic

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -417,7 +417,7 @@ func (m noOpChainBackend) BlockNumber(context.Context) (uint64, error) {
 	return 4, nil
 }
 func (m noOpChainBackend) BalanceAt(context.Context, common.Address, *big.Int) (*big.Int, error) {
-	panic("chain no op: BalanceAt")
+	return nil, postagecontract.ErrChainDisabled
 }
 func (m noOpChainBackend) NonceAt(context.Context, common.Address, *big.Int) (uint64, error) {
 	panic("chain no op: NonceAt")

--- a/pkg/postage/noop.go
+++ b/pkg/postage/noop.go
@@ -4,14 +4,19 @@
 
 package postage
 
-import "math/big"
+import (
+	"errors"
+	"math/big"
+)
 
 var _ Storer = (*NoOpBatchStore)(nil)
+
+var ErrChainDisabled = errors.New("chain disabled")
 
 // NoOpBatchStore is a placeholder implementation for postage.Storer
 type NoOpBatchStore struct{}
 
-func (b *NoOpBatchStore) Get([]byte) (*Batch, error) { return nil, nil }
+func (b *NoOpBatchStore) Get([]byte) (*Batch, error) { return nil, ErrChainDisabled }
 
 func (b *NoOpBatchStore) Exists([]byte) (bool, error) { return false, nil }
 


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
There's a case when a `noOp` method is being called and that crashes the process.

Closes: #3082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3093)
<!-- Reviewable:end -->
