### PR TITLE
refactor(blocker): migrate logger

### DIFF
--- a/pkg/blocker/blocker.go
+++ b/pkg/blocker/blocker.go
@@ -9,11 +9,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"go.uber.org/atomic"
 )
+
+// LoggerName is the tree path name of the logger for this package.
+const LoggerName = "blocker"
 
 // sequencerResolution represents monotonic sequencer resolution.
 // It must be in the time.Duration base form without a multiplier.
@@ -31,14 +34,14 @@ type Blocker struct {
 	flagTimeout       time.Duration // how long before blocking a flagged peer
 	blockDuration     time.Duration // how long to blocklist a bad peer
 	peers             map[string]*peer
-	logger            logging.Logger
+	logger            log.Logger
 	wakeupCh          chan struct{}
 	quit              chan struct{}
 	closeWg           sync.WaitGroup
 	blocklistCallback func(swarm.Address)
 }
 
-func New(blocklister p2p.Blocklister, flagTimeout, blockDuration, wakeUpTime time.Duration, callback func(swarm.Address), logger logging.Logger) *Blocker {
+func New(blocklister p2p.Blocklister, flagTimeout, blockDuration, wakeUpTime time.Duration, callback func(swarm.Address), logger log.Logger) *Blocker {
 	if flagTimeout <= sequencerResolution {
 		panic(fmt.Errorf("flag timeout %v cannot be equal to or lower then the sequencer resolution %v", flagTimeout, sequencerResolution))
 	}
@@ -102,7 +105,7 @@ func (b *Blocker) block() {
 
 		if 0 < peer.blockAfter && peer.blockAfter < b.sequence.Load() {
 			if err := b.blocklister.Blocklist(peer.address, b.blockDuration, "blocker: flag timeout"); err != nil {
-				b.logger.Warningf("blocker: blocking peer %s failed: %v", peer.address, err)
+				b.logger.Warning("failed blocking peer", "address", peer.address, "error", err)
 			}
 			if b.blocklistCallback != nil {
 				b.blocklistCallback(peer.address)

--- a/pkg/blocker/blocker_test.go
+++ b/pkg/blocker/blocker_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/logging"
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/swarm/test"
@@ -24,7 +24,7 @@ var (
 	checkTime = time.Millisecond * 100
 	blockTime = time.Second
 	addr      = test.RandomAddress()
-	logger    = logging.New(ioutil.Discard, 0)
+	logger    = log.NewLogger("test", log.WithSink(ioutil.Discard))
 )
 
 func TestMain(m *testing.M) {
@@ -89,8 +89,7 @@ func TestUnflagBeforeBlock(t *testing.T) {
 			mu.Unlock()
 			return nil
 		})
-		logger = logging.New(ioutil.Discard, 0)
-		b      = blocker.New(mock, flagTime, blockTime, time.Millisecond, nil, logger)
+		b = blocker.New(mock, flagTime, blockTime, time.Millisecond, nil, logger)
 	)
 	defer b.Close()
 	b.Flag(addr)

--- a/pkg/chainsyncer/chainsyncer.go
+++ b/pkg/chainsyncer/chainsyncer.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/pkg/blocker"
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -88,7 +89,7 @@ func New(backend transaction.Backend, p prover, peerIterator topology.EachPeerer
 		c.logger.Warningf("chainsyncer: peer %s is unsynced and will be temporarily blocklisted", a.String())
 		c.metrics.UnsyncedPeers.Inc()
 	}
-	c.blocker = blocker.New(disconnecter, o.FlagTimeout, blockDuration, o.BlockerPollTime, cb, logger)
+	c.blocker = blocker.New(disconnecter, o.FlagTimeout, blockDuration, o.BlockerPollTime, cb, log.NewLogger("root").WithName(blocker.LoggerName).Register()) // TODO: get the root logger from the source.
 
 	c.wg.Add(1)
 	go c.manage()

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/blocker"
 	"github.com/ethersphere/bee/pkg/discovery"
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/logging"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/pingpong"
@@ -191,7 +192,7 @@ func New(
 		k.metrics.Blocklist.Inc()
 	}
 
-	k.blocker = blocker.New(p2pSvc, flagTimeout, blockDuration, blockWorkerWakup, blocklistCallback, logger)
+	k.blocker = blocker.New(p2pSvc, flagTimeout, blockDuration, blockWorkerWakup, blocklistCallback, log.NewLogger("root").WithName(blocker.LoggerName).Register()) // TODO: get the root logger from the source.
 
 	if k.pruneFunc == nil {
 		k.pruneFunc = k.pruneOversaturatedBins


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.

### Description
Migrates the blocker package logger to the new structural logging style (part of #3134).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3146)
<!-- Reviewable:end -->
