### PR TITLE
chore: promote periodic status log from debug to info

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -137,7 +137,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 		s.lastRSize.Store(currentSize)
 
 		rate := s.syncer.Rate()
-		s.logger.Debug("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "chunks/sec rate", rate)
+		s.logger.Info("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "chunks/sec rate", rate)
 
 		// we have crossed 50% utilization
 		if currentSize > halfCapacity {


### PR DESCRIPTION
The pullsync rate is key to participation in the storage incentives.  By making this log visible at a lower verbosity level, it will be easier for people to diagnose non-participation issues.  It only occurs once every WakeupInterval which is currently set to 5 minutes.

(My apology for the incorrect commit messages.   But if someone else would pick this up and run a correct commit, then this PR can be summarily dismissed!)

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3568)
<!-- Reviewable:end -->
