### PR TITLE
fix: serialise amount into string

### DIFF
--- a/pkg/api/staking.go
+++ b/pkg/api/staking.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"errors"
+	"github.com/ethersphere/bee/pkg/bigint"
 	"math/big"
 	"net/http"
 
@@ -29,7 +30,7 @@ func (s *Service) stakingAccessHandler(h http.Handler) http.Handler {
 }
 
 type getStakeResponse struct {
-	StakedAmount *big.Int `json:"stakedAmount"`
+	StakedAmount *bigint.BigInt `json:"stakedAmount"`
 }
 
 func (s *Service) stakingDepositHandler(w http.ResponseWriter, r *http.Request) {
@@ -82,5 +83,5 @@ func (s *Service) getStakedAmountHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	jsonhttp.OK(w, getStakeResponse{StakedAmount: stakedAmount})
+	jsonhttp.OK(w, getStakeResponse{StakedAmount: bigint.Wrap(stakedAmount)})
 }

--- a/pkg/api/staking_test.go
+++ b/pkg/api/staking_test.go
@@ -7,6 +7,7 @@ package api_test
 import (
 	"context"
 	"fmt"
+	"github.com/ethersphere/bee/pkg/bigint"
 	"math/big"
 	"net/http"
 	"testing"
@@ -115,7 +116,7 @@ func TestGetStake(t *testing.T) {
 		)
 		ts, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true, StakingContract: contract})
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stake", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.GetStakeResponse{StakedAmount: big.NewInt(1)}))
+			jsonhttptest.WithExpectedJSONResponse(&api.GetStakeResponse{StakedAmount: bigint.Wrap(big.NewInt(1))}))
 	})
 
 	t.Run("with error", func(t *testing.T) {


### PR DESCRIPTION
Fixes serialization of staked amount into a string instead of a number that loses precision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3521)
<!-- Reviewable:end -->
