### PR TITLE
chore: simplyfy formatting for byte slice representing eth types

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -443,7 +443,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("using ethereum address", "address", fmt.Sprintf("%x", overlayEthAddress))
+	logger.Info("using ethereum address", "address", overlayEthAddress)
 
 	return &signerConfig{
 		signer:           signer,

--- a/pkg/api/transaction.go
+++ b/pkg/api/transaction.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"net/http"
 	"time"
@@ -56,8 +55,8 @@ func (s *Service) transactionListHandler(w http.ResponseWriter, r *http.Request)
 	for _, txHash := range txHashes {
 		storedTransaction, err := s.transaction.StoredTransaction(txHash)
 		if err != nil {
-			s.logger.Debug("transactions get: get stored transaction failed", "tx_hash", fmt.Sprintf("%x", txHash), "error", err)
-			s.logger.Error(nil, "transactions get: get stored transaction failed", "tx_hash", fmt.Sprintf("%x", txHash))
+			s.logger.Debug("transactions get: get stored transaction failed", "tx_hash", txHash, "error", err)
+			s.logger.Error(nil, "transactions get: get stored transaction failed", "tx_hash", txHash)
 			jsonhttp.InternalServerError(w, errCantGetTransaction)
 			return
 		}
@@ -87,8 +86,8 @@ func (s *Service) transactionDetailHandler(w http.ResponseWriter, r *http.Reques
 
 	storedTransaction, err := s.transaction.StoredTransaction(txHash)
 	if err != nil {
-		s.logger.Debug("transaction get: get stored transaction failed", "tx_hash", fmt.Sprintf("%x", txHash), "error", err)
-		s.logger.Error(nil, "transaction get: get stored transaction failed", "tx_hash", fmt.Sprintf("%x", txHash))
+		s.logger.Debug("transaction get: get stored transaction failed", "tx_hash", txHash, "error", err)
+		s.logger.Error(nil, "transaction get: get stored transaction failed", "tx_hash", txHash)
 		if errors.Is(err, transaction.ErrUnknownTransaction) {
 			jsonhttp.NotFound(w, errUnknownTransaction)
 		} else {
@@ -120,8 +119,8 @@ func (s *Service) transactionResendHandler(w http.ResponseWriter, r *http.Reques
 
 	err := s.transaction.ResendTransaction(r.Context(), txHash)
 	if err != nil {
-		s.logger.Debug("transaction post: resend transaction failed", "tx_hash", fmt.Sprintf("%x", txHash), "error", err)
-		s.logger.Error(nil, "transaction post: resend transaction failed", "tx_hash", fmt.Sprintf("%x", txHash))
+		s.logger.Debug("transaction post: resend transaction failed", "tx_hash", txHash, "error", err)
+		s.logger.Error(nil, "transaction post: resend transaction failed", "tx_hash", txHash)
 		if errors.Is(err, transaction.ErrUnknownTransaction) {
 			jsonhttp.NotFound(w, errUnknownTransaction)
 		} else if errors.Is(err, transaction.ErrAlreadyImported) {
@@ -154,8 +153,8 @@ func (s *Service) transactionCancelHandler(w http.ResponseWriter, r *http.Reques
 
 	txHash, err := s.transaction.CancelTransaction(ctx, txHash)
 	if err != nil {
-		s.logger.Debug("transactions delete: cancel transaction failed", "tx_hash", fmt.Sprintf("%x", txHash), "error", err)
-		s.logger.Error(nil, "transactions delete: cancel transaction failed", "tx_hash", fmt.Sprintf("%x", txHash))
+		s.logger.Debug("transactions delete: cancel transaction failed", "tx_hash", txHash, "error", err)
+		s.logger.Error(nil, "transactions delete: cancel transaction failed", "tx_hash", txHash)
 		if errors.Is(err, transaction.ErrUnknownTransaction) {
 			jsonhttp.NotFound(w, errUnknownTransaction)
 		} else if errors.Is(err, transaction.ErrAlreadyImported) {

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -119,12 +119,12 @@ func InitChequebookFactory(
 			return nil, fmt.Errorf("no known factory address for this network (chain id: %d)", chainID)
 		}
 		currentFactory = foundFactory
-		logger.Info("using default factory address", "chain_id", chainID, "factory_address", fmt.Sprintf("%x", currentFactory))
+		logger.Info("using default factory address", "chain_id", chainID, "factory_address", currentFactory)
 	} else if !common.IsHexAddress(factoryAddress) {
 		return nil, errors.New("malformed factory address")
 	} else {
 		currentFactory = common.HexToAddress(factoryAddress)
-		logger.Info("using custom factory address", "factory_address", fmt.Sprintf("%x", currentFactory))
+		logger.Info("using custom factory address", "factory_address", currentFactory)
 	}
 
 	if len(legacyFactoryAddresses) == 0 {

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -287,7 +287,6 @@ func InitSwap(
 }
 
 func GetTxHash(stateStore storage.StateStorer, logger log.Logger, trxString string) ([]byte, error) {
-
 	if trxString != "" {
 		txHashTrimmed := strings.TrimPrefix(trxString, "0x")
 		if len(txHashTrimmed) != 64 {
@@ -297,7 +296,7 @@ func GetTxHash(stateStore storage.StateStorer, logger log.Logger, trxString stri
 		if err != nil {
 			return nil, err
 		}
-		logger.Info("using the provided transaction hash", "tx_hash", fmt.Sprintf("%x", txHash))
+		logger.Info("using the provided transaction hash", "tx_hash", txHashTrimmed)
 		return txHash, nil
 	}
 

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -310,7 +310,7 @@ func GetTxHash(stateStore storage.StateStorer, logger log.Logger, trxString stri
 		return nil, err
 	}
 
-	logger.Info("using the chequebook transaction hash", "tx_hash", fmt.Sprintf("%x", txHash))
+	logger.Info("using the chequebook transaction hash", "tx_hash", txHash)
 	return txHash.Bytes(), nil
 }
 

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -161,14 +160,14 @@ func Init(
 				return nil, err
 			}
 
-			logger.Info("deploying new chequebook", "tx", fmt.Sprintf("%x", txHash))
+			logger.Info("deploying new chequebook", "tx", txHash)
 
 			err = stateStore.Put(ChequebookDeploymentKey, txHash)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			logger.Info("waiting for chequebook deployment", "tx", fmt.Sprintf("%x", txHash))
+			logger.Info("waiting for chequebook deployment", "tx", txHash)
 		}
 
 		chequebookAddress, err = chequebookFactory.WaitDeployed(ctx, txHash)
@@ -196,7 +195,7 @@ func Init(
 				return nil, err
 			}
 
-			logger.Info("sent deposit transaction", "tx", fmt.Sprintf("%x", depositHash))
+			logger.Info("sent deposit transaction", "tx", depositHash)
 			err = chequebookService.WaitForDeposit(ctx, depositHash)
 			if err != nil {
 				return nil, err

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -83,11 +83,11 @@ func checkBalance(
 			neededETH := new(big.Float).Quo(new(big.Float).SetInt(minimumEth), ethSmallUnit)
 
 			if insufficientETH && insufficientERC20 {
-				logger.Warning("cannot continue until there is at least min xDAI (for Gas) and at least min BZZ bridged on the xDAI network available on address", "min_xdai_amount", neededETH, "min_bzz_amount", neededERC20, "address", fmt.Sprintf("%x", overlayEthAddress))
+				logger.Warning("cannot continue until there is at least min xDAI (for Gas) and at least min BZZ bridged on the xDAI network available on address", "min_xdai_amount", neededETH, "min_bzz_amount", neededERC20, "address", overlayEthAddress)
 			} else if insufficientETH {
-				logger.Warning("cannot continue until there is at least min xDAI (for Gas) available on address", "min_xdai_amount", neededETH, "address", fmt.Sprintf("%x", overlayEthAddress))
+				logger.Warning("cannot continue until there is at least min xDAI (for Gas) available on address", "min_xdai_amount", neededETH, "address", overlayEthAddress)
 			} else {
-				logger.Warning("cannot continue until there is at least min BZZ available on address", "min_bzz_amount", neededERC20, "address", fmt.Sprintf("%x", overlayEthAddress))
+				logger.Warning("cannot continue until there is at least min BZZ available on address", "min_bzz_amount", neededERC20, "address", overlayEthAddress)
 			}
 			if chainId == 5 {
 				logger.Warning("learn how to fund your node by visiting our docs at https://docs.ethswarm.org/docs/installation/fund-your-node")
@@ -176,7 +176,7 @@ func Init(
 			return nil, err
 		}
 
-		logger.Info("chequebook deployed", "chequebook_address", fmt.Sprintf("%x", chequebookAddress))
+		logger.Info("chequebook deployed", "chequebook_address", chequebookAddress)
 
 		// save the address for later use
 		err = stateStore.Put(chequebookKey, chequebookAddress)
@@ -210,7 +210,7 @@ func Init(
 			return nil, err
 		}
 
-		logger.Info("using existing chequebook", "chequebook_address", fmt.Sprintf("%x", chequebookAddress))
+		logger.Info("using existing chequebook", "chequebook_address", chequebookAddress)
 	}
 
 	// regardless of how the chequebook service was initialised make sure that the chequebook is valid

--- a/pkg/transaction/monitor.go
+++ b/pkg/transaction/monitor.go
@@ -7,7 +7,6 @@ package transaction
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 	"sync"
@@ -101,7 +100,7 @@ func (tm *transactionMonitor) WatchTransaction(txHash common.Hash, nonce uint64)
 	default:
 	}
 
-	loggerV1.Debug("starting to watch transaction", "tx", fmt.Sprintf("%x", txHash), "nonce", nonce)
+	loggerV1.Debug("starting to watch transaction", "tx", txHash, "nonce", nonce)
 
 	return receiptC, errC, nil
 }

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -161,7 +161,7 @@ func (t *transactionService) Send(ctx context.Context, request *TxRequest) (txHa
 		return common.Hash{}, err
 	}
 
-	loggerV1.Debug("sending transaction", "tx", fmt.Sprintf("%x", signedTx.Hash()), "nonce", nonce)
+	loggerV1.Debug("sending transaction", "tx", signedTx.Hash(), "nonce", nonce)
 
 	err = t.backend.SendTransaction(ctx, signedTx)
 	if err != nil {
@@ -208,18 +208,18 @@ func (t *transactionService) waitForPendingTx(txHash common.Hash) {
 		_, err := t.WaitForReceipt(t.ctx, txHash)
 		if err != nil {
 			if !errors.Is(err, ErrTransactionCancelled) {
-				t.logger.Error(err, "error while waiting for pending transaction", "tx", fmt.Sprintf("%x", txHash))
+				t.logger.Error(err, "error while waiting for pending transaction", "tx", txHash)
 				return
 			} else {
-				t.logger.Warning("pending transaction cancelled", "tx", fmt.Sprintf("%x", txHash))
+				t.logger.Warning("pending transaction cancelled", "tx", txHash)
 			}
 		} else {
-			loggerV1.Debug("pending transaction confirmed", "tx", fmt.Sprintf("%x", txHash))
+			loggerV1.Debug("pending transaction confirmed", "tx", txHash)
 		}
 
 		err = t.store.Delete(pendingTransactionKey(txHash))
 		if err != nil {
-			t.logger.Error(err, "error while unregistering transaction as pending", "tx", fmt.Sprintf("%x", txHash))
+			t.logger.Error(err, "error while unregistering transaction as pending", "tx", txHash)
 		}
 	}()
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [x] My change requires a documentation update and I have done it
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description

`Hash` and `Address` types already implement `Stringer` interface so manual bytes slice formatting is not needed. 

Part of https://github.com/ethersphere/bee/issues/3157

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3217)
<!-- Reviewable:end -->
