### PR TITLE
refactor(auth): interface with duration

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/api"
+	"github.com/ethersphere/bee/pkg/auth"
 	mockauth "github.com/ethersphere/bee/pkg/auth/mock"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
@@ -97,7 +98,7 @@ type testServerOptions struct {
 	Post               postage.Service
 	Steward            steward.Interface
 	WsHeaders          http.Header
-	Authenticator      *mockauth.Auth
+	Authenticator      auth.Authenticator
 	DebugAPI           bool
 	Restricted         bool
 	DirectUpload       bool

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -57,17 +57,19 @@ func TestAuthorize(t *testing.T) {
 func TestExpiry(t *testing.T) {
 	t.Parallel()
 
+	const expiryDuration = time.Millisecond * 10
+
 	a, err := auth.New(encryptionKey, passwordHash, log.Noop)
 	if err != nil {
 		t.Error(err)
 	}
 
-	key, err := a.GenerateKey("consumer", 1)
+	key, err := a.GenerateKey("consumer", expiryDuration)
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(expiryDuration * 2)
 
 	result, err := a.Enforce(key, "/bytes/1", "GET")
 	if !errors.Is(err, auth.ErrTokenExpired) {
@@ -81,6 +83,8 @@ func TestExpiry(t *testing.T) {
 
 func TestEnforce(t *testing.T) {
 	t.Parallel()
+
+	const expiryDuration = time.Second
 
 	a, err := auth.New(encryptionKey, passwordHash, log.Noop)
 	if err != nil {
@@ -130,7 +134,7 @@ func TestEnforce(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			t.Parallel()
 
-			apiKey, err := a.GenerateKey(tC.role, 1)
+			apiKey, err := a.GenerateKey(tC.role, expiryDuration)
 
 			if err != nil {
 				t.Errorf("expected no error, got: %v", err)

--- a/pkg/auth/mock/auth.go
+++ b/pkg/auth/mock/auth.go
@@ -4,6 +4,8 @@
 
 package mock
 
+import "time"
+
 type Auth struct {
 	AuthorizeFunc   func(string) bool
 	GenerateKeyFunc func(string) (string, error)
@@ -16,13 +18,13 @@ func (ma *Auth) Authorize(u string) bool {
 	}
 	return ma.AuthorizeFunc(u)
 }
-func (ma *Auth) GenerateKey(k string, _ int) (string, error) {
+func (ma *Auth) GenerateKey(k string, _ time.Duration) (string, error) {
 	if ma.GenerateKeyFunc == nil {
 		return "", nil
 	}
 	return ma.GenerateKeyFunc(k)
 }
-func (ma *Auth) RefreshKey(k string, _ int) (string, error) {
+func (ma *Auth) RefreshKey(k string, _ time.Duration) (string, error) {
 	if ma.GenerateKeyFunc == nil {
 		return "", nil
 	}

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -139,7 +139,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		return nil, fmt.Errorf("eth address: %w", err)
 	}
 
-	var authenticator *auth.Authenticator
+	var authenticator auth.Authenticator
 
 	if o.Restricted {
 		if authenticator, err = auth.New(o.TokenEncryptionKey, o.AdminPasswordHash, logger); err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -306,7 +306,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 	b.transactionCloser = tracerCloser
 	b.transactionMonitorCloser = transactionMonitor
 
-	var authenticator *auth.Authenticator
+	var authenticator auth.Authenticator
 
 	if o.Restricted {
 		if authenticator, err = auth.New(o.TokenEncryptionKey, o.AdminPasswordHash, logger); err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Updated `auth.Authenticator` type use time.Duration instead of int in `GenerateKey` and `RefreshKey` methods. This enabled tests to specify much shorter `expiryDuration` thus reducing total execution time for tests.
Additionally, added `Authenticator` interface in order to be reused on other places.
