### PR TITLE
chore: add description checklist item to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
 - [ ] My change requires a documentation update and I have done it
 - [ ] I have added tests to cover my changes.
+- [ ] I have filled out the description and linked the related issues
 
 ### Description
 <!--Please include a summary of the change and which issue is fixed. -->


### PR DESCRIPTION
As per the discussion of today's backlog refinement meeting I add a checklist item to make sure that the description is filled out in the template and issues are linked.

It is possible to reference issues just by using a hash and the issue number. Github also recognises certain keywords and can automate the workflow if you use them. Here is the documentation about it:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3137)
<!-- Reviewable:end -->
