### PR TITLE
fix: do not skip eviction of batches with higher radius

### DIFF
--- a/pkg/postage/batchstore/reserve.go
+++ b/pkg/postage/batchstore/reserve.go
@@ -207,8 +207,10 @@ func (s *store) Unreserve(cb postage.UnreserveIteratorFn) error {
 			return false, err
 		}
 
-		b.StorageRadius = s.rs.StorageRadius
-		updates = append(updates, b)
+		if b.StorageRadius != s.rs.StorageRadius {
+			b.StorageRadius = s.rs.StorageRadius
+			updates = append(updates, b)
+		}
 
 		return stopped, nil
 	})

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -5,6 +5,7 @@
 package batchstore_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -328,12 +329,12 @@ func TestUnreserveAndLowerStorageRadius(t *testing.T) {
 		}
 
 		state := store.GetReserveState()
+		fmt.Println(wantStorageRadius, state.StorageRadius)
 
 		if state.StorageRadius != wantStorageRadius {
 			t.Fatalf("got storage radius %d, want %d", state.StorageRadius, wantStorageRadius)
 		}
 
-		_ = store.Unreserve(cb)
 		_ = store.Unreserve(cb)
 	}
 

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -5,7 +5,6 @@
 package batchstore_test
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -329,7 +328,6 @@ func TestUnreserveAndLowerStorageRadius(t *testing.T) {
 		}
 
 		state := store.GetReserveState()
-		fmt.Println(wantStorageRadius, state.StorageRadius)
 
 		if state.StorageRadius != wantStorageRadius {
 			t.Fatalf("got storage radius %d, want %d", state.StorageRadius, wantStorageRadius)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Currently, when an eviction is necessary, localstore will evict batches one by one until the reserve size falls below a certain threshold.
The radius of the evicted batch is increased by one so that when another eviction process runs in the future, chunks of lower radius batches will be evicted first.

The problem with this is that pull syncing continues to sync at storage radius so the node may receive chunks belonging to bins lower than the radius of the batch.

This change will not skip evictions on any batch and will call eviction of the batch not with the radius of the batch but the storage radius. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3565)
<!-- Reviewable:end -->
