### PR TITLE
docs: move staking endpoint to debug api

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1901,44 +1901,6 @@ paths:
         default:
           description: Default response
 
-  "/stake/{amount}":
-        post:
-          summary: Deposit some amount for staking.
-          description: Be aware, this endpoint creates an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance.
-          tags:
-            - Staking
-          parameters:
-            - in: path
-              name: amount
-              schema:
-                type: string
-              description: Amount of BZZ added that will be deposited for staking.
-            - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
-            - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
-          responses:
-            "200":
-              description: Amount successfully staked
-            "400":
-              $ref: "SwarmCommon.yaml#/components/responses/400"
-            "500":
-              $ref: "SwarmCommon.yaml#/components/responses/500"
-            default:
-              description: Default response
-
-  "/stake":
-          get:
-            summary: Get the staked amount.
-            description: This endpoint fetches the staked amount from the blockchain.
-            tags:
-              - Staking
-            responses:
-              "200":
-                $ref: "SwarmCommon.yaml#/components/schemas/GetStakeResponse"
-              "500":
-                $ref: "SwarmCommon.yaml#/components/responses/500"
-              default:
-                description: Default response
-
 components:
   securitySchemes:
     basicAuth:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -1019,6 +1019,44 @@ paths:
         default:
           description: Default response
 
+  "/stake/{amount}":
+    post:
+      summary: Deposit some amount for staking.
+      description: Be aware, this endpoint creates an on-chain transactions and transfers BZZ from the node's Ethereum account and hence directly manipulates the wallet balance.
+      tags:
+        - Staking
+      parameters:
+        - in: path
+          name: amount
+          schema:
+            type: string
+          description: Amount of BZZ added that will be deposited for staking.
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasPriceParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
+      responses:
+        "200":
+          description: Amount successfully staked
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
+
+  "/stake":
+    get:
+      summary: Get the staked amount.
+      description: This endpoint fetches the staked amount from the blockchain.
+      tags:
+        - Staking
+      responses:
+        "200":
+          $ref: "SwarmCommon.yaml#/components/schemas/GetStakeResponse"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
+
   "/loggers":
     get:
       summary: Get all available loggers.


### PR DESCRIPTION
Staking endpoints are documented under the main API, while it is being mounted on the `mountBusinessDebug()` function, so this PR reflects this placement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3517)
<!-- Reviewable:end -->
