### PR TITLE
fix: switch listeners to tcp6

### DIFF
--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -178,7 +178,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 	var debugApiService *api.Service
 
 	if o.DebugAPIAddr != "" {
-		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
+		debugAPIListener, err := net.Listen("tcp6", o.DebugAPIAddr)
 		if err != nil {
 			return nil, fmt.Errorf("debug api listener: %w", err)
 		}
@@ -434,7 +434,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		}, debugOpts, 1, chainBackend, erc20)
 	}
 
-	apiListener, err := net.Listen("tcp", o.APIAddr)
+	apiListener, err := net.Listen("tcp6", o.APIAddr)
 	if err != nil {
 		return nil, fmt.Errorf("api listener: %w", err)
 	}

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -178,7 +178,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 	var debugApiService *api.Service
 
 	if o.DebugAPIAddr != "" {
-		debugAPIListener, err := net.Listen("tcp6", o.DebugAPIAddr)
+		debugAPIListener, err := net.Listen("tcp6", "[::1]"+o.DebugAPIAddr)
 		if err != nil {
 			return nil, fmt.Errorf("debug api listener: %w", err)
 		}
@@ -434,7 +434,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		}, debugOpts, 1, chainBackend, erc20)
 	}
 
-	apiListener, err := net.Listen("tcp6", o.APIAddr)
+	apiListener, err := net.Listen("tcp6", "[::1]"+o.APIAddr)
 	if err != nil {
 		return nil, fmt.Errorf("api listener: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -323,7 +323,7 @@ func NewBee(interrupt chan struct{}, addr string, publicKey *ecdsa.PublicKey, si
 			runtime.SetBlockProfileRate(1)
 		}
 
-		debugAPIListener, err := net.Listen("tcp", o.DebugAPIAddr)
+		debugAPIListener, err := net.Listen("tcp6", "[::1]"+o.DebugAPIAddr)
 		if err != nil {
 			return nil, fmt.Errorf("debug api listener: %w", err)
 		}
@@ -363,7 +363,7 @@ func NewBee(interrupt chan struct{}, addr string, publicKey *ecdsa.PublicKey, si
 			ErrorLog:          stdlog.New(b.errorLogWriter, "", 0),
 		}
 
-		apiListener, err := net.Listen("tcp", o.APIAddr)
+		apiListener, err := net.Listen("tcp6", "[::1]"+o.APIAddr)
 		if err != nil {
 			return nil, fmt.Errorf("api listener: %w", err)
 		}
@@ -942,7 +942,7 @@ func NewBee(interrupt chan struct{}, addr string, publicKey *ecdsa.PublicKey, si
 				ErrorLog:          stdlog.New(b.errorLogWriter, "", 0),
 			}
 
-			apiListener, err := net.Listen("tcp", o.APIAddr)
+			apiListener, err := net.Listen("tcp6", "[::1]"+o.APIAddr)
 			if err != nil {
 				return nil, fmt.Errorf("api listener: %w", err)
 			}


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it

### Description

### Considerations
On linux it successfully resolves for both tcp4 and tcp6 but probably needs checking it on mac and win.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3168)
<!-- Reviewable:end -->
