### PR TITLE
fix: log nonce on cancellation 

### DIFF
--- a/pkg/api/transaction.go
+++ b/pkg/api/transaction.go
@@ -183,7 +183,7 @@ func (s *Service) transactionCancelHandler(w http.ResponseWriter, r *http.Reques
 
 	txHash, err := s.transaction.CancelTransaction(ctx, paths.Hash)
 	if err != nil {
-		logger.Debug("cancel transaction failed", "tx_hash", paths.Hash, "error", err, "canceled_tx_hash", txHash)
+		logger.Debug("cancel transaction failed", "tx_hash", paths.Hash, "error", err)
 		logger.Error(nil, "cancel transaction failed", "tx_hash", paths.Hash)
 		if errors.Is(err, transaction.ErrUnknownTransaction) {
 			jsonhttp.NotFound(w, errUnknownTransaction)

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -445,6 +445,8 @@ func (t *transactionService) ResendTransaction(ctx context.Context, txHash commo
 		return errors.New("transaction hash changed")
 	}
 
+	t.logger.Debug("resend transaction", "nonce", storedTransaction.Nonce)
+
 	err = t.backend.SendTransaction(t.ctx, signedTx)
 	if err != nil {
 		if strings.Contains(err.Error(), "already imported") {
@@ -486,6 +488,8 @@ func (t *transactionService) CancelTransaction(ctx context.Context, originalTxHa
 	if err != nil {
 		return common.Hash{}, err
 	}
+
+	t.logger.Debug("cancel transaction", "nonce", storedTransaction.Nonce)
 
 	err = t.backend.SendTransaction(t.ctx, signedTx)
 	if err != nil {


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
Cancel transaction fails with "nonce too low", the logs do not show the nonce.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3556)
<!-- Reviewable:end -->
