### PR TITLE
feat: decrease lower bound

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -23,7 +23,7 @@ const DefaultWakeupInterval = 5 * time.Minute
 
 // defaultMinimumRadius is the default value
 // for the depth monitor minimum radius.
-const defaultMinimumRadius uint8 = 4
+const defaultMinimumRadius uint8 = 0
 
 // ReserveReporter interface defines the functionality required from the local storage
 // of the node to report information about the reserve. The reserve storage is the storage


### PR DESCRIPTION
Removing minimum storage radius 4 for depthmonitor

The aim of this PR is to retire an artificial safeguard that kept the storage radius from descending below 4 to avoid a fully connected topology in case of the storage radius decrease erronously never stopped. With the given period of testing this doesn't seem necessary anymore, as well as inhibiting the full scalability of the network