### PR TITLE
fix: map trace level to v1

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -295,7 +295,7 @@ func newLogger(cmd *cobra.Command, verbosity string) (log.Logger, error) {
 	case "4", "debug":
 		vLevel = log.VerbosityDebug
 	case "5", "trace":
-		vLevel = log.VerbosityAll
+		vLevel = log.VerbosityDebug + 1 // For backwards compatibility, just enable v1 debugging as trace.
 	default:
 		return nil, fmt.Errorf("unknown verbosity level %q", verbosity)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues

### Description
Map legacy trace log level to v1 log level.
