### PR TITLE
feat(postage): use gas limit for transactions

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1783,6 +1783,7 @@ paths:
             type: boolean
           required: false
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "201":
           description: Returns the newly created postage batch ID
@@ -1821,6 +1822,8 @@ paths:
             type: integer
           required: true
           description: Amount of BZZ per chunk to top up to an existing postage batch.
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "202":
           description: Returns the postage batch ID that was topped up
@@ -1861,6 +1864,8 @@ paths:
             type: integer
           required: true
           description: New batch depth. Must be higher than the previous depth.
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "202":
           description: Returns the postage batch ID that was diluted.

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 3.2.0
+  version: 3.2.1
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 2.1.0
+  version: 2.1.1
   title: Bee Debug API
   description: "A list of the currently provided debug interfaces to interact with the bee node"
 

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -915,6 +915,7 @@ paths:
             type: boolean
           required: false
         - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "201":
           description: Returns the newly created postage batch ID
@@ -950,6 +951,8 @@ paths:
             type: integer
           required: true
           description: Amount of BZZ per chunk to top up to an existing postage batch.
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "202":
           description: Returns the postage batch ID that was topped up
@@ -987,6 +990,8 @@ paths:
             type: integer
           required: true
           description: New batch depth. Must be higher than the previous depth.
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "202":
           description: Returns the postage batch ID that was diluted.

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -103,6 +103,16 @@ func (s *Service) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 		ctx = sctx.SetGasPrice(ctx, p)
 	}
 
+	if limit, ok := r.Header[gasLimitHeader]; ok {
+		l, err := strconv.ParseUint(limit[0], 10, 64)
+		if err != nil {
+			s.logger.Error(err, "create batch: bad gas limit")
+			jsonhttp.BadRequest(w, errBadGasLimit)
+			return
+		}
+		ctx = sctx.SetGasLimit(ctx, l)
+	}
+
 	var immutable bool
 	if val, ok := r.Header[immutableHeader]; ok {
 		immutable, _ = strconv.ParseBool(val[0])

--- a/pkg/postage/postagecontract/contract.go
+++ b/pkg/postage/postagecontract/contract.go
@@ -114,11 +114,16 @@ func (c *postageContract) sendApproveTransaction(ctx context.Context, amount *bi
 }
 
 func (c *postageContract) sendTransaction(ctx context.Context, callData []byte, desc string) (*types.Receipt, error) {
+	gasLimit := sctx.GetGasLimit(ctx)
+	if gasLimit == 0 {
+		// if gas limit is not set, use the default limit.
+		gasLimit = 9_000_000
+	}
 	request := &transaction.TxRequest{
 		To:          &c.postageContractAddress,
 		Data:        callData,
 		GasPrice:    sctx.GetGasPrice(ctx),
-		GasLimit:    1600000,
+		GasLimit:    gasLimit,
 		Value:       big.NewInt(0),
 		Description: desc,
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Allow user to set gas limit for postage transactions using HTTP Header. This is existing functionality that is being used in the swap package. We will enable it for the postage contract as well.

As part of the changes, I have also updated the OpenAPI spec. Seems like the current spec did not show the `Gas-Price` header parameter. Updated it now to show both the options.
