### PR TITLE
refactor(libp2p): make the headers read/write timeout an option

### DIFF
--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -896,18 +896,18 @@ func TestTopologyOverSaturated(t *testing.T) {
 func TestWithDisconnectStreams(t *testing.T) {
 	t.Parallel()
 
-	defer func(t time.Duration) {
-		*libp2p.SendHeadersTimeout = t
-	}(*libp2p.SendHeadersTimeout)
-	*libp2p.SendHeadersTimeout = 60 * time.Second
+	const headersRWTimeout = 60 * time.Second
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	s1, overlay1 := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{
-		FullNode: true,
+		FullNode:         true,
+		HeadersRWTimeout: headersRWTimeout,
 	}})
-	s2, overlay2 := newService(t, 1, libp2pServiceOpts{})
+	s2, overlay2 := newService(t, 1, libp2pServiceOpts{libp2pOpts: libp2p.Options{
+		HeadersRWTimeout: headersRWTimeout,
+	}})
 
 	testSpec := p2p.ProtocolSpec{
 		Name:    testProtocolName,
@@ -926,12 +926,12 @@ func TestWithDisconnectStreams(t *testing.T) {
 
 	_ = s1.AddProtocol(testSpec)
 
-	s1_underlay := serviceUnderlayAddress(t, s1)
+	s1Underlay := serviceUnderlayAddress(t, s1)
 
 	expectPeers(t, s1)
 	expectPeers(t, s2)
 
-	if _, err := s2.Connect(ctx, s1_underlay); err != nil {
+	if _, err := s2.Connect(ctx, s1Underlay); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/p2p/libp2p/export_test.go
+++ b/pkg/p2p/libp2p/export_test.go
@@ -30,7 +30,6 @@ type StaticAddressResolver = staticAddressResolver
 
 var (
 	NewStaticAddressResolver = newStaticAddressResolver
-	SendHeadersTimeout       = &sendHeadersTimeout
 	UserAgent                = userAgent
 )
 

--- a/pkg/p2p/libp2p/headers.go
+++ b/pkg/p2p/libp2p/headers.go
@@ -7,7 +7,6 @@ package libp2p
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p/internal/headers/pb"
@@ -15,13 +14,8 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-var sendHeadersTimeout = 10 * time.Second
-
 func sendHeaders(ctx context.Context, headers p2p.Headers, stream *stream) error {
 	w, r := protobuf.NewWriterAndReader(stream)
-
-	ctx, cancel := context.WithTimeout(ctx, sendHeadersTimeout)
-	defer cancel()
 
 	if err := w.WriteMsgWithContext(ctx, headersP2PToPB(headers)); err != nil {
 		return fmt.Errorf("write message: %w", err)
@@ -37,11 +31,8 @@ func sendHeaders(ctx context.Context, headers p2p.Headers, stream *stream) error
 	return nil
 }
 
-func handleHeaders(headler p2p.HeadlerFunc, stream *stream, peerAddress swarm.Address) error {
+func handleHeaders(ctx context.Context, headler p2p.HeadlerFunc, stream *stream, peerAddress swarm.Address) error {
 	w, r := protobuf.NewWriterAndReader(stream)
-
-	ctx, cancel := context.WithTimeout(context.Background(), sendHeadersTimeout)
-	defer cancel()
 
 	headers := new(pb.Headers)
 	if err := r.ReadMsgWithContext(ctx, headers); err != nil {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -70,6 +70,8 @@ var (
 const (
 	defaultLightNodeLimit = 100
 	peerUserAgentTimeout  = time.Second
+
+	defaultHeadersRWTimeout = 10 * time.Second
 )
 
 func init() {
@@ -103,6 +105,7 @@ type Service struct {
 	protocolsmu       sync.RWMutex
 	reacher           p2p.Reacher
 	networkStatus     atomic.Int32
+	HeadersRWTimeout  time.Duration
 }
 
 type lightnodes interface {
@@ -114,15 +117,16 @@ type lightnodes interface {
 }
 
 type Options struct {
-	PrivateKey      *ecdsa.PrivateKey
-	NATAddr         string
-	EnableWS        bool
-	FullNode        bool
-	LightNodeLimit  int
-	WelcomeMessage  string
-	Nonce           []byte
-	ValidateOverlay bool
-	hostFactory     func(...libp2p.Option) (host.Host, error)
+	PrivateKey       *ecdsa.PrivateKey
+	NATAddr          string
+	EnableWS         bool
+	FullNode         bool
+	LightNodeLimit   int
+	WelcomeMessage   string
+	Nonce            []byte
+	ValidateOverlay  bool
+	hostFactory      func(...libp2p.Option) (host.Host, error)
+	HeadersRWTimeout time.Duration
 }
 
 func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay swarm.Address, addr string, ab addressbook.Putter, storer storage.StateStorer, lightNodes *lightnode.Container, logger log.Logger, tracer *tracing.Tracer, o Options) (*Service, error) {
@@ -235,6 +239,10 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		return nil, fmt.Errorf("autonat: %w", err)
 	}
 
+	if o.HeadersRWTimeout == 0 {
+		o.HeadersRWTimeout = defaultHeadersRWTimeout
+	}
+
 	var advertisableAddresser handshake.AdvertisableAddressResolver
 	var natAddrResolver *staticAddressResolver
 	if o.NATAddr == "" {
@@ -285,6 +293,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		ready:             make(chan struct{}),
 		halt:              make(chan struct{}),
 		lightNodes:        lightNodes,
+		HeadersRWTimeout:  o.HeadersRWTimeout,
 	}
 
 	peerRegistry.setDisconnecter(s)
@@ -523,14 +532,16 @@ func (s *Service) AddProtocol(p p2p.ProtocolSpec) (err error) {
 			stream := newStream(streamlibp2p)
 
 			// exchange headers
-			if err := handleHeaders(ss.Headler, stream, overlay); err != nil {
+			ctx, cancel := context.WithTimeout(s.ctx, s.HeadersRWTimeout)
+			defer cancel()
+			if err := handleHeaders(ctx, ss.Headler, stream, overlay); err != nil {
 				s.logger.Debug("handle protocol: handle headers failed", "protocol", p.Name, "version", p.Version, "stream", ss.Name, "peer", overlay, "error", err)
 				_ = stream.Reset()
 				return
 			}
 			s.metrics.HeadersExchangeDuration.Observe(time.Since(start).Seconds())
 
-			ctx, cancel := context.WithCancel(s.ctx)
+			ctx, cancel = context.WithCancel(s.ctx)
 
 			s.peers.addStream(peerID, streamlibp2p, cancel)
 			defer s.peers.removeStream(peerID, streamlibp2p)
@@ -880,6 +891,8 @@ func (s *Service) NewStream(ctx context.Context, overlay swarm.Address, headers 
 	}
 
 	// exchange headers
+	ctx, cancel := context.WithTimeout(ctx, s.HeadersRWTimeout)
+	defer cancel()
 	if err := sendHeaders(ctx, headers, stream); err != nil {
 		_ = stream.Reset()
 		return nil, fmt.Errorf("send headers: %w", err)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Make the headers read/write timeout an option that can be passed to prevent data races in tests.
Fixes the `TestWithDisconnectStreams` test flakiness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3327)
<!-- Reviewable:end -->
