### PR TITLE
fix: relax reserve eviction during GC

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -403,7 +403,7 @@ func (db *DB) evictReserve() (totalEvicted uint64, done bool, err error) {
 	if err != nil {
 		return 0, false, err
 	}
-	db.logger.Debug("gc: reserve size", reserveSizeStart, "target", target)
+	db.logger.Debug("gc: reserve eviction", "reserveSizeStart", reserveSizeStart, "target", target)
 	if reserveSizeStart <= target {
 		return 0, true, nil
 	}

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -388,7 +388,7 @@ func (db *DB) evictReserve() (totalEvicted uint64, done bool, err error) {
 		totalTimeMetric(db.metrics.TotalTimeEvictReserve, start)
 	}(time.Now())
 
-	target = db.reserveCapacity
+	target = db.reserveEvictionTarget()
 
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
@@ -396,6 +396,7 @@ func (db *DB) evictReserve() (totalEvicted uint64, done bool, err error) {
 	var reserveSizeStart uint64
 	if db.radiusFunc != nil {
 		reserveSizeStart, err = db.ComputeReserveSize(db.radiusFunc())
+		target = db.reserveCapacity
 	} else {
 		reserveSizeStart, err = db.reserveSize.Get()
 	}

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -387,13 +387,22 @@ func (db *DB) evictReserve() (totalEvicted uint64, done bool, err error) {
 		}
 		totalTimeMetric(db.metrics.TotalTimeEvictReserve, start)
 	}(time.Now())
-	target = db.reserveEvictionTarget()
+
+	target = db.reserveCapacity
+
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
-	reserveSizeStart, err := db.reserveSize.Get()
+
+	var reserveSizeStart uint64
+	if db.radiusFunc != nil {
+		reserveSizeStart, err = db.ComputeReserveSize(db.radiusFunc())
+	} else {
+		reserveSizeStart, err = db.reserveSize.Get()
+	}
 	if err != nil {
 		return 0, false, err
 	}
+	db.logger.Debug("gc: reserve size", reserveSizeStart, "target", target)
 	if reserveSizeStart <= target {
 		return 0, true, nil
 	}

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1309,7 +1309,9 @@ func TestReserveEvictionWorkerWithRadius(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount))
 
-	t.Run("gc index count", newItemsCountTest(db.gcIndex, 10))
+	// so GC could have been triggered or not. As this is not essential for the test
+	// we just ensure the gcIndexes are consistent.
+	t.Run("gc size", newIndexGCSizeTest(db))
 
 	t.Run("11-20 chunks should be accessible", func(t *testing.T) {
 		for _, a := range addrs[10:] {

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1165,3 +1165,158 @@ func TestReserveEvictionWorker(t *testing.T) {
 	})
 
 }
+
+func TestReserveEvictionWorkerWithRadius(t *testing.T) {
+	var (
+		chunkCount = 10
+		batchIDs   [][]byte
+		db         *DB
+		addrs      []swarm.Address
+		closed     chan struct{}
+		mtx        sync.Mutex
+	)
+	testHookEvictionChan := make(chan uint64)
+	t.Cleanup(setTestHookEviction(func(count uint64) {
+		select {
+		case testHookEvictionChan <- count:
+		case <-closed:
+		}
+	}))
+
+	t.Cleanup(setWithinRadiusFunc(func(_ *DB, _ shed.Item) bool { return true }))
+
+	unres := func(f postage.UnreserveIteratorFn) error {
+		mtx.Lock()
+		defer mtx.Unlock()
+		for i := 0; i < len(batchIDs); i++ {
+			// pop an element from batchIDs, call the Unreserve
+			item := batchIDs[i]
+			// here we mock the behavior of the batchstore
+			// that would call the localstore back with the
+			// batch IDs and the radiuses from the FIFO queue
+			stop, err := f(item, 2)
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+			stop, err = f(item, 4)
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+		}
+		batchIDs = nil
+		return nil
+	}
+
+	checkReserveComputation := func(t *testing.T, count uint64) {
+		t.Helper()
+
+		reserveSize, err := db.ComputeReserveSize(2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reserveSize != count {
+			t.Fatalf("unexpected reserve computation, expected %d got %d", count, reserveSize)
+		}
+	}
+
+	db = newTestDB(t, &Options{
+		Capacity:        10,
+		ReserveCapacity: 10,
+		UnreserveFunc:   unres,
+		RadiusFunc:      func() uint8 { return 2 },
+	})
+
+	closed = db.close
+	// insert 10 chunks that fall into the reserve, with the radius function, we will
+	// expect all chunks to be present
+	for i := 0; i < chunkCount; i++ {
+		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
+		if err != nil {
+			t.Fatal(err)
+		}
+		mtx.Lock()
+		addrs = append(addrs, ch.Address())
+		batchIDs = append(batchIDs, ch.Stamp().BatchID())
+		mtx.Unlock()
+	}
+
+	select {
+	case count := <-testHookEvictionChan:
+		if count != 0 {
+			t.Fatalf("unexpected eviction, got %d", count)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("eviction timeout")
+	}
+
+	checkReserveComputation(t, uint64(chunkCount))
+
+	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount))
+
+	t.Run("all chunks should be accessible", func(t *testing.T) {
+		for _, a := range addrs {
+			if _, err := db.Get(context.Background(), storage.ModeGetRequest, a); err != nil {
+				t.Errorf("got error %v, want none", err)
+			}
+		}
+	})
+
+	// Add more chunks to go above capacity, this time eviction should trigger and
+	// the first set of batches are evicted first in the test unreserve. Only the
+	// old set of chunks should be evicted and we should be able to retain all the
+	// new chunks only.
+	for i := 0; i < chunkCount; i++ {
+		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 3).WithBatch(2, 3, 2, false)
+		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
+		if err != nil {
+			t.Fatal(err)
+		}
+		mtx.Lock()
+		addrs = append(addrs, ch.Address())
+		batchIDs = append(batchIDs, ch.Stamp().BatchID())
+		mtx.Unlock()
+	}
+
+	var count uint64
+	for {
+		select {
+		case c := <-testHookEvictionChan:
+			count += c
+		case <-time.After(10 * time.Second):
+			t.Fatal("eviction timeout")
+		}
+		if count == 10 {
+			break
+		}
+	}
+
+	checkReserveComputation(t, uint64(chunkCount))
+
+	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount))
+
+	t.Run("gc index count", newItemsCountTest(db.gcIndex, 10))
+
+	t.Run("11-20 chunks should be accessible", func(t *testing.T) {
+		for _, a := range addrs[10:] {
+			if _, err := db.Get(context.Background(), storage.ModeGetRequest, a); err != nil {
+				t.Errorf("got error %v, want none", err)
+			}
+		}
+	})
+
+}

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -190,6 +190,7 @@ type DB struct {
 	logger log.Logger
 
 	validStamp postage.ValidStampFn
+	radiusFunc func() uint8
 }
 
 // Options struct holds optional parameters for configuring DB.
@@ -219,6 +220,7 @@ type Options struct {
 	// MetricsPrefix defines a prefix for metrics names.
 	MetricsPrefix string
 	Tags          *tags.Tags
+	RadiusFunc    func() uint8
 }
 
 type memFS struct {
@@ -272,6 +274,7 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 		metrics:                   newMetrics(),
 		logger:                    logger.WithName(loggerName).Register(),
 		validStamp:                o.ValidStamp,
+		radiusFunc:                o.RadiusFunc,
 	}
 	if db.cacheCapacity == 0 {
 		db.cacheCapacity = defaultCacheCapacity

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -658,6 +658,9 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 		WriteBufferSize:        o.DBWriteBufferSize,
 		DisableSeeksCompaction: o.DBDisableSeeksCompaction,
 		ValidStamp:             validStamp,
+		RadiusFunc: func() uint8 {
+			return batchStore.GetReserveState().StorageRadius
+		},
 	}
 
 	storer, err := localstore.New(path, swarmAddress.Bytes(), stateStore, lo, logger)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The localstore reserve size calculation is not correct and for storage incentives, we manually calculate the syncing index to calculate the reserve size.

In the private testnet we observed that the reserve eviction was causing some inconsistencies in the samples generated. During GC, we evict chunks from the reserve till we reach 90% capacity and move them to the cache. As we no longer consider cache chunks in the sample calculation, we have decided to relax the eviction till we are at 100% capacity. So, only evict if we have more chunks.

Also, as the storage radius is now dynamic, we will need to calculate the reserve size using the current radius during eviction. This might lead to node having to store some more data, but eventually, all the expiring batches should be cleaned up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3566)
<!-- Reviewable:end -->
