### PR TITLE
fix: cancel and resend to use new gas price

### DIFF
--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -58,7 +58,7 @@ type StoredTransaction struct {
 	To          *common.Address // recipient of the transaction
 	Data        []byte          // transaction data
 	GasPrice    *big.Int        // used gas price
-	GasTipBoost int             // percantage used to boost the priority fee (eg: tip)
+	GasTipBoost int             // percentage used to boost the priority fee (eg: tip)
 	GasLimit    uint64          // used gas limit
 	Value       *big.Int        // amount of wei to send
 	Nonce       uint64          // used nonce

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -40,8 +40,6 @@ var (
 	ErrAlreadyImported     = errors.New("already imported")
 )
 
-// minGasPrice determines the minimum gas price
-// threshold (in wei) for the creation of a transaction.
 const DefaultTipBoostPercent = 20
 
 // TxRequest describes a request for a transaction that can be executed.


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
As part of EIP 1559, cancel and resend trx should use new suggested price.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3506)
<!-- Reviewable:end -->
