### PR TITLE
fix: missing key in log line

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -670,7 +670,7 @@ func (a *Accounting) notifyPaymentThresholdUpgrade(peer swarm.Address, accountin
 	// announce new payment threshold to peer
 	err := a.pricing.AnnouncePaymentThreshold(context.Background(), peer, accountingPeer.paymentThresholdForPeer)
 	if err != nil {
-		a.logger.Error(err, "announcing increased payment threshold", accountingPeer.paymentThresholdForPeer, "to peer", peer)
+		a.logger.Error(err, "announcing increased payment threshold", "value", accountingPeer.paymentThresholdForPeer, "peer", peer)
 	}
 }
 


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
Fix for a malformed log line: 
```
"error"="send headers: read message: stream reset" "<non-string-key: \"117000000\">"="to peer" "<non-string-key: \"f365667f28ea14a>"="<no-value>"
```