### PR TITLE
fix: allow interruption while waiting for funds

### DIFF
--- a/cmd/bee/cmd/deploy.go
+++ b/cmd/bee/cmd/deploy.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -91,6 +92,7 @@ func (c *command) initDeployCmd() error {
 
 			_, err = node.InitChequebookService(
 				ctx,
+				make(chan os.Signal),
 				logger,
 				stateStore,
 				signer,

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"strings"
 	"time"
 
@@ -152,6 +153,7 @@ func InitChequebookFactory(
 // chequebook factory and chain backend.
 func InitChequebookService(
 	ctx context.Context,
+	interrupt chan os.Signal,
 	logger log.Logger,
 	stateStore storage.StateStorer,
 	signer crypto.Signer,
@@ -181,6 +183,7 @@ func InitChequebookService(
 
 	chequebookService, err := chequebook.Init(
 		ctx,
+		interrupt,
 		chequebookFactory,
 		stateStore,
 		logger,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -428,6 +428,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 		if o.ChequebookEnable && chainEnabled {
 			chequebookService, err = InitChequebookService(
 				p2pCtx,
+				sysInterrupt,
 				logger,
 				stateStore,
 				signer,


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
At the moment waiting for funding is an uninterruptible action, it can be stopped solely by killing the process.

This change listens to os signals and exits on user interruption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3275)
<!-- Reviewable:end -->
