### PR TITLE
fix: reserve size to return chunks with po greater than and equal to storage radius

### DIFF
--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -165,6 +165,9 @@ func withinRadius(db *DB, item shed.Item) bool {
 	return po >= item.Radius
 }
 
+// ComputeReserveSize iterates on the pull index to count all chunks
+// starting at some proximity order with an generated address whose PO
+// is used as a starting prefix by the index.
 func (db *DB) ComputeReserveSize(startPO uint8) (uint64, error) {
 
 	var count uint64
@@ -193,7 +196,7 @@ func generateAddressAt(baseBytes []byte, prox int) []byte {
 	}
 
 	if baseBytes[prox/8]&(1<<(7-(prox%8))) == 0 { // if baseBytes PO bit is zero
-		addr[prox/8] |= (1 << (7 - (prox % 8))) // set addr bit to 1
+		addr[prox/8] |= 1 << (7 - (prox % 8)) // set addr bit to 1
 	}
 
 	return addr

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -686,6 +686,7 @@ func TestReserveSize(t *testing.T) {
 }
 
 func TestComputeReserveSize(t *testing.T) {
+	t.Parallel()
 
 	const chunkCountPerPO = 10
 	const maxPO = 10

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -685,6 +685,43 @@ func TestReserveSize(t *testing.T) {
 	})
 }
 
+func TestComputeReserveSize(t *testing.T) {
+
+	const chunkCountPerPO = 10
+	const maxPO = 10
+	var chs []swarm.Chunk
+
+	db := newTestDB(t, &Options{
+		Capacity:        1000,
+		ReserveCapacity: 1000,
+	})
+
+	for po := 0; po < maxPO; po++ {
+		for i := 0; i < chunkCountPerPO; i++ {
+			ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
+			chs = append(chs, ch)
+		}
+	}
+
+	_, err := db.Put(context.Background(), storage.ModePutSync, chs...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("reserve size", reserveSizeTest(db, chunkCountPerPO*maxPO))
+
+	for po := 0; po < maxPO; po++ {
+		got, err := db.ComputeReserveSize(uint8(po))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := (maxPO - po) * chunkCountPerPO
+		if got != uint64(want) {
+			t.Fatalf("compute reserve size mismatch, po %d, got %d, want %d", po, got, want)
+		}
+	}
+}
+
 func TestDB_ReserveGC_BatchedUnreserve(t *testing.T) {
 	chunkCount := 100
 

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -241,7 +241,7 @@ type mockReserveReporter struct {
 	size     uint64
 }
 
-func (m *mockReserveReporter) ReserveSize() (uint64, error) {
+func (m *mockReserveReporter) ComputeReserveSize(uint8) (uint64, error) {
 	m.Lock()
 	defer m.Unlock()
 	return m.size, nil


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
When the depthmonitor changes the storage radius, this does not automatically alter the radius that the localstore keeps in it's reserve, so the `ReserveSize` does not return an accurate number. With this PR, we iterate on the pull index to manually count all chunks whose PO is greater than or equal to the storage radius.

#### Motivation and context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3322)
<!-- Reviewable:end -->
