### PR TITLE
fix: disabled parallel tests in TestPssSend

### DIFF
--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -167,10 +167,9 @@ func TestPssWebsocketMultiHandler(t *testing.T) {
 	waitMessage(t, msgContent2, nil, &mtx)
 }
 
+// nolint:paralleltest
 // TestPssSend tests that the pss message sending over http works correctly.
 func TestPssSend(t *testing.T) {
-	t.Parallel()
-
 	var (
 		logger = log.Noop
 
@@ -214,8 +213,6 @@ func TestPssSend(t *testing.T) {
 	}
 
 	t.Run("err - bad targets", func(t *testing.T) {
-		t.Parallel()
-
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/badtarget?recipient="+recipient, http.StatusBadRequest,
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
@@ -236,8 +233,6 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("err - bad batch", func(t *testing.T) {
-		t.Parallel()
-
 		hexbatch := hex.EncodeToString(batchInvalid)
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/12", http.StatusBadRequest,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
@@ -250,8 +245,6 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("ok batch", func(t *testing.T) {
-		t.Parallel()
-
 		hexbatch := hex.EncodeToString(batchOk)
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/12", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
@@ -259,8 +252,6 @@ func TestPssSend(t *testing.T) {
 		)
 	})
 	t.Run("bad request - batch empty", func(t *testing.T) {
-		t.Parallel()
-
 		hexbatch := hex.EncodeToString(batchEmpty)
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/to/12", http.StatusBadRequest,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, hexbatch),
@@ -269,8 +260,6 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		t.Parallel()
-
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12?recipient="+recipient, http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),
@@ -292,8 +281,6 @@ func TestPssSend(t *testing.T) {
 	})
 
 	t.Run("without recipient", func(t *testing.T) {
-		t.Parallel()
-
 		jsonhttptest.Request(t, client, http.MethodPost, "/pss/send/testtopic/12", http.StatusCreated,
 			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
 			jsonhttptest.WithRequestBody(bytes.NewReader(payload)),


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Disabling parallel tests in `TestPssSend` due to [data race issue](https://github.com/ethersphere/bee/actions/runs/3133612924/jobs/5087178378).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3349)
<!-- Reviewable:end -->
