### PR TITLE
chore(lint): make test execute in parallel (part #1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - nakedret
     - nilerr
     - noctx
+    - paralleltest
     - prealloc
     - promlinter
     - staticcheck
@@ -61,3 +62,68 @@ issues:
     - linters:
         - dogsled
       path: pkg/api/(.+)_test\.go # temporally disable dogsled in api test files
+      # temporally disable paralleltest in following packages
+    - linters: paralleltest
+      path: pkg/topology
+    - linters: paralleltest
+      path: pkg/topology
+    - linters: paralleltest
+      path: pkg/localstore
+    - linters: paralleltest
+      path: pkg/encryption
+    - linters: paralleltest
+      path: pkg/pricer
+    - linters: paralleltest
+      path: pkg/shed
+    - linters: paralleltest
+      path: pkg/file
+    - linters: paralleltest
+      path: pkg/postage
+    - linters: paralleltest
+      path: pkg/bmt
+    - linters: paralleltest
+      path: pkg/puller
+    - linters: paralleltest
+      path: pkg/manifest
+    - linters: paralleltest
+      path: pkg/api
+    - linters: paralleltest
+      path: pkg/retrieval
+    - linters: paralleltest
+      path: pkg/feeds
+    - linters: paralleltest
+      path: pkg/pushsync
+    - linters: paralleltest
+      path: pkg/pusher
+    - linters: paralleltest
+      path: pkg/log
+    - linters: paralleltest
+      path: pkg/resolver
+    - linters: paralleltest
+      path: pkg/pullsync
+    - linters: paralleltest
+      path: pkg/hive
+    - linters: paralleltest
+      path: pkg/statestore
+    - linters: paralleltest
+      path: pkg/p2p
+    - linters: paralleltest
+      path: pkg/intervalstore
+    - linters: paralleltest
+      path: pkg/sharky
+    - linters: paralleltest
+      path: pkg/soc
+    - linters: paralleltest
+      path: pkg/auth
+    - linters: paralleltest
+      path: pkg/pss
+    - linters: paralleltest
+      path: pkg/pinning
+    - linters: paralleltest
+      path: pkg/flipflop
+    - linters: paralleltest
+      path: pkg/chainsyncer
+    - linters: paralleltest
+      path: pkg/cac
+    - linters: paralleltest
+      path: pkg/traversal

--- a/cmd/bee/cmd/version_test.go
+++ b/cmd/bee/cmd/version_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestVersionCmd(t *testing.T) {
+	t.Parallel()
+
 	var outputBuf bytes.Buffer
 	if err := newCommand(t,
 		cmd.WithArgs("version"),

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -50,7 +50,11 @@ type bookingT struct {
 }
 
 func TestMutex(t *testing.T) {
+	t.Parallel()
+
 	t.Run("locked mutex can not be locked again", func(t *testing.T) {
+		t.Parallel()
+
 		m := accounting.NewMutex()
 		m.Lock()
 
@@ -76,6 +80,8 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("can lock after release", func(t *testing.T) {
+		t.Parallel()
+
 		m := accounting.NewMutex()
 		m.Lock()
 
@@ -89,6 +95,8 @@ func TestMutex(t *testing.T) {
 	})
 
 	t.Run("locked mutex takes context into account", func(t *testing.T) {
+		t.Parallel()
+
 		m := accounting.NewMutex()
 		m.Lock()
 
@@ -102,6 +110,8 @@ func TestMutex(t *testing.T) {
 
 // TestAccountingAddBalance does several accounting actions and verifies the balance after each steep
 func TestAccountingAddBalance(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -171,6 +181,8 @@ func TestAccountingAddBalance(t *testing.T) {
 
 // TestAccountingAddBalance does several accounting actions and verifies the balance after each steep
 func TestAccountingAddOriginatedBalance(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -294,6 +306,8 @@ func TestAccountingAddOriginatedBalance(t *testing.T) {
 // It creates an accounting instance, does some accounting
 // Then it creates a new accounting instance with the same store and verifies the balances
 func TestAccountingAdd_persistentBalances(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -366,6 +380,8 @@ func TestAccountingAdd_persistentBalances(t *testing.T) {
 
 // TestAccountingReserve tests that reserve returns an error if the payment threshold would be exceeded
 func TestAccountingReserve(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -399,6 +415,8 @@ func TestAccountingReserve(t *testing.T) {
 // TestAccountingReserve tests that reserve returns an error if the payment threshold would be exceeded,
 // but extends this limit by 'n' (max 2) seconds worth of refresh rate if last refreshment was 'n' seconds ago.
 func TestAccountingReserveAheadOfTime(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -543,6 +561,8 @@ func TestAccountingReserveAheadOfTime(t *testing.T) {
 
 // TestAccountingDisconnect tests that exceeding the disconnect threshold with Debit returns a p2p.DisconnectError
 func TestAccountingDisconnect(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -592,6 +612,8 @@ func TestAccountingDisconnect(t *testing.T) {
 
 // TestAccountingCallSettlement tests that settlement is called correctly if the payment threshold is hit
 func TestAccountingCallSettlement(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -710,6 +732,8 @@ func TestAccountingCallSettlement(t *testing.T) {
 }
 
 func TestAccountingCallSettlementMonetary(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -845,6 +869,8 @@ func TestAccountingCallSettlementMonetary(t *testing.T) {
 }
 
 func TestAccountingCallSettlementTooSoon(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mock.NewStateStore()
 	defer store.Close()
@@ -965,6 +991,8 @@ func TestAccountingCallSettlementTooSoon(t *testing.T) {
 
 // TestAccountingCallSettlementEarly tests that settlement is called correctly if the payment threshold minus early payment is hit
 func TestAccountingCallSettlementEarly(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1040,6 +1068,8 @@ func TestAccountingCallSettlementEarly(t *testing.T) {
 }
 
 func TestAccountingSurplusBalance(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1165,6 +1195,8 @@ func TestAccountingSurplusBalance(t *testing.T) {
 
 // TestAccountingNotifyPayment tests that payments adjust the balance
 func TestAccountingNotifyPaymentReceived(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1230,6 +1262,8 @@ func (p *pricingMock) AnnouncePaymentThreshold(ctx context.Context, peer swarm.A
 }
 
 func TestAccountingConnected(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1266,6 +1300,8 @@ func TestAccountingConnected(t *testing.T) {
 }
 
 func TestAccountingNotifyPaymentThreshold(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1325,6 +1361,8 @@ func TestAccountingNotifyPaymentThreshold(t *testing.T) {
 }
 
 func TestAccountingPeerDebt(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1387,6 +1425,8 @@ func TestAccountingPeerDebt(t *testing.T) {
 }
 
 func TestAccountingCallPaymentErrorRetries(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1539,6 +1579,8 @@ func TestAccountingCallPaymentErrorRetries(t *testing.T) {
 var errInvalidReason = errors.New("invalid blocklist reason")
 
 func TestAccountingGhostOverdraft(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1615,6 +1657,8 @@ func TestAccountingGhostOverdraft(t *testing.T) {
 }
 
 func TestAccountingReconnectBeforeAllowed(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1687,6 +1731,8 @@ func TestAccountingReconnectBeforeAllowed(t *testing.T) {
 }
 
 func TestAccountingResetBalanceAfterReconnect(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	store := mock.NewStateStore()
@@ -1893,12 +1939,14 @@ func testAccountingSettlementGrowingThresholds(t *testing.T, settleFunc func(t *
 }
 
 func TestAccountingRefreshGrowingThresholds(t *testing.T) {
+	t.Parallel()
 
 	testAccountingSettlementGrowingThresholds(t, debitAndRefresh, true, testPaymentThreshold, testRefreshRate)
 
 }
 
 func TestAccountingRefreshGrowingThresholdsLight(t *testing.T) {
+	t.Parallel()
 
 	lightPaymentThresholdDefault := new(big.Int).Div(testPaymentThreshold, big.NewInt(testLightFactor))
 	lightRefreshRate := testRefreshRate / testLightFactor
@@ -1908,12 +1956,14 @@ func TestAccountingRefreshGrowingThresholdsLight(t *testing.T) {
 }
 
 func TestAccountingSwapGrowingThresholds(t *testing.T) {
+	t.Parallel()
 
 	testAccountingSettlementGrowingThresholds(t, debitAndReceivePayment, true, testPaymentThreshold, testRefreshRate)
 
 }
 
 func TestAccountingSwapGrowingThresholdsLight(t *testing.T) {
+	t.Parallel()
 
 	lightPaymentThresholdDefault := new(big.Int).Div(testPaymentThreshold, big.NewInt(testLightFactor))
 	lightRefreshRate := testRefreshRate / testLightFactor

--- a/pkg/addressbook/addressbook_test.go
+++ b/pkg/addressbook/addressbook_test.go
@@ -21,6 +21,8 @@ import (
 type bookFunc func() (book addressbook.Interface)
 
 func TestInMem(t *testing.T) {
+	t.Parallel()
+
 	run(t, func() addressbook.Interface {
 		store := mock.NewStateStore()
 		book := addressbook.New(store)

--- a/pkg/bigint/bigint_test.go
+++ b/pkg/bigint/bigint_test.go
@@ -6,14 +6,17 @@ package bigint_test
 
 import (
 	"encoding/json"
-	"github.com/ethersphere/bee/pkg/bigint"
 	"math"
 	"math/big"
 	"reflect"
 	"testing"
+
+	"github.com/ethersphere/bee/pkg/bigint"
 )
 
 func TestMarshaling(t *testing.T) {
+	t.Parallel()
+
 	mar, err := json.Marshal(struct {
 		Bg *bigint.BigInt
 	}{

--- a/pkg/bitvector/bitvector_test.go
+++ b/pkg/bitvector/bitvector_test.go
@@ -23,6 +23,8 @@ import (
 
 // TestBitvectorNew checks that enforcements of argument length works in the constructors
 func TestBitvectorNew(t *testing.T) {
+	t.Parallel()
+
 	_, err := New(0)
 	if !errors.Is(err, errInvalidLength) {
 		t.Errorf("expected err %v, got %v", errInvalidLength, err)
@@ -46,6 +48,8 @@ func TestBitvectorNew(t *testing.T) {
 
 // TestBitvectorGetSet tests correctness of individual Set and Get commands
 func TestBitvectorGetSet(t *testing.T) {
+	t.Parallel()
+
 	for _, length := range []int{
 		1,
 		2,
@@ -90,6 +94,8 @@ func TestBitvectorGetSet(t *testing.T) {
 
 // TestBitvectorNewFromBytesGet tests that bit vector is initialized correctly from underlying byte slice
 func TestBitvectorNewFromBytesGet(t *testing.T) {
+	t.Parallel()
+
 	bv, err := NewFromBytes([]byte{8}, 8)
 	if err != nil {
 		t.Error(err)

--- a/pkg/blocker/blocker_test.go
+++ b/pkg/blocker/blocker_test.go
@@ -36,6 +36,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestBlocksAfterFlagTimeout(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mu      sync.Mutex
 		blocked = make(map[string]time.Duration)
@@ -79,6 +81,8 @@ func TestBlocksAfterFlagTimeout(t *testing.T) {
 }
 
 func TestUnflagBeforeBlock(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mu      sync.Mutex
 		blocked = make(map[string]time.Duration)
@@ -115,6 +119,8 @@ func TestUnflagBeforeBlock(t *testing.T) {
 }
 
 func TestPruneBeforeBlock(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mu      sync.Mutex
 		blocked = make(map[string]time.Duration)

--- a/pkg/bzz/address_test.go
+++ b/pkg/bzz/address_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestBzzAddress(t *testing.T) {
+	t.Parallel()
+
 	node1ma, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1634/p2p/16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cac/cac_test.go
+++ b/pkg/cac/cac_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestNewCAC(t *testing.T) {
+	t.Parallel()
+
 	data := []byte("greaterthanspan")
 	bmtHashOfData := "27913f1bdb6e8e52cbd5a5fd4ab577c857287edf6969b41efe926b51de0f4f23"
 	address := swarm.MustParseHexAddress(bmtHashOfData)
@@ -41,6 +43,8 @@ func TestNewCAC(t *testing.T) {
 }
 
 func TestNewWithDataSpan(t *testing.T) {
+	t.Parallel()
+
 	data := []byte("greaterthanspan")
 	bmtHashOfData := "95022e6af5c6d6a564ee55a67f8455a3e18c511b5697c932d9e44f07f2fb8c53"
 	address := swarm.MustParseHexAddress(bmtHashOfData)
@@ -60,6 +64,8 @@ func TestNewWithDataSpan(t *testing.T) {
 }
 
 func TestChunkInvariants(t *testing.T) {
+	t.Parallel()
+
 	chunkerFunc := []struct {
 		name    string
 		chunker func(data []byte) (swarm.Chunk, error)
@@ -74,6 +80,7 @@ func TestChunkInvariants(t *testing.T) {
 		},
 	}
 
+	// nolint:paralleltest
 	for _, f := range chunkerFunc {
 		for _, cc := range []struct {
 			name    string
@@ -109,6 +116,8 @@ func TestChunkInvariants(t *testing.T) {
 
 // TestValid checks whether a chunk is a valid content-addressed chunk
 func TestValid(t *testing.T) {
+	t.Parallel()
+
 	bmtHashOfFoo := "2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48"
 	address := swarm.MustParseHexAddress(bmtHashOfFoo)
 
@@ -125,6 +134,8 @@ func TestValid(t *testing.T) {
 
 /// TestInvalid checks whether a chunk is not a valid content-addressed chunk
 func TestInvalid(t *testing.T) {
+	t.Parallel()
+
 	// Generates a chunk with the given data. No validation is performed here,
 	// the chunks are create as it is.
 	chunker := func(addr string, dataBytes []byte) swarm.Chunk {
@@ -180,7 +191,10 @@ func TestInvalid(t *testing.T) {
 			data:    []byte(strings.Repeat("a", swarm.ChunkSize+swarm.SpanSize+1)),
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			ch := chunker(c.address, c.data)
 			if cac.Valid(ch) {
 				t.Fatalf("data '%s' should not have validated to hash '%s'", ch.Data(), ch.Address())

--- a/pkg/cac/cac_test.go
+++ b/pkg/cac/cac_test.go
@@ -43,8 +43,6 @@ func TestNewCAC(t *testing.T) {
 }
 
 func TestNewWithDataSpan(t *testing.T) {
-	t.Parallel()
-
 	data := []byte("greaterthanspan")
 	bmtHashOfData := "95022e6af5c6d6a564ee55a67f8455a3e18c511b5697c932d9e44f07f2fb8c53"
 	address := swarm.MustParseHexAddress(bmtHashOfData)
@@ -64,8 +62,6 @@ func TestNewWithDataSpan(t *testing.T) {
 }
 
 func TestChunkInvariants(t *testing.T) {
-	t.Parallel()
-
 	chunkerFunc := []struct {
 		name    string
 		chunker func(data []byte) (swarm.Chunk, error)
@@ -80,7 +76,6 @@ func TestChunkInvariants(t *testing.T) {
 		},
 	}
 
-	// nolint:paralleltest
 	for _, f := range chunkerFunc {
 		for _, cc := range []struct {
 			name    string

--- a/pkg/chainsync/chainsync_test.go
+++ b/pkg/chainsync/chainsync_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestProve(t *testing.T) {
+	t.Parallel()
+
 	var (
 		expHash     = "9de2787d1d80a6164f4bc6359d9017131cbc14402ee0704bff0c6d691701c1dc"
 		mtx         sync.Mutex
@@ -71,6 +73,8 @@ func TestProve(t *testing.T) {
 }
 
 func TestProveErr(t *testing.T) {
+	t.Parallel()
+
 	headerByNum := backendmock.WithHeaderbyNumberFunc(func(ctx context.Context, number *big.Int) (*types.Header, error) {
 		return nil, errors.New("some error")
 	})

--- a/pkg/crypto/clef/clef_test.go
+++ b/pkg/crypto/clef/clef_test.go
@@ -45,6 +45,8 @@ func (m *mockClef) SignTx(account accounts.Account, transaction *types.Transacti
 }
 
 func TestNewClefSigner(t *testing.T) {
+	t.Parallel()
+
 	ethAddress := common.HexToAddress("0x31415b599f636129AD03c196cef9f8f8b184D5C7")
 	testSignature := make([]byte, 65)
 
@@ -103,6 +105,8 @@ func TestNewClefSigner(t *testing.T) {
 }
 
 func TestNewClefSignerSpecificAccount(t *testing.T) {
+	t.Parallel()
+
 	ethAddress := common.HexToAddress("0x31415b599f636129AD03c196cef9f8f8b184D5C7")
 	wantedAddress := common.HexToAddress("0x41415b599f636129AD03c196cef9f8f8b184D5C7")
 	testSignature := make([]byte, 65)
@@ -162,6 +166,8 @@ func TestNewClefSignerSpecificAccount(t *testing.T) {
 }
 
 func TestNewClefSignerAccountUnavailable(t *testing.T) {
+	t.Parallel()
+
 	ethAddress := common.HexToAddress("0x31415b599f636129AD03c196cef9f8f8b184D5C7")
 	wantedAddress := common.HexToAddress("0x41415b599f636129AD03c196cef9f8f8b184D5C7")
 
@@ -182,6 +188,8 @@ func TestNewClefSignerAccountUnavailable(t *testing.T) {
 }
 
 func TestClefNoAccounts(t *testing.T) {
+	t.Parallel()
+
 	mock := &mockClef{
 		accounts: []accounts.Account{},
 	}
@@ -204,6 +212,8 @@ func (m *mockRpc) Call(result interface{}, method string, args ...interface{}) e
 }
 
 func TestClefTypedData(t *testing.T) {
+	t.Parallel()
+
 	key, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestGenerateSecp256k1Key(t *testing.T) {
+	t.Parallel()
+
 	k1, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -36,6 +38,8 @@ func TestGenerateSecp256k1Key(t *testing.T) {
 }
 
 func TestNewAddress(t *testing.T) {
+	t.Parallel()
+
 	k, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +59,8 @@ func TestNewAddress(t *testing.T) {
 }
 
 func TestEncodeSecp256k1PrivateKey(t *testing.T) {
+	t.Parallel()
+
 	k1, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -70,6 +76,8 @@ func TestEncodeSecp256k1PrivateKey(t *testing.T) {
 }
 
 func TestSecp256k1PrivateKeyFromBytes(t *testing.T) {
+	t.Parallel()
+
 	data := []byte("data")
 
 	k1 := crypto.Secp256k1PrivateKeyFromBytes(data)
@@ -88,6 +96,8 @@ func TestSecp256k1PrivateKeyFromBytes(t *testing.T) {
 }
 
 func TestNewEthereumAddress(t *testing.T) {
+	t.Parallel()
+
 	privKeyHex := "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
 	privKeyBytes, err := hex.DecodeString(privKeyHex)
 	if err != nil {

--- a/pkg/crypto/dh_test.go
+++ b/pkg/crypto/dh_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestECDHCorrect(t *testing.T) {
+	t.Parallel()
+
 	key0, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -49,6 +51,8 @@ func TestECDHCorrect(t *testing.T) {
 }
 
 func TestSharedKey(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("c786dd84b61485de12146fd9c4c02d87e8fd95f0542765cb7fc3d2e428c0bcfa")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/crypto/signer_test.go
+++ b/pkg/crypto/signer_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestDefaultSigner(t *testing.T) {
+	t.Parallel()
+
 	testBytes := []byte("test string")
 	privKey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
@@ -32,6 +34,8 @@ func TestDefaultSigner(t *testing.T) {
 	}
 
 	t.Run("OK - sign & recover", func(t *testing.T) {
+		t.Parallel()
+
 		pubKey, err := crypto.Recover(signature, testBytes)
 		if err != nil {
 			t.Fatal(err)
@@ -43,6 +47,8 @@ func TestDefaultSigner(t *testing.T) {
 	})
 
 	t.Run("OK - recover with invalid data", func(t *testing.T) {
+		t.Parallel()
+
 		pubKey, err := crypto.Recover(signature, []byte("invalid"))
 		if err != nil {
 			t.Fatal(err)
@@ -54,6 +60,8 @@ func TestDefaultSigner(t *testing.T) {
 	})
 
 	t.Run("OK - recover with short signature", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := crypto.Recover([]byte("invalid"), testBytes)
 		if err == nil {
 			t.Fatal("expected invalid length error but got none")
@@ -65,6 +73,8 @@ func TestDefaultSigner(t *testing.T) {
 }
 
 func TestDefaultSignerEthereumAddress(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd")
 	if err != nil {
 		t.Fatal(err)
@@ -88,6 +98,8 @@ func TestDefaultSignerEthereumAddress(t *testing.T) {
 }
 
 func TestDefaultSignerSignTx(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd")
 	if err != nil {
 		t.Fatal(err)
@@ -164,6 +176,8 @@ var testTypedData = &eip712.TypedData{
 }
 
 func TestDefaultSignerTypedData(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd")
 	if err != nil {
 		t.Fatal(err)
@@ -192,6 +206,8 @@ func TestDefaultSignerTypedData(t *testing.T) {
 }
 
 func TestRecoverEIP712(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd")
 	if err != nil {
 		t.Fatal(err)
@@ -222,6 +238,8 @@ func TestRecoverEIP712(t *testing.T) {
 }
 
 func TestDefaultSignerDeterministic(t *testing.T) {
+	t.Parallel()
+
 	data, err := hex.DecodeString("634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/file/pipeline/encryption/encryption_test.go
+++ b/pkg/file/pipeline/encryption/encryption_test.go
@@ -39,6 +39,8 @@ func init() {
 
 // TestEncyrption tests that the encyption writer works correctly.
 func TestEncryption(t *testing.T) {
+	t.Parallel()
+
 	mockChainWriter := mock.NewChainWriter()
 	writer := encryption.NewEncryptionWriter(mockenc.NewChunkEncrypter(key), mockChainWriter)
 
@@ -58,6 +60,8 @@ func TestEncryption(t *testing.T) {
 
 // TestSum tests that calling Sum on the store writer results in Sum on the next writer in the chain.
 func TestSum(t *testing.T) {
+	t.Parallel()
+
 	mockChainWriter := mock.NewChainWriter()
 	writer := encryption.NewEncryptionWriter(nil, mockChainWriter)
 

--- a/pkg/jsonhttp/handlers_test.go
+++ b/pkg/jsonhttp/handlers_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestMethodHandler(t *testing.T) {
+	t.Parallel()
+
 	contentType := "application/swarm"
 
 	h := jsonhttp.MethodHandler{
@@ -31,6 +33,8 @@ func TestMethodHandler(t *testing.T) {
 	}
 
 	t.Run("method allowed", func(t *testing.T) {
+		t.Parallel()
+
 		body := "test body"
 
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
@@ -56,6 +60,8 @@ func TestMethodHandler(t *testing.T) {
 	})
 
 	t.Run("method not allowed", func(t *testing.T) {
+		t.Parallel()
+
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
@@ -87,6 +93,8 @@ func TestMethodHandler(t *testing.T) {
 }
 
 func TestNotFoundHandler(t *testing.T) {
+	t.Parallel()
+
 	w := httptest.NewRecorder()
 
 	jsonhttp.NotFoundHandler(w, nil)
@@ -116,6 +124,8 @@ func TestNotFoundHandler(t *testing.T) {
 }
 
 func TestNewMaxBodyBytesHandler(t *testing.T) {
+	t.Parallel()
+
 	var limit int64 = 10
 
 	h := jsonhttp.NewMaxBodyBytesHandler(limit)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -163,7 +173,10 @@ func TestNewMaxBodyBytesHandler(t *testing.T) {
 			wantCode:             http.StatusRequestEntityTooLarge,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tc.body))
 			if tc.withoutContentLength {
 				r.Header.Del("Content-Length")

--- a/pkg/jsonhttp/jsonhttp_test.go
+++ b/pkg/jsonhttp/jsonhttp_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestRespond_defaults(t *testing.T) {
+	t.Parallel()
+
 	w := httptest.NewRecorder()
 
 	jsonhttp.Respond(w, 0, nil)
@@ -46,6 +48,8 @@ func TestRespond_defaults(t *testing.T) {
 }
 
 func TestRespond_statusResponse(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		code int
 	}{
@@ -125,6 +129,8 @@ func TestRespond_statusResponse(t *testing.T) {
 }
 
 func TestRespond_special(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name        string
 		code        int
@@ -168,7 +174,10 @@ func TestRespond_special(t *testing.T) {
 			wantMessage: "2.4.8.16",
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			w := httptest.NewRecorder()
 
 			jsonhttp.Respond(w, tc.code, tc.response)
@@ -198,6 +207,8 @@ func TestRespond_special(t *testing.T) {
 }
 
 func TestRespond_custom(t *testing.T) {
+	t.Parallel()
+
 	w := httptest.NewRecorder()
 
 	wantCode := http.StatusTeapot
@@ -232,6 +243,8 @@ func TestRespond_custom(t *testing.T) {
 }
 
 func TestStandardHTTPResponds(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		f    func(w http.ResponseWriter, response interface{})
 		code int
@@ -304,6 +317,8 @@ func TestStandardHTTPResponds(t *testing.T) {
 }
 
 func TestPanicRespond(t *testing.T) {
+	t.Parallel()
+
 	w := httptest.NewRecorder()
 
 	defer func() {

--- a/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
+++ b/pkg/jsonhttp/jsonhttptest/jsonhttptest_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestRequest_statusCode(t *testing.T) {
+	t.Parallel()
+
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -37,6 +39,8 @@ func TestRequest_statusCode(t *testing.T) {
 }
 
 func TestRequest_method(t *testing.T) {
+	t.Parallel()
+
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -54,6 +58,8 @@ func TestRequest_method(t *testing.T) {
 }
 
 func TestRequest_url(t *testing.T) {
+	t.Parallel()
+
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			w.WriteHeader(http.StatusNotFound)
@@ -70,6 +76,8 @@ func TestRequest_url(t *testing.T) {
 }
 
 func TestRequest_responseHeader(t *testing.T) {
+	t.Parallel()
+
 	headerName := "Swarm-Header"
 	headerValue := "somevalue"
 	var gotValue string
@@ -87,6 +95,8 @@ func TestRequest_responseHeader(t *testing.T) {
 }
 
 func TestWithContext(t *testing.T) {
+	t.Parallel()
+
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -100,6 +110,8 @@ func TestWithContext(t *testing.T) {
 }
 
 func TestWithRequestBody(t *testing.T) {
+	t.Parallel()
+
 	wantBody := []byte("somebody")
 	var gotBody []byte
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +133,8 @@ func TestWithRequestBody(t *testing.T) {
 }
 
 func TestWithJSONRequestBody(t *testing.T) {
+	t.Parallel()
+
 	type response struct {
 		Message string `json:"message"`
 	}
@@ -153,6 +167,8 @@ func TestWithJSONRequestBody(t *testing.T) {
 }
 
 func TestWithMultipartRequest(t *testing.T) {
+	t.Parallel()
+
 	wantBody := []byte("somebody")
 	filename := "swarm.jpg"
 	contentType := "image/jpeg"
@@ -202,6 +218,8 @@ func TestWithMultipartRequest(t *testing.T) {
 }
 
 func TestWithRequestHeader(t *testing.T) {
+	t.Parallel()
+
 	headerName := "Swarm-Header"
 	headerValue := "somevalue"
 	var gotValue string
@@ -221,6 +239,8 @@ func TestWithRequestHeader(t *testing.T) {
 }
 
 func TestWithExpectedResponse(t *testing.T) {
+	t.Parallel()
+
 	body := []byte("something to want")
 
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -244,6 +264,8 @@ func TestWithExpectedResponse(t *testing.T) {
 }
 
 func TestWithExpectedJSONResponse(t *testing.T) {
+	t.Parallel()
+
 	type response struct {
 		Message string `json:"message"`
 	}
@@ -272,6 +294,8 @@ func TestWithExpectedJSONResponse(t *testing.T) {
 }
 
 func TestWithUnmarhalJSONResponse(t *testing.T) {
+	t.Parallel()
+
 	message := "text"
 
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -290,6 +314,8 @@ func TestWithUnmarhalJSONResponse(t *testing.T) {
 }
 
 func TestWithPutResponseBody(t *testing.T) {
+	t.Parallel()
+
 	wantBody := []byte("somebody")
 
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -311,6 +337,8 @@ func TestWithPutResponseBody(t *testing.T) {
 }
 
 func TestWithNoResponseBody(t *testing.T) {
+	t.Parallel()
+
 	c, endpoint := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			fmt.Fprint(w, "not found")

--- a/pkg/keystore/file/service_test.go
+++ b/pkg/keystore/file/service_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	test.Service(t, file.New(dir))

--- a/pkg/keystore/mem/service_test.go
+++ b/pkg/keystore/mem/service_test.go
@@ -12,5 +12,7 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
+
 	test.Service(t, mem.New())
 }

--- a/pkg/manifest/mantaray/marshal_test.go
+++ b/pkg/manifest/mantaray/marshal_test.go
@@ -53,6 +53,8 @@ func init() {
 }
 
 func TestVersion01(t *testing.T) {
+	t.Parallel()
+
 	hasher := sha3.NewLegacyKeccak256()
 
 	_, err := hasher.Write([]byte(version01String))
@@ -69,6 +71,8 @@ func TestVersion01(t *testing.T) {
 }
 
 func TestVersion02(t *testing.T) {
+	t.Parallel()
+
 	hasher := sha3.NewLegacyKeccak256()
 
 	_, err := hasher.Write([]byte(version02String))
@@ -85,6 +89,8 @@ func TestVersion02(t *testing.T) {
 }
 
 func TestUnmarshal01(t *testing.T) {
+	t.Parallel()
+
 	input, _ := hex.DecodeString(testMarshalOutput01)
 	n := &Node{}
 	err := n.UnmarshalBinary(input)
@@ -117,6 +123,8 @@ func TestUnmarshal01(t *testing.T) {
 }
 
 func TestUnmarshal02(t *testing.T) {
+	t.Parallel()
+
 	input, _ := hex.DecodeString(testMarshalOutput02)
 	n := &Node{}
 	err := n.UnmarshalBinary(input)
@@ -154,6 +162,8 @@ func TestUnmarshal02(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
+	t.Parallel()
+
 	rand.Seed(1)
 	ctx := context.Background()
 	n := New()
@@ -258,6 +268,7 @@ func Test_UnmarshalBinary(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/manifest/simple/walker_test.go
+++ b/pkg/manifest/simple/walker_test.go
@@ -12,8 +12,13 @@ import (
 )
 
 func TestWalkEntry(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := simple.NewManifest()
 
 			// add entries

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestPrometheusCollectorsFromFields(t *testing.T) {
+	t.Parallel()
+
 	s := newService()
 	collectors := metrics.PrometheusCollectorsFromFields(s)
 

--- a/pkg/netstore/netstore_test.go
+++ b/pkg/netstore/netstore_test.go
@@ -28,6 +28,8 @@ var chunkStamp = postagetesting.MustNewStamp()
 // TestNetstoreRetrieval verifies that a chunk is asked from the network whenever
 // it is not found locally
 func TestNetstoreRetrieval(t *testing.T) {
+	t.Parallel()
+
 	retrieve, store, nstore := newRetrievingNetstore(t, noopValidStamp)
 	addr := testChunk.Address()
 	_, err := nstore.Get(context.Background(), storage.ModeGetRequest, addr)
@@ -69,6 +71,8 @@ func TestNetstoreRetrieval(t *testing.T) {
 // TestNetstoreNoRetrieval verifies that a chunk is not requested from the network
 // whenever it is found locally.
 func TestNetstoreNoRetrieval(t *testing.T) {
+	t.Parallel()
+
 	retrieve, store, nstore := newRetrievingNetstore(t, noopValidStamp)
 	addr := testChunk.Address()
 
@@ -94,6 +98,8 @@ func TestNetstoreNoRetrieval(t *testing.T) {
 }
 
 func TestInvalidChunkNetstoreRetrieval(t *testing.T) {
+	t.Parallel()
+
 	retrieve, store, nstore := newRetrievingNetstore(t, noopValidStamp)
 
 	invalidChunk := swarm.NewChunk(testChunk.Address(), []byte("deadbeef"))
@@ -140,6 +146,8 @@ func TestInvalidChunkNetstoreRetrieval(t *testing.T) {
 }
 
 func TestInvalidPostageStamp(t *testing.T) {
+	t.Parallel()
+
 	f := func(c swarm.Chunk, _ []byte) (swarm.Chunk, error) {
 		return nil, errors.New("invalid postage stamp")
 	}

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -43,6 +43,8 @@ const (
 )
 
 func TestAddresses(t *testing.T) {
+	t.Parallel()
+
 	s, _ := newService(t, 1, libp2pServiceOpts{})
 
 	addrs, err := s.Addresses()
@@ -55,6 +57,8 @@ func TestAddresses(t *testing.T) {
 }
 
 func TestConnectDisconnect(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -82,6 +86,8 @@ func TestConnectDisconnect(t *testing.T) {
 }
 
 func TestConnectToLightPeer(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -102,6 +108,8 @@ func TestConnectToLightPeer(t *testing.T) {
 }
 
 func TestLightPeerLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -150,6 +158,8 @@ func TestLightPeerLimit(t *testing.T) {
 // concurrent streams is bellow the limit, new streams are created without
 // errors.
 func TestStreamsMaxIncomingLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -266,6 +276,8 @@ func TestStreamsMaxIncomingLimit(t *testing.T) {
 }
 
 func TestDoubleConnect(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -292,6 +304,8 @@ func TestDoubleConnect(t *testing.T) {
 }
 
 func TestDoubleDisconnect(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -326,6 +340,8 @@ func TestDoubleDisconnect(t *testing.T) {
 }
 
 func TestMultipleConnectDisconnect(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -369,6 +385,8 @@ func TestMultipleConnectDisconnect(t *testing.T) {
 }
 
 func TestConnectDisconnectOnAllAddresses(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -401,6 +419,8 @@ func TestConnectDisconnectOnAllAddresses(t *testing.T) {
 }
 
 func TestDoubleConnectOnAllAddresses(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -443,6 +463,8 @@ func TestDoubleConnectOnAllAddresses(t *testing.T) {
 }
 
 func TestDifferentNetworkIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -460,6 +482,8 @@ func TestDifferentNetworkIDs(t *testing.T) {
 }
 
 func TestConnectWithEnabledWSTransports(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -489,6 +513,8 @@ func TestConnectWithEnabledWSTransports(t *testing.T) {
 
 // TestConnectRepeatHandshake tests if handshake was attempted more then once by the same peer
 func TestConnectRepeatHandshake(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -526,6 +552,8 @@ func TestConnectRepeatHandshake(t *testing.T) {
 }
 
 func TestBlocklisting(t *testing.T) {
+	t.Parallel()
+
 	s1, overlay1 := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{
 		FullNode: true,
 	}})
@@ -567,6 +595,8 @@ func TestBlocklisting(t *testing.T) {
 }
 
 func TestTopologyNotifier(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mtx sync.Mutex
 		ctx = context.Background()
@@ -686,6 +716,8 @@ func TestTopologyNotifier(t *testing.T) {
 // TestTopologyAnnounce checks that announcement
 // works correctly for full nodes and light nodes.
 func TestTopologyAnnounce(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mtx sync.Mutex
 		ctx = context.Background()
@@ -802,6 +834,8 @@ func TestTopologyAnnounce(t *testing.T) {
 }
 
 func TestTopologyOverSaturated(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mtx sync.Mutex
 		ctx = context.Background()
@@ -860,6 +894,7 @@ func TestTopologyOverSaturated(t *testing.T) {
 }
 
 func TestWithDisconnectStreams(t *testing.T) {
+	t.Parallel()
 
 	defer func(t time.Duration) {
 		*libp2p.SendHeadersTimeout = t
@@ -912,6 +947,8 @@ func TestWithDisconnectStreams(t *testing.T) {
 }
 
 func TestWithBlocklistStreams(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("test flakes")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -963,6 +1000,7 @@ func TestWithBlocklistStreams(t *testing.T) {
 }
 
 func TestUserAgentLogging(t *testing.T) {
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1000,6 +1038,8 @@ func TestUserAgentLogging(t *testing.T) {
 }
 
 func TestReachabilityUpdate(t *testing.T) {
+	t.Parallel()
+
 	s1, _ := newService(t, 1, libp2pServiceOpts{
 		libp2pOpts: libp2p.WithHostFactory(
 			func(_ ...libp2pm.Option) (host.Host, error) {

--- a/pkg/p2p/libp2p/headers_test.go
+++ b/pkg/p2p/libp2p/headers_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestHeaders(t *testing.T) {
+	t.Parallel()
+
 	headers := p2p.Headers{
 		"test-header-key": []byte("header-value"),
 		"other-key":       []byte("other-value"),
@@ -70,6 +72,8 @@ func TestHeaders(t *testing.T) {
 }
 
 func TestHeaders_empty(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -119,6 +123,8 @@ func TestHeaders_empty(t *testing.T) {
 }
 
 func TestHeadler(t *testing.T) {
+	t.Parallel()
+
 	receivedHeaders := p2p.Headers{
 		"test-header-key": []byte("header-value"),
 		"other-key":       []byte("other-value"),

--- a/pkg/p2p/libp2p/internal/blocklist/blocklist_test.go
+++ b/pkg/p2p/libp2p/internal/blocklist/blocklist_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestExist(t *testing.T) {
+	t.Parallel()
+
 	addr1 := swarm.NewAddress([]byte{0, 1, 2, 3})
 	addr2 := swarm.NewAddress([]byte{4, 5, 6, 7})
 	ctMock := &currentTimeMock{}
@@ -61,6 +63,8 @@ func TestExist(t *testing.T) {
 }
 
 func TestPeers(t *testing.T) {
+	t.Parallel()
+
 	addr1 := swarm.NewAddress([]byte{0, 1, 2, 3})
 	addr2 := swarm.NewAddress([]byte{4, 5, 6, 7})
 	ctMock := &currentTimeMock{}

--- a/pkg/p2p/libp2p/internal/breaker/breaker_test.go
+++ b/pkg/p2p/libp2p/internal/breaker/breaker_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestExecute(t *testing.T) {
+	t.Parallel()
+
 	testErr := errors.New("test error")
 	shouldNotBeCalledErr := errors.New("should not be called")
 	failInterval := 10 * time.Minute
@@ -72,6 +74,8 @@ func TestExecute(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			ctMock := &currentTimeMock{
 				times: tc.times,
 			}
@@ -98,6 +102,8 @@ func TestExecute(t *testing.T) {
 }
 
 func TestClosedUntil(t *testing.T) {
+	t.Parallel()
+
 	timestamp := time.Now()
 	startBackoff := 1 * time.Minute
 	testError := errors.New("test error")

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -25,7 +25,10 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+//nolint:paralleltest
 func TestHandshake(t *testing.T) {
+	t.Parallel()
+
 	const (
 		testWelcomeMessage = "HelloWorld"
 	)
@@ -176,7 +179,6 @@ func TestHandshake(t *testing.T) {
 	})
 
 	t.Run("Handshake - picker error", func(t *testing.T) {
-
 		handshakeService, err := handshake.New(signer1, aaddresser, node1Info.BzzAddress.Overlay, networkID, true, nonce, "", true, node1AddrInfo.ID, logger)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -25,10 +25,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-//nolint:paralleltest
 func TestHandshake(t *testing.T) {
-	t.Parallel()
-
 	const (
 		testWelcomeMessage = "HelloWorld"
 	)

--- a/pkg/p2p/libp2p/internal/reacher/reacher_test.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher_test.go
@@ -26,6 +26,7 @@ var defaultOptions = reacher.Options{
 }
 
 func TestPingSuccess(t *testing.T) {
+	t.Parallel()
 
 	done := make(chan struct{})
 
@@ -60,7 +61,6 @@ func TestPingSuccess(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-
 			mock := newMock(tc.pingFunc, tc.reachableFunc)
 
 			r := reacher.New(mock, mock, &defaultOptions)
@@ -80,6 +80,7 @@ func TestPingSuccess(t *testing.T) {
 }
 
 func TestDisconnected(t *testing.T) {
+	t.Parallel()
 
 	var (
 		disconnectedOverlay = test.RandomAddress()

--- a/pkg/p2p/libp2p/internal/reacher/reacher_test.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher_test.go
@@ -26,8 +26,6 @@ var defaultOptions = reacher.Options{
 }
 
 func TestPingSuccess(t *testing.T) {
-	t.Parallel()
-
 	done := make(chan struct{})
 
 	for _, tc := range []struct {

--- a/pkg/p2p/libp2p/protocols_test.go
+++ b/pkg/p2p/libp2p/protocols_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestNewStream(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -55,6 +57,8 @@ func TestNewStream(t *testing.T) {
 // TestNewStream_OnlyFull tests that the handler gets the full
 // node information communicated correctly.
 func TestNewStream_OnlyFull(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -93,6 +97,8 @@ func TestNewStream_OnlyFull(t *testing.T) {
 // TestNewStream_Mixed tests that the handler gets the full
 // node information communicated correctly for light node
 func TestNewStream_Mixed(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -130,6 +136,8 @@ func TestNewStream_Mixed(t *testing.T) {
 // the right handler when multiple streams are registered under
 // a single protocol.
 func TestNewStreamMulti(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -178,6 +186,8 @@ func TestNewStreamMulti(t *testing.T) {
 }
 
 func TestNewStream_errNotSupported(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -215,6 +225,8 @@ func TestNewStream_errNotSupported(t *testing.T) {
 }
 
 func TestNewStream_semanticVersioning(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -276,6 +288,8 @@ func TestNewStream_semanticVersioning(t *testing.T) {
 }
 
 func TestDisconnectError(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -306,6 +320,8 @@ func TestDisconnectError(t *testing.T) {
 }
 
 func TestConnectDisconnectEvents(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -383,6 +399,8 @@ func TestConnectDisconnectEvents(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 

--- a/pkg/p2p/libp2p/static_resolver_test.go
+++ b/pkg/p2p/libp2p/static_resolver_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestStaticAddressResolver(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name              string
 		natAddr           string
@@ -80,7 +82,10 @@ func TestStaticAddressResolver(t *testing.T) {
 			want:              "/dns/ipv4and6.com/tcp/30777/p2p/16Uiu2HAkyyGKpjBiCkVqCKoJa6RzzZw9Nr7hGogsMPcdad1KyMmd",
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			r, err := libp2p.NewStaticAddressResolver(tc.natAddr, func(host string) ([]net.IP, error) {
 				hosts := map[string][]net.IP{
 					"ipv4.com": {

--- a/pkg/p2p/libp2p/tracing_test.go
+++ b/pkg/p2p/libp2p/tracing_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestTracing(t *testing.T) {
+	t.Parallel()
+
 	tracer1, closer1, err := tracing.NewTracer(&tracing.Options{
 		Enabled:     true,
 		ServiceName: "bee-test",

--- a/pkg/p2p/libp2p/welcome_message_test.go
+++ b/pkg/p2p/libp2p/welcome_message_test.go
@@ -12,10 +12,13 @@ import (
 )
 
 func TestDynamicWelcomeMessage(t *testing.T) {
+	t.Parallel()
+
 	const TestWelcomeMessage = "Hello World!"
-	svc, _ := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{WelcomeMessage: TestWelcomeMessage}})
 
 	t.Run("Get current message - OK", func(t *testing.T) {
+		t.Parallel()
+		svc, _ := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{WelcomeMessage: TestWelcomeMessage}})
 		got := svc.GetWelcomeMessage()
 		if got != TestWelcomeMessage {
 			t.Fatalf("expected %s, got %s", TestWelcomeMessage, got)
@@ -24,6 +27,9 @@ func TestDynamicWelcomeMessage(t *testing.T) {
 
 	t.Run("Set new message", func(t *testing.T) {
 		t.Run("OK", func(t *testing.T) {
+			t.Parallel()
+
+			svc, _ := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{WelcomeMessage: TestWelcomeMessage}})
 			const testMessage = "I'm the new message!"
 
 			err := svc.SetWelcomeMessage(testMessage)
@@ -36,6 +42,9 @@ func TestDynamicWelcomeMessage(t *testing.T) {
 			}
 		})
 		t.Run("error - message too long", func(t *testing.T) {
+			t.Parallel()
+
+			svc, _ := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{WelcomeMessage: TestWelcomeMessage}})
 			const testMessage = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 			Maecenas eu aliquam enim. Nulla tincidunt arcu nec nulla condimentum nullam sodales` // 141 characters
 

--- a/pkg/p2p/p2p_test.go
+++ b/pkg/p2p/p2p_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestNewSwarmStreamName(t *testing.T) {
+	t.Parallel()
+
 	want := "/swarm/hive/1.2.0/peers"
 	got := p2p.NewSwarmStreamName("hive", "1.2.0", "peers")
 
@@ -21,6 +23,8 @@ func TestNewSwarmStreamName(t *testing.T) {
 }
 
 func TestReachabilityStatus_String(t *testing.T) {
+	t.Parallel()
+
 	mapping := map[string]string{
 		p2p.ReachabilityStatusUnknown.String(): network.ReachabilityUnknown.String(),
 		p2p.ReachabilityStatusPrivate.String(): network.ReachabilityPrivate.String(),

--- a/pkg/p2p/protobuf/protobuf_test.go
+++ b/pkg/p2p/protobuf/protobuf_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestReader_ReadMsg(t *testing.T) {
+	t.Parallel()
+
 	messages := []string{"first", "second", "third"}
 
 	for _, tc := range []struct {
@@ -42,7 +44,10 @@ func TestReader_ReadMsg(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := tc.readerFunc()
 			var msg pb.Message
 			for i := 0; i < len(messages); i++ {
@@ -67,6 +72,8 @@ func TestReader_ReadMsg(t *testing.T) {
 }
 
 func TestReader_timeout(t *testing.T) {
+	t.Parallel()
+
 	messages := []string{"first", "second", "third"}
 
 	for _, tc := range []struct {
@@ -91,8 +98,13 @@ func TestReader_timeout(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			t.Run("WithContext", func(t *testing.T) {
+				t.Parallel()
+
 				r := tc.readerFunc()
 				var msg pb.Message
 				for i := 0; i < len(messages); i++ {
@@ -107,6 +119,7 @@ func TestReader_timeout(t *testing.T) {
 					err := r.ReadMsgWithContext(ctx, &msg)
 					if i == 0 {
 						if err != nil {
+							t.Parallel()
 							t.Fatal(err)
 						}
 					} else {
@@ -127,6 +140,8 @@ func TestReader_timeout(t *testing.T) {
 }
 
 func TestWriter(t *testing.T) {
+	t.Parallel()
+
 	messages := []string{"first", "second", "third"}
 
 	for _, tc := range []struct {
@@ -149,7 +164,10 @@ func TestWriter(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			w, msgs := tc.writerFunc()
 
 			for _, m := range messages {
@@ -168,6 +186,8 @@ func TestWriter(t *testing.T) {
 }
 
 func TestWriter_timeout(t *testing.T) {
+	t.Parallel()
+
 	messages := []string{"first", "second", "third"}
 
 	for _, tc := range []struct {
@@ -190,8 +210,11 @@ func TestWriter_timeout(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("WithContext", func(t *testing.T) {
+				t.Parallel()
+
 				w, msgs := tc.writerFunc()
 
 				for i, m := range messages {
@@ -226,6 +249,8 @@ func TestWriter_timeout(t *testing.T) {
 }
 
 func TestReadMessages(t *testing.T) {
+	t.Parallel()
+
 	messages := []string{"first", "second", "third"}
 
 	r := newMessageReader(messages, 0)

--- a/pkg/p2p/protobuf/protobuf_test.go
+++ b/pkg/p2p/protobuf/protobuf_test.go
@@ -186,8 +186,6 @@ func TestWriter(t *testing.T) {
 }
 
 func TestWriter_timeout(t *testing.T) {
-	t.Parallel()
-
 	messages := []string{"first", "second", "third"}
 
 	for _, tc := range []struct {

--- a/pkg/p2p/specwrapper_test.go
+++ b/pkg/p2p/specwrapper_test.go
@@ -30,6 +30,8 @@ func newTestProtocol(h p2p.HandlerFunc) p2p.ProtocolSpec {
 }
 
 func TestBlocklistError(t *testing.T) {
+	t.Parallel()
+
 	tp := newTestProtocol(func(context.Context, p2p.Peer, p2p.Stream) error {
 		return errors.New("test")
 	})
@@ -49,6 +51,8 @@ func TestBlocklistError(t *testing.T) {
 }
 
 func TestDisconnectError(t *testing.T) {
+	t.Parallel()
+
 	tp := newTestProtocol(func(context.Context, p2p.Peer, p2p.Stream) error {
 		return errors.New("test")
 	})

--- a/pkg/p2p/streamtest/streamtest_test.go
+++ b/pkg/p2p/streamtest/streamtest_test.go
@@ -173,8 +173,6 @@ func TestRecorder_fullcloseWithRemoteClose(t *testing.T) {
 }
 
 func TestRecorder_fullcloseWithoutRemoteClose(t *testing.T) {
-	t.Parallel()
-
 	streamtest.SetFullCloseTimeout(500 * time.Millisecond)
 	defer streamtest.ResetFullCloseTimeout()
 	recorder := streamtest.New(

--- a/pkg/p2p/streamtest/streamtest_test.go
+++ b/pkg/p2p/streamtest/streamtest_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestRecorder(t *testing.T) {
+	t.Parallel()
+
 	var answers = map[string]string{
 		"What is your name?":                                    "Sir Lancelot of Camelot",
 		"What is your quest?":                                   "To seek the Holy Grail.",
@@ -113,6 +115,8 @@ func TestRecorder(t *testing.T) {
 }
 
 func TestRecorder_errStreamNotSupported(t *testing.T) {
+	t.Parallel()
+
 	r := streamtest.New()
 
 	_, err := r.NewStream(context.Background(), swarm.ZeroAddress, nil, "testing", "messages", "1.0.1")
@@ -122,6 +126,8 @@ func TestRecorder_errStreamNotSupported(t *testing.T) {
 }
 
 func TestRecorder_fullcloseWithRemoteClose(t *testing.T) {
+	t.Parallel()
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(
 			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
@@ -167,6 +173,8 @@ func TestRecorder_fullcloseWithRemoteClose(t *testing.T) {
 }
 
 func TestRecorder_fullcloseWithoutRemoteClose(t *testing.T) {
+	t.Parallel()
+
 	streamtest.SetFullCloseTimeout(500 * time.Millisecond)
 	defer streamtest.ResetFullCloseTimeout()
 	recorder := streamtest.New(
@@ -216,6 +224,8 @@ func TestRecorder_fullcloseWithoutRemoteClose(t *testing.T) {
 }
 
 func TestRecorder_multipleParallelFullCloseAndClose(t *testing.T) {
+	t.Parallel()
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(
 			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
@@ -279,6 +289,8 @@ func TestRecorder_multipleParallelFullCloseAndClose(t *testing.T) {
 }
 
 func TestRecorder_closeAfterPartialWrite(t *testing.T) {
+	t.Parallel()
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(
 			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
@@ -345,6 +357,8 @@ func TestRecorder_closeAfterPartialWrite(t *testing.T) {
 }
 
 func TestRecorder_resetAfterPartialWrite(t *testing.T) {
+	t.Parallel()
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(
 			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
@@ -407,6 +421,8 @@ func TestRecorder_resetAfterPartialWrite(t *testing.T) {
 }
 
 func TestRecorder_withMiddlewares(t *testing.T) {
+	t.Parallel()
+
 	recorder := streamtest.New(
 		streamtest.WithProtocols(
 			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
@@ -522,6 +538,8 @@ func TestRecorder_withMiddlewares(t *testing.T) {
 }
 
 func TestRecorder_recordErr(t *testing.T) {
+	t.Parallel()
+
 	testErr := errors.New("test error")
 
 	recorder := streamtest.New(
@@ -580,6 +598,8 @@ func TestRecorder_recordErr(t *testing.T) {
 }
 
 func TestRecorder_withPeerProtocols(t *testing.T) {
+	t.Parallel()
+
 	peer1 := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000")
 	peer2 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
 	recorder := streamtest.New(
@@ -672,6 +692,8 @@ func TestRecorder_withPeerProtocols(t *testing.T) {
 }
 
 func TestRecorder_withStreamError(t *testing.T) {
+	t.Parallel()
+
 	peer1 := swarm.MustParseHexAddress("1000000000000000000000000000000000000000000000000000000000000000")
 	peer2 := swarm.MustParseHexAddress("2000000000000000000000000000000000000000000000000000000000000000")
 	testErr := errors.New("dummy stream error")
@@ -759,6 +781,8 @@ func TestRecorder_withStreamError(t *testing.T) {
 }
 
 func TestRecorder_ping(t *testing.T) {
+	t.Parallel()
+
 	testAddr, _ := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
 
 	rec := streamtest.New()

--- a/pkg/pingpong/pingpong_test.go
+++ b/pkg/pingpong/pingpong_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestPing(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	// create a pingpong server that handles the incoming stream

--- a/pkg/pinning/pinning_test.go
+++ b/pkg/pinning/pinning_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestPinningService(t *testing.T) {
-	t.Parallel()
-
 	const content = "Hello, Bee!"
 
 	var (

--- a/pkg/pinning/pinning_test.go
+++ b/pkg/pinning/pinning_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestPinningService(t *testing.T) {
+	t.Parallel()
+
 	const content = "Hello, Bee!"
 
 	var (

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -25,7 +25,6 @@ type testBatch struct {
 // TestBatchSave adds batches to the batchstore, and after each batch, checks
 // the reserve state radius.
 func TestBatchSave(t *testing.T) {
-	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -105,7 +104,6 @@ func TestBatchSave(t *testing.T) {
 // TestBatchUpdate adds an initial group of batches to the batchstore and one by one
 // updates their depth and value fields while checking the batchstore radius values.
 func TestBatchUpdate(t *testing.T) {
-	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -207,7 +205,6 @@ func TestBatchUpdate(t *testing.T) {
 // TestPutChainState add a group of batches to the batchstore, and after updating the chainstate,
 // checks the batchstore radius reflects the updates.
 func TestPutChainState(t *testing.T) {
-	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -25,6 +25,7 @@ type testBatch struct {
 // TestBatchSave adds batches to the batchstore, and after each batch, checks
 // the reserve state radius.
 func TestBatchSave(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -104,6 +105,7 @@ func TestBatchSave(t *testing.T) {
 // TestBatchUpdate adds an initial group of batches to the batchstore and one by one
 // updates their depth and value fields while checking the batchstore radius values.
 func TestBatchUpdate(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -205,6 +207,7 @@ func TestBatchUpdate(t *testing.T) {
 // TestPutChainState add a group of batches to the batchstore, and after updating the chainstate,
 // checks the batchstore radius reflects the updates.
 func TestPutChainState(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 

--- a/pkg/pricing/pricing_test.go
+++ b/pkg/pricing/pricing_test.go
@@ -34,6 +34,8 @@ func (t *testThresholdObserver) NotifyPaymentThreshold(peerAddr swarm.Address, p
 }
 
 func TestAnnouncePaymentThreshold(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	testThreshold := big.NewInt(100000)
 	testLightThreshold := big.NewInt(10000)
@@ -101,6 +103,8 @@ func TestAnnouncePaymentThreshold(t *testing.T) {
 }
 
 func TestAnnouncePaymentWithInsufficientThreshold(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	testThreshold := big.NewInt(100_000)
 	testLightThreshold := big.NewInt(10_000)
@@ -158,6 +162,8 @@ func TestAnnouncePaymentWithInsufficientThreshold(t *testing.T) {
 }
 
 func TestInitialPaymentThreshold(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	testThreshold := big.NewInt(100000)
 	testLightThreshold := big.NewInt(10000)
@@ -224,6 +230,8 @@ func TestInitialPaymentThreshold(t *testing.T) {
 }
 
 func TestInitialPaymentThresholdLightNode(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	testThreshold := big.NewInt(100000)
 	testLightThreshold := big.NewInt(10000)

--- a/pkg/rate/rate_test.go
+++ b/pkg/rate/rate_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRateFirstBucket(t *testing.T) {
+	t.Parallel()
 
 	windowSize := 1000 * time.Millisecond
 	var r = 15
@@ -28,6 +29,7 @@ func TestRateFirstBucket(t *testing.T) {
 
 // // TestIgnoreOldBuckets tests that the buckets older than the most recent two buckets are ignored in rate calculation.
 func TestIgnoreOldBuckets(t *testing.T) {
+	t.Parallel()
 
 	windowSize := 1000 * time.Millisecond
 	var r = 100
@@ -48,6 +50,7 @@ func TestIgnoreOldBuckets(t *testing.T) {
 }
 
 func TestRate(t *testing.T) {
+	t.Parallel()
 
 	// windowSizeMs := 1000
 	windowSize := 1000 * time.Millisecond

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRateLimit(t *testing.T) {
+	t.Parallel()
 
 	var (
 		key1  = "test1"

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -260,6 +260,8 @@ func testCaseAccepted(t *testing.T, recorder *streamtest.Recorder, payerObserver
 }
 
 func TestPayment(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	storeRecipient := mock.NewStateStore()
@@ -294,6 +296,8 @@ func TestPayment(t *testing.T) {
 }
 
 func TestTimeLimitedPayment(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	storeRecipient := mock.NewStateStore()
@@ -348,6 +352,8 @@ func TestTimeLimitedPayment(t *testing.T) {
 }
 
 func TestTimeLimitedPaymentLight(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 
 	storeRecipient := mock.NewStateStore()

--- a/pkg/settlement/swap/chequebook/cashout_test.go
+++ b/pkg/settlement/swap/chequebook/cashout_test.go
@@ -27,6 +27,8 @@ var (
 )
 
 func TestCashout(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("abcd")
 	recipientAddress := common.HexToAddress("efff")
 	txHash := common.HexToHash("dddd")
@@ -121,6 +123,8 @@ func TestCashout(t *testing.T) {
 }
 
 func TestCashoutBounced(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("abcd")
 	recipientAddress := common.HexToAddress("efff")
 	txHash := common.HexToHash("dddd")
@@ -219,6 +223,8 @@ func TestCashoutBounced(t *testing.T) {
 }
 
 func TestCashoutStatusReverted(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("abcd")
 	recipientAddress := common.HexToAddress("efff")
 	txHash := common.HexToHash("dddd")
@@ -293,6 +299,8 @@ func TestCashoutStatusReverted(t *testing.T) {
 }
 
 func TestCashoutStatusPending(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("abcd")
 	recipientAddress := common.HexToAddress("efff")
 	txHash := common.HexToHash("dddd")

--- a/pkg/settlement/swap/chequebook/cheque_test.go
+++ b/pkg/settlement/swap/chequebook/cheque_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestSignCheque(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("0x8d3766440f0d7b949a5e32995d09619a7f86e632")
 	beneficiaryAddress := common.HexToAddress("0xb8d424e9662fe0837fb1d728f1ac97cebb1085fe")
 	signature := common.Hex2Bytes("abcd")
@@ -62,6 +64,8 @@ func TestSignCheque(t *testing.T) {
 }
 
 func TestSignChequeIntegration(t *testing.T) {
+	t.Parallel()
+
 	chequebookAddress := common.HexToAddress("0xfa02D396842E6e1D319E8E3D4D870338F791AA25")
 	beneficiaryAddress := common.HexToAddress("0x98E6C644aFeB94BBfB9FF60EB26fc9D83BBEcA79")
 	cumulativePayout := big.NewInt(500)

--- a/pkg/settlement/swap/chequebook/chequebook_test.go
+++ b/pkg/settlement/swap/chequebook/chequebook_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestChequebookAddress(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	chequebookService, err := chequebook.New(
@@ -41,6 +43,8 @@ func TestChequebookAddress(t *testing.T) {
 }
 
 func TestChequebookBalance(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	balance := big.NewInt(10)
@@ -69,6 +73,8 @@ func TestChequebookBalance(t *testing.T) {
 }
 
 func TestChequebookDeposit(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	balance := big.NewInt(30)
@@ -113,6 +119,8 @@ func TestChequebookDeposit(t *testing.T) {
 }
 
 func TestChequebookWaitForDeposit(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	txHash := common.HexToHash("0xdddd")
@@ -144,6 +152,8 @@ func TestChequebookWaitForDeposit(t *testing.T) {
 }
 
 func TestChequebookWaitForDepositReverted(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	txHash := common.HexToHash("0xdddd")
@@ -178,6 +188,8 @@ func TestChequebookWaitForDepositReverted(t *testing.T) {
 }
 
 func TestChequebookIssue(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	beneficiary := common.HexToAddress("0xdddd")
 	ownerAdress := common.HexToAddress("0xfff")
@@ -329,6 +341,8 @@ func TestChequebookIssue(t *testing.T) {
 }
 
 func TestChequebookIssueErrorSend(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	beneficiary := common.HexToAddress("0xdddd")
 	ownerAdress := common.HexToAddress("0xfff")
@@ -368,6 +382,8 @@ func TestChequebookIssueErrorSend(t *testing.T) {
 }
 
 func TestChequebookIssueOutOfFunds(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	beneficiary := common.HexToAddress("0xdddd")
 	ownerAdress := common.HexToAddress("0xfff")
@@ -407,6 +423,8 @@ func TestChequebookIssueOutOfFunds(t *testing.T) {
 }
 
 func TestChequebookWithdraw(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	balance := big.NewInt(30)
@@ -442,6 +460,8 @@ func TestChequebookWithdraw(t *testing.T) {
 }
 
 func TestChequebookWithdrawInsufficientFunds(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	ownerAdress := common.HexToAddress("0xfff")
 	withdrawAmount := big.NewInt(20)
@@ -472,6 +492,8 @@ func TestChequebookWithdrawInsufficientFunds(t *testing.T) {
 }
 
 func TestStateStoreKeys(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 
 	expected := "swap_cashout_000000000000000000000000000000000000abcd"

--- a/pkg/settlement/swap/chequebook/chequestore_test.go
+++ b/pkg/settlement/swap/chequebook/chequestore_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestReceiveCheque(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -121,6 +123,8 @@ func TestReceiveCheque(t *testing.T) {
 }
 
 func TestReceiveChequeInvalidBeneficiary(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -157,6 +161,8 @@ func TestReceiveChequeInvalidBeneficiary(t *testing.T) {
 }
 
 func TestReceiveChequeInvalidAmount(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -215,6 +221,8 @@ func TestReceiveChequeInvalidAmount(t *testing.T) {
 }
 
 func TestReceiveChequeInvalidChequebook(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -256,6 +264,8 @@ func TestReceiveChequeInvalidChequebook(t *testing.T) {
 }
 
 func TestReceiveChequeInvalidSignature(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -296,6 +306,8 @@ func TestReceiveChequeInvalidSignature(t *testing.T) {
 }
 
 func TestReceiveChequeInsufficientBalance(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -338,6 +350,8 @@ func TestReceiveChequeInsufficientBalance(t *testing.T) {
 }
 
 func TestReceiveChequeSufficientBalancePaidOut(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -380,6 +394,8 @@ func TestReceiveChequeSufficientBalancePaidOut(t *testing.T) {
 }
 
 func TestReceiveChequeNotEnoughValue(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")
@@ -437,6 +453,8 @@ func TestReceiveChequeNotEnoughValue(t *testing.T) {
 }
 
 func TestReceiveChequeNotEnoughValueAfterDeduction(t *testing.T) {
+	t.Parallel()
+
 	store := storemock.NewStateStore()
 	beneficiary := common.HexToAddress("0xffff")
 	issuer := common.HexToAddress("0xbeee")

--- a/pkg/settlement/swap/chequebook/factory_test.go
+++ b/pkg/settlement/swap/chequebook/factory_test.go
@@ -26,6 +26,8 @@ var (
 )
 
 func TestFactoryERC20Address(t *testing.T) {
+	t.Parallel()
+
 	factoryAddress := common.HexToAddress("0xabcd")
 	erc20Address := common.HexToAddress("0xeffff")
 	factory := chequebook.NewFactory(
@@ -68,11 +70,15 @@ func backendWithCodeAt(codeMap map[common.Address]string) transaction.Backend {
 }
 
 func TestFactoryVerifySelf(t *testing.T) {
+	t.Parallel()
+
 	factoryAddress := common.HexToAddress("0xabcd")
 	legacyFactory1 := common.HexToAddress("0xbbbb")
 	legacyFactory2 := common.HexToAddress("0xcccc")
 
 	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendWithCodeAt(map[common.Address]string{
 				factoryAddress: sw3abi.SimpleSwapFactoryDeployedBinv0_4_0,
@@ -91,6 +97,8 @@ func TestFactoryVerifySelf(t *testing.T) {
 	})
 
 	t.Run("invalid deploy factory", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendWithCodeAt(map[common.Address]string{
 				factoryAddress: "abcd",
@@ -110,6 +118,8 @@ func TestFactoryVerifySelf(t *testing.T) {
 	})
 
 	t.Run("invalid legacy factories", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendWithCodeAt(map[common.Address]string{
 				factoryAddress: sw3abi.SimpleSwapFactoryDeployedBinv0_4_0,
@@ -132,12 +142,16 @@ func TestFactoryVerifySelf(t *testing.T) {
 }
 
 func TestFactoryVerifyChequebook(t *testing.T) {
+	t.Parallel()
+
 	factoryAddress := common.HexToAddress("0xabcd")
 	chequebookAddress := common.HexToAddress("0xefff")
 	legacyFactory1 := common.HexToAddress("0xbbbb")
 	legacyFactory2 := common.HexToAddress("0xcccc")
 
 	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendmock.New(),
 			transactionmock.New(
@@ -159,6 +173,8 @@ func TestFactoryVerifyChequebook(t *testing.T) {
 	})
 
 	t.Run("valid legacy", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendmock.New(),
 			transactionmock.New(
@@ -196,6 +212,8 @@ func TestFactoryVerifyChequebook(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+
 		factory := chequebook.NewFactory(
 			backendmock.New(),
 			transactionmock.New(
@@ -237,6 +255,8 @@ func TestFactoryVerifyChequebook(t *testing.T) {
 }
 
 func TestFactoryDeploy(t *testing.T) {
+	t.Parallel()
+
 	factoryAddress := common.HexToAddress("0xabcd")
 	issuerAddress := common.HexToAddress("0xefff")
 	defaultTimeout := big.NewInt(1)
@@ -295,6 +315,8 @@ func TestFactoryDeploy(t *testing.T) {
 }
 
 func TestFactoryDeployReverted(t *testing.T) {
+	t.Parallel()
+
 	factoryAddress := common.HexToAddress("0xabcd")
 	deployTransactionHash := common.HexToHash("0xffff")
 	factory := chequebook.NewFactory(

--- a/pkg/settlement/swap/erc20/erc20_test.go
+++ b/pkg/settlement/swap/erc20/erc20_test.go
@@ -21,6 +21,8 @@ var (
 )
 
 func TestBalanceOf(t *testing.T) {
+	t.Parallel()
+
 	erc20Address := common.HexToAddress("00")
 	account := common.HexToAddress("01")
 	expectedBalance := big.NewInt(100)
@@ -49,6 +51,8 @@ func TestBalanceOf(t *testing.T) {
 }
 
 func TestTransfer(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	account := common.HexToAddress("01")
 	value := big.NewInt(20)

--- a/pkg/settlement/swap/headers/utilities_test.go
+++ b/pkg/settlement/swap/headers/utilities_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/p2p"
-	"github.com/ethersphere/bee/pkg/settlement/swap/headers"
+	swap "github.com/ethersphere/bee/pkg/settlement/swap/headers"
 )
 
 func TestParseSettlementResponseHeaders(t *testing.T) {
+	t.Parallel()
+
 	headers := p2p.Headers{
 		swap.ExchangeRateFieldName: []byte{10},
 		swap.DeductionFieldName:    []byte{20},
@@ -34,6 +36,7 @@ func TestParseSettlementResponseHeaders(t *testing.T) {
 }
 
 func TestMakeSettlementHeaders(t *testing.T) {
+	t.Parallel()
 
 	makeHeaders := swap.MakeSettlementHeaders(big.NewInt(906000), big.NewInt(5348))
 
@@ -48,6 +51,8 @@ func TestMakeSettlementHeaders(t *testing.T) {
 }
 
 func TestParseExchangeHeader(t *testing.T) {
+	t.Parallel()
+
 	toReadHeaders := p2p.Headers{
 		swap.ExchangeRateFieldName: []byte{13, 211, 16},
 	}
@@ -64,6 +69,8 @@ func TestParseExchangeHeader(t *testing.T) {
 }
 
 func TestParseDeductionHeader(t *testing.T) {
+	t.Parallel()
+
 	toReadHeaders := p2p.Headers{
 		swap.DeductionFieldName: []byte{20, 228},
 	}

--- a/pkg/settlement/swap/priceoracle/priceoracle_test.go
+++ b/pkg/settlement/swap/priceoracle/priceoracle_test.go
@@ -22,6 +22,8 @@ var (
 )
 
 func TestExchangeGetPrice(t *testing.T) {
+	t.Parallel()
+
 	priceOracleAddress := common.HexToAddress("0xabcd")
 
 	expectedPrice := big.NewInt(100)

--- a/pkg/settlement/swap/swap_test.go
+++ b/pkg/settlement/swap/swap_test.go
@@ -153,6 +153,8 @@ func (m *cashoutMock) CashoutStatus(ctx context.Context, chequebookAddress commo
 }
 
 func TestReceiveCheque(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
@@ -257,6 +259,8 @@ func TestReceiveCheque(t *testing.T) {
 }
 
 func TestReceiveChequeReject(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
@@ -320,6 +324,8 @@ func TestReceiveChequeReject(t *testing.T) {
 }
 
 func TestReceiveChequeWrongChequebook(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 	chequebookService := mockchequebook.NewChequebook()
@@ -376,6 +382,8 @@ func TestReceiveChequeWrongChequebook(t *testing.T) {
 }
 
 func TestPay(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -431,6 +439,8 @@ func TestPay(t *testing.T) {
 }
 
 func TestPayIssueError(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -487,6 +497,8 @@ func TestPayIssueError(t *testing.T) {
 }
 
 func TestPayUnknownBeneficiary(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -534,6 +546,8 @@ func TestPayUnknownBeneficiary(t *testing.T) {
 }
 
 func TestHandshake(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -586,6 +600,8 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestHandshakeNewPeer(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -637,6 +653,8 @@ func TestHandshakeNewPeer(t *testing.T) {
 }
 
 func TestMigratePeer(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -676,6 +694,8 @@ func TestMigratePeer(t *testing.T) {
 }
 
 func TestCashout(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -726,6 +746,8 @@ func TestCashout(t *testing.T) {
 }
 
 func TestCashoutStatus(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	store := mockstore.NewStateStore()
 
@@ -773,6 +795,8 @@ func TestCashoutStatus(t *testing.T) {
 }
 
 func TestStateStoreKeys(t *testing.T) {
+	t.Parallel()
+
 	address := common.HexToAddress("0xabcd")
 	swarmAddress := swarm.MustParseHexAddress("deff")
 

--- a/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
+++ b/pkg/settlement/swap/swapprotocol/swapprotocol_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestEmitCheques(t *testing.T) {
+	t.Parallel()
 
 	// Test negotiating / sending cheques
 
@@ -145,6 +146,8 @@ func TestEmitCheques(t *testing.T) {
 }
 
 func TestCantEmitChequeRateMismatch(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")
@@ -208,6 +211,7 @@ func TestCantEmitChequeRateMismatch(t *testing.T) {
 }
 
 func TestCantEmitChequeDeductionMismatch(t *testing.T) {
+	t.Parallel()
 
 	logger := log.Noop
 	commonAddr := common.HexToAddress("0xab")
@@ -272,6 +276,8 @@ func TestCantEmitChequeDeductionMismatch(t *testing.T) {
 }
 
 func TestCantEmitChequeIneligibleDeduction(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	commonAddr := common.HexToAddress("0xab")
 	peerID := swarm.MustParseHexAddress("9ee7add7")

--- a/pkg/shed/db_test.go
+++ b/pkg/shed/db_test.go
@@ -23,6 +23,8 @@ import (
 // TestNewDB constructs a new DB
 // and validates if the schema is initialized properly.
 func TestNewDB(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 
 	s, err := db.getSchema()
@@ -46,6 +48,8 @@ func TestNewDB(t *testing.T) {
 // TestDB_persistence creates one DB, saves a field and closes that DB.
 // Then, it constructs another DB and tries to retrieve the saved value.
 func TestDB_persistence(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	db, err := NewDB(dir, nil)

--- a/pkg/shed/field_string_test.go
+++ b/pkg/shed/field_string_test.go
@@ -27,15 +27,14 @@ import (
 func TestStringField(t *testing.T) {
 	t.Parallel()
 
-	db := newTestDB(t)
-
-	simpleString, err := db.NewStringField("simple-string")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	t.Run("get empty", func(t *testing.T) {
 		t.Parallel()
+
+		db := newTestDB(t)
+		simpleString, err := db.NewStringField("simple-string")
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		got, err := simpleString.Get()
 		if err != nil {
@@ -49,6 +48,12 @@ func TestStringField(t *testing.T) {
 
 	t.Run("put", func(t *testing.T) {
 		t.Parallel()
+
+		db := newTestDB(t)
+		simpleString, err := db.NewStringField("simple-string")
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		want := "simple string value"
 		err = simpleString.Put(want)
@@ -83,6 +88,12 @@ func TestStringField(t *testing.T) {
 
 	t.Run("put in batch", func(t *testing.T) {
 		t.Parallel()
+
+		db := newTestDB(t)
+		simpleString, err := db.NewStringField("simple-string")
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		batch := new(leveldb.Batch)
 		want := "simple string batch value"

--- a/pkg/shed/field_string_test.go
+++ b/pkg/shed/field_string_test.go
@@ -25,6 +25,8 @@ import (
 // TestStringField validates put and get operations
 // of the StringField.
 func TestStringField(t *testing.T) {
+	t.Parallel()
+
 	db := newTestDB(t)
 
 	simpleString, err := db.NewStringField("simple-string")
@@ -33,6 +35,8 @@ func TestStringField(t *testing.T) {
 	}
 
 	t.Run("get empty", func(t *testing.T) {
+		t.Parallel()
+
 		got, err := simpleString.Get()
 		if err != nil {
 			t.Fatal(err)
@@ -44,6 +48,8 @@ func TestStringField(t *testing.T) {
 	})
 
 	t.Run("put", func(t *testing.T) {
+		t.Parallel()
+
 		want := "simple string value"
 		err = simpleString.Put(want)
 		if err != nil {
@@ -58,6 +64,8 @@ func TestStringField(t *testing.T) {
 		}
 
 		t.Run("overwrite", func(t *testing.T) {
+			t.Parallel()
+
 			want := "overwritten string value"
 			err = simpleString.Put(want)
 			if err != nil {
@@ -74,6 +82,8 @@ func TestStringField(t *testing.T) {
 	})
 
 	t.Run("put in batch", func(t *testing.T) {
+		t.Parallel()
+
 		batch := new(leveldb.Batch)
 		want := "simple string batch value"
 		simpleString.PutInBatch(batch, want)
@@ -90,6 +100,8 @@ func TestStringField(t *testing.T) {
 		}
 
 		t.Run("overwrite", func(t *testing.T) {
+			t.Parallel()
+
 			batch := new(leveldb.Batch)
 			want := "overwritten string batch value"
 			simpleString.PutInBatch(batch, want)

--- a/pkg/skippeers/skip_peers_test.go
+++ b/pkg/skippeers/skip_peers_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAddOverdraft(t *testing.T) {
+	t.Parallel()
+
 	var (
 		p1 = swarm.NewAddress([]byte("0xab"))
 		p2 = swarm.NewAddress([]byte("0xbc"))

--- a/pkg/soc/soc_test.go
+++ b/pkg/soc/soc_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	payload := []byte("foo")
 	ch, err := cac.New(payload)
 	if err != nil {
@@ -46,6 +48,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewSigned(t *testing.T) {
+	t.Parallel()
+
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
 	// signature of hash(id + chunk address of foo)
 	sig, err := hex.DecodeString("5acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a053deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c1348311b")
@@ -93,6 +97,8 @@ func TestNewSigned(t *testing.T) {
 // TestChunk verifies that the chunk created from the SOC object
 // corresponds to the SOC spec.
 func TestChunk(t *testing.T) {
+	t.Parallel()
+
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
 	sig, err := hex.DecodeString("5acd384febc133b7b245e5ddc62d82d2cded9182d2716126cd8844509af65a053deb418208027f548e3e88343af6f84a8772fb3cebc0a1833a0ea7ec0c1348311b")
 	if err != nil {
@@ -155,6 +161,8 @@ func TestChunk(t *testing.T) {
 }
 
 func TestChunkErrorWithoutOwner(t *testing.T) {
+	t.Parallel()
+
 	payload := []byte("foo")
 	ch, err := cac.New(payload)
 	if err != nil {
@@ -173,6 +181,8 @@ func TestChunkErrorWithoutOwner(t *testing.T) {
 
 // TestSign tests whether a soc is correctly signed.
 func TestSign(t *testing.T) {
+	t.Parallel()
+
 	privKey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)
@@ -230,6 +240,8 @@ func TestSign(t *testing.T) {
 // TestFromChunk verifies that valid chunk data deserializes to
 // a fully populated soc object.
 func TestFromChunk(t *testing.T) {
+	t.Parallel()
+
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
 	// signed soc chunk of:
@@ -283,6 +295,8 @@ func TestFromChunk(t *testing.T) {
 }
 
 func TestCreateAddress(t *testing.T) {
+	t.Parallel()
+
 	id := make([]byte, swarm.HashSize)
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
@@ -297,6 +311,8 @@ func TestCreateAddress(t *testing.T) {
 }
 
 func TestRecoverAddress(t *testing.T) {
+	t.Parallel()
+
 	owner := common.HexToAddress("8d3766440f0d7b949a5e32995d09619a7f86e632")
 	id := make([]byte, swarm.HashSize)
 	chunkAddress := swarm.MustParseHexAddress("2387e8e7d8a48c2a9339c97c1dc3461a9a7aa07e994c5cb8b38fd7c1b3e6ea48")

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -15,8 +15,6 @@ import (
 // TestValid verifies that the validator can detect
 // valid soc chunks.
 func TestValid(t *testing.T) {
-	t.Parallel()
-
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
 	// signed soc chunk of:
@@ -34,8 +32,6 @@ func TestValid(t *testing.T) {
 // TestInvalid verifies that the validator can detect chunks
 // with invalid data and invalid address.
 func TestInvalid(t *testing.T) {
-	t.Parallel()
-
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
 	// signed soc chunk of:
@@ -109,10 +105,7 @@ func TestInvalid(t *testing.T) {
 			},
 		},
 	} {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
 			if soc.Valid(c.chunk()) {
 				t.Fatal("chunk with invalid data evaluates to valid")
 			}

--- a/pkg/soc/validator_test.go
+++ b/pkg/soc/validator_test.go
@@ -15,6 +15,8 @@ import (
 // TestValid verifies that the validator can detect
 // valid soc chunks.
 func TestValid(t *testing.T) {
+	t.Parallel()
+
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
 	// signed soc chunk of:
@@ -32,6 +34,8 @@ func TestValid(t *testing.T) {
 // TestInvalid verifies that the validator can detect chunks
 // with invalid data and invalid address.
 func TestInvalid(t *testing.T) {
+	t.Parallel()
+
 	socAddress := swarm.MustParseHexAddress("9d453ebb73b2fedaaf44ceddcf7a0aa37f3e3d6453fea5841c31f0ea6d61dc85")
 
 	// signed soc chunk of:
@@ -105,7 +109,10 @@ func TestInvalid(t *testing.T) {
 			},
 		},
 	} {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			if soc.Valid(c.chunk()) {
 				t.Fatal("chunk with invalid data evaluates to valid")
 			}

--- a/pkg/steward/steward_test.go
+++ b/pkg/steward/steward_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestSteward(t *testing.T) {
+	t.Parallel()
+
 	var (
 		ctx            = context.Background()
 		chunks         = 1000
@@ -79,6 +81,8 @@ func TestSteward(t *testing.T) {
 }
 
 func TestSteward_ErrWantSelf(t *testing.T) {
+	t.Parallel()
+
 	var (
 		ctx           = context.Background()
 		chunks        = 10

--- a/pkg/storage/inmemstore/store_test.go
+++ b/pkg/storage/inmemstore/store_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestStorePutGet(t *testing.T) {
+	t.Parallel()
+
 	s := inmemstore.New()
 
 	keyFound, err := swarm.ParseHexAddress("aabbcc")

--- a/pkg/storage/mock/storer_test.go
+++ b/pkg/storage/mock/storer_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestMockStorer(t *testing.T) {
+	t.Parallel()
+
 	s := mock.NewStorer()
 
 	keyFound, err := swarm.ParseHexAddress("aabbcc")

--- a/pkg/swarm/distance_test.go
+++ b/pkg/swarm/distance_test.go
@@ -54,6 +54,8 @@ var (
 
 // TestDistance tests the correctness of the distance calculation.
 func TestDistance(t *testing.T) {
+	t.Parallel()
+
 	for _, dt := range distanceTests {
 		distance, err := Distance(dt.x, dt.y)
 		if err != nil {
@@ -67,6 +69,8 @@ func TestDistance(t *testing.T) {
 
 // TestDistanceCmp tests the distance comparison method.
 func TestDistanceCmp(t *testing.T) {
+	t.Parallel()
+
 	for _, dt := range distanceCmpTests {
 		direction, err := DistanceCmp(dt.a, dt.x, dt.y)
 		if err != nil {

--- a/pkg/swarm/proximity_test.go
+++ b/pkg/swarm/proximity_test.go
@@ -24,6 +24,8 @@ import (
 // values in a table-driven test. It is highly dependant on
 // MaxPO constant and it validates cases up to MaxPO=32.
 func TestProximity(t *testing.T) {
+	t.Parallel()
+
 	// adjust expected bins in respect to MaxPO
 	limitPO := func(po uint8) uint8 {
 		if po > MaxPO {

--- a/pkg/swarm/swarm_test.go
+++ b/pkg/swarm/swarm_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAddress(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name    string
 		hex     string
@@ -46,7 +48,10 @@ func TestAddress(t *testing.T) {
 			want: swarm.NewAddress([]byte{0x35, 0xa2, 0x6b, 0x7b, 0xb6, 0x45, 0x5c, 0xba, 0xbe, 0x7a, 0xe, 0x5, 0xaa, 0xfb, 0xd0, 0xb8, 0xb2, 0x6f, 0xea, 0xc8, 0x43, 0xe3, 0xb9, 0xa6, 0x49, 0x46, 0x8d, 0xe, 0xa3, 0x7a, 0x12, 0xb2}),
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			a, err := swarm.ParseHexAddress(tc.hex)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("got error %v, want %v", err, tc.wantErr)
@@ -65,6 +70,8 @@ func TestAddress(t *testing.T) {
 }
 
 func TestAddress_jsonMarshalling(t *testing.T) {
+	t.Parallel()
+
 	a1 := swarm.MustParseHexAddress("24798dd5a470e927fa")
 
 	b, err := json.Marshal(a1)
@@ -83,6 +90,8 @@ func TestAddress_jsonMarshalling(t *testing.T) {
 }
 
 func TestAddress_MemberOf(t *testing.T) {
+	t.Parallel()
+
 	a1 := swarm.MustParseHexAddress("24798dd5a470e927fa")
 	a2 := swarm.MustParseHexAddress("24798dd5a470e927fa")
 	a3 := swarm.MustParseHexAddress("24798dd5a470e927fb")
@@ -101,6 +110,8 @@ func TestAddress_MemberOf(t *testing.T) {
 }
 
 func TestCloser(t *testing.T) {
+	t.Parallel()
+
 	a := swarm.MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000")
 	x := swarm.MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000")
 	y := swarm.MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000")

--- a/pkg/swarm/test/helper_test.go
+++ b/pkg/swarm/test/helper_test.go
@@ -16,6 +16,8 @@ import (
 // at a given proximity order. It compares the number of leading equal bits in the generated
 // address to the base address.
 func TestRandomAddressAt(t *testing.T) {
+	t.Parallel()
+
 	base := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 	b0 := base.Bytes()
 	hw0 := []byte{b0[0], b0[1], 0, 0} // highest words of base address

--- a/pkg/tags/tag_test.go
+++ b/pkg/tags/tag_test.go
@@ -33,6 +33,8 @@ var (
 
 // TestTagSingleIncrements tests if Inc increments the tag state value
 func TestTagSingleIncrements(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	tg := &Tag{Total: 10, stateStore: mockStatestore, logger: logger}
@@ -68,6 +70,8 @@ func TestTagSingleIncrements(t *testing.T) {
 
 // TestTagStatus is a unit test to cover Tag.Status method functionality
 func TestTagStatus(t *testing.T) {
+	t.Parallel()
+
 	tg := &Tag{Total: 10}
 	err := tg.Inc(StateSeen)
 	if err != nil {
@@ -118,6 +122,8 @@ func TestTagStatus(t *testing.T) {
 
 // tests ETA is precise
 func TestTagETA(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 	maxDiff := 100000 // 100 microsecond
 	tg := &Tag{Total: 10, StartedAt: now}
@@ -138,6 +144,8 @@ func TestTagETA(t *testing.T) {
 
 // TestTagConcurrentIncrements tests Inc calls concurrently
 func TestTagConcurrentIncrements(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	tg := &Tag{stateStore: mockStatestore, logger: logger}
@@ -168,6 +176,8 @@ func TestTagConcurrentIncrements(t *testing.T) {
 
 // TestTagsMultipleConcurrentIncrements tests Inc calls concurrently
 func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	ts := NewTags(mockStatestore, logger)
@@ -219,6 +229,8 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 // TestMarshallingWithAddr tests that marshalling and unmarshalling is done correctly when the
 // tag Address (byte slice) contains some arbitrary value
 func TestMarshallingWithAddr(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)
@@ -268,6 +280,8 @@ func TestMarshallingWithAddr(t *testing.T) {
 
 // TestMarshallingNoAddress tests that marshalling and unmarshalling is done correctly
 func TestMarshallingNoAddr(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	tg := NewTag(context.Background(), 111, 10, nil, mockStatestore, logger)

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestAll(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	ts := NewTags(mockStatestore, logger)
@@ -64,6 +66,8 @@ func TestAll(t *testing.T) {
 }
 
 func TestListAll(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 
@@ -142,6 +146,8 @@ func TestListAll(t *testing.T) {
 }
 
 func TestPersistence(t *testing.T) {
+	t.Parallel()
+
 	mockStatestore := statestore.NewStateStore()
 	logger := log.Noop
 	ts := NewTags(mockStatestore, logger)

--- a/pkg/topology/lightnode/container_test.go
+++ b/pkg/topology/lightnode/container_test.go
@@ -18,10 +18,13 @@ import (
 )
 
 func TestContainer(t *testing.T) {
+	t.Parallel()
 
 	base := test.RandomAddress()
 
 	t.Run("new container is empty container", func(t *testing.T) {
+		t.Parallel()
+
 		c := lightnode.NewContainer(base)
 
 		var empty topology.BinInfo
@@ -32,6 +35,8 @@ func TestContainer(t *testing.T) {
 	})
 
 	t.Run("can add peers to container", func(t *testing.T) {
+		t.Parallel()
+
 		c := lightnode.NewContainer(base)
 
 		p1 := swarm.NewAddress([]byte("123"))
@@ -77,6 +82,8 @@ func TestContainer(t *testing.T) {
 		}
 	})
 	t.Run("empty container after peer disconnect", func(t *testing.T) {
+		t.Parallel()
+
 		c := lightnode.NewContainer(base)
 
 		peer := p2p.Peer{Address: swarm.NewAddress([]byte("123"))}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestSpanFromHeaders(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -50,6 +52,8 @@ func TestSpanFromHeaders(t *testing.T) {
 }
 
 func TestSpanWithContextFromHeaders(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -82,6 +86,8 @@ func TestSpanWithContextFromHeaders(t *testing.T) {
 }
 
 func TestFromContext(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -104,6 +110,8 @@ func TestFromContext(t *testing.T) {
 }
 
 func TestWithContext(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -128,6 +136,8 @@ func TestWithContext(t *testing.T) {
 }
 
 func TestStartSpanFromContext_logger(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -160,6 +170,8 @@ func TestStartSpanFromContext_logger(t *testing.T) {
 }
 
 func TestStartSpanFromContext_nilLogger(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -172,6 +184,8 @@ func TestStartSpanFromContext_nilLogger(t *testing.T) {
 }
 
 func TestNewLoggerWithTraceID(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 
@@ -206,6 +220,8 @@ func TestNewLoggerWithTraceID(t *testing.T) {
 }
 
 func TestNewLoggerWithTraceID_nilLogger(t *testing.T) {
+	t.Parallel()
+
 	tracer, closer := newTracer(t)
 	defer closer.Close()
 

--- a/pkg/transaction/backend_test.go
+++ b/pkg/transaction/backend_test.go
@@ -17,12 +17,16 @@ import (
 )
 
 func TestIsSynced(t *testing.T) {
+	t.Parallel()
+
 	maxDelay := 10 * time.Second
 	now := time.Now().UTC()
 	ctx := context.Background()
 	blockNumber := uint64(100)
 
 	t.Run("synced", func(t *testing.T) {
+		t.Parallel()
+
 		synced, _, err := transaction.IsSynced(
 			ctx,
 			backendmock.New(
@@ -49,6 +53,8 @@ func TestIsSynced(t *testing.T) {
 	})
 
 	t.Run("not synced", func(t *testing.T) {
+		t.Parallel()
+
 		synced, _, err := transaction.IsSynced(
 			ctx,
 			backendmock.New(
@@ -75,6 +81,8 @@ func TestIsSynced(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
 		expectedErr := errors.New("err")
 		_, _, err := transaction.IsSynced(
 			ctx,

--- a/pkg/transaction/event_test.go
+++ b/pkg/transaction/event_test.go
@@ -38,11 +38,15 @@ func newTransferLog(address, from, to common.Address, value *big.Int) *types.Log
 }
 
 func TestParseEvent(t *testing.T) {
+	t.Parallel()
+
 	from := common.HexToAddress("00")
 	to := common.HexToAddress("01")
 	value := big.NewInt(0)
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
 		var event transferEvent
 		err := transaction.ParseEvent(&erc20ABI, "Transfer", &event, *newTransferLog(common.Address{}, from, to, value))
 		if err != nil {
@@ -63,6 +67,8 @@ func TestParseEvent(t *testing.T) {
 	})
 
 	t.Run("no topic", func(t *testing.T) {
+		t.Parallel()
+
 		var event transferEvent
 		err := transaction.ParseEvent(&erc20ABI, "Transfer", &event, types.Log{
 			Topics: []common.Hash{},
@@ -74,12 +80,16 @@ func TestParseEvent(t *testing.T) {
 }
 
 func TestFindSingleEvent(t *testing.T) {
+	t.Parallel()
+
 	contractAddress := common.HexToAddress("abcd")
 	from := common.HexToAddress("00")
 	to := common.HexToAddress("01")
 	value := big.NewInt(0)
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
 		var event transferEvent
 		err := transaction.FindSingleEvent(
 			&erc20ABI,
@@ -113,6 +123,8 @@ func TestFindSingleEvent(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
 		var event transferEvent
 		err := transaction.FindSingleEvent(
 			&erc20ABI,
@@ -133,6 +145,8 @@ func TestFindSingleEvent(t *testing.T) {
 	})
 
 	t.Run("Reverted", func(t *testing.T) {
+		t.Parallel()
+
 		var event transferEvent
 		err := transaction.FindSingleEvent(
 			&erc20ABI,

--- a/pkg/transaction/monitor_test.go
+++ b/pkg/transaction/monitor_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestMonitorWatchTransaction(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	txHash := common.HexToHash("0xabcd")
 	nonce := uint64(10)
@@ -27,6 +29,8 @@ func TestMonitorWatchTransaction(t *testing.T) {
 	testTimeout := 5 * time.Second
 
 	t.Run("single transaction confirmed", func(t *testing.T) {
+		t.Parallel()
+
 		monitor := transaction.NewMonitor(
 			logger,
 			backendsimulation.New(
@@ -76,6 +80,8 @@ func TestMonitorWatchTransaction(t *testing.T) {
 	})
 
 	t.Run("single transaction cancelled", func(t *testing.T) {
+		t.Parallel()
+
 		monitor := transaction.NewMonitor(
 			logger,
 			backendsimulation.New(
@@ -131,6 +137,8 @@ func TestMonitorWatchTransaction(t *testing.T) {
 	})
 
 	t.Run("multiple transactions mixed", func(t *testing.T) {
+		t.Parallel()
+
 		txHash2 := common.HexToHash("bbbb")
 		txHash3 := common.HexToHash("cccc")
 
@@ -253,6 +261,8 @@ func TestMonitorWatchTransaction(t *testing.T) {
 	})
 
 	t.Run("single transaction no confirm", func(t *testing.T) {
+		t.Parallel()
+
 		txHash2 := common.HexToHash("bbbb")
 		monitor := transaction.NewMonitor(
 			logger,
@@ -331,6 +341,8 @@ func TestMonitorWatchTransaction(t *testing.T) {
 	})
 
 	t.Run("shutdown while waiting", func(t *testing.T) {
+		t.Parallel()
+
 		monitor := transaction.NewMonitor(
 			logger,
 			backendsimulation.New(

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -75,6 +75,8 @@ func signerMockForTransaction(t *testing.T, signedTx *types.Transaction, sender 
 }
 
 func TestTransactionSend(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	sender := common.HexToAddress("0xddff")
 	recipient := common.HexToAddress("0xabcd")
@@ -86,6 +88,8 @@ func TestTransactionSend(t *testing.T) {
 	chainID := big.NewInt(5)
 
 	t.Run("send", func(t *testing.T) {
+		t.Parallel()
+
 		signedTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			To:       &recipient,
@@ -205,6 +209,8 @@ func TestTransactionSend(t *testing.T) {
 	})
 
 	t.Run("send_no_nonce", func(t *testing.T) {
+		t.Parallel()
+
 		signedTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			To:       &recipient,
@@ -274,6 +280,8 @@ func TestTransactionSend(t *testing.T) {
 	})
 
 	t.Run("send_skipped_nonce", func(t *testing.T) {
+		t.Parallel()
+
 		nextNonce := nonce + 5
 		signedTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nextNonce,
@@ -348,6 +356,8 @@ func TestTransactionSend(t *testing.T) {
 }
 
 func TestTransactionWaitForReceipt(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	txHash := common.HexToHash("0xabcdee")
 	chainID := big.NewInt(5)
@@ -406,6 +416,8 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 }
 
 func TestTransactionResend(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
@@ -465,6 +477,8 @@ func TestTransactionResend(t *testing.T) {
 }
 
 func TestTransactionCancel(t *testing.T) {
+	t.Parallel()
+
 	logger := log.Noop
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
@@ -498,6 +512,8 @@ func TestTransactionCancel(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
 		cancelTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			To:       &recipient,
@@ -537,6 +553,8 @@ func TestTransactionCancel(t *testing.T) {
 	})
 
 	t.Run("custom gas price", func(t *testing.T) {
+		t.Parallel()
+
 		customGasPrice := big.NewInt(5)
 		cancelTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
@@ -578,6 +596,8 @@ func TestTransactionCancel(t *testing.T) {
 	})
 
 	t.Run("too low gas price", func(t *testing.T) {
+		t.Parallel()
+
 		customGasPrice := big.NewInt(0)
 		cancelTx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -489,7 +489,7 @@ func TestTransactionCancel(t *testing.T) {
 	value := big.NewInt(0)
 
 	store := storemock.NewStateStore()
-	defer store.Close()
+	t.Cleanup(func() { store.Close() })
 
 	signedTx := types.NewTx(&types.LegacyTx{
 		Nonce:    nonce,

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -71,6 +71,8 @@ func (i *addressIterator) Next(addr swarm.Address) error {
 }
 
 func TestTraversalBytes(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		dataSize              int
 		wantHashCount         int
@@ -147,6 +149,8 @@ func TestTraversalBytes(t *testing.T) {
 	for _, tc := range testCases {
 		chunkCount := int(math.Ceil(float64(tc.dataSize) / swarm.ChunkSize))
 		t.Run(fmt.Sprintf("%d-chunk-%d-bytes", chunkCount, tc.dataSize), func(t *testing.T) {
+			t.Parallel()
+
 			var (
 				data       = generateSample(tc.dataSize)
 				iter       = newAddressIterator(tc.ignoreDuplicateHashes)
@@ -185,6 +189,8 @@ func TestTraversalBytes(t *testing.T) {
 }
 
 func TestTraversalFiles(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		filesSize             int
 		contentType           string
@@ -237,6 +243,8 @@ func TestTraversalFiles(t *testing.T) {
 	for _, tc := range testCases {
 		chunkCount := int(math.Ceil(float64(tc.filesSize) / swarm.ChunkSize))
 		t.Run(fmt.Sprintf("%d-chunk-%d-bytes", chunkCount, tc.filesSize), func(t *testing.T) {
+			t.Parallel()
+
 			var (
 				data       = generateSample(tc.filesSize)
 				iter       = newAddressIterator(tc.ignoreDuplicateHashes)

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -147,6 +147,7 @@ func TestTraversalBytes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		chunkCount := int(math.Ceil(float64(tc.dataSize) / swarm.ChunkSize))
 		t.Run(fmt.Sprintf("%d-chunk-%d-bytes", chunkCount, tc.dataSize), func(t *testing.T) {
 			t.Parallel()
@@ -241,6 +242,7 @@ func TestTraversalFiles(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		chunkCount := int(math.Ceil(float64(tc.filesSize) / swarm.ChunkSize))
 		t.Run(fmt.Sprintf("%d-chunk-%d-bytes", chunkCount, tc.filesSize), func(t *testing.T) {
 			t.Parallel()
@@ -399,6 +401,7 @@ func TestTraversalManifest(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("%s-%d-files-%d-chunks", defaultMediaType, len(tc.files), tc.wantHashCount), func(t *testing.T) {
 			var (
 				storerMock = mock.NewStorer()

--- a/pkg/util/ioutil/ioutil_test.go
+++ b/pkg/util/ioutil/ioutil_test.go
@@ -16,7 +16,11 @@ import (
 )
 
 func TestTimeoutReader(t *testing.T) {
+	t.Parallel()
+
 	t.Run("normal read", func(t *testing.T) {
+		t.Parallel()
+
 		read := uint64(0)
 		data := "0123456789"
 		timeout := 100 * time.Millisecond
@@ -44,6 +48,8 @@ func TestTimeoutReader(t *testing.T) {
 		}
 	})
 	t.Run("stuck read", func(t *testing.T) {
+		t.Parallel()
+
 		read := uint64(0)
 		data := "0123456789"
 		timeout := 100 * time.Millisecond
@@ -63,6 +69,8 @@ func TestTimeoutReader(t *testing.T) {
 		}
 	})
 	t.Run("EOF read", func(t *testing.T) {
+		t.Parallel()
+
 		read := uint64(0)
 		timeout := 100 * time.Millisecond
 		cancelFn := func(u uint64) { atomic.StoreUint64(&read, u) }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR is the first part of effort to improve static code analysis (issue https://github.com/ethersphere/bee/issues/3255)

* Enabeld `paralleltest` with configuration temporally disabling it on packages which remain to be resolved. Lint is enabled so that currently fixed packages won't drift away from this rule.
* This PR just set some test to execute in parallel. There will be more effort split into many PRs which fix and enable lint in currently disabled packages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3293)
<!-- Reviewable:end -->
