### PR TITLE
fix: save stamp issuer data after usage not service close

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -799,13 +799,10 @@ func (s *Service) newStamperPutter(r *http.Request) (storage.Storer, func() erro
 	}
 
 	if deferred {
-		p, err := newStoringStamperPutter(s.storer, issuer, s.signer, batch)
-		wait := func() error {
-			return save()
-		}
-		return p, wait, err
+		p, err := newStoringStamperPutter(s.storer, issuer, s.signer)
+		return p, save, err
 	}
-	p, err := newPushStamperPutter(s.storer, issuer, s.signer, batch, s.chunkPushC)
+	p, err := newPushStamperPutter(s.storer, issuer, s.signer, s.chunkPushC)
 
 	wait := func() error {
 		if err := save(); err != nil {
@@ -825,7 +822,7 @@ type pushStamperPutter struct {
 	sem     chan struct{}
 }
 
-func newPushStamperPutter(s storage.Storer, i *postage.StampIssuer, signer crypto.Signer, batch []byte, cc chan *pusher.Op) (*pushStamperPutter, error) {
+func newPushStamperPutter(s storage.Storer, i *postage.StampIssuer, signer crypto.Signer, cc chan *pusher.Op) (*pushStamperPutter, error) {
 	stamper := postage.NewStamper(i, signer)
 	return &pushStamperPutter{Storer: s, stamper: stamper, c: cc, sem: make(chan struct{}, uploadSem)}, nil
 }
@@ -887,7 +884,7 @@ type stamperPutter struct {
 	stamper postage.Stamper
 }
 
-func newStoringStamperPutter(s storage.Storer, i *postage.StampIssuer, signer crypto.Signer, batch []byte) (*stamperPutter, error) {
+func newStoringStamperPutter(s storage.Storer, i *postage.StampIssuer, signer crypto.Signer) (*stamperPutter, error) {
 	stamper := postage.NewStamper(i, signer)
 	return &stamperPutter{Storer: s, stamper: stamper}, nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -801,15 +801,16 @@ func (s *Service) newStamperPutter(r *http.Request) (storage.Storer, func() erro
 	if deferred {
 		p, err := newStoringStamperPutter(s.storer, issuer, s.signer, batch)
 		wait := func() error {
-			save()
-			return nil
+			return save()
 		}
 		return p, wait, err
 	}
 	p, err := newPushStamperPutter(s.storer, issuer, s.signer, batch, s.chunkPushC)
 
 	wait := func() error {
-		save()
+		if err := save(); err != nil {
+			return err
+		}
 		return p.eg.Wait()
 	}
 

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -287,7 +287,11 @@ func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.R
 		}
 		return
 	}
-	defer func() { _ = save() }()
+	defer func() {
+		if err := save(); err != nil {
+			s.logger.Debug("stamp issuer save", "error", err)
+		}
+	}()
 
 	b := issuer.Buckets()
 	resp := postageStampBucketsResponse{

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -273,7 +273,7 @@ func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.R
 	}
 	hexBatchID := hex.EncodeToString(paths.BatchID)
 
-	issuer, err := s.post.GetStampIssuer(paths.BatchID)
+	issuer, save, err := s.post.GetStampIssuer(paths.BatchID)
 	if err != nil {
 		logger.Debug("get stamp issuer: get issuer failed", "batch_id", hexBatchID, "error", err)
 		logger.Error(nil, "get stamp issuer: get issuer failed")
@@ -287,6 +287,7 @@ func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.R
 		}
 		return
 	}
+	defer save()
 
 	b := issuer.Buckets()
 	resp := postageStampBucketsResponse{

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -287,7 +287,7 @@ func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.R
 		}
 		return
 	}
-	defer save()
+	defer func() { _ = save() }()
 
 	b := issuer.Buckets()
 	resp := postageStampBucketsResponse{

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -78,7 +78,7 @@ func (s *Service) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.BadRequest(w, "invalid postage batch id")
 		return
 	}
-	i, err := s.post.GetStampIssuer(batch)
+	i, save, err := s.post.GetStampIssuer(batch)
 	if err != nil {
 		logger.Debug("get postage batch issuer failed", "batch_id", hex.EncodeToString(batch), "error", err)
 		logger.Error(nil, "get postage batch issuer failed")
@@ -92,6 +92,8 @@ func (s *Service) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	defer save()
+
 	stamper := postage.NewStamper(i, s.signer)
 
 	err = s.pss.Send(r.Context(), topic, payload, stamper, queries.Recipient, targets)

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -92,7 +92,11 @@ func (s *Service) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer func() { _ = save() }()
+	defer func() {
+		if err := save(); err != nil {
+			s.logger.Debug("stamp issuer save", "error", err)
+		}
+	}()
 
 	stamper := postage.NewStamper(i, s.signer)
 

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -92,7 +92,7 @@ func (s *Service) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer save()
+	defer func() { _ = save() }()
 
 	stamper := postage.NewStamper(i, s.signer)
 

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -120,7 +120,7 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	i, err := s.post.GetStampIssuer(batch)
+	i, save, err := s.post.GetStampIssuer(batch)
 	if err != nil {
 		logger.Debug("get postage batch issuer failed", "batch_id", hex.EncodeToString(batch), "error", err)
 		logger.Error(nil, "get postage batch issue")
@@ -134,6 +134,8 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	defer save()
+
 	stamper := postage.NewStamper(i, s.signer)
 	stamp, err := stamper.Stamp(sch.Address())
 	if err != nil {

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -134,7 +134,7 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer save()
+	defer func() { _ = save() }()
 
 	stamper := postage.NewStamper(i, s.signer)
 	stamp, err := stamper.Stamp(sch.Address())

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -134,7 +134,11 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	defer func() { _ = save() }()
+	defer func() {
+		if err := save(); err != nil {
+			s.logger.Debug("stamp issuer save", "error", err)
+		}
+	}()
 
 	stamper := postage.NewStamper(i, s.signer)
 	stamp, err := stamper.Stamp(sch.Address())

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -85,9 +85,9 @@ func (m *mockPostage) StampIssuers() []*postage.StampIssuer {
 	return issuers
 }
 
-func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, error) {
+func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, func(), error) {
 	if m.acceptAll {
-		return postage.NewStampIssuer("test fallback", "test identity", id, big.NewInt(3), 24, 6, 1000, true), nil
+		return postage.NewStampIssuer("test fallback", "test identity", id, big.NewInt(3), 24, 6, 1000, true), func() {}, nil
 	}
 
 	m.issuerLock.Lock()
@@ -95,9 +95,9 @@ func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, error) {
 
 	i, exists := m.issuersMap[string(id)]
 	if !exists {
-		return nil, postage.ErrNotFound
+		return nil, nil, postage.ErrNotFound
 	}
-	return i, nil
+	return i, func() {}, nil
 }
 
 func (m *mockPostage) IssuerUsable(_ *postage.StampIssuer) bool {

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -85,9 +85,9 @@ func (m *mockPostage) StampIssuers() []*postage.StampIssuer {
 	return issuers
 }
 
-func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, func(), error) {
+func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, func() error, error) {
 	if m.acceptAll {
-		return postage.NewStampIssuer("test fallback", "test identity", id, big.NewInt(3), 24, 6, 1000, true), func() {}, nil
+		return postage.NewStampIssuer("test fallback", "test identity", id, big.NewInt(3), 24, 6, 1000, true), func() error { return nil }, nil
 	}
 
 	m.issuerLock.Lock()
@@ -97,7 +97,7 @@ func (m *mockPostage) GetStampIssuer(id []byte) (*postage.StampIssuer, func(), e
 	if !exists {
 		return nil, nil, postage.ErrNotFound
 	}
-	return i, func() {}, nil
+	return i, func() error { return nil }, nil
 }
 
 func (m *mockPostage) IssuerUsable(_ *postage.StampIssuer) bool {

--- a/pkg/postage/postagecontract/contract_test.go
+++ b/pkg/postage/postagecontract/contract_test.go
@@ -128,7 +128,7 @@ func TestCreateBatch(t *testing.T) {
 			t.Fatalf("got wrong batchId. wanted %v, got %v", batchID, returnedID)
 		}
 
-		si, err := postageMock.GetStampIssuer(returnedID)
+		si, _, err := postageMock.GetStampIssuer(returnedID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -314,7 +314,7 @@ func TestTopUpBatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		si, err := postageMock.GetStampIssuer(batch.ID)
+		si, _, err := postageMock.GetStampIssuer(batch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -496,7 +496,7 @@ func TestDiluteBatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		si, err := postageMock.GetStampIssuer(batch.ID)
+		si, _, err := postageMock.GetStampIssuer(batch.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -33,7 +33,7 @@ var (
 type Service interface {
 	Add(*StampIssuer) error
 	StampIssuers() []*StampIssuer
-	GetStampIssuer([]byte) (*StampIssuer, func(), error)
+	GetStampIssuer([]byte) (*StampIssuer, func() error, error)
 	IssuerUsable(*StampIssuer) bool
 	BatchEventListener
 	BatchExpiryHandler
@@ -162,7 +162,7 @@ func (ps *service) IssuerUsable(st *StampIssuer) bool {
 }
 
 // GetStampIssuer finds a stamp issuer by batch ID.
-func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func(), error) {
+func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func() error, error) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 	for _, st := range ps.issuers {
@@ -170,7 +170,7 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func(), error) 
 			if !ps.IssuerUsable(st) {
 				return nil, nil, ErrNotUsable
 			}
-			return st, func() { _ = ps.save() }, nil
+			return st, func() error { return ps.save() }, nil
 		}
 	}
 	return nil, nil, ErrNotFound

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -178,6 +178,8 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func(), error) 
 
 // Close saves all the active stamp issuers to statestore.
 func (ps *service) save() error {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
 	for i, st := range ps.issuers {
 		if err := ps.store.Put(ps.keyForIndex(i), st); err != nil {
 			return err

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -176,7 +176,7 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func(), error) 
 	return nil, nil, ErrNotFound
 }
 
-// Close saves all the active stamp issuers to statestore.
+// Save saves all the active stamp issuers to statestore.
 func (ps *service) save() error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
@@ -188,7 +188,6 @@ func (ps *service) save() error {
 	return nil
 }
 
-// Close saves all the active stamp issuers to statestore.
 func (ps *service) Close() error {
 	return ps.save()
 }

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -170,7 +170,7 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func() error, e
 			if !ps.IssuerUsable(st) {
 				return nil, nil, ErrNotUsable
 			}
-			return st, func() error { return ps.save() }, nil
+			return st, ps.save, nil
 		}
 	}
 	return nil, nil, ErrNotFound

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -106,7 +106,7 @@ func TestGetStampIssuer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
-			save()
+			_ = save()
 			if st.Label() != string(id) {
 				t.Fatalf("wrong issuer returned")
 			}

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -99,7 +99,7 @@ func TestGetStampIssuer(t *testing.T) {
 	}
 	t.Run("found", func(t *testing.T) {
 		for _, id := range ids[1:4] {
-			st, err := ps.GetStampIssuer(id)
+			st, _, err := ps.GetStampIssuer(id)
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
@@ -109,14 +109,14 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	})
 	t.Run("not found", func(t *testing.T) {
-		_, err := ps.GetStampIssuer(ids[0])
+		_, _, err := ps.GetStampIssuer(ids[0])
 		if !errors.Is(err, postage.ErrNotFound) {
 			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 	})
 	t.Run("not usable", func(t *testing.T) {
 		for _, id := range ids[4:] {
-			_, err := ps.GetStampIssuer(id)
+			_, _, err := ps.GetStampIssuer(id)
 			if !errors.Is(err, postage.ErrNotUsable) {
 				t.Fatalf("expected ErrNotUsable, got %v", err)
 			}
@@ -130,7 +130,7 @@ func TestGetStampIssuer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		st, err := ps.GetStampIssuer(b.ID)
+		st, _, err := ps.GetStampIssuer(b.ID)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -140,7 +140,7 @@ func TestGetStampIssuer(t *testing.T) {
 	})
 	t.Run("topup", func(t *testing.T) {
 		ps.HandleTopUp(ids[1], big.NewInt(10))
-		_, err := ps.GetStampIssuer(ids[1])
+		_, _, err := ps.GetStampIssuer(ids[1])
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -150,7 +150,7 @@ func TestGetStampIssuer(t *testing.T) {
 	})
 	t.Run("dilute", func(t *testing.T) {
 		ps.HandleDepthIncrease(ids[2], 17)
-		_, err := ps.GetStampIssuer(ids[2])
+		_, _, err := ps.GetStampIssuer(ids[2])
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
We have seen MANY chunks whose stamp indexes are colliding with others chunks belonging to the same batch.
This is possible if stamp issuer data is not stored to disk properly on `Close()` such that on the next restart of the node, the same bucket and indexes are assigned to a different uploaded chunk. 

This change makes sure that after a stamp is used, the bucket data is stored immediately with a callback.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3577)
<!-- Reviewable:end -->
