### PR TITLE
ci: trigger bee-factory only in the event latest image is being pushed

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -364,6 +364,7 @@ jobs:
           docker push quay.io/ethersphere/bee:latest
           echo RUN_TYPE="MERGE RUN" >> $GITHUB_ENV
       - name: Trigger Bee Factory latest build
+        if: github.ref == 'refs/heads/master' && github.event.action != 'beekeeper' && success()
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.GHA_PAT_BASIC }}


### PR DESCRIPTION
Trigger bee-factory build only in the [events](https://github.com/ethersphere/bee/blob/master/.github/workflows/beekeeper.yml#L357) when latest bee image is being pushed to the registry