### PR TITLE
fix: increase timeout for release action and bump base docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
           echo "BEE_API_VERSION=$(grep '^  version:' openapi/Swarm.yaml | awk '{print $2}')" >> $GITHUB_ENV
           echo "BEE_DEBUG_API_VERSION=$(grep '^  version:' openapi/SwarmDebug.yaml | awk '{print $2}')" >> $GITHUB_ENV
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --timeout 1h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_PAT: ${{ secrets.GHA_PAT_BASIC }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . ./
 
 RUN make binary
 
-FROM debian:11.2-slim
+FROM debian:11.5-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM debian:11.2-slim
+FROM debian:11.5-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,4 +1,4 @@
-FROM debian:11.2-slim
+FROM debian:11.5-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Latest RC release failed in the end because of default timeout that goreleaser uses (30min). Good is that artifacts were uploaded but workflow was cut by the timeout and release is marked as failed.
Base docker images are upgraded as a part of a regular update of all infra components.