### PR TITLE
chore: format int numbers using strconv

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -537,11 +537,11 @@ func (s *Service) contentLengthMetricMiddleware() func(h http.Handler) http.Hand
 					return
 				}
 				if contentLength > 0 {
-					s.metrics.ContentApiDuration.WithLabelValues(fmt.Sprintf("%d", toFileSizeBucket(int64(contentLength))), r.Method).Observe(time.Since(now).Seconds())
+					s.metrics.ContentApiDuration.WithLabelValues(strconv.FormatInt(toFileSizeBucket(int64(contentLength)), 10), r.Method).Observe(time.Since(now).Seconds())
 				}
 			case http.MethodPost:
 				if r.ContentLength > 0 {
-					s.metrics.ContentApiDuration.WithLabelValues(fmt.Sprintf("%d", toFileSizeBucket(r.ContentLength)), r.Method).Observe(time.Since(now).Seconds())
+					s.metrics.ContentApiDuration.WithLabelValues(strconv.FormatInt(toFileSizeBucket(r.ContentLength), 10), r.Method).Observe(time.Since(now).Seconds())
 				}
 			}
 		})

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -171,6 +172,6 @@ func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
 		// soc
 		span = int64(len(ch.Data()))
 	}
-	w.Header().Add("Content-Length", fmt.Sprintf("%d", span))
+	w.Header().Add("Content-Length", strconv.FormatInt(span, 10))
 	w.WriteHeader(http.StatusOK) // HEAD requests do not write a body
 }

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -453,8 +454,8 @@ func (s *Service) downloadHandler(w http.ResponseWriter, r *http.Request, refere
 	if etag {
 		w.Header().Set("ETag", fmt.Sprintf("%q", reference))
 	}
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", l))
-	w.Header().Set("Decompressed-Content-Length", fmt.Sprintf("%d", l))
+	w.Header().Set("Content-Length", strconv.FormatInt(l, 10))
+	w.Header().Set("Decompressed-Content-Length", strconv.FormatInt(l, 10))
 	w.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 	http.ServeContent(w, r, "", time.Now(), langos.NewBufferedLangos(reader, lookaheadBufferSize(l)))
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -5,8 +5,8 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/ethersphere/bee"
@@ -96,7 +96,7 @@ func (s *Service) responseCodeMetricsHandler(h http.Handler) http.Handler {
 		wrapper := newResponseWriter(w)
 		h.ServeHTTP(wrapper, r)
 		s.metrics.ResponseCodeCounts.WithLabelValues(
-			fmt.Sprintf("%d", wrapper.statusCode),
+			strconv.Itoa(wrapper.statusCode),
 			r.Method,
 		).Inc()
 	})

--- a/pkg/feeds/sequence/sequence.go
+++ b/pkg/feeds/sequence/sequence.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -41,7 +41,7 @@ type index struct {
 }
 
 func (i *index) String() string {
-	return fmt.Sprintf("%d", i.index)
+	return strconv.FormatUint(i.index, 10)
 }
 
 func (i *index) MarshalBinary() ([]byte, error) {

--- a/pkg/file/buffer_test.go
+++ b/pkg/file/buffer_test.go
@@ -37,7 +37,7 @@ var (
 // various write length combinations.
 func TestChunkPipe(t *testing.T) {
 	for i := range dataWrites {
-		t.Run(fmt.Sprintf("%d", i), testChunkPipe)
+		t.Run(strconv.Itoa(i), testChunkPipe)
 	}
 }
 

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -162,11 +161,11 @@ func (ts *Tags) Delete(k interface{}) {
 func (ts *Tags) MarshalJSON() (out []byte, err error) {
 	m := make(map[string]*Tag)
 	ts.Range(func(k, v interface{}) bool {
-		key := fmt.Sprintf("%d", k)
 		val := v.(*Tag)
 
 		// don't persist tags which were already done
 		if !val.Done(StateSynced) {
+			key := strconv.Itoa(int(k.(uint32)))
 			m[key] = val
 		}
 		return true

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -165,7 +165,7 @@ func (ts *Tags) MarshalJSON() (out []byte, err error) {
 
 		// don't persist tags which were already done
 		if !val.Done(StateSynced) {
-			key := strconv.Itoa(int(k.(uint32)))
+			key := strconv.FormatInt(int64(k.(uint32)), 10)
 			m[key] = val
 		}
 		return true
@@ -300,5 +300,5 @@ func (ts *Tags) Close() (err error) {
 }
 
 func tagKey(uid uint32) string {
-	return tagKeyPrefix + strconv.Itoa(int(uid))
+	return tagKeyPrefix + strconv.FormatInt(int64(uid), 10)
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description
Occurrences of `fmt.Sprintf("%d",...)` were replaced with `strconv.FormatInt(..)`; later approach is already suggested in [go style guide](https://github.com/ethersphere/bee/blob/master/CODINGSTYLE.md#prefer-strconv-over-fmt).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3226)
<!-- Reviewable:end -->
