### PR TITLE
fix: remove forgotten fmt string in log message

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -119,7 +119,7 @@ func InitChequebookFactory(
 			return nil, fmt.Errorf("no known factory address for this network (chain id: %d)", chainID)
 		}
 		currentFactory = foundFactory
-		logger.Info("using default factory address for chain id %d: %x", "chain_id", chainID, "factory_address", fmt.Sprintf("%x", currentFactory))
+		logger.Info("using default factory address", "chain_id", chainID, "factory_address", fmt.Sprintf("%x", currentFactory))
 	} else if !common.IsHexAddress(factoryAddress) {
 		return nil, errors.New("malformed factory address")
 	} else {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues

### Description
Removes forgotten fmt string part in the log message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3169)
<!-- Reviewable:end -->
