### PR TITLE
fix: set stamp expiration to false if batch exists

### DIFF
--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -62,7 +62,7 @@ func (m *mockPostage) HandleStampExpiry(id []byte) {
 
 	for _, v := range m.issuersMap {
 		if bytes.Equal(id, v.ID()) {
-			v.SetExpired()
+			v.SetExpired(true)
 		}
 	}
 }

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -220,11 +220,7 @@ func (ps *service) SetExpired() error {
 		if err != nil {
 			return err
 		}
-		if !exists {
-			v.SetExpired(true)
-		} else {
-			v.SetExpired(false)
-		}
+		v.SetExpired(!exists)
 	}
 	return nil
 }

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -205,7 +205,7 @@ func (ps *service) HandleStampExpiry(id []byte) {
 
 	for _, v := range ps.issuers {
 		if bytes.Equal(id, v.ID()) {
-			v.SetExpired()
+			v.SetExpired(true)
 		}
 	}
 }
@@ -221,7 +221,9 @@ func (ps *service) SetExpired() error {
 			return err
 		}
 		if !exists {
-			v.SetExpired()
+			v.SetExpired(true)
+		} else {
+			v.SetExpired(false)
 		}
 	}
 	return nil

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -177,6 +177,6 @@ func (si *StampIssuer) Expired() bool {
 }
 
 // SetExpired is setter for Expired property
-func (si *StampIssuer) SetExpired() {
-	si.data.Expired = true
+func (si *StampIssuer) SetExpired(e bool) {
+	si.data.Expired = e
 }


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
If the batchstore is unstable due to whatever reason, on reboot, if a batch exists, then the stamp should have field false regardless of previous value.

#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3289)
<!-- Reviewable:end -->
