### PR TITLE
fix: larger tip on cancellation

### DIFF
--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -671,6 +671,9 @@ func TestTransactionCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	gasTipCap := new(big.Int).Div(new(big.Int).Mul(big.NewInt(int64(10)+100), gasTip), big.NewInt(100))
+	gasFeeCap := new(big.Int).Add(gasFee, gasTipCap)
+
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
@@ -680,8 +683,8 @@ func TestTransactionCancel(t *testing.T) {
 			To:        &recipient,
 			Value:     big.NewInt(0),
 			Gas:       21000,
-			GasTipCap: big.NewInt(0).Add(gasTip, big.NewInt(1)),
-			GasFeeCap: big.NewInt(0).Add(gasFee, big.NewInt(1)),
+			GasTipCap: gasTipCap,
+			GasFeeCap: gasFeeCap,
 			Data:      []byte{},
 		})
 
@@ -731,7 +734,7 @@ func TestTransactionCancel(t *testing.T) {
 			To:        &recipient,
 			Value:     big.NewInt(0),
 			Gas:       21000,
-			GasFeeCap: big.NewInt(0).Add(gasFee, big.NewInt(1)),
+			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTip,
 			Data:      []byte{},
 		})


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
Adding one for the gas tip is not enough to prioritize the transaction for cancellation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3559)
<!-- Reviewable:end -->
