### PR TITLE
wip: feat: stream cache

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ethersphere/bee/pkg/netstore"
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/p2p/libp2p"
+	"github.com/ethersphere/bee/pkg/p2p/streamcache"
 	"github.com/ethersphere/bee/pkg/pingpong"
 	"github.com/ethersphere/bee/pkg/pinning"
 	"github.com/ethersphere/bee/pkg/postage"
@@ -916,7 +917,9 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 
 	pinningService := pinning.NewService(storer, stateStore, traversalService)
 
-	pushSyncProtocol := pushsync.New(swarmAddress, nonce, p2ps, storer, kad, tagService, o.FullNodeMode, pssService.TryUnwrap, validStamp, logger, acc, pricer, signer, tracer, warmupTime)
+	streamCache := streamcache.New(p2ps)
+
+	pushSyncProtocol := pushsync.New(swarmAddress, nonce, streamCache, storer, kad, tagService, o.FullNodeMode, pssService.TryUnwrap, validStamp, logger, acc, pricer, signer, tracer, warmupTime)
 
 	// set the pushSyncer in the PSS
 	pssService.SetPushSyncer(pushSyncProtocol)

--- a/pkg/p2p/streamcache/cache.go
+++ b/pkg/p2p/streamcache/cache.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pushsync provides the pushsync protocol
+// implementation.
+package streamcache
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"container/list"
+
+	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type Cache struct {
+	sd    p2p.StreamerDisconnecter
+	mu    sync.Mutex
+	cache sync.Map // "${overlay}/swarm/pushsync/1.1.0/pushsync" -> queue of *CachedStream{}
+}
+
+type cacheItem struct {
+	ss *list.List
+	mu sync.Mutex
+}
+
+func New(sd p2p.StreamerDisconnecter) *Cache {
+	list.New()
+	return &Cache{
+		sd: sd,
+	}
+}
+
+func (s *Cache) Disconnect(overlay swarm.Address, reason string) error {
+	addressKey := overlay.String()
+	var keys []string
+
+	// collect the keys for the overlay
+	s.cache.Range(func(key, _ interface{}) bool {
+		k := key.(string)
+		if strings.HasPrefix(k, addressKey) {
+			keys = append(keys, k)
+		}
+		return true
+	})
+
+	for _, key := range keys {
+		if cs, found := s.cache.LoadAndDelete(key); found {
+			streams := cs.(*cacheItem)
+			f := streams.ss.Front()
+			for {
+				if f == nil {
+					break
+				}
+				_ = f.Value.(*CachedStream).stream.FullClose()
+				f = f.Next()
+			}
+		}
+	}
+
+	return s.sd.Disconnect(overlay, reason)
+}
+
+func (s *Cache) NewStream(ctx context.Context, address swarm.Address, h p2p.Headers, protocol, version, stream string) (p2p.Stream, error) {
+	streamFullName := p2p.NewSwarmStreamName(protocol, version, stream)
+
+	sfKey := address.String() + streamFullName
+
+	ci, found := s.cache.Load(sfKey)
+	if !found {
+		// vast majority of cases the item will be found
+		// so it makes sense to minimize
+		s.mu.Lock()
+		// check if no other thread has put to cache while
+		// we were waiting for the lock
+		ci, found = s.cache.Load(sfKey)
+
+		if !found {
+			ci = &cacheItem{
+				ss: list.New(),
+			}
+			s.cache.Store(sfKey, ci)
+		}
+
+		s.mu.Unlock()
+	}
+
+	item := ci.(*cacheItem)
+
+	item.mu.Lock()
+	defer item.mu.Unlock()
+
+	strm := item.ss.Front()
+
+	if strm == nil {
+		newStream, err := s.sd.NewStream(ctx, address, h, protocol, version, stream)
+		if err != nil {
+			return nil, err
+		}
+
+		cs := &CachedStream{stream: newStream}
+
+		// callback for putting the stream back in cache
+		cs.ret = func() {
+			item.mu.Lock()
+			defer item.mu.Unlock()
+			item.ss.PushBack(cs)
+		}
+
+		return cs, nil
+	}
+
+	item.ss.Remove(strm)
+
+	return strm.Value.(p2p.Stream), nil
+}
+
+func (s *Cache) NetworkStatus() p2p.NetworkStatus {
+	return s.sd.NetworkStatus()
+}
+
+func (s *Cache) Blocklist(overlay swarm.Address, duration time.Duration, reason string) error {
+	return s.sd.Blocklist(overlay, duration, reason)
+}

--- a/pkg/p2p/streamcache/cache_test.go
+++ b/pkg/p2p/streamcache/cache_test.go
@@ -1,0 +1,100 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pushsync provides the pushsync protocol
+// implementation.
+package streamcache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/p2p/streamcache"
+	"github.com/ethersphere/bee/pkg/p2p/streamtest"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+var (
+	stream, version, streamName = "test", "0.1", "testStream"
+)
+
+func TestStreamIsReused(t *testing.T) {
+	pivotNode := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
+	recorder := streamtest.New(streamtest.WithProtocols(protocol(t)), streamtest.WithBaseAddr(pivotNode))
+
+	rc := streamtest.NewRecorderDisconnecter(recorder)
+
+	cache := streamcache.New(rc)
+
+	s, err := cache.NewStream(context.Background(), pivotNode, nil, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.Reset()
+
+	_, err = cache.NewStream(context.Background(), pivotNode, nil, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recs, err := rc.Records(pivotNode, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recs) != 1 {
+		t.Fatal("wanted one record, got", len(recs))
+	}
+}
+
+func TestStreamIsPurgedOnDisconnect(t *testing.T) {
+	pivotNode := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
+	recorder := streamtest.New(streamtest.WithProtocols(protocol(t)), streamtest.WithBaseAddr(pivotNode))
+
+	rc := streamtest.NewRecorderDisconnecter(recorder)
+
+	cache := streamcache.New(rc)
+
+	_, err := cache.NewStream(context.Background(), pivotNode, nil, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cache.Disconnect(pivotNode, "dummy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cache.NewStream(context.Background(), pivotNode, nil, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recs, err := rc.Records(pivotNode, stream, version, streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recs) != 2 {
+		t.Fatal("wanted two records, got", len(recs))
+	}
+}
+
+func protocol(t *testing.T) p2p.ProtocolSpec {
+	t.Helper()
+	return p2p.ProtocolSpec{
+		Name:    "test",
+		Version: "0.1",
+		StreamSpecs: []p2p.StreamSpec{
+			{
+				Name: "testStream",
+				Handler: func(ctx context.Context, p p2p.Peer, s p2p.Stream) error {
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/pkg/p2p/streamcache/stream.go
+++ b/pkg/p2p/streamcache/stream.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pushsync provides the pushsync protocol
+// implementation.
+package streamcache
+
+import (
+	"github.com/ethersphere/bee/pkg/p2p"
+)
+
+type CachedStream struct {
+	ret    func()
+	stream p2p.Stream
+}
+
+func (s *CachedStream) Headers() p2p.Headers {
+	return s.stream.Headers()
+}
+
+func (s *CachedStream) ResponseHeaders() p2p.Headers {
+	return s.stream.ResponseHeaders()
+}
+
+func (s *CachedStream) Read(p []byte) (n int, err error) {
+	return s.stream.Read(p)
+}
+
+func (s *CachedStream) Write(p []byte) (n int, err error) {
+	return s.stream.Write(p)
+}
+
+func (s *CachedStream) Close() error {
+	s.ret()
+	return nil
+}
+
+func (s *CachedStream) Reset() error {
+	s.ret()
+	return nil
+}
+
+func (s *CachedStream) FullClose() error {
+	s.ret()
+	return nil
+}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -450,7 +450,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 				skipPeers.AddOverdraft(result.peer)
 			}
 
-			if ps.warmedUp() && !errors.Is(result.err, errNotAttempted) {
+			if ps.warmedUp() && !errors.Is(result.err, errNotAttempted) && result.pushed {
 				ps.skipList.Add(ch.Address(), result.peer, sanctionWait)
 				ps.metrics.TotalSkippedPeers.Inc()
 				logger.Debug("adding peer to skiplist", "peer_address", result.peer)


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] I have added tests to cover my changes.

### Description
libp2p version 0.18 has a heavier (memory wise) stream object, and the suggested approach is to re-use streams as much as possible. This PR introduces a cache for the streams.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3453)
<!-- Reviewable:end -->
