### PR TITLE
refactor: adding EntityStore as utility abstraction on top of StateStorer

### DIFF
--- a/pkg/addressbook/addressbook_test.go
+++ b/pkg/addressbook/addressbook_test.go
@@ -17,10 +17,10 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-type bookFunc func(t *testing.T) (book addressbook.Interface)
+type bookFunc func(t *testing.T) (book addressbook.Store)
 
 func TestInMem(t *testing.T) {
-	run(t, func(t *testing.T) addressbook.Interface {
+	run(t, func(t *testing.T) addressbook.Store {
 		store := mock.NewStateStore()
 		book := addressbook.New(store)
 		return book

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -288,7 +288,7 @@ func TestBroadcastPeers(t *testing.T) {
 	}
 }
 
-func expectOverlaysEventually(t *testing.T, exporter ab.Interface, wantOverlays []swarm.Address) {
+func expectOverlaysEventually(t *testing.T, exporter ab.Store, wantOverlays []swarm.Address) {
 	var (
 		overlays []swarm.Address
 		err      error
@@ -329,7 +329,7 @@ func expectOverlaysEventually(t *testing.T, exporter ab.Interface, wantOverlays 
 	}
 }
 
-func expectBzzAddresessEventually(t *testing.T, exporter ab.Interface, wantBzzAddresses []bzz.Address) {
+func expectBzzAddresessEventually(t *testing.T, exporter ab.Store, wantBzzAddresses []bzz.Address) {
 	var (
 		addresses []bzz.Address
 		err       error

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -66,7 +66,7 @@ func bootstrapNode(
 	txHash []byte,
 	chainID int64,
 	overlayEthAddress common.Address,
-	addressbook addressbook.Interface,
+	addressbook addressbook.Store,
 	bootnodes []ma.Multiaddr,
 	lightNodes *lightnode.Container,
 	senderMatcher p2p.SenderMatcher,

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -27,7 +27,7 @@ import (
 
 type libp2pServiceOpts struct {
 	Logger      logging.Logger
-	Addressbook addressbook.Interface
+	Addressbook addressbook.Store
 	PrivateKey  *ecdsa.PrivateKey
 	MockPeerKey *ecdsa.PrivateKey
 	libp2pOpts  libp2p.Options

--- a/pkg/storage/entity_store.go
+++ b/pkg/storage/entity_store.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package storage
+
+// EntityStore provides abstraction on top of StateStorer for usecase when
+// StateStorer is used for mapping on fixed key to value types.
+//
+// EntityStore should be improved using generic types once when codebase bumps go version to >=1.18.
+type EntityStore interface {
+	Get(key interface{}, val interface{}) (err error)
+	Put(key interface{}, val interface{}) (err error)
+	Delete(key interface{}) (err error)
+	IterateKeys(prefix string, iterFunc func(key interface{}) (stop bool, err error)) (err error)
+	IterateValues(prefix string, iterFunc func(val interface{}) (stop bool, err error)) (err error)
+}
+
+type (
+	KeyFromEntityFunc  = func(key interface{}) string
+	EntityFromKeyFunc  = func(key string) (interface{}, error)
+	ValueUnmarshalFunc = func(v []byte) (interface{}, error)
+)
+
+func NewEntityStore(
+	store StateStorer,
+	toKeyFunc KeyFromEntityFunc,
+	fromKeyFunc EntityFromKeyFunc,
+	valueUnmarshalFunc ValueUnmarshalFunc,
+) EntityStore {
+	return &entityStore{
+		store:              store,
+		toKeyFunc:          toKeyFunc,
+		fromKeyFunc:        fromKeyFunc,
+		valueUnmarshalFunc: valueUnmarshalFunc,
+	}
+}
+
+type entityStore struct {
+	store              StateStorer
+	toKeyFunc          KeyFromEntityFunc
+	fromKeyFunc        EntityFromKeyFunc
+	valueUnmarshalFunc ValueUnmarshalFunc
+}
+
+func (s *entityStore) Get(key interface{}, val interface{}) (err error) {
+	return s.store.Get(s.toKeyFunc(key), val)
+}
+
+func (s *entityStore) Put(key interface{}, val interface{}) (err error) {
+	return s.store.Put(s.toKeyFunc(key), val)
+}
+
+func (s *entityStore) Delete(key interface{}) (err error) {
+	return s.store.Delete(s.toKeyFunc(key))
+}
+
+func (s *entityStore) IterateKeys(prefix string, iterFunc func(key interface{}) (stop bool, err error)) (err error) {
+	return s.store.Iterate(prefix, func(rawKey []byte, rawVal []byte) (stop bool, err error) {
+		k, err := s.fromKeyFunc(string(rawKey))
+		if err != nil {
+			return false, nil
+		}
+
+		return iterFunc(k)
+	})
+}
+
+func (s *entityStore) IterateValues(prefix string, iterFunc func(val interface{}) (stop bool, err error)) (err error) {
+	return s.store.Iterate(prefix, func(rawKey []byte, rawVal []byte) (stop bool, err error) {
+		v, err := s.valueUnmarshalFunc(rawVal)
+		if err != nil {
+			return false, nil
+		}
+
+		return iterFunc(v)
+	})
+}

--- a/pkg/storage/entity_store_test.go
+++ b/pkg/storage/entity_store_test.go
@@ -1,0 +1,79 @@
+package storage_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+const keyPrefix = "test-entity-store"
+
+func TestEntityStore(t *testing.T) {
+	store := mock.NewStateStore()
+
+	// This store will map int to ValueType
+	s := storage.NewEntityStore(store, keyFromEntityFunc, entityFromKeyFunc, valueUnmarshalFunc)
+
+	// Put some elements to store
+	assert.NoError(t, s.Put(1, ValueType{111}))
+	assert.NoError(t, s.Put(2, ValueType{222}))
+
+	// Assert interation over keys
+	keys := make([]int, 0)
+	s.IterateKeys(keyPrefix, func(key interface{}) (stop bool, err error) {
+		keys = append(keys, key.(int))
+		return false, nil
+	})
+	assert.ElementsMatch(t, []int{1, 2}, keys)
+
+	// Assert interation over values
+	values := make([]ValueType, 0)
+	s.IterateValues(keyPrefix, func(value interface{}) (stop bool, err error) {
+		values = append(values, value.(ValueType))
+		return false, nil
+	})
+	assert.ElementsMatch(t, []ValueType{{111}, {222}}, values)
+
+	// Assert getting element
+	value := &ValueType{}
+	assert.NoError(t, s.Get(1, value))
+	assert.Equal(t, ValueType{111}, *value)
+
+	// Assert removing element
+	assert.NoError(t, s.Delete(1))
+
+	// Assert getting element (should return error)
+	assert.EqualError(t, s.Get(1, value), storage.ErrNotFound.Error())
+}
+
+func keyFromEntityFunc(key interface{}) string {
+	return keyPrefix + strconv.Itoa(key.(int))
+}
+
+func entityFromKeyFunc(key string) (interface{}, error) {
+	convertedKey, err := strconv.Atoi(key[len(keyPrefix):])
+	if err != nil {
+		return nil, fmt.Errorf("invalid key: %s, err: %w", key, err)
+	}
+
+	return convertedKey, nil
+}
+
+func valueUnmarshalFunc(v []byte) (interface{}, error) {
+	value := &ValueType{}
+
+	if err := json.Unmarshal(v, value); err != nil {
+		return nil, err
+	}
+
+	return *value, nil
+}
+
+type ValueType struct {
+	V int
+}

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -93,15 +93,15 @@ type Options struct {
 
 // Kad is the Swarm forwarding kademlia implementation.
 type Kad struct {
-	base              swarm.Address         // this node's overlay address
-	discovery         discovery.Driver      // the discovery driver
-	addressBook       addressbook.Interface // address book to get underlays
-	p2p               p2p.Service           // p2p service to connect to nodes with
-	saturationFunc    binSaturationFunc     // pluggable saturation function
-	bitSuffixLength   int                   // additional depth of common prefix for bin
-	commonBinPrefixes [][]swarm.Address     // list of address prefixes for each bin
-	connectedPeers    *pslice.PSlice        // a slice of peers sorted and indexed by po, indexes kept in `bins`
-	knownPeers        *pslice.PSlice        // both are po aware slice of addresses
+	base              swarm.Address     // this node's overlay address
+	discovery         discovery.Driver  // the discovery driver
+	addressBook       addressbook.Store // address book to get underlays
+	p2p               p2p.Service       // p2p service to connect to nodes with
+	saturationFunc    binSaturationFunc // pluggable saturation function
+	bitSuffixLength   int               // additional depth of common prefix for bin
+	commonBinPrefixes [][]swarm.Address // list of address prefixes for each bin
+	connectedPeers    *pslice.PSlice    // a slice of peers sorted and indexed by po, indexes kept in `bins`
+	knownPeers        *pslice.PSlice    // both are po aware slice of addresses
 	bootnodes         []ma.Multiaddr
 	depth             uint8         // current neighborhood depth
 	radius            uint8         // storage area of responsibility
@@ -132,7 +132,7 @@ type Kad struct {
 // New returns a new Kademlia.
 func New(
 	base swarm.Address,
-	addressbook addressbook.Interface,
+	addressbook addressbook.Store,
 	discovery discovery.Driver,
 	p2pSvc p2p.Service,
 	pinger pingpong.Interface,

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1813,7 +1813,7 @@ func newTestKademliaWithAddrDiscovery(
 	disc *mock.Discovery,
 	connCounter, failedConnCounter *int32,
 	kadOpts kademlia.Options,
-) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+) (swarm.Address, *kademlia.Kad, addressbook.Store, *mock.Discovery, beeCrypto.Signer) {
 	t.Helper()
 
 	metricsDB, err := shed.NewDB("", nil)
@@ -1845,7 +1845,7 @@ func newTestKademliaWithAddrDiscovery(
 	return base, kad, ab, disc, signer
 }
 
-func newTestKademlia(t *testing.T, connCounter, failedConnCounter *int32, kadOpts kademlia.Options) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+func newTestKademlia(t *testing.T, connCounter, failedConnCounter *int32, kadOpts kademlia.Options) (swarm.Address, *kademlia.Kad, addressbook.Store, *mock.Discovery, beeCrypto.Signer) {
 	t.Helper()
 
 	base := test.RandomAddress()
@@ -1853,7 +1853,7 @@ func newTestKademlia(t *testing.T, connCounter, failedConnCounter *int32, kadOpt
 	return newTestKademliaWithAddrDiscovery(t, base, disc, connCounter, failedConnCounter, kadOpts)
 }
 
-func newTestKademliaWithAddr(t *testing.T, base swarm.Address, connCounter, failedConnCounter *int32, kadOpts kademlia.Options) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+func newTestKademliaWithAddr(t *testing.T, base swarm.Address, connCounter, failedConnCounter *int32, kadOpts kademlia.Options) (swarm.Address, *kademlia.Kad, addressbook.Store, *mock.Discovery, beeCrypto.Signer) {
 	t.Helper()
 
 	disc := mock.NewDiscovery() // mock discovery protocol
@@ -1865,14 +1865,14 @@ func newTestKademliaWithDiscovery(
 	disc *mock.Discovery,
 	connCounter, failedConnCounter *int32,
 	kadOpts kademlia.Options,
-) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
+) (swarm.Address, *kademlia.Kad, addressbook.Store, *mock.Discovery, beeCrypto.Signer) {
 	t.Helper()
 
 	base := test.RandomAddress()
 	return newTestKademliaWithAddrDiscovery(t, base, disc, connCounter, failedConnCounter, kadOpts)
 }
 
-func p2pMock(ab addressbook.Interface, signer beeCrypto.Signer, counter, failedCounter *int32) p2p.Service {
+func p2pMock(ab addressbook.Store, signer beeCrypto.Signer, counter, failedCounter *int32) p2p.Service {
 	p2ps := p2pmock.New(
 		p2pmock.WithConnectFunc(func(ctx context.Context, addr ma.Multiaddr) (*bzz.Address, error) {
 			if addr.Equal(nonConnectableAddress) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description
This PR adds `EntityStore` as utility abstraction when `StateStorer` is used for mapping on fixed key to value types. This will help to eliminate some of boilerplate code when dealing with this use case and futher improve readability. Once when codebase starts supporting go version >=1.8 we could benefit event more from such abstraction (for example we would benefit from `PluckValues` and `PluckKeys` functions which now would be messy to implement). 

As utility example this PR also has refactored `addressbook` to use this type. After this PR gets approved I'll refactor other places with this use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3155)
<!-- Reviewable:end -->
