### PR TITLE
chore(lint): make test execute in parallel (part 7) 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,8 +118,6 @@ issues:
     - linters: paralleltest
       path: pkg/pushsync
     - linters: paralleltest
-      path: pkg/pusher
-    - linters: paralleltest
       path: pkg/log
     - linters: paralleltest
       path: pkg/resolver

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -921,7 +921,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 	// set the pushSyncer in the PSS
 	pssService.SetPushSyncer(pushSyncProtocol)
 
-	pusherService := pusher.New(networkID, storer, kad, pushSyncProtocol, validStamp, tagService, logger, tracer, warmupTime)
+	pusherService := pusher.New(networkID, storer, kad, pushSyncProtocol, validStamp, tagService, logger, tracer, warmupTime, pusher.DefaultRetryCount)
 	b.pusherCloser = pusherService
 
 	pullStorage := pullstorage.New(storer)

--- a/pkg/pusher/export_test.go
+++ b/pkg/pusher/export_test.go
@@ -1,6 +1,0 @@
-package pusher
-
-var (
-	RetryInterval = &retryInterval
-	RetryCount    = &retryCount
-)

--- a/pkg/pusher/inflight.go
+++ b/pkg/pusher/inflight.go
@@ -42,8 +42,9 @@ func (i *inflight) set(addr []byte) bool {
 }
 
 type attempts struct {
-	mtx      sync.Mutex
-	attempts map[string]int
+	mtx        sync.Mutex
+	retryCount int
+	attempts   map[string]int
 }
 
 // try to log a chunk sync attempt. returns false when
@@ -53,7 +54,7 @@ func (a *attempts) try(ch swarm.Address) bool {
 	defer a.mtx.Unlock()
 	key := ch.ByteString()
 	a.attempts[key]++
-	return a.attempts[key] < retryCount
+	return a.attempts[key] < a.retryCount
 }
 
 func (a *attempts) delete(ch swarm.Address) {

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -446,6 +446,8 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 }
 
 func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
+	t.Helper()
+
 	return createPusherWithRetryCount(t, addr, pushSyncService, validStamp, pusher.DefaultRetryCount, mockOpts...)
 }
 

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -37,6 +37,10 @@ var defaultMockValidStamp = func(ch swarm.Chunk, stamp []byte) (swarm.Chunk, err
 	return ch, nil
 }
 
+// createLocalstoreLock is used to prevent data race issues detected when multiple localstore.New functions
+// are being called in the tests.
+var createLocalstoreLock sync.Mutex
+
 // Wrap the actual storer to intercept the modeSet that the pusher will call when a valid receipt is received
 type Store struct {
 	storage.Storer
@@ -78,6 +82,8 @@ func (s *Store) Close() error {
 // once the receipt is got this check to see if the localstore is updated to see if the chunk is set
 // as ModeSetSync status.
 func TestSendChunkToSyncWithTag(t *testing.T) {
+	t.Parallel()
+
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
@@ -95,9 +101,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 		return receipt, nil
 	})
 
-	mtags, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
+	mtags, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	ta, err := mtags.Create(1)
 	if err != nil {
@@ -133,6 +137,8 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 // TestSendChunkToPushSyncWithoutTag is similar to TestSendChunkToPushSync, excep that the tags are not
 // present to simulate bzz api withotu splitter condition
 func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
+	t.Parallel()
+
 	chunk := testingc.GenerateTestRandomChunk()
 
 	// create a trigger  and a closestpeer
@@ -152,9 +158,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 		return receipt, nil
 	})
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -178,6 +182,8 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 
 // TestSendChunkToPushSyncViaApiChannel sends chunks via the api channel
 func TestSendChunkToPushSyncViaApiChannel(t *testing.T) {
+	t.Parallel()
+
 	chunk := testingc.GenerateTestRandomChunk()
 
 	// create a trigger  and a closestpeer
@@ -198,8 +204,6 @@ func TestSendChunkToPushSyncViaApiChannel(t *testing.T) {
 	})
 
 	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
 
 	apiC := make(chan *pusher.Op)
 	p.AddFeed(apiC)
@@ -224,6 +228,8 @@ func TestSendChunkToPushSyncViaApiChannel(t *testing.T) {
 
 // TestSendChunkToPushSyncDirect sends chunks via the api channel
 func TestSendChunkToPushSyncDirect(t *testing.T) {
+	t.Parallel()
+
 	chunk := testingc.GenerateTestRandomChunk()
 
 	// create a trigger  and a closestpeer
@@ -234,9 +240,7 @@ func TestSendChunkToPushSyncDirect(t *testing.T) {
 		return nil, topology.ErrWantSelf
 	})
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
+	_, p, _ := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	apiC := make(chan *pusher.Op)
 	p.AddFeed(apiC)
@@ -259,6 +263,8 @@ func TestSendChunkToPushSyncDirect(t *testing.T) {
 // get a invalid receipt (not with the address of the chunk sent). The test makes sure that this error
 // is received and the ModeSetSync is not set for the chunk.
 func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
+	t.Parallel()
+
 	chunk := testingc.GenerateTestRandomChunk()
 
 	// create a trigger  and a closestpeer
@@ -269,9 +275,7 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 		return nil, errors.New("invalid receipt")
 	})
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer))
-	defer storer.Close()
-	defer p.Close()
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -297,6 +301,8 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 // expects a timeout to get instead of getting a receipt. The test makes sure that timeout error
 // is received and the ModeSetSync is not set for the chunk.
 func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
+	t.Parallel()
+
 	chunk := testingc.GenerateTestRandomChunk()
 
 	// create a trigger  and a closestpeer
@@ -317,9 +323,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 		return receipt, nil
 	})
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -342,12 +346,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 }
 
 func TestPusherRetryShallow(t *testing.T) {
-	defer func(d time.Duration, retryCount int) {
-		*pusher.RetryInterval = d
-		*pusher.RetryCount = retryCount
-	}(*pusher.RetryInterval, *pusher.RetryCount)
-	*pusher.RetryInterval = 500 * time.Millisecond
-	*pusher.RetryCount = 3
+	t.Parallel()
 
 	var (
 		pivotPeer   = swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
@@ -355,6 +354,7 @@ func TestPusherRetryShallow(t *testing.T) {
 		key, _      = crypto.GenerateSecp256k1Key()
 		signer      = crypto.NewDefaultSigner(key)
 		callCount   = int32(0)
+		retryCount  = 3
 	)
 	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		atomic.AddInt32(&callCount, 1)
@@ -370,8 +370,7 @@ func TestPusherRetryShallow(t *testing.T) {
 	// create the pivot peer pusher with depth 31, this makes
 	// sure that virtually any receipt generated by the random
 	// key will be considered too shallow
-	_, ps, storer := createPusher(t, pivotPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(31))
-	defer ps.Close()
+	_, _, storer := createPusherWithRetryCount(t, pivotPeer, pushSyncService, defaultMockValidStamp, retryCount, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(31))
 
 	// generate a chunk at PO 1 with closestPeer, meaning that we get a
 	// receipt which is shallower than the pivot peer's depth, resulting
@@ -385,20 +384,22 @@ func TestPusherRetryShallow(t *testing.T) {
 	c := 0
 	for i := 0; i < 5; i++ {
 		c = int(atomic.LoadInt32(&callCount))
-		if c == *pusher.RetryCount {
+		if c == retryCount {
 			return
 		}
-		if c > *pusher.RetryCount {
-			t.Fatalf("too many retries. got %d want %d", c, *pusher.RetryCount)
+		if c > retryCount {
+			t.Fatalf("too many retries. got %d want %d", c, retryCount)
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Second)
 	}
 
-	t.Fatalf("timed out waiting for retries. got %d want %d", c, *pusher.RetryCount)
+	t.Fatalf("timed out waiting for retries. got %d want %d", c, retryCount)
 }
 
 // TestChunkWithInvalidStampSkipped tests that chunks with invalid stamps are skipped in pusher
 func TestChunkWithInvalidStampSkipped(t *testing.T) {
+	t.Parallel()
+
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
 	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
@@ -420,9 +421,7 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 		return nil, errors.New("valid stamp error")
 	}
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, validStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-	defer storer.Close()
-	defer p.Close()
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, validStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	chunk := testingc.GenerateTestRandomChunk()
 
@@ -447,12 +446,20 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 }
 
 func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
+	return createPusherWithRetryCount(t, addr, pushSyncService, validStamp, pusher.DefaultRetryCount, mockOpts...)
+}
+
+func createPusherWithRetryCount(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, retryCount int, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
 	t.Helper()
 	logger := log.Noop
+
+	createLocalstoreLock.Lock()
 	storer, err := localstore.New("", addr.Bytes(), nil, nil, logger)
 	if err != nil {
+		createLocalstoreLock.Unlock()
 		t.Fatal(err)
 	}
+	createLocalstoreLock.Unlock()
 
 	mockStatestore := statestore.NewStateStore()
 	mtags := tags.NewTags(mockStatestore, logger)
@@ -464,7 +471,13 @@ func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.Pus
 	}
 	peerSuggester := mock.NewTopologyDriver(mockOpts...)
 
-	pusherService := pusher.New(1, pusherStorer, peerSuggester, pushSyncService, validStamp, mtags, logger, nil, 0)
+	pusherService := pusher.New(1, pusherStorer, peerSuggester, pushSyncService, validStamp, mtags, logger, nil, 0, retryCount)
+
+	t.Cleanup(func() {
+		pusherService.Close()
+		pusherStorer.Close()
+	})
+
 	return mtags, pusherService, pusherStorer
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR is the first part of effort to improve static code analysis (issue https://github.com/ethersphere/bee/issues/3255)

- fixed `paralleltest` lint errors in `pusher` package and enabled check for it
