### PR TITLE
fix: response for slash in website index document

### DIFF
--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -147,7 +147,7 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 		return
 	}
 
-	// filename cannot contain a "/" in prefix
+	// filename cannot contain a "/" in prefix because the specification is that we cannot start with slash but can have a slash at a later position
 	if strings.HasPrefix(fileName, "/") {
 		fileName = strings.TrimLeft(fileName, "/")
 	}

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -149,7 +149,7 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 
 	// filename cannot contain a "/" in prefix because the specification is that we cannot start with slash but can have a slash at a later position
 	if strings.HasPrefix(fileName, "/") {
-		logger.Debug("bzz upload file: / in prefix not allowed ", "file_name", fileName, "error", err)
+		logger.Debug("bzz upload file: / in prefix not allowed", "file_name", fileName, "error", err)
 		logger.Error(nil, "bzz upload file: / in prefix not allowed", "file_name", fileName)
 		jsonhttp.BadRequest(w, "bzz upload file: / in prefix not allowed")
 		return

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -147,10 +147,12 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 		return
 	}
 
+	if strings.HasPrefix(fileName, "/") {
+		fileName = strings.TrimLeft(fileName, "/")
+	}
 	rootMetadata := map[string]string{
 		manifest.WebsiteIndexDocumentSuffixKey: fileName,
 	}
-
 	err = m.Add(ctx, manifest.RootPath, manifest.NewEntry(swarm.ZeroAddress, rootMetadata))
 	if err != nil {
 		logger.Debug("bzz upload file: adding metadata to manifest failed", "file_name", fileName, "error", err)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -149,7 +149,10 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 
 	// filename cannot contain a "/" in prefix because the specification is that we cannot start with slash but can have a slash at a later position
 	if strings.HasPrefix(fileName, "/") {
-		fileName = strings.TrimLeft(fileName, "/")
+		logger.Debug("bzz upload file: / in prefix not allowed ", "file_name", fileName, "error", err)
+		logger.Error(nil, "bzz upload file: / in prefix not allowed", "file_name", fileName)
+		jsonhttp.BadRequest(w, "bzz upload file: / in prefix not allowed")
+		return
 	}
 	rootMetadata := map[string]string{
 		manifest.WebsiteIndexDocumentSuffixKey: fileName,

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -147,6 +147,7 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 		return
 	}
 
+	// filename cannot contain a "/" in prefix
 	if strings.HasPrefix(fileName, "/") {
 		fileName = strings.TrimLeft(fileName, "/")
 	}

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -249,7 +249,9 @@ func (s *Service) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		// NOTE: leave one slash if there was some
 		pathVar += "/"
 	}
-
+	if strings.HasPrefix(nameOrHex, "/") {
+		nameOrHex = strings.TrimLeft(nameOrHex, "/")
+	}
 	address, err := s.resolveNameOrAddress(nameOrHex)
 	if err != nil {
 		logger.Debug("bzz download: parse address string failed", "string", nameOrHex, "error", err)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -151,7 +151,7 @@ func (s *Service) fileUploadHandler(w http.ResponseWriter, r *http.Request, stor
 	if strings.HasPrefix(fileName, "/") {
 		logger.Debug("bzz upload file: / in prefix not allowed", "file_name", fileName, "error", err)
 		logger.Error(nil, "bzz upload file: / in prefix not allowed", "file_name", fileName)
-		jsonhttp.BadRequest(w, "bzz upload file: / in prefix not allowed")
+		jsonhttp.BadRequest(w, "/ in prefix not allowed")
 		return
 	}
 	rootMetadata := map[string]string{
@@ -248,13 +248,11 @@ func (s *Service) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 
 	nameOrHex := mux.Vars(r)["address"]
 	pathVar := mux.Vars(r)["path"]
+
 	if strings.HasSuffix(pathVar, "/") {
 		pathVar = strings.TrimRight(pathVar, "/")
 		// NOTE: leave one slash if there was some
 		pathVar += "/"
-	}
-	if strings.HasPrefix(nameOrHex, "/") {
-		nameOrHex = strings.TrimLeft(nameOrHex, "/")
 	}
 	address, err := s.resolveNameOrAddress(nameOrHex)
 	if err != nil {

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -213,6 +213,24 @@ func TestBzzFiles(t *testing.T) {
 		}
 	})
 
+	t.Run("check for slash in prefix in filename", func(t *testing.T) {
+		fileName := "/my-pictures.jpeg"
+
+		var resp api.BzzUploadResponse
+
+		_ = jsonhttptest.Request(t, client, http.MethodPost,
+			fileUploadResource+"?name="+fileName, http.StatusBadRequest,
+			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
+			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
+			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
+			jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
+			jsonhttptest.WithUnmarshalJSONResponse(&resp),
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Message: "bzz upload file: / in prefix not allowed",
+				Code:    http.StatusBadRequest,
+			}))
+	})
+
 	t.Run("filter out filename path", func(t *testing.T) {
 		fileName := "my-pictures.jpeg"
 		fileNameWithPath := "../../" + fileName

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -223,7 +223,7 @@ func TestBzzFiles(t *testing.T) {
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
 			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
-				Message: "bzz upload file: / in prefix not allowed",
+				Message: "/ in prefix not allowed",
 				Code:    http.StatusBadRequest,
 			}))
 	})

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -216,15 +216,12 @@ func TestBzzFiles(t *testing.T) {
 	t.Run("check for slash in prefix in filename", func(t *testing.T) {
 		fileName := "/my-pictures.jpeg"
 
-		var resp api.BzzUploadResponse
-
 		_ = jsonhttptest.Request(t, client, http.MethodPost,
 			fileUploadResource+"?name="+fileName, http.StatusBadRequest,
 			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 			jsonhttptest.WithRequestHeader("Content-Type", "image/jpeg; charset=utf-8"),
-			jsonhttptest.WithUnmarshalJSONResponse(&resp),
 			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
 				Message: "bzz upload file: / in prefix not allowed",
 				Code:    http.StatusBadRequest,


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description
<!--Please include a summary of the change and which issue is fixed. -->
Please refer to tagged issue for details. This pr sends correct response if there is a slash in website index document
#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->
This pr fixes #2661 
### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3229)
<!-- Reviewable:end -->
