### PR TITLE
fix: gofmt replace interface with any

### DIFF
--- a/cmd/bee/cmd/start_unix.go
+++ b/cmd/bee/cmd/start_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package cmd
 

--- a/cmd/bee/cmd/start_windows.go
+++ b/cmd/bee/cmd/start_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package cmd
@@ -41,47 +42,47 @@ type windowsEventLogger struct {
 	winlog debug.Log
 }
 
-func (l *windowsEventLogger) Tracef(format string, args ...interface{}) {
+func (l *windowsEventLogger) Tracef(format string, args ...any) {
 	// ignore
 }
 
-func (l *windowsEventLogger) Trace(args ...interface{}) {
+func (l *windowsEventLogger) Trace(args ...any) {
 	// ignore
 }
 
-func (l *windowsEventLogger) Debugf(format string, args ...interface{}) {
+func (l *windowsEventLogger) Debugf(format string, args ...any) {
 	// ignore
 }
 
-func (l *windowsEventLogger) Debug(args ...interface{}) {
+func (l *windowsEventLogger) Debug(args ...any) {
 	// ignore
 }
 
-func (l *windowsEventLogger) Infof(format string, args ...interface{}) {
+func (l *windowsEventLogger) Infof(format string, args ...any) {
 	_ = l.winlog.Info(1633, fmt.Sprintf(format, args...))
 }
 
-func (l *windowsEventLogger) Info(args ...interface{}) {
+func (l *windowsEventLogger) Info(args ...any) {
 	_ = l.winlog.Info(1633, fmt.Sprint(args...))
 }
 
-func (l *windowsEventLogger) Warningf(format string, args ...interface{}) {
+func (l *windowsEventLogger) Warningf(format string, args ...any) {
 	_ = l.winlog.Warning(1633, fmt.Sprintf(format, args...))
 }
 
-func (l *windowsEventLogger) Warning(args ...interface{}) {
+func (l *windowsEventLogger) Warning(args ...any) {
 	_ = l.winlog.Warning(1633, fmt.Sprint(args...))
 }
 
-func (l *windowsEventLogger) Errorf(format string, args ...interface{}) {
+func (l *windowsEventLogger) Errorf(format string, args ...any) {
 	_ = l.winlog.Error(1633, fmt.Sprintf(format, args...))
 }
 
-func (l *windowsEventLogger) Error(args ...interface{}) {
+func (l *windowsEventLogger) Error(args ...any) {
 	_ = l.winlog.Error(1633, fmt.Sprint(args...))
 }
 
-func (l *windowsEventLogger) WithField(key string, value interface{}) *logrus.Entry {
+func (l *windowsEventLogger) WithField(key string, value any) *logrus.Entry {
 	return l.logger.WithField(key, value)
 }
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -663,7 +663,7 @@ func TestPostageAccessHandler(t *testing.T) {
 		method   string
 		url      string
 		respCode int
-		resp     interface{}
+		resp     any
 	}
 
 	success := []operation{

--- a/pkg/crypto/clef/clef.go
+++ b/pkg/crypto/clef/clef.go
@@ -36,7 +36,7 @@ type ExternalSignerInterface interface {
 
 // Client is the interface for rpc.RpcClient.
 type Client interface {
-	Call(result interface{}, method string, args ...interface{}) error
+	Call(result any, method string, args ...any) error
 }
 
 type clefSigner struct {

--- a/pkg/crypto/clef/clef_test.go
+++ b/pkg/crypto/clef/clef_test.go
@@ -196,10 +196,10 @@ func TestClefNoAccounts(t *testing.T) {
 }
 
 type mockRpc struct {
-	call func(result interface{}, method string, args ...interface{}) error
+	call func(result any, method string, args ...any) error
 }
 
-func (m *mockRpc) Call(result interface{}, method string, args ...interface{}) error {
+func (m *mockRpc) Call(result any, method string, args ...any) error {
 	return m.call(result, method, args...)
 }
 
@@ -225,7 +225,7 @@ func TestClefTypedData(t *testing.T) {
 		},
 		signature: make([]byte, 65),
 	}, &mockRpc{
-		call: func(result interface{}, method string, args ...interface{}) error {
+		call: func(result any, method string, args ...any) error {
 			if method != "account_signTypedData" {
 				t.Fatalf("called wrong method. was %s", method)
 			}

--- a/pkg/jsonhttp/jsonhttp.go
+++ b/pkg/jsonhttp/jsonhttp.go
@@ -37,7 +37,7 @@ type StatusResponse struct {
 }
 
 // Respond writes a JSON-encoded body to http.ResponseWriter.
-func Respond(w http.ResponseWriter, statusCode int, response interface{}) {
+func Respond(w http.ResponseWriter, statusCode int, response any) {
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
@@ -81,32 +81,32 @@ func Respond(w http.ResponseWriter, statusCode int, response interface{}) {
 }
 
 // Continue writes a response with status code 100.
-func Continue(w http.ResponseWriter, response interface{}) {
+func Continue(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusContinue, response)
 }
 
 // SwitchingProtocols writes a response with status code 101.
-func SwitchingProtocols(w http.ResponseWriter, response interface{}) {
+func SwitchingProtocols(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusSwitchingProtocols, response)
 }
 
 // OK writes a response with status code 200.
-func OK(w http.ResponseWriter, response interface{}) {
+func OK(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusOK, response)
 }
 
 // Created writes a response with status code 201.
-func Created(w http.ResponseWriter, response interface{}) {
+func Created(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusCreated, response)
 }
 
 // Accepted writes a response with status code 202.
-func Accepted(w http.ResponseWriter, response interface{}) {
+func Accepted(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusAccepted, response)
 }
 
 // NonAuthoritativeInfo writes a response with status code 203.
-func NonAuthoritativeInfo(w http.ResponseWriter, response interface{}) {
+func NonAuthoritativeInfo(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusNonAuthoritativeInfo, response)
 }
 
@@ -118,201 +118,201 @@ func NoContent(w http.ResponseWriter) {
 }
 
 // ResetContent writes a response with status code 205.
-func ResetContent(w http.ResponseWriter, response interface{}) {
+func ResetContent(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusResetContent, response)
 }
 
 // PartialContent writes a response with status code 206.
-func PartialContent(w http.ResponseWriter, response interface{}) {
+func PartialContent(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusPartialContent, response)
 }
 
 // MultipleChoices writes a response with status code 300.
-func MultipleChoices(w http.ResponseWriter, response interface{}) {
+func MultipleChoices(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusMultipleChoices, response)
 }
 
 // MovedPermanently writes a response with status code 301.
-func MovedPermanently(w http.ResponseWriter, response interface{}) {
+func MovedPermanently(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusMovedPermanently, response)
 }
 
 // Found writes a response with status code 302.
-func Found(w http.ResponseWriter, response interface{}) {
+func Found(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusFound, response)
 }
 
 // SeeOther writes a response with status code 303.
-func SeeOther(w http.ResponseWriter, response interface{}) {
+func SeeOther(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusSeeOther, response)
 }
 
 // NotModified writes a response with status code 304.
-func NotModified(w http.ResponseWriter, response interface{}) {
+func NotModified(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusNotModified, response)
 }
 
 // UseProxy writes a response with status code 305.
-func UseProxy(w http.ResponseWriter, response interface{}) {
+func UseProxy(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusUseProxy, response)
 }
 
 // TemporaryRedirect writes a response with status code 307.
-func TemporaryRedirect(w http.ResponseWriter, response interface{}) {
+func TemporaryRedirect(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusTemporaryRedirect, response)
 }
 
 // PermanentRedirect writes a response with status code 308.
-func PermanentRedirect(w http.ResponseWriter, response interface{}) {
+func PermanentRedirect(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusPermanentRedirect, response)
 }
 
 // BadRequest writes a response with status code 400.
-func BadRequest(w http.ResponseWriter, response interface{}) {
+func BadRequest(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusBadRequest, response)
 }
 
 // Unauthorized writes a response with status code 401.
-func Unauthorized(w http.ResponseWriter, response interface{}) {
+func Unauthorized(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusUnauthorized, response)
 }
 
 // PaymentRequired writes a response with status code 402.
-func PaymentRequired(w http.ResponseWriter, response interface{}) {
+func PaymentRequired(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusPaymentRequired, response)
 }
 
 // Forbidden writes a response with status code 403.
-func Forbidden(w http.ResponseWriter, response interface{}) {
+func Forbidden(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusForbidden, response)
 }
 
 // NotFound writes a response with status code 404.
-func NotFound(w http.ResponseWriter, response interface{}) {
+func NotFound(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusNotFound, response)
 }
 
 // MethodNotAllowed writes a response with status code 405.
-func MethodNotAllowed(w http.ResponseWriter, response interface{}) {
+func MethodNotAllowed(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusMethodNotAllowed, response)
 }
 
 // NotAcceptable writes a response with status code 406.
-func NotAcceptable(w http.ResponseWriter, response interface{}) {
+func NotAcceptable(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusNotAcceptable, response)
 }
 
 // ProxyAuthRequired writes a response with status code 407.
-func ProxyAuthRequired(w http.ResponseWriter, response interface{}) {
+func ProxyAuthRequired(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusProxyAuthRequired, response)
 }
 
 // RequestTimeout writes a response with status code 408.
-func RequestTimeout(w http.ResponseWriter, response interface{}) {
+func RequestTimeout(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusRequestTimeout, response)
 }
 
 // Conflict writes a response with status code 409.
-func Conflict(w http.ResponseWriter, response interface{}) {
+func Conflict(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusConflict, response)
 }
 
 // Gone writes a response with status code 410.
-func Gone(w http.ResponseWriter, response interface{}) {
+func Gone(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusGone, response)
 }
 
 // LengthRequired writes a response with status code 411.
-func LengthRequired(w http.ResponseWriter, response interface{}) {
+func LengthRequired(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusLengthRequired, response)
 }
 
 // PreconditionFailed writes a response with status code 412.
-func PreconditionFailed(w http.ResponseWriter, response interface{}) {
+func PreconditionFailed(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusPreconditionFailed, response)
 }
 
 // RequestEntityTooLarge writes a response with status code 413.
-func RequestEntityTooLarge(w http.ResponseWriter, response interface{}) {
+func RequestEntityTooLarge(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusRequestEntityTooLarge, response)
 }
 
 // RequestURITooLong writes a response with status code 414.
-func RequestURITooLong(w http.ResponseWriter, response interface{}) {
+func RequestURITooLong(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusRequestURITooLong, response)
 }
 
 // UnsupportedMediaType writes a response with status code 415.
-func UnsupportedMediaType(w http.ResponseWriter, response interface{}) {
+func UnsupportedMediaType(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusUnsupportedMediaType, response)
 }
 
 // RequestedRangeNotSatisfiable writes a response with status code 416.
-func RequestedRangeNotSatisfiable(w http.ResponseWriter, response interface{}) {
+func RequestedRangeNotSatisfiable(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusRequestedRangeNotSatisfiable, response)
 }
 
 // ExpectationFailed writes a response with status code 417.
-func ExpectationFailed(w http.ResponseWriter, response interface{}) {
+func ExpectationFailed(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusExpectationFailed, response)
 }
 
 // Teapot writes a response with status code 418.
-func Teapot(w http.ResponseWriter, response interface{}) {
+func Teapot(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusTeapot, response)
 }
 
 // UpgradeRequired writes a response with status code 426.
-func UpgradeRequired(w http.ResponseWriter, response interface{}) {
+func UpgradeRequired(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusUpgradeRequired, response)
 }
 
 // PreconditionRequired writes a response with status code 428.
-func PreconditionRequired(w http.ResponseWriter, response interface{}) {
+func PreconditionRequired(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusPreconditionRequired, response)
 }
 
 // TooManyRequests writes a response with status code 429.
-func TooManyRequests(w http.ResponseWriter, response interface{}) {
+func TooManyRequests(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusTooManyRequests, response)
 }
 
 // RequestHeaderFieldsTooLarge writes a response with status code 431.
-func RequestHeaderFieldsTooLarge(w http.ResponseWriter, response interface{}) {
+func RequestHeaderFieldsTooLarge(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusRequestHeaderFieldsTooLarge, response)
 }
 
 // UnavailableForLegalReasons writes a response with status code 451.
-func UnavailableForLegalReasons(w http.ResponseWriter, response interface{}) {
+func UnavailableForLegalReasons(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusUnavailableForLegalReasons, response)
 }
 
 // InternalServerError writes a response with status code 500.
-func InternalServerError(w http.ResponseWriter, response interface{}) {
+func InternalServerError(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusInternalServerError, response)
 }
 
 // NotImplemented writes a response with status code 501.
-func NotImplemented(w http.ResponseWriter, response interface{}) {
+func NotImplemented(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusNotImplemented, response)
 }
 
 // BadGateway writes a response with status code 502.
-func BadGateway(w http.ResponseWriter, response interface{}) {
+func BadGateway(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusBadGateway, response)
 }
 
 // ServiceUnavailable writes a response with status code 503.
-func ServiceUnavailable(w http.ResponseWriter, response interface{}) {
+func ServiceUnavailable(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusServiceUnavailable, response)
 }
 
 // GatewayTimeout writes a response with status code 504.
-func GatewayTimeout(w http.ResponseWriter, response interface{}) {
+func GatewayTimeout(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusGatewayTimeout, response)
 }
 
 // HTTPVersionNotSupported writes a response with status code 505.
-func HTTPVersionNotSupported(w http.ResponseWriter, response interface{}) {
+func HTTPVersionNotSupported(w http.ResponseWriter, response any) {
 	Respond(w, http.StatusHTTPVersionNotSupported, response)
 }

--- a/pkg/jsonhttp/jsonhttp_test.go
+++ b/pkg/jsonhttp/jsonhttp_test.go
@@ -128,7 +128,7 @@ func TestRespond_special(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		code        int
-		response    interface{}
+		response    any
 		wantMessage string
 	}{
 		{
@@ -233,7 +233,7 @@ func TestRespond_custom(t *testing.T) {
 
 func TestStandardHTTPResponds(t *testing.T) {
 	for _, tc := range []struct {
-		f    func(w http.ResponseWriter, response interface{})
+		f    func(w http.ResponseWriter, response any)
 		code int
 	}{
 		{f: jsonhttp.Continue, code: http.StatusContinue},

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest.go
@@ -129,7 +129,7 @@ func WithRequestBody(body io.Reader) Option {
 
 // WithJSONRequestBody writes a request JSON-encoded body to the request made by
 // the Request function.
-func WithJSONRequestBody(r interface{}) Option {
+func WithJSONRequestBody(r any) Option {
 	return optionFunc(func(o *options) error {
 		b, err := json.Marshal(r)
 		if err != nil {
@@ -199,7 +199,7 @@ func WithExpectedResponse(response []byte) Option {
 
 // WithExpectedJSONResponse validates that the response from the request in the
 // Request function matches JSON-encoded body provided here.
-func WithExpectedJSONResponse(response interface{}) Option {
+func WithExpectedJSONResponse(response any) Option {
 	return optionFunc(func(o *options) error {
 		o.expectedJSONResponse = response
 		return nil
@@ -208,7 +208,7 @@ func WithExpectedJSONResponse(response interface{}) Option {
 
 // WithUnmarshalJSONResponse unmarshals response body from the request in the
 // Request function to the provided response. Response must be a pointer.
-func WithUnmarshalJSONResponse(response interface{}) Option {
+func WithUnmarshalJSONResponse(response any) Option {
 	return optionFunc(func(o *options) error {
 		o.unmarshalResponse = response
 		return nil
@@ -247,8 +247,8 @@ type options struct {
 	requestBody          io.Reader
 	requestHeaders       http.Header
 	expectedResponse     []byte
-	expectedJSONResponse interface{}
-	unmarshalResponse    interface{}
+	expectedJSONResponse any
+	unmarshalResponse    any
 	responseBody         *[]byte
 	noResponseBody       bool
 }

--- a/pkg/jsonhttp/jsonhttptest/testing_mock_test.go
+++ b/pkg/jsonhttp/jsonhttptest/testing_mock_test.go
@@ -59,11 +59,11 @@ func (m *mock) Helper() {
 	m.isHelper = true
 }
 
-func (m *mock) Errorf(format string, args ...interface{}) {
+func (m *mock) Errorf(format string, args ...any) {
 	m.gotError = fmt.Sprintf(format, args...)
 }
 
-func (m *mock) Fatal(args ...interface{}) {
+func (m *mock) Fatal(args ...any) {
 	m.gotFatal = fmt.Sprint(args...)
 	panic(errFailed) // terminate the goroutine to detect it in the assert function
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -13,17 +13,17 @@ import (
 )
 
 type Logger interface {
-	Tracef(format string, args ...interface{})
-	Trace(args ...interface{})
-	Debugf(format string, args ...interface{})
-	Debug(args ...interface{})
-	Infof(format string, args ...interface{})
-	Info(args ...interface{})
-	Warningf(format string, args ...interface{})
-	Warning(args ...interface{})
-	Errorf(format string, args ...interface{})
-	Error(args ...interface{})
-	WithField(key string, value interface{}) *logrus.Entry
+	Tracef(format string, args ...any)
+	Trace(args ...any)
+	Debugf(format string, args ...any)
+	Debug(args ...any)
+	Infof(format string, args ...any)
+	Info(args ...any)
+	Warningf(format string, args ...any)
+	Warning(args ...any)
+	Errorf(format string, args ...any)
+	Error(args ...any)
+	WithField(key string, value any) *logrus.Entry
 	WithFields(fields logrus.Fields) *logrus.Entry
 	WriterLevel(logrus.Level) *io.PipeWriter
 	NewEntry() *logrus.Entry

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,7 +18,7 @@ type Collector interface {
 	Metrics() []prometheus.Collector
 }
 
-func PrometheusCollectorsFromFields(i interface{}) (cs []prometheus.Collector) {
+func PrometheusCollectorsFromFields(i any) (cs []prometheus.Collector) {
 	v := reflect.Indirect(reflect.ValueOf(i))
 	for i := 0; i < v.NumField(); i++ {
 		if !v.Field(i).CanInterface() {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -300,7 +300,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 }
 
 func (s *Service) reachabilityWorker() error {
-	sub, err := s.host.EventBus().Subscribe([]interface{}{new(event.EvtLocalReachabilityChanged)})
+	sub, err := s.host.EventBus().Subscribe([]any{new(event.EvtLocalReachabilityChanged)})
 	if err != nil {
 		return fmt.Errorf("failed subscribing to reachability event %w", err)
 	}
@@ -956,7 +956,7 @@ func (s *Service) peerUserAgent(ctx context.Context, peerID libp2ppeer.ID) strin
 	ctx, cancel := context.WithTimeout(ctx, peerUserAgentTimeout)
 	defer cancel()
 	var (
-		v   interface{}
+		v   any
 		err error
 	)
 	// Peerstore may not contain all keys and values right after the connections is created.

--- a/pkg/p2p/libp2p/unreachable_errors_unix.go
+++ b/pkg/p2p/libp2p/unreachable_errors_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package libp2p
 

--- a/pkg/p2p/libp2p/unreachable_errors_windows.go
+++ b/pkg/p2p/libp2p/unreachable_errors_windows.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package libp2p
 

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -233,7 +233,7 @@ func TestBatchStore_Reset(t *testing.T) {
 	}
 }
 
-func stateStoreGet(t *testing.T, st storage.StateStorer, k string, v interface{}) {
+func stateStoreGet(t *testing.T, st storage.StateStorer, k string, v any) {
 	t.Helper()
 
 	if err := st.Get(k, v); err != nil {
@@ -241,7 +241,7 @@ func stateStoreGet(t *testing.T, st storage.StateStorer, k string, v interface{}
 	}
 }
 
-func stateStorePut(t *testing.T, st storage.StateStorer, k string, v interface{}) {
+func stateStorePut(t *testing.T, st storage.StateStorer, k string, v any) {
 	t.Helper()
 
 	if err := st.Put(k, v); err != nil {

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -429,15 +429,15 @@ func TestListenerBatchState(t *testing.T) {
 	}
 }
 
-func newEventUpdaterMock() (*updater, chan interface{}) {
-	c := make(chan interface{})
+func newEventUpdaterMock() (*updater, chan any) {
+	c := make(chan any)
 	return &updater{
 		eventC: c,
 	}, c
 }
 
-func newEventUpdaterMockWithBlockNumberUpdateError(err error) (*updater, chan interface{}) {
-	c := make(chan interface{})
+func newEventUpdaterMockWithBlockNumberUpdateError(err error) (*updater, chan any) {
+	c := make(chan any)
 	return &updater{
 		eventC:                 c,
 		blockNumberUpdateError: err,
@@ -445,7 +445,7 @@ func newEventUpdaterMockWithBlockNumberUpdateError(err error) (*updater, chan in
 }
 
 type updater struct {
-	eventC                 chan interface{}
+	eventC                 chan any
 	blockNumberUpdateError error
 }
 

--- a/pkg/pullsync/pullstorage/pullstorage.go
+++ b/pkg/pullsync/pullstorage/pullstorage.go
@@ -67,7 +67,7 @@ func (s *PullStorer) IntervalChunks(ctx context.Context, bin uint8, from, to uin
 	s.metrics.TotalSubscribePullRequests.Inc()
 	defer s.metrics.TotalSubscribePullRequestsComplete.Inc()
 
-	v, _, err := s.intervalsSF.Do(ctx, fmt.Sprintf("%v-%v-%v-%v", bin, from, to, limit), func(ctx context.Context) (interface{}, error) {
+	v, _, err := s.intervalsSF.Do(ctx, fmt.Sprintf("%v-%v-%v-%v", bin, from, to, limit), func(ctx context.Context) (any, error) {
 		var (
 			chs     []swarm.Address
 			topmost uint64

--- a/pkg/resolver/client/ens/ens_integration_test.go
+++ b/pkg/resolver/client/ens/ens_integration_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build integration
 // +build integration
 
 package ens_test

--- a/pkg/resolver/client/ens/ens_integration_test.go
+++ b/pkg/resolver/client/ens/ens_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package ens_test
 

--- a/pkg/resolver/multiresolver/multierror/multierror.go
+++ b/pkg/resolver/multiresolver/multierror/multierror.go
@@ -96,7 +96,7 @@ func (ec chain) Unwrap() error {
 }
 
 // As implements errors.As by attempting to map the current value.
-func (ec chain) As(target interface{}) bool {
+func (ec chain) As(target any) bool {
 	return errors.As(ec[0], target)
 }
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -115,7 +115,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, addr swarm.Address, origin 
 
 	// topCtx is passing the tracing span to the first singleflight call
 	topCtx := ctx
-	v, _, err := s.singleflight.Do(ctx, flightRoute, func(ctx context.Context) (interface{}, error) {
+	v, _, err := s.singleflight.Do(ctx, flightRoute, func(ctx context.Context) (any, error) {
 		maxPeers := 1
 		if origin {
 			maxPeers = maxSelects

--- a/pkg/settlement/swap/chequebook/factory.go
+++ b/pkg/settlement/swap/chequebook/factory.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"math/big"
 
+	"context"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/sctx"
 	"github.com/ethersphere/bee/pkg/transaction"
 	"github.com/ethersphere/go-sw3-abi/sw3abi"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/pkg/shed/field_struct.go
+++ b/pkg/shed/field_struct.go
@@ -45,7 +45,7 @@ func (db *DB) NewStructField(name string) (f StructField, err error) {
 
 // Get unmarshals data from the database to a provided val.
 // If the data is not found leveldb.ErrNotFound is returned.
-func (f StructField) Get(val interface{}) (err error) {
+func (f StructField) Get(val any) (err error) {
 	b, err := f.db.Get(f.key)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (f StructField) Get(val interface{}) (err error) {
 }
 
 // Put marshals provided val and saves it to the database.
-func (f StructField) Put(val interface{}) (err error) {
+func (f StructField) Put(val any) (err error) {
 	b, err := json.Marshal(val)
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func (f StructField) Put(val interface{}) (err error) {
 }
 
 // PutInBatch marshals provided val and puts it into the batch.
-func (f StructField) PutInBatch(batch *leveldb.Batch, val interface{}) (err error) {
+func (f StructField) PutInBatch(batch *leveldb.Batch, val any) (err error) {
 	b, err := json.Marshal(val)
 	if err != nil {
 		return err

--- a/pkg/statestore/leveldb/leveldb.go
+++ b/pkg/statestore/leveldb/leveldb.go
@@ -100,7 +100,7 @@ func migrate(s *Store) error {
 
 // Get retrieves a value of the requested key. If no results are found,
 // storage.ErrNotFound will be returned.
-func (s *Store) Get(key string, i interface{}) error {
+func (s *Store) Get(key string, i any) error {
 	data, err := s.db.Get([]byte(key), nil)
 	if err != nil {
 		if errors.Is(err, leveldb.ErrNotFound) {
@@ -119,7 +119,7 @@ func (s *Store) Get(key string, i interface{}) error {
 // Put stores a value for an arbitrary key. BinaryMarshaler
 // interface method will be called on the provided value
 // with fallback to JSON serialization.
-func (s *Store) Put(key string, i interface{}) (err error) {
+func (s *Store) Put(key string, i any) (err error) {
 	var bytes []byte
 	if marshaler, ok := i.(encoding.BinaryMarshaler); ok {
 		if bytes, err = marshaler.MarshalBinary(); err != nil {

--- a/pkg/statestore/mock/store.go
+++ b/pkg/statestore/mock/store.go
@@ -36,7 +36,7 @@ func NewStateStore() storage.StateStorer {
 	return s
 }
 
-func (s *store) Get(key string, i interface{}) (err error) {
+func (s *store) Get(key string, i any) (err error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
@@ -52,7 +52,7 @@ func (s *store) Get(key string, i interface{}) (err error) {
 	return json.Unmarshal(data, i)
 }
 
-func (s *store) Put(key string, i interface{}) (err error) {
+func (s *store) Put(key string, i any) (err error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -170,8 +170,8 @@ type PullSubscriber interface {
 // StateStorer defines methods required to get, set, delete values for different keys
 // and close the underlying resources.
 type StateStorer interface {
-	Get(key string, i interface{}) (err error)
-	Put(key string, i interface{}) (err error)
+	Get(key string, i any) (err error)
+	Put(key string, i any) (err error)
 	Delete(key string) (err error)
 	Iterate(prefix string, iterFunc StateIterFunc) (err error)
 	// DB returns the underlying DB storage.

--- a/pkg/tags/tag_test.go
+++ b/pkg/tags/tag_test.go
@@ -196,7 +196,7 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 	}
 	wg.Wait()
 	i := 0
-	ts.Range(func(k, v interface{}) bool {
+	ts.Range(func(k, v any) bool {
 		i++
 		uid := k.(uint32)
 		for _, f := range allStates {

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -96,7 +96,7 @@ func (ts *Tags) Create(total int64) (*Tag, error) {
 // All returns all existing tags in Tags' sync.Map
 // Note that tags are returned in no particular order
 func (ts *Tags) All() (t []*Tag) {
-	ts.tags.Range(func(k, v interface{}) bool {
+	ts.tags.Range(func(k, v any) bool {
 		t = append(t, v.(*Tag))
 
 		return true
@@ -125,7 +125,7 @@ func (ts *Tags) Get(uid uint32) (*Tag, error) {
 func (ts *Tags) GetByAddress(address swarm.Address) (*Tag, error) {
 	var t *Tag
 	var lastTime time.Time
-	ts.tags.Range(func(key interface{}, value interface{}) bool {
+	ts.tags.Range(func(key any, value any) bool {
 		rcvdTag := value.(*Tag)
 		if rcvdTag.Address.Equal(address) && rcvdTag.StartedAt.After(lastTime) {
 			t = rcvdTag
@@ -141,11 +141,11 @@ func (ts *Tags) GetByAddress(address swarm.Address) (*Tag, error) {
 }
 
 // Range exposes sync.Map's iterator
-func (ts *Tags) Range(fn func(k, v interface{}) bool) {
+func (ts *Tags) Range(fn func(k, v any) bool) {
 	ts.tags.Range(fn)
 }
 
-func (ts *Tags) Delete(k interface{}) {
+func (ts *Tags) Delete(k any) {
 	ts.tags.Delete(k)
 
 	// k is a uint32, try to create the tag key and remove
@@ -158,7 +158,7 @@ func (ts *Tags) Delete(k interface{}) {
 
 func (ts *Tags) MarshalJSON() (out []byte, err error) {
 	m := make(map[string]*Tag)
-	ts.Range(func(k, v interface{}) bool {
+	ts.Range(func(k, v any) bool {
 		key := fmt.Sprintf("%d", k)
 		val := v.(*Tag)
 

--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -277,7 +277,7 @@ func (c *Collector) Snapshot(t time.Time, addresses ...swarm.Address) map[string
 	}
 
 	if len(addresses) == 0 {
-		c.counters.Range(func(key, val interface{}) bool {
+		c.counters.Range(func(key, val any) bool {
 			cs := val.(*Counters)
 			snapshot[cs.peerAddress.ByteString()] = cs.snapshot(t)
 			return true
@@ -312,8 +312,8 @@ func (c *Collector) Inspect(addr swarm.Address) *Snapshot {
 // Flush sync the dirty in memory counters for all peers by flushing their
 // values to the underlying storage.
 func (c *Collector) Flush() error {
-	counters := make(map[string]interface{})
-	c.counters.Range(func(key, val interface{}) bool {
+	counters := make(map[string]any)
+	c.counters.Range(func(key, val any) bool {
 		cs := val.(*Counters)
 		counters[cs.peerAddress.ByteString()] = val
 		return true
@@ -327,7 +327,7 @@ func (c *Collector) Flush() error {
 
 // Finalize tries to log out all ongoing peer sessions.
 func (c *Collector) Finalize(t time.Time, delete bool) error {
-	c.counters.Range(func(_, val interface{}) bool {
+	c.counters.Range(func(_, val any) bool {
 		cs := val.(*Counters)
 		PeerLogOut(t)(cs)
 		return true
@@ -338,7 +338,7 @@ func (c *Collector) Finalize(t time.Time, delete bool) error {
 	}
 
 	if delete {
-		c.counters.Range(func(_, val interface{}) bool {
+		c.counters.Range(func(_, val any) bool {
 			cs := val.(*Counters)
 			c.counters.Delete(cs.peerAddress.ByteString())
 			return true

--- a/pkg/transaction/event.go
+++ b/pkg/transaction/event.go
@@ -18,7 +18,7 @@ var (
 )
 
 // ParseEvent will parse the specified abi event from the given log
-func ParseEvent(a *abi.ABI, eventName string, c interface{}, e types.Log) error {
+func ParseEvent(a *abi.ABI, eventName string, c any, e types.Log) error {
 	if len(e.Topics) == 0 {
 		return ErrNoTopic
 	}
@@ -37,7 +37,7 @@ func ParseEvent(a *abi.ABI, eventName string, c interface{}, e types.Log) error 
 }
 
 // FindSingleEvent will find the first event of the given kind.
-func FindSingleEvent(abi *abi.ABI, receipt *types.Receipt, contractAddress common.Address, event abi.Event, out interface{}) error {
+func FindSingleEvent(abi *abi.ABI, receipt *types.Receipt, contractAddress common.Address, event abi.Event, out any) error {
 	if receipt.Status != 1 {
 		return ErrTransactionReverted
 	}

--- a/pkg/transaction/mock/transaction.go
+++ b/pkg/transaction/mock/transaction.go
@@ -152,10 +152,10 @@ type Call struct {
 	to     common.Address
 	result []byte
 	method string
-	params []interface{}
+	params []any
 }
 
-func ABICall(abi *abi.ABI, to common.Address, result []byte, method string, params ...interface{}) Call {
+func ABICall(abi *abi.ABI, to common.Address, result []byte, method string, params ...any) Call {
 	return Call{
 		to:     to,
 		abi:    abi,
@@ -197,11 +197,11 @@ func WithABICallSequence(calls ...Call) Option {
 	})
 }
 
-func WithABICall(abi *abi.ABI, to common.Address, result []byte, method string, params ...interface{}) Option {
+func WithABICall(abi *abi.ABI, to common.Address, result []byte, method string, params ...any) Option {
 	return WithABICallSequence(ABICall(abi, to, result, method, params...))
 }
 
-func WithABISend(abi *abi.ABI, txHash common.Hash, expectedAddress common.Address, expectedValue *big.Int, method string, params ...interface{}) Option {
+func WithABISend(abi *abi.ABI, txHash common.Hash, expectedAddress common.Address, expectedValue *big.Int, method string, params ...any) Option {
 	return optionFunc(func(s *transactionServiceMock) {
 		s.send = func(ctx context.Context, request *transaction.TxRequest) (common.Hash, error) {
 			data, err := abi.Pack(method, params...)

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,7 +21,6 @@ import (
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/sctx"
 	"github.com/ethersphere/bee/pkg/storage"
-	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
In the spirit of go1.18 the old `interface{}` becomes `any`.

It also looks like there's a change in syntax of the build tags, I think it's good to keep up with these changes.

commands ran:

```
go fix ./pkg/... ./cmd/... 
gofmt -r 'interface{} -> any' -w .
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3103)
<!-- Reviewable:end -->
