### PR TITLE
fix: set stamps expiration field after batch sync completes

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -757,7 +757,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 			}
 			isDone = syncStatus.Load() != nil
 			if isDone && !statusStampsSynced {
-				err = post.HandleStamps()
+				err = post.AddStampsToService()
 				if err != nil {
 					return isDone, fmt.Errorf("postage service load: %w", err)
 				}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -767,6 +767,10 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 				syncErr.Store(err)
 				return nil, fmt.Errorf("unable to start batch service: %w", err)
 			}
+			err = post.SetExpired()
+			if err != nil {
+				return nil, fmt.Errorf("unable to set expirations: %w", err)
+			}
 		} else {
 			go func() {
 				logger.Info("started postage contract data sync in the background...")
@@ -783,10 +787,6 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 				}
 			}()
 		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("postage service expiry setter: %w", err)
 	}
 
 	minThreshold := big.NewInt(2 * refreshRate)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -777,7 +777,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 					logger.Error(err, "unable to sync batches")
 					b.syncingStopped.Signal() // trigger shutdown in start.go
 				}
-				err = post.ExpirySetter()
+				err = post.SetExpired()
 				if err != nil {
 					logger.Error(err, "unable to set expirations")
 				}
@@ -785,7 +785,6 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 		}
 	}
 
-	err = post.ExpirySetter()
 	if err != nil {
 		return nil, fmt.Errorf("postage service expiry setter: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -744,6 +744,8 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 	hive.SetAddPeersHandler(kad.AddPeers)
 	p2ps.SetPickyNotifier(kad)
 
+	var statusStampsSynced bool
+
 	var (
 		syncErr    atomic.Value
 		syncStatus atomic.Value
@@ -754,6 +756,13 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 				err = iErr.(error)
 			}
 			isDone = syncStatus.Load() != nil
+			if isDone && !statusStampsSynced {
+				err = post.HandleStamps()
+				if err != nil {
+					return isDone, fmt.Errorf("postage service load: %w", err)
+				}
+				statusStampsSynced = true
+			}
 			return isDone, err
 		}
 	)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -766,10 +766,11 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 			if err != nil {
 				syncErr.Store(err)
 				return nil, fmt.Errorf("unable to start batch service: %w", err)
-			}
-			err = post.SetExpired()
-			if err != nil {
-				return nil, fmt.Errorf("unable to set expirations: %w", err)
+			} else {
+				err = post.SetExpired()
+				if err != nil {
+					return nil, fmt.Errorf("unable to set expirations: %w", err)
+				}
 			}
 		} else {
 			go func() {
@@ -780,10 +781,11 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 					syncErr.Store(err)
 					logger.Error(err, "unable to sync batches")
 					b.syncingStopped.Signal() // trigger shutdown in start.go
-				}
-				err = post.SetExpired()
-				if err != nil {
-					logger.Error(err, "unable to set expirations")
+				} else {
+					err = post.SetExpired()
+					if err != nil {
+						logger.Error(err, "unable to set expirations")
+					}
 				}
 			}()
 		}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -789,7 +789,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 	if err != nil {
 		return nil, fmt.Errorf("postage service expiry setter: %w", err)
 	}
-	
+
 	minThreshold := big.NewInt(2 * refreshRate)
 	maxThreshold := big.NewInt(24 * refreshRate)
 

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -111,5 +111,5 @@ type BatchEventListener interface {
 
 type BatchExpiryHandler interface {
 	HandleStampExpiry([]byte)
-	ExpirySetter() error
+	SetExpired() error
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -111,4 +111,5 @@ type BatchEventListener interface {
 
 type BatchExpiryHandler interface {
 	HandleStampExpiry([]byte)
+	HandleStamps() error
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -111,8 +111,5 @@ type BatchEventListener interface {
 
 type BatchExpiryHandler interface {
 	HandleStampExpiry([]byte)
-}
-
-type StampsSyncHandler interface {
-	AddStampsToService() error
+	ExpirySetter() error
 }

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -111,5 +111,8 @@ type BatchEventListener interface {
 
 type BatchExpiryHandler interface {
 	HandleStampExpiry([]byte)
-	HandleStamps() error
+}
+
+type StampsSyncHandler interface {
+	AddStampsToService() error
 }

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -52,7 +52,7 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
-func (m *mockPostage) ExpirySetter() error {
+func (m *mockPostage) SetExpired() error {
 	return nil
 }
 

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -52,7 +52,7 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
-func (m *mockPostage) AddStampsToService() error {
+func (m *mockPostage) ExpirySetter() error {
 	return nil
 }
 

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -52,7 +52,7 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
-func (m *mockPostage) HandleStamps() error {
+func (m *mockPostage) AddStampsToService() error {
 	return nil
 }
 

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -52,6 +52,10 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
+func (m *mockPostage) HandleStamps() error {
+	return nil
+}
+
 func (m *mockPostage) HandleStampExpiry(id []byte) {
 	m.issuerLock.Lock()
 	defer m.issuerLock.Unlock()

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -209,7 +209,7 @@ func (ps *service) HandleStampExpiry(id []byte) {
 	}
 }
 
-func (ps *service) ExpirySetter() error {
+func (ps *service) SetExpired() error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -197,6 +197,7 @@ func (ps *service) key() string {
 	return fmt.Sprintf(postagePrefix+"%d", ps.chainID)
 }
 
+// HandleStampExpiry handles stamp expiry for a given id.
 func (ps *service) HandleStampExpiry(id []byte) {
 
 	ps.lock.Lock()
@@ -209,6 +210,7 @@ func (ps *service) HandleStampExpiry(id []byte) {
 	}
 }
 
+// SetExpired sets expiry for all non-existing batches.
 func (ps *service) SetExpired() error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -37,6 +37,7 @@ type Service interface {
 	IssuerUsable(*StampIssuer) bool
 	BatchEventListener
 	BatchExpiryHandler
+	StampsSyncHandler
 	io.Closer
 }
 
@@ -198,7 +199,7 @@ func (ps *service) HandleStampExpiry(id []byte) {
 	}
 }
 
-func (ps *service) HandleStamps() error {
+func (ps *service) AddStampsToService() error {
 	if err := ps.store.Iterate(ps.key(), func(_, value []byte) (bool, error) {
 		st := &StampIssuer{}
 		if err := st.UnmarshalBinary(value); err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)

### Description
<!--Please include a summary of the change and which issue is fixed. -->
set stamps expiration field after batch sync completes
#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3269)
<!-- Reviewable:end -->
