### PR TITLE
feat(lint): enable dogsled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - bidichk
     - deadcode
     - depguard
+    - dogsled
     - errcheck
     - errname
     - exportloopref
@@ -33,7 +34,6 @@ linters:
     - unused
     - varcheck
     - wastedassign
-    - dogsled
 
 linters-settings:
   goheader:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - unused
     - varcheck
     - wastedassign
+    - dogsled
 
 linters-settings:
   goheader:
@@ -55,3 +56,6 @@ issues:
         - forbidigo
       path: cmd/bee/cmd
       text: "use of `fmt.Print"   ## allow fmt.Print in cmd directory
+    - linters:
+        - dogsled
+      path: pkg/api/(.+)_test\.go # temporally disable dogsled in api test files

--- a/pkg/pricer/headerutils/utilities_test.go
+++ b/pkg/pricer/headerutils/utilities_test.go
@@ -174,11 +174,13 @@ func TestReadMalformedHeaders(t *testing.T) {
 		t.Fatal("Expected error from bad length of price bytes")
 	}
 
+	// nolint:dogsled
 	_, _, _, err = headerutils.ParsePricingResponseHeaders(toReadHeaders)
 	if err == nil {
 		t.Fatal("Expected error caused by bad length of fields")
 	}
 
+	// nolint:dogsled
 	_, _, err = headerutils.ParsePricingHeaders(toReadHeaders)
 	if err == nil {
 		t.Fatal("Expected error caused by bad length of fields")


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR is part of effort to improve static code analysis (issue https://github.com/ethersphere/bee/issues/3255)

 - enable `dogsled` lint rule
 - ignored all issues in api test files; because there are a lot of occurrences with construct `testServer, _, _, _ := newTestServer(..)`, which can be addressed later

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3308)
<!-- Reviewable:end -->
