### PR TITLE
refactor(depthmonitor): pass the wakeup interval for manage method

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -954,7 +954,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 	}
 
 	if o.FullNodeMode {
-		depthMonitor := depthmonitor.New(kad, pullSyncProtocol, storer, batchStore, logger, warmupTime)
+		depthMonitor := depthmonitor.New(kad, pullSyncProtocol, storer, batchStore, logger, warmupTime, depthmonitor.DefaultWakeupInterval)
 		b.depthMonitorCloser = depthMonitor
 	}
 

--- a/pkg/topology/depthmonitor/export_test.go
+++ b/pkg/topology/depthmonitor/export_test.go
@@ -4,10 +4,7 @@
 
 package depthmonitor
 
-var (
-	ManageWait    = &manageWait
-	MinimumRadius = &minimumRadius
-)
+var MinimumRadius = &minimumRadius
 
 func (s *Service) StorageDepth() uint8 {
 	return s.bs.GetReserveState().StorageRadius


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Passes the wakeup interval of the manage method as a service parameter to prevent data races in tests.
Fixes #3286

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3328)
<!-- Reviewable:end -->
