### PR TITLE
fix: programmatically set test network ID

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -38,6 +38,12 @@ const (
 	serviceName = "SwarmBeeSvc"
 )
 
+// default values for network IDs
+const (
+	defaultMainNetworkID uint64 = 1
+	defaultTestNetworkID uint64 = 10
+)
+
 //go:embed bee-welcome-message.txt
 var beeWelcomeMessage string
 
@@ -108,19 +114,19 @@ func (c *command) initStartCmd() (err error) {
 			mainnet := c.config.GetBool(optionNameMainNet)
 			userHasSetNetworkID := c.config.IsSet(optionNameNetworkID)
 
-			var networkID uint64 = 10
-
 			// if the user has provided a value - we use it and overwrite the default
-			// if mainnet is true then we only accept networkID value 1
-			// if the user has not provided a network ID but mainnet is true - just overwrite with 1
-			// in all the other cases default to value 10
+			// if mainnet is true then we only accept networkID value 1, error otherwise
+			// if the user has not provided a network ID but mainnet is true - just overwrite with mainnet network ID (1)
+			// in all the other cases we default to test network ID (10)
+			var networkID = defaultTestNetworkID
+
 			if userHasSetNetworkID {
 				networkID = c.config.GetUint64(optionNameNetworkID)
-				if mainnet && networkID != 1 {
+				if mainnet && networkID != defaultMainNetworkID {
 					return errors.New("provided network ID does not match mainnet")
 				}
 			} else if mainnet {
-				networkID = 1
+				networkID = defaultMainNetworkID
 			}
 
 			bootnodes := c.config.GetStringSlice(optionNameBootnodes)

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -106,13 +106,20 @@ func (c *command) initStartCmd() (err error) {
 			}
 
 			mainnet := c.config.GetBool(optionNameMainNet)
-			networkID := c.config.GetUint64(optionNameNetworkID)
+			userHasSetNetworkID := c.config.IsSet(optionNameNetworkID)
 
-			if mainnet {
-				userHasSetNetworkID := c.config.IsSet(optionNameNetworkID)
-				if userHasSetNetworkID && networkID != 1 {
+			var networkID uint64 = 10
+
+			// if the user has provided a value - we use it and overwrite the default
+			// if mainnet is true then we only accept networkID value 1
+			// if the user has not provided a network ID but mainnet is true - just overwrite with 1
+			// in all the other cases default to value 10
+			if userHasSetNetworkID {
+				networkID = c.config.GetUint64(optionNameNetworkID)
+				if mainnet && networkID != 1 {
 					return errors.New("provided network ID does not match mainnet")
 				}
+			} else if mainnet {
 				networkID = 1
 			}
 


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [X] My change requires a documentation update and I have done it

### Description
if the user has set `mainnet` to false and not provided a network ID we should default to ID `10`

this is a regression introduced after the default network ID was set to `1` in order to remediate an inconsistency in `printconfig` command: #3141 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3154)
<!-- Reviewable:end -->
