### PR TITLE
fix: long directory name error

### DIFF
--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -118,62 +118,6 @@ func TestBzzFiles(t *testing.T) {
 			t.Fatalf("root pin count mismatch: have %d; want %d", have, want)
 		}
 	})
-	t.Run("tar-file-upload-long-directory", func(t *testing.T) {
-		tr := tarFiles(t, []f{
-			{
-				data: []byte("robots text"),
-				name: "robots.txt",
-				dir:  "",
-				header: http.Header{
-					"Content-Type": {"text/plain; charset=utf-8"},
-				},
-			},
-			{
-				data: []byte("image 1"),
-				name: "1.png",
-				dir:  "img",
-				header: http.Header{
-					"Content-Type": {"image/png"},
-				},
-			},
-			{
-				data: []byte("image 2"),
-				name: "2.png",
-				dir:  "specification-for-fairdrive-and-everything-else-you-need-to-know-about-your-digital-safe-zone",
-				header: http.Header{
-					"Content-Type": {"image/png"},
-				},
-			},
-		})
-		address := swarm.MustParseHexAddress("5d4b0a469c9a601f349211bd90a70b67ce16ceb76b8688450921c662cb3082ba")
-		rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusCreated,
-			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
-			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
-			jsonhttptest.WithRequestBody(tr),
-			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
-			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
-				Reference: address,
-			}),
-		)
-
-		isTagFoundInResponse(t, rcvdHeader, nil)
-
-		has, err := storerMock.Has(context.Background(), address)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !has {
-			t.Fatal("storer check root chunk address: have none; want one")
-		}
-
-		refs, err := pinningMock.Pins()
-		if err != nil {
-			t.Fatal("unable to get pinned references")
-		}
-		if have, want := len(refs), 0; have != want {
-			t.Fatalf("root pin count mismatch: have %d; want %d", have, want)
-		}
-	})
 
 	t.Run("tar-file-upload-with-pinning", func(t *testing.T) {
 		tr := tarFiles(t, []f{

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -118,6 +118,62 @@ func TestBzzFiles(t *testing.T) {
 			t.Fatalf("root pin count mismatch: have %d; want %d", have, want)
 		}
 	})
+	t.Run("tar-file-upload-long-directory", func(t *testing.T) {
+		tr := tarFiles(t, []f{
+			{
+				data: []byte("robots text"),
+				name: "robots.txt",
+				dir:  "",
+				header: http.Header{
+					"Content-Type": {"text/plain; charset=utf-8"},
+				},
+			},
+			{
+				data: []byte("image 1"),
+				name: "1.png",
+				dir:  "img",
+				header: http.Header{
+					"Content-Type": {"image/png"},
+				},
+			},
+			{
+				data: []byte("image 2"),
+				name: "2.png",
+				dir:  "specification-for-fairdrive-and-everything-else-you-need-to-know-about-your-digital-safe-zone",
+				header: http.Header{
+					"Content-Type": {"image/png"},
+				},
+			},
+		})
+		address := swarm.MustParseHexAddress("f30c0aa7e9e2a0ef4c9b1b750ebfeaeb7c7c24da700bb089da19a46e3677824b")
+		rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusCreated,
+			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
+			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
+			jsonhttptest.WithRequestBody(tr),
+			jsonhttptest.WithRequestHeader("Content-Type", api.ContentTypeTar),
+			jsonhttptest.WithExpectedJSONResponse(api.BzzUploadResponse{
+				Reference: address,
+			}),
+		)
+
+		isTagFoundInResponse(t, rcvdHeader, nil)
+
+		has, err := storerMock.Has(context.Background(), address)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !has {
+			t.Fatal("storer check root chunk address: have none; want one")
+		}
+
+		refs, err := pinningMock.Pins()
+		if err != nil {
+			t.Fatal("unable to get pinned references")
+		}
+		if have, want := len(refs), 0; have != want {
+			t.Fatalf("root pin count mismatch: have %d; want %d", have, want)
+		}
+	})
 
 	t.Run("tar-file-upload-with-pinning", func(t *testing.T) {
 		tr := tarFiles(t, []f{

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -145,7 +145,7 @@ func TestBzzFiles(t *testing.T) {
 				},
 			},
 		})
-		address := swarm.MustParseHexAddress("f30c0aa7e9e2a0ef4c9b1b750ebfeaeb7c7c24da700bb089da19a46e3677824b")
+		address := swarm.MustParseHexAddress("5d4b0a469c9a601f349211bd90a70b67ce16ceb76b8688450921c662cb3082ba")
 		rcvdHeader := jsonhttptest.Request(t, client, http.MethodPost, fileUploadResource, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -95,7 +95,7 @@ func (s *Service) dirUploadHandler(w http.ResponseWriter, r *http.Request, store
 			jsonhttp.PaymentRequired(w, "batch is overissued")
 		case errors.Is(err, errEmptyDir):
 			jsonhttp.BadRequest(w, errEmptyDir)
-		case errors.Is(err, errInvalidTar):
+		case err.Error() == errInvalidTar.Error():
 			jsonhttp.BadRequest(w, "invalid filename in tar archive")
 		default:
 			jsonhttp.InternalServerError(w, errDirectoryStore)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -32,7 +32,6 @@ import (
 )
 
 var errEmptyDir = errors.New("no files in root directory")
-var errInvalidTar = errors.New("read tar stream: archive/tar: invalid tar header")
 
 // dirUploadHandler uploads a directory supplied as a tar in an HTTP request
 func (s *Service) dirUploadHandler(w http.ResponseWriter, r *http.Request, storer storage.Storer, waitFn func() error) {
@@ -95,7 +94,7 @@ func (s *Service) dirUploadHandler(w http.ResponseWriter, r *http.Request, store
 			jsonhttp.PaymentRequired(w, "batch is overissued")
 		case errors.Is(err, errEmptyDir):
 			jsonhttp.BadRequest(w, errEmptyDir)
-		case err.Error() == errInvalidTar.Error():
+		case errors.Is(err, tar.ErrHeader):
 			jsonhttp.BadRequest(w, "invalid filename in tar archive")
 		default:
 			jsonhttp.InternalServerError(w, errDirectoryStore)

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -32,6 +32,7 @@ import (
 )
 
 var errEmptyDir = errors.New("no files in root directory")
+var errInvalidTar = errors.New("read tar stream: archive/tar: invalid tar header")
 
 // dirUploadHandler uploads a directory supplied as a tar in an HTTP request
 func (s *Service) dirUploadHandler(w http.ResponseWriter, r *http.Request, storer storage.Storer, waitFn func() error) {
@@ -94,6 +95,8 @@ func (s *Service) dirUploadHandler(w http.ResponseWriter, r *http.Request, store
 			jsonhttp.PaymentRequired(w, "batch is overissued")
 		case errors.Is(err, errEmptyDir):
 			jsonhttp.BadRequest(w, errEmptyDir)
+		case errors.Is(err, errInvalidTar):
+			jsonhttp.BadRequest(w, "invalid filename in tar archive")
 		default:
 			jsonhttp.InternalServerError(w, errDirectoryStore)
 		}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.

### Description
fix for POST /bzz - Very long directory name yields store dir err: read tar stream: archive/tar: invalid tar header

#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3133)
<!-- Reviewable:end -->
