### PR TITLE
feat: basic support for libp2p secp256r1 keys

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -414,7 +414,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 		}
 	} else {
 		logger.Warning("clef is not enabled; portability and security of your keys is sub optimal")
-		swarmPrivateKey, _, err := keystore.Key("swarm", password)
+		swarmPrivateKey, _, err := keystore.Key("swarm", password, crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 		if err != nil {
 			return nil, fmt.Errorf("swarm key: %w", err)
 		}
@@ -424,7 +424,8 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 
 	logger.Info("swarm public key", "public_key", hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(publicKey)))
 
-	libp2pPrivateKey, created, err := keystore.Key("libp2p", password)
+	// use secp256r1 for libp2p as requires specific elliptic curve implementations only
+	libp2pPrivateKey, created, err := keystore.Key("libp2p", password, crypto.GenerateSecp256r1Key, crypto.EncodeSecp256r1PrivateKey, crypto.DecodeSecp256r1PrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("libp2p key: %w", err)
 	}
@@ -434,7 +435,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 		logger.Debug("using existing libp2p key")
 	}
 
-	pssPrivateKey, created, err := keystore.Key("pss", password)
+	pssPrivateKey, created, err := keystore.Key("pss", password, crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("pss key: %w", err)
 	}

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -64,8 +65,8 @@ func GenerateSecp256k1Key() (*ecdsa.PrivateKey, error) {
 }
 
 // EncodeSecp256k1PrivateKey encodes raw ECDSA private key.
-func EncodeSecp256k1PrivateKey(k *ecdsa.PrivateKey) []byte {
-	return (*btcec.PrivateKey)(k).Serialize()
+func EncodeSecp256k1PrivateKey(k *ecdsa.PrivateKey) ([]byte, error) {
+	return (*btcec.PrivateKey)(k).Serialize(), nil
 }
 
 // EncodeSecp256k1PublicKey encodes raw ECDSA public key in a 33-byte compressed format.
@@ -80,6 +81,22 @@ func DecodeSecp256k1PrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 	}
 	privk, _ := btcec.PrivKeyFromBytes(btcec.S256(), data)
 	return (*ecdsa.PrivateKey)(privk), nil
+}
+
+// GenerateSecp256k1Key generates an ECDSA private key using
+// secp256k1 elliptic curve.
+func GenerateSecp256r1Key() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+// EncodeSecp256k1PrivateKey encodes raw ECDSA private key.
+func EncodeSecp256r1PrivateKey(k *ecdsa.PrivateKey) ([]byte, error) {
+	return x509.MarshalECPrivateKey(k)
+}
+
+// DecodeSecp256k1PrivateKey decodes raw ECDSA private key.
+func DecodeSecp256r1PrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
+	return x509.ParseECPrivateKey(data)
 }
 
 // Secp256k1PrivateKeyFromBytes returns an ECDSA private key based on

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -65,7 +65,10 @@ func TestEncodeSecp256k1PrivateKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d := crypto.EncodeSecp256k1PrivateKey(k1)
+	d, err := crypto.EncodeSecp256k1PrivateKey(k1)
+	if err != nil {
+		t.Fatal(err)
+	}
 	k2, err := crypto.DecodeSecp256k1PrivateKey(d)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -19,7 +19,7 @@ type Service interface {
 	// the provided password. If the private key does not exists it creates
 	// a new one with a name and the password, and returns with created set
 	// to true.
-	Key(name, password string) (k *ecdsa.PrivateKey, created bool, err error)
+	Key(name, password string, generateFunc func() (*ecdsa.PrivateKey, error), encodeFunc func(k *ecdsa.PrivateKey) ([]byte, error), decodeFunc func(data []byte) (*ecdsa.PrivateKey, error)) (pk *ecdsa.PrivateKey, created bool, err error)
 	// Exists returns true if the key with specified name exists.
 	Exists(name string) (bool, error)
 }

--- a/pkg/keystore/mem/service.go
+++ b/pkg/keystore/mem/service.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/keystore"
 )
 
@@ -40,13 +39,13 @@ func (s *Service) Exists(name string) (bool, error) {
 
 }
 
-func (s *Service) Key(name, password string) (pk *ecdsa.PrivateKey, created bool, err error) {
+func (s *Service) Key(name, password string, generateFunc func() (*ecdsa.PrivateKey, error), encodeFunc func(k *ecdsa.PrivateKey) ([]byte, error), decodeFunc func(data []byte) (*ecdsa.PrivateKey, error)) (pk *ecdsa.PrivateKey, created bool, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	k, ok := s.m[name]
 	if !ok {
-		pk, err := crypto.GenerateSecp256k1Key()
+		pk, err := generateFunc()
 		if err != nil {
 			return nil, false, fmt.Errorf("generate secp256k1 key: %w", err)
 		}

--- a/pkg/keystore/test/test.go
+++ b/pkg/keystore/test/test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/keystore"
 )
 
@@ -26,7 +27,7 @@ func Service(t *testing.T, s keystore.Service) {
 		t.Fatal("should not exist")
 	}
 	// create a new swarm key
-	k1, created, err := s.Key("swarm", "pass123456")
+	k1, created, err := s.Key("swarm", "pass123456", crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +45,7 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	// get swarm key
-	k2, created, err := s.Key("swarm", "pass123456")
+	k2, created, err := s.Key("swarm", "pass123456", crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,13 +57,13 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	// invalid password
-	_, _, err = s.Key("swarm", "invalid password")
+	_, _, err = s.Key("swarm", "invalid password", crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if !errors.Is(err, keystore.ErrInvalidPassword) {
 		t.Fatal(err)
 	}
 
 	// create a new libp2p key
-	k3, created, err := s.Key("libp2p", "p2p pass")
+	k3, created, err := s.Key("libp2p", "p2p pass", crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	// get libp2p key
-	k4, created, err := s.Key("libp2p", "p2p pass")
+	k4, created, err := s.Key("libp2p", "p2p pass", crypto.GenerateSecp256k1Key, crypto.EncodeSecp256k1PrivateKey, crypto.DecodeSecp256k1PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR extends keystore to support different ecdsa keys, particularly to have secp256r1 for libp2p keys as latest libp2p versions are more restrictive on supported ecdsa keys making the already used secp256k1 incompatible.

TODO:

- test backward compatibility or implement migration for loading previously generated secp256k1 keys
- evaluate if replacing the three new func arguments can be replaced with an interface and creating singletons for both secp256k1 and secp256r1 implementations, current changes are to see if the approach is appropriate

### Related Issue (Optional)
https://github.com/ethersphere/bee/pull/3319

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3479)
<!-- Reviewable:end -->
