### PR TITLE
refactor(depthmonitor): avoid configuration using global vars

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -52,6 +52,7 @@ func newTestSvc(
 }
 
 func TestDepthMonitorService(t *testing.T) {
+	t.Parallel()
 
 	waitForDepth := func(t *testing.T, svc *depthmonitor.Service, depth uint8, timeout time.Duration) {
 		t.Helper()
@@ -69,6 +70,8 @@ func TestDepthMonitorService(t *testing.T) {
 	}
 
 	t.Run("stop service within warmup time", func(t *testing.T) {
+		t.Parallel()
+
 		svc := newTestSvc(nil, nil, nil, nil, nil, time.Second, depthmonitor.DefaultWakeupInterval)
 		err := svc.Close()
 		if err != nil {
@@ -77,6 +80,8 @@ func TestDepthMonitorService(t *testing.T) {
 	})
 
 	t.Run("start with radius", func(t *testing.T) {
+		t.Parallel()
+
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
 		svc := newTestSvc(nil, nil, nil, nil, bs, 100*time.Millisecond, depthmonitor.DefaultWakeupInterval)
 		waitForDepth(t, svc, 3, time.Second)
@@ -87,12 +92,9 @@ func TestDepthMonitorService(t *testing.T) {
 	})
 
 	t.Run("depth decrease due to under utilization", func(t *testing.T) {
-		const depthMonitorWakeUpInterval = 200 * time.Millisecond
+		t.Parallel()
 
-		defer func(w uint8) {
-			*depthmonitor.MinimumRadius = w
-		}(*depthmonitor.MinimumRadius)
-		*depthmonitor.MinimumRadius = 0
+		const depthMonitorWakeUpInterval = 200 * time.Millisecond
 
 		topo := &mockTopology{peers: 1}
 		// >50% utilized reserve
@@ -101,6 +103,7 @@ func TestDepthMonitorService(t *testing.T) {
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
 
 		svc := newTestSvc(topo, nil, reserve, nil, bs, 100*time.Millisecond, depthMonitorWakeUpInterval)
+		svc.SetMinimumRadius(0)
 
 		waitForDepth(t, svc, 3, time.Second)
 		// simulate huge eviction to trigger manage worker
@@ -117,6 +120,8 @@ func TestDepthMonitorService(t *testing.T) {
 	})
 
 	t.Run("depth doesnt change due to non-zero pull rate", func(t *testing.T) {
+		t.Parallel()
+
 		const depthMonitorWakeUpInterval = 200 * time.Millisecond
 
 		// under utilized reserve
@@ -138,6 +143,8 @@ func TestDepthMonitorService(t *testing.T) {
 	})
 
 	t.Run("depth doesnt change for utilized reserve", func(t *testing.T) {
+		t.Parallel()
+
 		const depthMonitorWakeUpInterval = 200 * time.Millisecond
 
 		// >50% utilized reserve
@@ -158,6 +165,8 @@ func TestDepthMonitorService(t *testing.T) {
 	})
 
 	t.Run("radius setter handler", func(t *testing.T) {
+		t.Parallel()
+
 		const depthMonitorWakeUpInterval = 200 * time.Millisecond
 
 		topo := &mockTopology{connDepth: 3}

--- a/pkg/topology/depthmonitor/export_test.go
+++ b/pkg/topology/depthmonitor/export_test.go
@@ -4,8 +4,6 @@
 
 package depthmonitor
 
-var MinimumRadius = &minimumRadius
-
 func (s *Service) StorageDepth() uint8 {
 	return s.bs.GetReserveState().StorageRadius
 }
@@ -14,4 +12,8 @@ func (s *Service) SetStorageRadius(r uint8) {
 	_ = s.bs.SetStorageRadius(func(_ uint8) uint8 {
 		return r
 	})
+}
+
+func (s *Service) SetMinimumRadius(radius uint8) {
+	s.minimumRadius = radius
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Refactored `depthmonitor` so that custom `minimumRadius` is set using setter, instead of hacky approach using global vars. 