### PR TITLE
docs: remove Open API spec question checkbox from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 
 - [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
 - [ ] My change requires a documentation update, and I have done it.
-- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
 - [ ] I have added tests to cover my changes.
 - [ ] I have filled out the description and linked the related issues.
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] My change requires updating the Open API specification and/or changing its version, and I've done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Removes the checkbox from the PR template which reminds of the necessary changes to the Open API specification, if applicable.

### Related Issue (Optional)
#3354

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3353)
<!-- Reviewable:end -->
