### PR TITLE
feat(localstorev2): add cache store

### DIFF
--- a/pkg/localstorev2/internal/cache/cache.go
+++ b/pkg/localstorev2/internal/cache/cache.go
@@ -132,7 +132,8 @@ func New(storg internal.Storage, capacity uint64) (*Cache, error) {
 	if capacity < state.Count {
 		entry := &cacheEntry{Address: state.Start}
 		var i uint64
-		for i = 0; i < (state.Count - capacity); i++ {
+		itemsToRemove := state.Count - capacity
+		for i = 0; i < itemsToRemove; i++ {
 			err = storg.Store().Get(entry)
 			if err != nil {
 				return nil, fmt.Errorf("failed reading cache entry %s: %w", state.Start, err)

--- a/pkg/localstorev2/internal/cache/cache.go
+++ b/pkg/localstorev2/internal/cache/cache.go
@@ -329,19 +329,6 @@ func (c *Cache) Getter(store storage.Store, chStore storage.ChunkStore) storage.
 			prev := &cacheEntry{Address: entry.Prev}
 			next := &cacheEntry{Address: entry.Next}
 
-			// if it is the first chunk, we dont need to update the prev entry.
-			if !c.state.Start.Equal(address) {
-				err = store.Get(prev)
-				if err != nil {
-					return err
-				}
-			}
-
-			err = store.Get(next)
-			if err != nil {
-				return err
-			}
-
 			// move the chunk to the end due to the access. Dont send duplicate
 			// chunk put operation.
 			err = c.pushBack(ctx, entry, nil, store, chStore)
@@ -352,6 +339,14 @@ func (c *Cache) Getter(store storage.Store, chStore storage.ChunkStore) storage.
 			// if this is first chunk we dont need to update both the prev or the
 			// next.
 			if !c.state.Start.Equal(address) {
+				err = store.Get(prev)
+				if err != nil {
+					return err
+				}
+				err = store.Get(next)
+				if err != nil {
+					return err
+				}
 				prev.Next = next.Address.Clone()
 				err = store.Put(prev)
 				if err != nil {

--- a/pkg/localstorev2/internal/cache/cache.go
+++ b/pkg/localstorev2/internal/cache/cache.go
@@ -1,0 +1,241 @@
+package cache
+
+import (
+	"context"
+	"sync"
+
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type cacheEntry struct {
+	Address swarm.Address
+	Prev    swarm.Address
+	Next    swarm.Address
+}
+
+func (cacheEntry) Namespace() string { return "entry" }
+
+func (c *cacheEntry) ID() string { return c.Address.ByteString() }
+
+func (c *cacheEntry) Marshal() ([]byte, error) { return nil, nil }
+
+func (c *cacheEntry) Unmarshal(buf []byte) error { return nil }
+
+type cacheStart struct {
+	Address swarm.Address
+}
+
+func (cacheStart) Namespace() string { return "start" }
+
+func (cacheStart) ID() string { return "e" }
+
+func (c *cacheStart) Marshal() ([]byte, error) { return nil, nil }
+
+func (c *cacheStart) Unmarshal(buf []byte) error { return nil }
+
+type cacheEnd struct {
+	Address swarm.Address
+}
+
+func (cacheEnd) Namespace() string { return "end" }
+
+func (cacheEnd) ID() string { return "e" }
+
+func (c *cacheEnd) Marshal() ([]byte, error) { return nil, nil }
+
+func (c *cacheEnd) Unmarshal(buf []byte) error { return nil }
+
+type cacheSize struct {
+	Size uint64
+}
+
+func (cacheSize) Namespace() string { return "size" }
+
+func (cacheSize) ID() string { return "e" }
+
+func (c *cacheSize) Marshal() ([]byte, error) { return nil, nil }
+
+func (c *cacheSize) Unmarshal(buf []byte) error { return nil }
+
+type cache struct {
+	mtx      sync.Mutex
+	capacity uint64
+}
+
+func (c *cache) popFront(
+	ctx context.Context,
+	store storage.Store,
+	chStore storage.ChunkStore,
+) error {
+	start := &cacheStart{}
+	err := store.Get(start)
+	if err != nil {
+		return err
+	}
+	expiredEntry := &cacheEntry{Address: start.Address}
+	err = store.Get(expiredEntry)
+	if err != nil {
+		return err
+	}
+	start.Address = expiredEntry.Next
+	err = store.Put(start)
+	if err != nil {
+		return err
+	}
+	err = store.Delete(expiredEntry)
+	if err != nil {
+		return err
+	}
+	err = chStore.Delete(ctx, expiredEntry.Address)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *cache) pushBack(
+	ctx context.Context,
+	newEntry *cacheEntry,
+	chunk swarm.Chunk,
+	store storage.Store,
+	chStore storage.ChunkStore,
+) error {
+	end := &cacheEnd{}
+	err := store.Get(end)
+	if err != nil {
+		return err
+	}
+
+	entry := &cacheEntry{Address: end.Address}
+	err = store.Get(entry)
+	if err != nil {
+		return err
+	}
+
+	entry.Next = newEntry.Address
+	newEntry.Prev = entry.Address
+
+	err = store.Put(newEntry)
+	if err != nil {
+		return err
+	}
+
+	err = store.Put(entry)
+	if err != nil {
+		return err
+	}
+
+	end.Address = newEntry.Address
+	err = store.Put(end)
+	if err != nil {
+		return err
+	}
+
+	_, err = chStore.Put(ctx, chunk)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *cache) Putter(store storage.Store, chStore storage.ChunkStore) storage.Putter {
+	return storage.PutterFunc(func(ctx context.Context, chunk swarm.Chunk) (bool, error) {
+		c.mtx.Lock()
+		defer c.mtx.Unlock()
+
+		newEntry := &cacheEntry{Address: chunk.Address()}
+		// if chunk is already part of cache, return found
+		found, err := store.Has(newEntry)
+		if err != nil {
+			return false, err
+		}
+
+		if found {
+			return true, nil
+		}
+
+		err = c.pushBack(ctx, newEntry, chunk, store, chStore)
+		if err != nil {
+			return false, err
+		}
+
+		size := &cacheSize{}
+		err = store.Get(size)
+		if err != nil {
+			return false, err
+		}
+
+		if size.Size == c.capacity {
+			err = c.popFront(ctx, store, chStore)
+		} else {
+			size.Size++
+			err = store.Put(size)
+		}
+		if err != nil {
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func (c *cache) Getter(store storage.Store, chStore storage.ChunkStore) storage.Getter {
+	return storage.GetterFunc(func(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
+		ch, err := chStore.Get(ctx, address)
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &cacheEntry{Address: address}
+		err = store.Get(entry)
+		if err != nil {
+			return ch, nil
+		}
+
+		err = func() error {
+			c.mtx.Lock()
+			defer c.mtx.Unlock()
+
+			prev := &cacheEntry{Address: entry.Prev}
+			next := &cacheEntry{Address: entry.Next}
+
+			err = store.Get(prev)
+			if err != nil {
+				return err
+			}
+
+			err = store.Get(next)
+			if err != nil {
+				return err
+			}
+
+			err = c.pushBack(ctx, entry, nil, store, chStore)
+			if err != nil {
+				return err
+			}
+
+			next.Prev = prev.Address
+			prev.Next = next.Address
+
+			err = store.Put(prev)
+			if err != nil {
+				return err
+			}
+
+			err = store.Put(next)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}()
+		if err != nil {
+			// log error
+		}
+
+		return ch, nil
+	})
+}

--- a/pkg/localstorev2/internal/cache/cache.go
+++ b/pkg/localstorev2/internal/cache/cache.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package cache
 
 import (

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package cache_test
 
 import (

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -179,6 +179,13 @@ func TestCache(t *testing.T) {
 			}
 		})
 
+		t.Run("new cache retains state", func(t *testing.T) {
+			c2, err := cache.New(st, 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifyCacheState(t, c2, chunks[0].Address(), chunks[len(chunks)-1].Address(), uint64(len(chunks)))
+		})
 	})
 }
 

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -406,8 +406,8 @@ func verifyCacheState(
 	state := c.State()
 	expState := cache.CacheState{Head: expStart, Tail: expEnd, Count: expCount}
 
-	if !cmp.Equal(expState, state) {
-		t.Fatalf("state mismatch (-want +have):\n%s", cmp.Diff(expState, state))
+	if diff := cmp.Diff(expState, state); diff != "" {
+		t.Fatalf("state mismatch (-want +have):\n%s", diff)
 	}
 }
 

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -1,0 +1,206 @@
+package cache_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/localstorev2/internal/cache"
+	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
+	inmem "github.com/ethersphere/bee/pkg/storagev2/inmemstore"
+	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func TestCacheStateItem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test *storagetest.ItemMarshalAndUnmarshalTest
+	}{{
+		name: "zero values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item:    &cache.CacheState{},
+			Factory: func() storage.Item { return new(cache.CacheState) },
+		},
+	}, {
+		name: "zero and non-zero 1",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &cache.CacheState{
+				End: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+			},
+			Factory: func() storage.Item { return new(cache.CacheState) },
+		},
+	}, {
+		name: "zero and non-zero 2",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &cache.CacheState{
+				Start: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+			},
+			Factory: func() storage.Item { return new(cache.CacheState) },
+		},
+	}, {
+		name: "max values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &cache.CacheState{
+				Start: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				End:   swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				Count: math.MaxUint64,
+			},
+			Factory: func() storage.Item { return new(cache.CacheState) },
+		},
+	}, {
+		name: "invalid size",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &storagetest.ItemStub{
+				MarshalBuf:   []byte{0xFF},
+				UnmarshalBuf: []byte{0xFF},
+			},
+			Factory:      func() storage.Item { return new(cache.CacheState) },
+			UnmarshalErr: cache.ErrUnmarshalCacheStateInvalidSize,
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			storagetest.TestItemMarshalAndUnmarshal(t, tc.test)
+		})
+	}
+}
+
+func TestCacheEntryItem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		test *storagetest.ItemMarshalAndUnmarshalTest
+	}{{
+		name: "zero address",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item:       &cache.CacheEntry{},
+			Factory:    func() storage.Item { return new(cache.CacheEntry) },
+			MarshalErr: cache.ErrMarshalCacheEntryInvalidAddress,
+		},
+	}, {
+		name: "zero values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &cache.CacheEntry{
+				Address: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+			},
+			Factory: func() storage.Item { return new(cache.CacheEntry) },
+		},
+	}, {
+		name: "max values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &cache.CacheEntry{
+				Address: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				Prev:    swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				Next:    swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+			},
+			Factory: func() storage.Item { return new(cache.CacheEntry) },
+		},
+	}, {
+		name: "invalid size",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &storagetest.ItemStub{
+				MarshalBuf:   []byte{0xFF},
+				UnmarshalBuf: []byte{0xFF},
+			},
+			Factory:      func() storage.Item { return new(cache.CacheEntry) },
+			UnmarshalErr: cache.ErrUnmarshalCacheEntryInvalidSize,
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			storagetest.TestItemMarshalAndUnmarshal(t, tc.test)
+		})
+	}
+}
+
+type testStorage struct {
+	store   storage.Store
+	chStore storage.ChunkStore
+}
+
+func (testStorage) Ctx() context.Context { return context.TODO() }
+
+func (t *testStorage) Store() storage.Store {
+	return t.store
+}
+
+func (t *testStorage) ChunkStore() storage.ChunkStore {
+	return t.chStore
+}
+
+func TestCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fresh new cache", func(t *testing.T) {
+		st := &testStorage{
+			store:   inmem.New(),
+			chStore: inmemchunkstore.New(),
+		}
+		_, err := cache.New(st, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("putter", func(t *testing.T) {
+		st := &testStorage{
+			store:   inmem.New(),
+			chStore: inmemchunkstore.New(),
+		}
+		c, err := cache.New(st, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		chunks := chunktest.GenerateTestRandomChunks(10)
+
+		t.Run("add till full", func(t *testing.T) {
+			for idx, ch := range chunks {
+				found, err := c.Putter(st.Store(), st.ChunkStore()).Put(context.TODO(), ch)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if found {
+					t.Fatalf("expected chunk %s to not be found", ch.Address())
+				}
+				verifyCacheState(t, c, chunks[0].Address(), chunks[idx].Address(), uint64(idx+1))
+			}
+		})
+
+	})
+}
+
+func verifyCacheState(
+	t *testing.T,
+	c *cache.Cache,
+	expStart, expEnd swarm.Address,
+	expCount uint64,
+) {
+	t.Helper()
+
+	start, end, count := c.State()
+
+	if !start.Equal(expStart) {
+		t.Fatalf("unexpected start, exp: %s found: %s", expStart, start)
+	}
+
+	if !end.Equal(expEnd) {
+		t.Fatalf("unexpected end, exp: %s found: %s", expEnd, end)
+	}
+
+	if expCount != count {
+		t.Fatalf("unexpected count, exp: %d found: %d", expCount, count)
+	}
+}

--- a/pkg/localstorev2/internal/cache/export_test.go
+++ b/pkg/localstorev2/internal/cache/export_test.go
@@ -1,0 +1,24 @@
+package cache
+
+import "github.com/ethersphere/bee/pkg/swarm"
+
+type (
+	CacheEntry = cacheEntry
+	CacheState = cacheState
+)
+
+var (
+	ErrUnmarshalCacheStateInvalidSize  = errUnmarshalCacheStateInvalidSize
+	ErrMarshalCacheEntryInvalidAddress = errMarshalCacheEntryInvalidAddress
+	ErrUnmarshalCacheEntryInvalidSize  = errUnmarshalCacheEntryInvalidSize
+)
+
+func (c *Cache) State() (swarm.Address, swarm.Address, uint64) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	start := swarm.NewAddress(append(make([]byte, 0, swarm.HashSize), c.state.Start.Bytes()...))
+	end := swarm.NewAddress(append(make([]byte, 0, swarm.HashSize), c.state.End.Bytes()...))
+
+	return start, end, c.state.Count
+}

--- a/pkg/localstorev2/internal/cache/export_test.go
+++ b/pkg/localstorev2/internal/cache/export_test.go
@@ -21,7 +21,7 @@ func (c *Cache) State() (swarm.Address, swarm.Address, uint64) {
 	defer c.mtx.Unlock()
 
 	start := c.state.Start.Clone()
-	end := c.state.Start.Clone()
+	end := c.state.End.Clone()
 
 	return start, end, c.state.Count
 }

--- a/pkg/localstorev2/internal/cache/export_test.go
+++ b/pkg/localstorev2/internal/cache/export_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package cache
 
 import (

--- a/pkg/localstorev2/internal/cache/export_test.go
+++ b/pkg/localstorev2/internal/cache/export_test.go
@@ -16,14 +16,14 @@ var (
 	ErrUnmarshalCacheEntryInvalidSize  = errUnmarshalCacheEntryInvalidSize
 )
 
-func (c *Cache) State() (swarm.Address, swarm.Address, uint64) {
+func (c *Cache) State() CacheState {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	start := c.state.Start.Clone()
-	end := c.state.End.Clone()
+	start := c.state.Head.Clone()
+	end := c.state.Tail.Clone()
 
-	return start, end, c.state.Count
+	return cacheState{Head: start, Tail: end, Count: c.state.Count}
 }
 
 func (c *Cache) IterateOldToNew(

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -44,6 +44,12 @@ func (f PutterFunc) Put(ctx context.Context, chunk swarm.Chunk) (bool, error) {
 	return f(ctx, chunk)
 }
 
+type GetterFunc func(context.Context, swarm.Address) (swarm.Chunk, error)
+
+func (f GetterFunc) Get(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
+	return f(ctx, address)
+}
+
 type IterateChunkFn func(swarm.Chunk) (stop bool, err error)
 
 // ChunkGetterDeleter is a storage that provides

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -123,9 +123,14 @@ func (a Address) MarshalJSON() ([]byte, error) {
 }
 
 // Closer returns if x is closer to a than y
-func (x Address) Closer(a Address, y Address) (bool, error) {
-	cmp, err := DistanceCmp(a.b, x.b, y.b)
+func (a Address) Closer(x Address, y Address) (bool, error) {
+	cmp, err := DistanceCmp(x.b, a.b, y.b)
 	return cmp == 1, err
+}
+
+// Clone returns a new swarm address which is a copy of this one.
+func (a Address) Clone() Address {
+	return NewAddress(append(make([]byte, 0, HashSize), a.Bytes()...))
 }
 
 // ZeroAddress is the address that has no value.


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR adds the Cache component of the new localstore. The Cache is modeled as a queue that keeps the old content at the start and the recently accessed/stored content at the end. The capacity can be specified by the user and if we go above capacity, we will start evicting chunks from the cache.

The main goal of the current design is to not have any background processes to do GC. The GC brings indeterministic behavior and hence a self-cleaning cache is considered better in the long term. The additional indexes to be updated are hence considered okay.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3469)
<!-- Reviewable:end -->
