### PR TITLE
fix(puller): missing po assignment in new sync peer

### DIFF
--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -494,14 +494,14 @@ func TestPeerGone(t *testing.T) {
 
 	p, _, kad, pullsync := newPuller(opts{
 		kad: []mockk.Option{
-			mockk.WithEachPeerRevCalls(mockk.AddrTuple{Addr: addr, PO: 0}),
+			mockk.WithEachPeerRevCalls(mockk.AddrTuple{Addr: addr, PO: 1}),
 			mockk.WithDepth(0),
 		},
 		pullSync: []mockps.Option{
-			mockps.WithCursors([]uint64{1}),
+			mockps.WithCursors([]uint64{1, 1}),
 		},
-		bins:         1,
-		syncRadius:   0,
+		bins:         2,
+		syncRadius:   1,
 		syncSleepDur: time.Millisecond * 10,
 	})
 	defer p.Close()

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -413,15 +413,18 @@ func TestDepthChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			var syncRadius uint8
+			if len(tc.binsSyncing) > 0 {
+				syncRadius = tc.binsSyncing[0]
+			}
+
 			puller, st, kad, pullsync := newPuller(opts{
 				kad: []mockk.Option{
-					mockk.WithEachPeerRevCalls(
-						mockk.AddrTuple{Addr: addr, PO: 3},
-					), mockk.WithDepthCalls(tc.depths...),
+					mockk.WithEachPeerRevCalls(mockk.AddrTuple{Addr: addr, PO: 3}), mockk.WithDepthCalls(tc.depths...),
 				},
 				pullSync:   []mockps.Option{mockps.WithCursors(tc.cursors), mockps.WithLateSyncReply(tc.syncReplies...)},
 				bins:       5,
-				syncRadius: tc.depths[len(tc.depths)-1],
+				syncRadius: syncRadius,
 			})
 			defer puller.Close()
 			defer pullsync.Close()
@@ -433,7 +436,7 @@ func TestDepthChange(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 			pullsync.TriggerChange()
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(time.Second)
 
 			// check the intervals
 			for _, b := range tc.binsSyncing {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Because of the missing PO assignment, disconnected peers were not getting cleaned up in puller.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3501)
<!-- Reviewable:end -->
