### PR TITLE
chore: remove global var from blocklist,breaker packages

### DIFF
--- a/pkg/p2p/libp2p/internal/blocklist/blocklist.go
+++ b/pkg/p2p/libp2p/internal/blocklist/blocklist.go
@@ -15,15 +15,18 @@ import (
 
 var keyPrefix = "blocklist-"
 
-// timeNow is used to deterministically mock time.Now() in tests.
-var timeNow = time.Now
+type currentTimeFn = func() time.Time
 
 type Blocklist struct {
-	store storage.StateStorer
+	store         storage.StateStorer
+	currentTimeFn currentTimeFn
 }
 
 func NewBlocklist(store storage.StateStorer) *Blocklist {
-	return &Blocklist{store: store}
+	return &Blocklist{
+		store:         store,
+		currentTimeFn: time.Now,
+	}
 }
 
 type entry struct {
@@ -42,8 +45,7 @@ func (b *Blocklist) Exists(overlay swarm.Address) (bool, error) {
 		return false, err
 	}
 
-	// using timeNow.Sub() so it can be mocked in unit tests
-	if timeNow().Sub(timestamp) > duration && duration != 0 {
+	if b.currentTimeFn().Sub(timestamp) > duration && duration != 0 {
 		_ = b.store.Delete(key)
 		return false, nil
 	}
@@ -66,7 +68,7 @@ func (b *Blocklist) Add(overlay swarm.Address, duration time.Duration) (err erro
 	}
 
 	return b.store.Put(key, &entry{
-		Timestamp: timeNow(),
+		Timestamp: b.currentTimeFn(),
 		Duration:  duration.String(),
 	})
 }
@@ -88,7 +90,7 @@ func (b *Blocklist) Peers() ([]p2p.Peer, error) {
 			return true, err
 		}
 
-		if timeNow().Sub(t) > d && d != 0 {
+		if b.currentTimeFn().Sub(t) > d && d != 0 {
 			// skip to the next item
 			return false, nil
 		}
@@ -122,6 +124,6 @@ func generateKey(overlay swarm.Address) string {
 }
 
 func unmarshalKey(s string) (swarm.Address, error) {
-	addr := strings.TrimPrefix(s, keyPrefix)
+	addr := s[len(keyPrefix):] // trim prefix
 	return swarm.ParseHexAddress(addr)
 }

--- a/pkg/p2p/libp2p/internal/blocklist/export_test.go
+++ b/pkg/p2p/libp2p/internal/blocklist/export_test.go
@@ -4,8 +4,13 @@
 
 package blocklist
 
-import "time"
+import (
+	"github.com/ethersphere/bee/pkg/storage"
+)
 
-func SetTimeNow(f func() time.Time) {
-	timeNow = f
+func NewBlocklistWithCurrentTimeFn(store storage.StateStorer, currentTimeFn currentTimeFn) *Blocklist {
+	return &Blocklist{
+		store:         store,
+		currentTimeFn: currentTimeFn,
+	}
 }

--- a/pkg/p2p/libp2p/internal/breaker/breaker.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker.go
@@ -21,9 +21,6 @@ const (
 var (
 	_ Interface = (*breaker)(nil)
 
-	// timeNow is used to deterministically mock time.Now() in tests.
-	timeNow = time.Now
-
 	// ErrClosed is the special error type that indicates that breaker is closed and that is not executing functions at the moment.
 	ErrClosed = errors.New("breaker closed")
 )
@@ -38,6 +35,8 @@ type Interface interface {
 	ClosedUntil() time.Time
 }
 
+type currentTimeFn = func() time.Time
+
 type breaker struct {
 	limit                int // breaker will not execute any more tasks after limit number of consecutive failures happen
 	consFailedCalls      int // current number of consecutive fails
@@ -46,6 +45,7 @@ type breaker struct {
 	backoff              time.Duration // initial backoff duration
 	maxBackoff           time.Duration
 	failInterval         time.Duration // consecutive failures are counted if they happen within this interval
+	currentTimeFn        currentTimeFn
 	mtx                  sync.Mutex
 }
 
@@ -57,11 +57,16 @@ type Options struct {
 }
 
 func NewBreaker(o Options) Interface {
+	return newBreakerWithCurrentTimeFn(o, time.Now)
+}
+
+func newBreakerWithCurrentTimeFn(o Options, currentTimeFn currentTimeFn) Interface {
 	breaker := &breaker{
-		limit:        o.Limit,
-		backoff:      o.StartBackoff,
-		maxBackoff:   o.MaxBackoff,
-		failInterval: o.FailInterval,
+		limit:         o.Limit,
+		backoff:       o.StartBackoff,
+		maxBackoff:    o.MaxBackoff,
+		failInterval:  o.FailInterval,
+		currentTimeFn: currentTimeFn,
 	}
 
 	if o.Limit == 0 {
@@ -99,16 +104,16 @@ func (b *breaker) ClosedUntil() time.Time {
 		return b.closedTimestamp.Add(b.backoff)
 	}
 
-	return timeNow()
+	return b.currentTimeFn()
 }
 
 func (b *breaker) beforef() error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 
-	// use timeNow().Sub() instead of time.Since() so it can be deterministically mocked in tests
+	// use currentTimeFn().Sub() instead of time.Since() so it can be deterministically mocked in tests
 	if b.consFailedCalls >= b.limit {
-		if b.closedTimestamp.IsZero() || timeNow().Sub(b.closedTimestamp) < b.backoff {
+		if b.closedTimestamp.IsZero() || b.currentTimeFn().Sub(b.closedTimestamp) < b.backoff {
 			return ErrClosed
 		}
 
@@ -120,7 +125,7 @@ func (b *breaker) beforef() error {
 		}
 	}
 
-	if !b.firstFailedTimestamp.IsZero() && timeNow().Sub(b.firstFailedTimestamp) >= b.failInterval {
+	if !b.firstFailedTimestamp.IsZero() && b.currentTimeFn().Sub(b.firstFailedTimestamp) >= b.failInterval {
 		b.resetFailed()
 	}
 
@@ -132,12 +137,12 @@ func (b *breaker) afterf(err error) error {
 	defer b.mtx.Unlock()
 	if err != nil {
 		if b.consFailedCalls == 0 {
-			b.firstFailedTimestamp = timeNow()
+			b.firstFailedTimestamp = b.currentTimeFn()
 		}
 
 		b.consFailedCalls++
 		if b.consFailedCalls == b.limit {
-			b.closedTimestamp = timeNow()
+			b.closedTimestamp = b.currentTimeFn()
 		}
 
 		return err

--- a/pkg/p2p/libp2p/internal/breaker/breaker_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker_test.go
@@ -72,18 +72,15 @@ func TestExecute(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			b := breaker.NewBreaker(breaker.Options{
+			ctMock := &currentTimeMock{
+				times: tc.times,
+			}
+
+			b := breaker.NewBreakerWithCurrentTimeFn(breaker.Options{
 				Limit:        tc.limit,
 				StartBackoff: startBackoff,
 				FailInterval: failInterval,
-			})
-
-			if tc.times != nil {
-				timeMock := timeMock{times: tc.times}
-				breaker.SetTimeNow(timeMock.next)
-			} else {
-				breaker.SetTimeNow(time.Now)
-			}
+			}, ctMock.Time)
 
 			for i := 0; i < tc.iterations; i++ {
 				if err := b.Execute(func() error {
@@ -104,13 +101,14 @@ func TestClosedUntil(t *testing.T) {
 	timestamp := time.Now()
 	startBackoff := 1 * time.Minute
 	testError := errors.New("test error")
-	timeMock := timeMock{times: []time.Time{timestamp, timestamp, timestamp}}
-	breaker.SetTimeNow(timeMock.next)
+	ctMock := &currentTimeMock{
+		times: []time.Time{timestamp, timestamp, timestamp},
+	}
 
-	b := breaker.NewBreaker(breaker.Options{
+	b := breaker.NewBreakerWithCurrentTimeFn(breaker.Options{
 		Limit:        1,
 		StartBackoff: startBackoff,
-	})
+	}, ctMock.Time)
 
 	notClosed := b.ClosedUntil()
 	if notClosed != timestamp {
@@ -129,12 +127,17 @@ func TestClosedUntil(t *testing.T) {
 	}
 }
 
-type timeMock struct {
+type currentTimeMock struct {
 	times []time.Time
 	curr  int
 }
 
-func (t *timeMock) next() time.Time {
-	defer func() { t.curr++ }()
-	return t.times[t.curr]
+func (c *currentTimeMock) Time() time.Time {
+	if c.times == nil {
+		return time.Now()
+	}
+
+	t := c.times[c.curr]
+	c.curr++
+	return t
 }

--- a/pkg/p2p/libp2p/internal/breaker/export_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/export_test.go
@@ -4,8 +4,6 @@
 
 package breaker
 
-import "time"
-
-func SetTimeNow(f func() time.Time) {
-	timeNow = f
+func NewBreakerWithCurrentTimeFn(o Options, currentTimeFn currentTimeFn) Interface {
+	return newBreakerWithCurrentTimeFn(o, currentTimeFn)
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [x] I have added tests to cover my changes.

### Description
`blocklist` and `breaker` packages had a hacky way for mocking current time in tests using global variable. 
This PR provides cleaner solution for mocking current time in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3125)
<!-- Reviewable:end -->
