### PR TITLE
fix: make wallet endpoint avaiable only when swap-enabled is set to true

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -452,9 +452,11 @@ func (s *Service) mountBusinessDebug(restricted bool) {
 			"POST": http.HandlerFunc(s.chequebookWithdrawHandler),
 		})
 
-		handle("/wallet", jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.walletHandler),
-		})
+		if s.swapEnabled {
+			handle("/wallet", jsonhttp.MethodHandler{
+				"GET": http.HandlerFunc(s.walletHandler),
+			})
+		}
 	}
 
 	handle("/stamps", web.ChainHandlers(


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md)
- [ ] My change requires a documentation update and I have done it
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues

### Description
Fixes the case when the `swap-enable` flag/configuration value is set to false, then the `/wallet` endpoint should not be available because it uses the swap-backend.

Fixes #3268

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3271)
<!-- Reviewable:end -->
