### PR TITLE
fix: remove defaults for swap endpint

### DIFF
--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -62,8 +62,8 @@ password-file: /var/lib/bee/password
 # resolver-options: []
 ## enable swap (default true)
 # swap-enable: true
-## swap ethereum blockchain endpoint (default "ws://localhost:8546")
-# swap-endpoint: ws://localhost:8546
+## swap ethereum blockchain endpoint (default "")
+# swap-endpoint: ""
 ## swap factory address
 # swap-factory-address: ""
 ## legacy swap factory addresses

--- a/packaging/homebrew-amd64/bee.yaml
+++ b/packaging/homebrew-amd64/bee.yaml
@@ -62,8 +62,8 @@ password-file: /usr/local/var/lib/swarm-bee/password
 # resolver-options: []
 ## enable swap (default true)
 # swap-enable: true
-## swap ethereum blockchain endpoint (default "ws://localhost:8546")
-# swap-endpoint: ws://localhost:8546
+## swap ethereum blockchain endpoint (default "")
+# swap-endpoint: ""
 ## swap factory address
 # swap-factory-address: ""
 ## legacy swap factory addresses

--- a/packaging/homebrew-arm64/bee.yaml
+++ b/packaging/homebrew-arm64/bee.yaml
@@ -62,8 +62,8 @@ password-file: /opt/homebrew/var/lib/swarm-bee/password
 # resolver-options: []
 ## enable swap (default true)
 # swap-enable: true
-## swap ethereum blockchain endpoint (default "ws://localhost:8546")
-# swap-endpoint: ws://localhost:8546
+## swap ethereum blockchain endpoint (default "")
+# swap-endpoint: ""
 ## swap factory address
 # swap-factory-address: ""
 ## legacy swap factory addresses

--- a/packaging/scoop/bee.yaml
+++ b/packaging/scoop/bee.yaml
@@ -52,8 +52,8 @@ password-file: ./password
 # resolver-options: []
 ## enable swap (default true)
 # swap-enable: true
-## swap ethereum blockchain endpoint (default "ws://localhost:8546")
-# swap-endpoint: ws://localhost:8546
+## swap ethereum blockchain endpoint (default "")
+# swap-endpoint: ""
 ## swap factory address
 # swap-factory-address: ""
 ## legacy swap factory addresses


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
Currently we are using the empty value for the `swap-endpoint` to indicate that we want to start in "chainless" mode.

For this we need to not have any defaults, this PR removes them from the packaging files.