### PR TITLE
chore(lint): make test execute in parallel (part 8)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,17 +114,11 @@ issues:
     - linters: paralleltest
       path: pkg/puller
     - linters: paralleltest
-      path: pkg/manifest
-    - linters: paralleltest
       path: pkg/pushsync
     - linters: paralleltest
       path: pkg/pusher
     - linters: paralleltest
       path: pkg/log
-    - linters: paralleltest
-      path: pkg/resolver
-    - linters: paralleltest
-      path: pkg/pullsync
     - linters: paralleltest
       path: pkg/statestore
     - linters: paralleltest

--- a/pkg/manifest/mantaray/marshal_test.go
+++ b/pkg/manifest/mantaray/marshal_test.go
@@ -162,9 +162,8 @@ func TestUnmarshal02(t *testing.T) {
 	}
 }
 
+// nolint:paralleltest
 func TestMarshal(t *testing.T) {
-	t.Parallel()
-
 	rand.Seed(1)
 	ctx := context.Background()
 	n := New()

--- a/pkg/manifest/mantaray/node_test.go
+++ b/pkg/manifest/mantaray/node_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestNilPath(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	n := mantaray.New()
 	_, err := n.Lookup(ctx, nil, nil)
@@ -24,6 +26,8 @@ func TestNilPath(t *testing.T) {
 }
 
 func TestAddAndLookup(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	n := mantaray.New()
 	testCases := [][]byte{
@@ -59,6 +63,8 @@ func TestAddAndLookup(t *testing.T) {
 }
 
 func TestAddAndLookupNode(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name  string
 		toAdd [][]byte
@@ -130,7 +136,10 @@ func TestAddAndLookupNode(t *testing.T) {
 		},
 	} {
 		ctx := context.Background()
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			n := mantaray.New()
 
 			for i := 0; i < len(tc.toAdd); i++ {
@@ -156,7 +165,10 @@ func TestAddAndLookupNode(t *testing.T) {
 				}
 			}
 		})
+
 		t.Run(tc.name+"/with load save", func(t *testing.T) {
+			t.Parallel()
+
 			n := mantaray.New()
 
 			for i := 0; i < len(tc.toAdd); i++ {
@@ -194,6 +206,8 @@ func TestAddAndLookupNode(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		toAdd    []mantaray.NodeEntry
@@ -250,7 +264,10 @@ func TestRemove(t *testing.T) {
 		},
 	} {
 		ctx := context.Background()
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			n := mantaray.New()
 
 			for i := 0; i < len(tc.toAdd); i++ {
@@ -294,6 +311,8 @@ func TestRemove(t *testing.T) {
 }
 
 func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name        string
 		toAdd       [][]byte
@@ -335,7 +354,10 @@ func TestHasPrefix(t *testing.T) {
 		},
 	} {
 		ctx := context.Background()
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			n := mantaray.New()
 
 			for i := 0; i < len(tc.toAdd); i++ {

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestPersistIdempotence(t *testing.T) {
+	t.Parallel()
+
 	n := mantaray.New()
 	paths := [][]byte{
 		[]byte("aa"),

--- a/pkg/manifest/mantaray/walker_test.go
+++ b/pkg/manifest/mantaray/walker_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestWalkNode(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		toAdd    [][]byte
@@ -39,6 +41,7 @@ func TestWalkNode(t *testing.T) {
 		},
 	} {
 		ctx := context.Background()
+		tc := tc
 
 		createTree := func(t *testing.T, toAdd [][]byte) *mantaray.Node {
 			t.Helper()
@@ -70,6 +73,8 @@ func TestWalkNode(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			n := createTree(t, tc.toAdd)
 
 			walkedCount := 0
@@ -94,6 +99,8 @@ func TestWalkNode(t *testing.T) {
 		})
 
 		t.Run(tc.name+"/with load save", func(t *testing.T) {
+			t.Parallel()
+
 			n := createTree(t, tc.toAdd)
 
 			ls := newMockLoadSaver()
@@ -130,6 +137,8 @@ func TestWalkNode(t *testing.T) {
 }
 
 func TestWalk(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name     string
 		toAdd    [][]byte
@@ -189,7 +198,9 @@ func TestWalk(t *testing.T) {
 			return pathFound
 		}
 
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			n := createTree(t, tc.toAdd)
 
@@ -217,6 +228,7 @@ func TestWalk(t *testing.T) {
 		})
 
 		t.Run(tc.name+"/with load save", func(t *testing.T) {
+			t.Parallel()
 
 			n := createTree(t, tc.toAdd)
 

--- a/pkg/manifest/simple/manifest_test.go
+++ b/pkg/manifest/simple/manifest_test.go
@@ -25,6 +25,8 @@ func randomAddress() string {
 }
 
 func TestNilPath(t *testing.T) {
+	t.Parallel()
+
 	m := simple.NewManifest()
 	n, err := m.Lookup("")
 	if err == nil {
@@ -100,8 +102,13 @@ var testCases = []struct {
 }
 
 func TestEntries(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := simple.NewManifest()
 
 			checkLength(t, m, 0)
@@ -193,8 +200,13 @@ func checkEntry(t *testing.T, m simple.Manifest, reference, path string) {
 // This function wil add all test case entries to a manifest and marshal it.
 // After, it will unmarshal the result, and verify that it is equal to the original manifest.
 func TestMarshal(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := simple.NewManifest()
 
 			for _, e := range tc.entries {
@@ -222,6 +234,8 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name        string
 		toAdd       []string
@@ -262,7 +276,10 @@ func TestHasPrefix(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := simple.NewManifest()
 
 			for _, e := range tc.toAdd {

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -49,6 +49,8 @@ func init() {
 // Expected behavior is that an offer message with the requested
 // To value is returned to the requester, but offer.Hashes is empty.
 func TestIncoming_WantEmptyInterval(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockTopmost        = uint64(5)
 		ps, _              = newPullSync(nil, mock.WithIntervalsResp([]swarm.Address{}, mockTopmost, nil))
@@ -71,6 +73,8 @@ func TestIncoming_WantEmptyInterval(t *testing.T) {
 
 }
 func TestIncoming_WantNone(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockTopmost        = uint64(5)
 		ps, _              = newPullSync(nil, mock.WithIntervalsResp(addrs, mockTopmost, nil), mock.WithChunks(chunks...))
@@ -92,6 +96,8 @@ func TestIncoming_WantNone(t *testing.T) {
 }
 
 func TestIncoming_WantOne(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockTopmost        = uint64(5)
 		ps, _              = newPullSync(nil, mock.WithIntervalsResp(addrs, mockTopmost, nil), mock.WithChunks(chunks...))
@@ -116,6 +122,8 @@ func TestIncoming_WantOne(t *testing.T) {
 }
 
 func TestIncoming_WantAll(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockTopmost        = uint64(5)
 		ps, _              = newPullSync(nil, mock.WithIntervalsResp(addrs, mockTopmost, nil), mock.WithChunks(chunks...))
@@ -140,6 +148,8 @@ func TestIncoming_WantAll(t *testing.T) {
 }
 
 func TestIncoming_UnsolicitedChunk(t *testing.T) {
+	t.Parallel()
+
 	evilAddr := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000666")
 	evilData := []byte{0x66, 0x66, 0x66}
 	stamp := postagetesting.MustNewStamp()
@@ -159,6 +169,8 @@ func TestIncoming_UnsolicitedChunk(t *testing.T) {
 }
 
 func TestGetCursors(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockCursors = []uint64{100, 101, 102, 103}
 		ps, _       = newPullSync(nil, mock.WithCursors(mockCursors))
@@ -183,6 +195,8 @@ func TestGetCursors(t *testing.T) {
 }
 
 func TestGetCursorsError(t *testing.T) {
+	t.Parallel()
+
 	var (
 		e           = errors.New("erring")
 		ps, _       = newPullSync(nil, mock.WithCursorsErr(e))

--- a/pkg/resolver/cidv1/cidv1_test.go
+++ b/pkg/resolver/cidv1/cidv1_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCIDResolver(t *testing.T) {
+	t.Parallel()
+
 	r := cidv1.Resolver{}
 	t.Cleanup(func() {
 		err := r.Close()
@@ -22,6 +24,8 @@ func TestCIDResolver(t *testing.T) {
 	})
 
 	t.Run("resolve manifest CID", func(t *testing.T) {
+		t.Parallel()
+
 		addr, err := r.Resolve("bah5acgzazjrvpieogf6rl3cwb7xtjzgel6hrt4a4g4vkody5u4v7u7y2im4a")
 		if err != nil {
 			t.Fatal(err)
@@ -33,6 +37,8 @@ func TestCIDResolver(t *testing.T) {
 		}
 	})
 	t.Run("resolve feed CID", func(t *testing.T) {
+		t.Parallel()
+
 		addr, err := r.Resolve("bah5qcgzazjrvpieogf6rl3cwb7xtjzgel6hrt4a4g4vkody5u4v7u7y2im4a")
 		if err != nil {
 			t.Fatal(err)
@@ -44,12 +50,16 @@ func TestCIDResolver(t *testing.T) {
 		}
 	})
 	t.Run("fail other codecs", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := r.Resolve("bafybeiekkklkqtypmqav6ytqjbdqucxfwuk5cgige4245d2qhkccuyfnly")
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
 	t.Run("fail on invalid CID", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := r.Resolve("bafybeiekk")
 		if !errors.Is(err, resolver.ErrParse) {
 			t.Fatal("expected error", resolver.ErrParse, "got", err)

--- a/pkg/resolver/client/ens/ens_test.go
+++ b/pkg/resolver/client/ens/ens_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestNewENSClient(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc         string
 		endpoint     string
@@ -51,7 +53,10 @@ func TestNewENSClient(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
 			cl, err := ens.NewClient(tC.endpoint,
 				ens.WithConnectFunc(tC.connectFn),
 				ens.WithContractAddress(tC.address),
@@ -73,7 +78,11 @@ func TestNewENSClient(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
+
 	t.Run("connected", func(t *testing.T) {
+		t.Parallel()
+
 		rpcServer := rpc.NewServer()
 		defer rpcServer.Stop()
 		ethCl := ethclient.NewClient(rpc.DialInProc(rpcServer))
@@ -97,6 +106,8 @@ func TestClose(t *testing.T) {
 		}
 	})
 	t.Run("not connected", func(t *testing.T) {
+		t.Parallel()
+
 		cl, err := ens.NewClient("",
 			ens.WithConnectFunc(func(endpoint, contractAddr string) (*ethclient.Client, *goens.Registry, error) {
 				return nil, nil, nil
@@ -118,6 +129,8 @@ func TestClose(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
+	t.Parallel()
+
 	testContractAddrString := "00000000000C2E074eC69A0dFb2997BA6C702e1B"
 	testContractAddr := common.HexToAddress(testContractAddrString)
 	testSwarmAddr := swarm.MustParseHexAddress("aaabbbcc")
@@ -173,7 +186,10 @@ func TestResolve(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
 			cl, err := ens.NewClient("example.com",
 				ens.WithContractAddress(testContractAddrString),
 				ens.WithConnectFunc(func(endpoint, contractAddr string) (*ethclient.Client, *goens.Registry, error) {

--- a/pkg/resolver/multiresolver/config_test.go
+++ b/pkg/resolver/multiresolver/config_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestParseConnectionStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc       string
 		conStrings []string
@@ -116,7 +118,10 @@ func TestParseConnectionStrings(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := multiresolver.ParseConnectionStrings(tC.conStrings)
 			if err != nil {
 				if !errors.Is(err, tC.wantErr) {

--- a/pkg/resolver/multiresolver/multiresolver_test.go
+++ b/pkg/resolver/multiresolver/multiresolver_test.go
@@ -24,6 +24,8 @@ func newAddr(s string) Address {
 }
 
 func TestMultiresolverOpts(t *testing.T) {
+	t.Parallel()
+
 	wantLog := log.Noop
 	wantCfgs := []multiresolver.ConnectionConfig{
 		{
@@ -56,6 +58,8 @@ func TestMultiresolverOpts(t *testing.T) {
 }
 
 func TestPushResolver(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		desc    string
 		tld     string
@@ -72,7 +76,10 @@ func TestPushResolver(t *testing.T) {
 	}
 
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
 			mr := multiresolver.NewMultiResolver()
 
 			if mr.ChainCount(tC.tld) != 0 {
@@ -96,6 +103,8 @@ func TestPushResolver(t *testing.T) {
 		})
 	}
 	t.Run("pop empty chain", func(t *testing.T) {
+		t.Parallel()
+
 		mr := multiresolver.NewMultiResolver()
 		err := mr.PopResolver("")
 		if !errors.Is(err, multiresolver.ErrResolverChainEmpty) {
@@ -105,6 +114,8 @@ func TestPushResolver(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
+	t.Parallel()
+
 	addr := newAddr("aaaabbbbccccdddd")
 	addrAlt := newAddr("ddddccccbbbbaaaa")
 	errUnregisteredName := fmt.Errorf("unregistered name")
@@ -230,7 +241,10 @@ func TestResolve(t *testing.T) {
 	}
 
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.name, func(t *testing.T) {
+			t.Parallel()
+
 			addr, err := mr.Resolve(tC.name)
 			if err != nil {
 				if tC.wantErr == nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR is the first part of effort to improve static code analysis (issue https://github.com/ethersphere/bee/issues/3255)

- fixed paralleltest lint errors in `manifest`, `resolver` and `pullsync` packages and enabled checks for it
