### PR TITLE
feat: add metrics around stream lifecycle

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -450,7 +450,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 				skipPeers.AddOverdraft(result.peer)
 			}
 
-			if ps.warmedUp() && !errors.Is(result.err, errNotAttempted) {
+			if ps.warmedUp() && !errors.Is(result.err, errNotAttempted) && result.pushed {
 				ps.skipList.Add(ch.Address(), result.peer, sanctionWait)
 				ps.metrics.TotalSkippedPeers.Inc()
 				logger.Debug("adding peer to skiplist", "peer_address", result.peer)


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
We suspect that the batchstores are `out of sync` and this generates a large amount of stream resets.

This branch will print the batchstore fingerprint to allow for detection of inconsistencies.

Closes: #3439 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3431)
<!-- Reviewable:end -->
