### PR TITLE
fix(node): nonce log formatting

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -484,13 +485,13 @@ func NewBee(interrupt chan struct{}, addr string, publicKey *ecdsa.PublicKey, si
 		for prox := uint8(0); prox < swarm.MaxPO && j < uint64(limit); j++ {
 			binary.LittleEndian.PutUint64(nonce, j)
 			if (j/1000000)*1000000 == j {
-				logger.Info("finding new overlay corresponding to previous overlay with nonce", "nonce", nonce)
+				logger.Info("finding new overlay corresponding to previous overlay with nonce", "nonce", hex.EncodeToString(nonce))
 			}
 			newOverlayCandidate, err = crypto.NewOverlayAddress(*pubKey, networkID, nonce)
 			if err == nil {
 				prox = swarm.Proximity(existingOverlay.Bytes(), newOverlayCandidate.Bytes())
 			} else {
-				logger.Info("error finding new overlay", "error", err, "nonce", nonce)
+				logger.Info("error finding new overlay", "nonce", hex.EncodeToString(nonce), "error", err)
 			}
 		}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -485,13 +485,13 @@ func NewBee(interrupt chan struct{}, addr string, publicKey *ecdsa.PublicKey, si
 		for prox := uint8(0); prox < swarm.MaxPO && j < uint64(limit); j++ {
 			binary.LittleEndian.PutUint64(nonce, j)
 			if (j/1000000)*1000000 == j {
-				logger.Info("finding new overlay corresponding to previous overlay with nonce", "nonce", hex.EncodeToString(nonce))
+				logger.Debug("finding new overlay corresponding to previous overlay with nonce", "nonce", hex.EncodeToString(nonce))
 			}
 			newOverlayCandidate, err = crypto.NewOverlayAddress(*pubKey, networkID, nonce)
 			if err == nil {
 				prox = swarm.Proximity(existingOverlay.Bytes(), newOverlayCandidate.Bytes())
 			} else {
-				logger.Info("error finding new overlay", "nonce", hex.EncodeToString(nonce), "error", err)
+				logger.Debug("error finding new overlay", "nonce", hex.EncodeToString(nonce), "error", err)
 			}
 		}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description
Fixes formatting of the nonce in the log messages:
before: `..."msg"="finding new overlay corresponding to previous overlay with nonce" "nonce"=[0,9,61,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]`

after: `..."msg"="finding new overlay corresponding to previous overlay with nonce" "nonce"="0052bc0f00000000000000000000000000000000000000000000000000000000"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3235)
<!-- Reviewable:end -->
