### PR TITLE
fix: preserve new overlay on db nuke

### DIFF
--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -334,7 +334,7 @@ func deleteKeys(s *Store, keys []string) error {
 func (s *Store) Nuke(forgetStamps bool) error {
 	var (
 		keys               []string
-		prefixesToPreserve = []string{"accounting", "pseudosettle", "swap", "non-mineable-overlay"}
+		prefixesToPreserve = []string{"accounting", "pseudosettle", "swap", "non-mineable-overlay", "overlayV2_nonce"}
 		err                error
 	)
 


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [N/A] My change requires a documentation update, and I have done it.
- [N/A] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
#3331 fixed by preserving an additional prefix on db nuke

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
db nuking an already migrated and nonce-mined node will no longer re-mine the nonce.

### Related Issue (Optional)
#3331 

### Screenshots (if appropriate):
