### PR TITLE
docs: add Open API spec question checkbox to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,10 @@
 ### Checklist
 
-- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
-- [ ] My change requires a documentation update and I have done it
+- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
+- [ ] My change requires a documentation update, and I have done it.
+- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
 - [ ] I have added tests to cover my changes.
-- [ ] I have filled out the description and linked the related issues
+- [ ] I have filled out the description and linked the related issues.
 
 ### Description
 <!--Please include a summary of the change and which issue is fixed. -->


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues

### Description
Adds a checkbox to the PR template to remind of the necessary changes to the Open API specification, if applicable.

#### Motivation and context (Optional)
PR authors often forget to update (or change the version number of) the Open API specification when changes are made to the endpoints, adding a checkbox should remind them to make those changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3244)
<!-- Reviewable:end -->
