### PR TITLE
fix: depth monitor default wakeup interval

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -17,7 +17,7 @@ const loggerName = "depthmonitor"
 
 // DefaultWakeupInterval is the default value
 // for the depth monitor wake-up interval.
-const DefaultWakeupInterval = 10 * time.Second
+const DefaultWakeupInterval = 5 * time.Minute
 
 var minimumRadius uint8 = 4
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixes the depth monitor default wakeup interval changed in #3328

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3348)
<!-- Reviewable:end -->
