### PR TITLE
fix(localstore): remove reserve calculation from localstore

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -41,18 +41,7 @@ var (
 	// transaction on garbage collection.
 	gcBatchSize uint64 = 10_000
 
-	// reserveCollectionRatio is the ratio of the cache to evict from
-	// the reserve every time it hits the limit. If the cache size is
-	// 1000 chunks then we will evict 500 chunks from the reserve, this is
-	// not to overwhelm the cache with too many chunks which it will flush
-	// anyway.
-	reserveCollectionRatio = 0.5
-	// reserveEvictionBatch limits the number of chunks collected in
-	// a single reserve eviction run.
 	reserveEvictionBatch uint64 = 200
-	// maxPurgeablePercentageOfReserve is a ceiling of size of the reserve
-	// to evict in case the cache size is bigger than the reserve
-	maxPurgeablePercentageOfReserve = 0.1
 )
 
 // collectGarbageWorker is a long running function that waits for
@@ -255,15 +244,6 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 // target value, calculated from db.capacity and gcTargetRatio.
 func (db *DB) gcTarget() (target uint64) {
 	return uint64(float64(db.cacheCapacity) * gcTargetRatio)
-}
-
-func (db *DB) reserveEvictionTarget() (target uint64) {
-	targetCache := db.reserveCapacity - uint64(float64(db.cacheCapacity)*reserveCollectionRatio)
-	targetCeiling := db.reserveCapacity - uint64(float64(db.reserveCapacity)*maxPurgeablePercentageOfReserve)
-	if targetCeiling > targetCache {
-		return targetCeiling
-	}
-	return targetCache
 }
 
 // triggerGarbageCollection signals collectGarbageWorker

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -19,7 +19,6 @@ package localstore
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/sharky"
@@ -171,7 +170,6 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 	// get rid of dirty entries
 	for _, item := range candidates {
 		if swarm.NewAddress(item.Address).MemberOf(db.dirtyAddresses) {
-			fmt.Println("skipping", swarm.NewAddress(item.Address))
 			continue
 		}
 
@@ -184,7 +182,6 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 		// the target since the gc size always is bound to change even if to a minor degree in the time between
 		// candidate collection and the mutex acquisition.
 		if gcSize-totalChunksEvicted <= target {
-			fmt.Println("stopping", totalChunksEvicted, gcSize, target)
 			done = true
 			break
 		}
@@ -217,6 +214,10 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 			return 0, false, err
 		}
 		err = db.gcIndex.DeleteInBatch(batch, item)
+		if err != nil {
+			return 0, false, err
+		}
+		err = db.postageIndexIndex.DeleteInBatch(batch, storedItem)
 		if err != nil {
 			return 0, false, err
 		}

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -188,13 +188,12 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 
 		totalChunksEvicted++
 
-		i, err := db.retrievalDataIndex.Get(item)
+		storedItem, err := db.retrievalDataIndex.Get(item)
 		if err != nil {
 			return 0, false, err
 		}
-		item.Location = i.Location
 
-		db.metrics.GCStoreTimeStamps.Set(float64(item.StoreTimestamp))
+		db.metrics.GCStoreTimeStamps.Set(float64(storedItem.StoreTimestamp))
 		db.metrics.GCStoreAccessTimeStamps.Set(float64(item.AccessTimestamp))
 
 		// delete from retrieve, pull, gc
@@ -206,7 +205,7 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 		if err != nil {
 			return 0, false, err
 		}
-		err = db.pushIndex.DeleteInBatch(batch, item)
+		err = db.pushIndex.DeleteInBatch(batch, storedItem)
 		if err != nil {
 			return 0, false, err
 		}
@@ -226,7 +225,7 @@ func (db *DB) collectGarbage() (evicted uint64, done bool, err error) {
 		if err != nil {
 			return 0, false, err
 		}
-		loc, err := sharky.LocationFromBinary(item.Location)
+		loc, err := sharky.LocationFromBinary(storedItem.Location)
 		if err != nil {
 			return 0, false, err
 		}

--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -343,7 +343,7 @@ func (db *DB) evictReserve() (totalEvicted uint64, done bool, err error) {
 		return 0, false, err
 	}
 
-	db.logger.Debug("gc: reserve eviction", "reserve-size-start", reserveSizeStart, "target", target)
+	db.logger.Debug("gc: reserve eviction", "reserve_size_start", reserveSizeStart, "target", target)
 
 	if reserveSizeStart <= target {
 		return 0, true, nil

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1080,7 +1080,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 	select {
 	case c := <-testHookEvictionChan:
 		if c != 1 {
-			t.Fatal("expected eviction of 1 chunk, found %d", c)
+			t.Fatalf("expected eviction of 1 chunk, found %d", c)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("eviction timeout")

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -121,7 +121,7 @@ func testDBCollectGarbageWorker(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, int(gcTarget)))
 
@@ -234,7 +234,7 @@ func TestPinGC(t *testing.T) {
 	// the pinned chunks will not be added to pullSync index
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)+pinChunksCount))
 
 	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)+pinChunksCount))
 
@@ -446,7 +446,7 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(db.cacheCapacity)))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
 
 	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)))
 
@@ -917,7 +917,7 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
 
 	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)))
 
@@ -1180,7 +1180,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount-1))
 
 	// postage index will not be deleted
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount*2))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount+8))
 
 	// this is deleted on chunk removal
 	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, chunkCount+8))

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1079,8 +1079,8 @@ func TestReserveEvictionWorker(t *testing.T) {
 
 	select {
 	case c := <-testHookEvictionChan:
-		if c == 1 {
-			break
+		if c != 1 {
+			t.Fatal("expected eviction of 1 chunk, found %d", c)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("eviction timeout")

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1075,12 +1075,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, 0, 11))
-
-	err := db.SetReserveSize(11)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("reserve size", reserveSizeTest(db, 11, 2))
 
 	select {
 	case c := <-testHookEvictionChan:
@@ -1125,12 +1120,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, 0, 21))
-
-	err = db.SetReserveSize(21)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("reserve size", reserveSizeTest(db, 21, 2))
 
 	var evictCount uint64
 	for {
@@ -1160,7 +1150,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		}
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, 0, 10))
+	t.Run("reserve size", reserveSizeTest(db, 10, 0))
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount-1))
 

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -1060,18 +1060,6 @@ func TestReserveEvictionWorker(t *testing.T) {
 		UnreserveFunc:   unres,
 	})
 
-	checkReserveComputation := func(t *testing.T, count uint64) {
-		t.Helper()
-
-		reserveSize, err := db.ComputeReserveSize(2)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if reserveSize != count {
-			t.Fatalf("unexpected reserve computation, expected %d got %d", count, reserveSize)
-		}
-	}
-
 	closed = db.close
 	// insert 11 chunks that fall into the reserve, then
 	// expect one to be evicted
@@ -1087,7 +1075,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
-	checkReserveComputation(t, 11)
+	t.Run("reserve size", reserveSizeTest(db, 0, 11))
 
 	err := db.SetReserveSize(11)
 	if err != nil {
@@ -1137,7 +1125,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
-	checkReserveComputation(t, 21)
+	t.Run("reserve size", reserveSizeTest(db, 0, 21))
 
 	err = db.SetReserveSize(21)
 	if err != nil {
@@ -1172,10 +1160,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 		}
 	}
 
-<<<<<<< HEAD
-	t.Run("9/10 of the first chunks should be accessible", func(t *testing.T) {
-=======
-	checkReserveComputation(t, 10)
+	t.Run("reserve size", reserveSizeTest(db, 0, 10))
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount-1))
 
@@ -1202,162 +1187,4 @@ func TestReserveEvictionWorker(t *testing.T) {
 			t.Errorf("got %d chunks, want atleast 7", has)
 		}
 	})
-
-}
-
-func TestReserveEvictionWorkerWithRadius(t *testing.T) {
-	var (
-		chunkCount = 10
-		batchIDs   [][]byte
-		db         *DB
-		addrs      []swarm.Address
-		closed     chan struct{}
-		mtx        sync.Mutex
-	)
-	testHookEvictionChan := make(chan uint64)
-	t.Cleanup(setTestHookEviction(func(count uint64) {
-		select {
-		case testHookEvictionChan <- count:
-		case <-closed:
-		}
-	}))
-
-	t.Cleanup(setWithinRadiusFunc(func(_ *DB, _ shed.Item) bool { return true }))
-
-	unres := func(f postage.UnreserveIteratorFn) error {
-		mtx.Lock()
-		defer mtx.Unlock()
-		for i := 0; i < len(batchIDs); i++ {
-			// pop an element from batchIDs, call the Unreserve
-			item := batchIDs[i]
-			// here we mock the behavior of the batchstore
-			// that would call the localstore back with the
-			// batch IDs and the radiuses from the FIFO queue
-			stop, err := f(item, 2)
-			if err != nil {
-				return err
-			}
-			if stop {
-				return nil
-			}
-			stop, err = f(item, 4)
-			if err != nil {
-				return err
-			}
-			if stop {
-				return nil
-			}
-		}
-		batchIDs = nil
-		return nil
-	}
-
-	checkReserveComputation := func(t *testing.T, count uint64) {
-		t.Helper()
-
-		reserveSize, err := db.ComputeReserveSize(2)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if reserveSize != count {
-			t.Fatalf("unexpected reserve computation, expected %d got %d", count, reserveSize)
-		}
-	}
-
-	db = newTestDB(t, &Options{
-		Capacity:        10,
-		ReserveCapacity: 10,
-		UnreserveFunc:   unres,
-		RadiusFunc:      func() uint8 { return 2 },
-	})
-
-	closed = db.close
-	// insert 10 chunks that fall into the reserve, with the radius function, we will
-	// expect all chunks to be present
-	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
-		if err != nil {
-			t.Fatal(err)
-		}
-		mtx.Lock()
-		addrs = append(addrs, ch.Address())
-		batchIDs = append(batchIDs, ch.Stamp().BatchID())
-		mtx.Unlock()
-	}
-
-	select {
-	case count := <-testHookEvictionChan:
-		if count != 0 {
-			t.Fatalf("unexpected eviction, got %d", count)
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("eviction timeout")
-	}
-
-	checkReserveComputation(t, uint64(chunkCount))
-
-	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount))
-
-	t.Run("all chunks should be accessible", func(t *testing.T) {
-		for _, a := range addrs {
-			if _, err := db.Get(context.Background(), storage.ModeGetRequest, a); err != nil {
-				t.Errorf("got error %v, want none", err)
-			}
-		}
-	})
-
-	// Add more chunks to go above capacity, this time eviction should trigger and
-	// the first set of batches are evicted first in the test unreserve. Only the
-	// old set of chunks should be evicted and we should be able to retain all the
-	// new chunks only.
-	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 3).WithBatch(2, 3, 2, false)
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
-		if err != nil {
-			t.Fatal(err)
-		}
-		mtx.Lock()
-		addrs = append(addrs, ch.Address())
-		batchIDs = append(batchIDs, ch.Stamp().BatchID())
-		mtx.Unlock()
-	}
-
-	var count uint64
-	for {
-		select {
-		case c := <-testHookEvictionChan:
-			count += c
-		case <-time.After(10 * time.Second):
-			t.Fatal("eviction timeout")
-		}
-		if count == 10 {
-			break
-		}
-	}
-
-	checkReserveComputation(t, uint64(chunkCount))
-
-	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount))
-
-	// so GC could have been triggered or not. As this is not essential for the test
-	// we just ensure the gcIndexes are consistent.
-	t.Run("gc size", newIndexGCSizeTest(db))
-
-	t.Run("11-20 chunks should be accessible", func(t *testing.T) {
-		for _, a := range addrs[10:] {
-			if _, err := db.Get(context.Background(), storage.ModeGetRequest, a); err != nil {
-				t.Errorf("got error %v, want none", err)
-			}
-		}
-	})
-
 }

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -121,7 +121,7 @@ func testDBCollectGarbageWorker(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, int(gcTarget)))
 
@@ -231,9 +231,12 @@ func TestPinGC(t *testing.T) {
 
 	t.Run("pin Index count", newItemsCountTest(db.pinIndex, pinChunksCount))
 
-	t.Run("pull index count", newItemsCountTest(db.pullIndex, pinChunksCount))
+	// the pinned chunks will not be added to pullSync index
+	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)+pinChunksCount))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+
+	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)+pinChunksCount))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, int(gcTarget)))
 
@@ -443,7 +446,9 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(db.cacheCapacity)))
+
+	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, int(gcTarget)))
 
@@ -912,7 +917,9 @@ func TestGC_NoEvictDirty(t *testing.T) {
 
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, 0))
 
-	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, int(gcTarget)))
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+
+	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, int(gcTarget)))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, int(gcTarget)))
 
@@ -985,7 +992,7 @@ func setTestHookEviction(h func(count uint64)) (reset func()) {
 // gc index.
 func TestReserveEvictionWorker(t *testing.T) {
 	var (
-		chunkCount = 10
+		chunkCount = 11
 		batchIDs   [][]byte
 		db         *DB
 		addrs      []swarm.Address
@@ -1053,16 +1060,24 @@ func TestReserveEvictionWorker(t *testing.T) {
 		UnreserveFunc:   unres,
 	})
 
-	closed = db.close
-	// insert 10 chunks that fall into the reserve, then
-	// expect first one to be evicted
-	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+	checkReserveComputation := func(t *testing.T, count uint64) {
+		t.Helper()
+
+		reserveSize, err := db.ComputeReserveSize(2)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
+		if reserveSize != count {
+			t.Fatalf("unexpected reserve computation, expected %d got %d", count, reserveSize)
+		}
+	}
+
+	closed = db.close
+	// insert 11 chunks that fall into the reserve, then
+	// expect one to be evicted
+	for i := 0; i < chunkCount; i++ {
+		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1072,31 +1087,35 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
-	evictTarget := db.reserveEvictionTarget()
+	checkReserveComputation(t, 11)
 
-	for {
-		select {
-		case <-testHookEvictionChan:
-		case <-time.After(10 * time.Second):
-			t.Fatal("eviction timeout")
-		}
-		reserveSize, err := db.reserveSize.Get()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if reserveSize == evictTarget {
+	err := db.SetReserveSize(11)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case c := <-testHookEvictionChan:
+		if c == 1 {
 			break
 		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("eviction timeout")
 	}
 	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount-1))
 
 	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount))
+
+	// this is deleted on chunk removal
+	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, chunkCount))
 
 	t.Run("postage radius count", newItemsCountTest(db.postageRadiusIndex, 1))
 
 	t.Run("gc index count", newItemsCountTest(db.gcIndex, 1))
 
 	t.Run("gc size", newIndexGCSizeTest(db))
+
+	t.Run("retrievalDataIndex count", newItemsCountTest(db.retrievalDataIndex, chunkCount))
 
 	t.Run("all chunks should be accessible", func(t *testing.T) {
 		for _, a := range addrs {
@@ -1106,13 +1125,9 @@ func TestReserveEvictionWorker(t *testing.T) {
 		}
 	})
 
-	for i := 0; i < chunkCount-1; i++ {
+	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 3).WithBatch(2, 3, 2, false)
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = db.Set(context.Background(), storage.ModeSetSync, ch.Address())
+		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1122,17 +1137,22 @@ func TestReserveEvictionWorker(t *testing.T) {
 		mtx.Unlock()
 	}
 
+	checkReserveComputation(t, 21)
+
+	err = db.SetReserveSize(21)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var evictCount uint64
 	for {
 		select {
-		case <-testHookEvictionChan:
+		case c := <-testHookEvictionChan:
+			evictCount += c
 		case <-time.After(10 * time.Second):
 			t.Fatal("eviction timeout")
 		}
-		reserveSize, err := db.reserveSize.Get()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if reserveSize == evictTarget {
+		if evictCount == 11 {
 			break
 		}
 	}
@@ -1152,15 +1172,34 @@ func TestReserveEvictionWorker(t *testing.T) {
 		}
 	}
 
+<<<<<<< HEAD
 	t.Run("9/10 of the first chunks should be accessible", func(t *testing.T) {
+=======
+	checkReserveComputation(t, 10)
+
+	t.Run("pull index count", newItemsCountTest(db.pullIndex, chunkCount-1))
+
+	// postage index will not be deleted
+	t.Run("postage index count", newItemsCountTest(db.postageIndexIndex, chunkCount*2))
+
+	// this is deleted on chunk removal
+	t.Run("postage chunks count", newItemsCountTest(db.postageChunksIndex, chunkCount+8))
+
+	t.Run("postage radius count", newItemsCountTest(db.postageRadiusIndex, 12))
+
+	t.Run("retrievalDataIndex count", newItemsCountTest(db.retrievalDataIndex, chunkCount+8))
+
+	t.Run("gc index count", newItemsCountTest(db.gcIndex, 9))
+
+	t.Run("atleast 7/10 of the first chunks should be accessible", func(t *testing.T) {
 		has := 0
 		for _, a := range addrs[:10] {
 			if _, err := db.Get(context.Background(), storage.ModeGetRequest, a); err == nil {
 				has++
 			}
 		}
-		if has != 9 {
-			t.Errorf("got %d chunks, want 9", has)
+		if has < 7 {
+			t.Errorf("got %d chunks, want atleast 7", has)
 		}
 	})
 

--- a/pkg/localstore/index_test.go
+++ b/pkg/localstore/index_test.go
@@ -45,7 +45,7 @@ func TestDB_pullIndex(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,8 +104,9 @@ func TestDB_gcIndex(t *testing.T) {
 		}
 	}
 
-	// check if all chunks are stored
-	newItemsCountTest(db.pullIndex, chunkCount)(t)
+	newItemsCountTest(db.pullIndex, 0)(t)
+
+	newItemsCountTest(db.pushIndex, chunkCount)(t)
 
 	// check that chunks are not collectable for garbage
 	newItemsCountTest(db.gcIndex, 0)(t)

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -677,14 +677,6 @@ func (db *DB) safeInit(rootPath, sharkyBasePath string) error {
 	return nil
 }
 
-func (db *DB) ReserveSize() (uint64, error) {
-	return db.reserveSize.Get()
-}
-
-func (db *DB) ReserveCapacity() uint64 {
-	return db.reserveCapacity
-}
-
 // Close closes the underlying database.
 func (db *DB) Close() error {
 	close(db.close)

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -628,6 +628,7 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 
 	// start garbage collection worker
 	go db.collectGarbageWorker()
+	go db.reserveEvictionWorker()
 	return db, nil
 }
 

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -628,7 +628,6 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 
 	// start garbage collection worker
 	go db.collectGarbageWorker()
-	go db.reserveEvictionWorker()
 	return db, nil
 }
 

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -190,7 +190,6 @@ type DB struct {
 	logger log.Logger
 
 	validStamp postage.ValidStampFn
-	radiusFunc func() uint8
 }
 
 // Options struct holds optional parameters for configuring DB.
@@ -220,7 +219,6 @@ type Options struct {
 	// MetricsPrefix defines a prefix for metrics names.
 	MetricsPrefix string
 	Tags          *tags.Tags
-	RadiusFunc    func() uint8
 }
 
 type memFS struct {
@@ -274,7 +272,6 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 		metrics:                   newMetrics(),
 		logger:                    logger.WithName(loggerName).Register(),
 		validStamp:                o.ValidStamp,
-		radiusFunc:                o.RadiusFunc,
 	}
 	if db.cacheCapacity == 0 {
 		db.cacheCapacity = defaultCacheCapacity

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -496,11 +496,11 @@ func newIndexGCSizeTest(db *DB) func(t *testing.T) {
 
 // reserveSizeTest checks that the reserveSize scalar is equal
 // to the expected value.
-func reserveSizeTest(db *DB, want uint64) func(t *testing.T) {
+func reserveSizeTest(db *DB, want uint64, depth uint8) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
-		got, err := db.reserveSize.Get()
+		got, err := db.ComputeReserveSize(depth)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -690,7 +690,7 @@ func TestDBDebugIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testIndexCounts(t, 1, 1, 0, 0, 1, 0, indexCounts)
+	testIndexCounts(t, 1, 0, 0, 0, 1, 0, indexCounts)
 
 	// set the chunk for pinning and expect the index count to grow
 	err = db.Set(ctx, storage.ModeSetPin, ch.Address())
@@ -704,5 +704,17 @@ func TestDBDebugIndexes(t *testing.T) {
 	}
 
 	// assert that there's a pin and gc exclude entry now
+	testIndexCounts(t, 1, 0, 0, 1, 1, 0, indexCounts)
+
+	_, err = db.Put(ctx, storage.ModePutSync, ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexCounts, err = db.DebugIndices()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testIndexCounts(t, 1, 1, 0, 1, 1, 0, indexCounts)
 }

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -31,8 +31,8 @@ import (
 )
 
 var (
-	ErrOverwrite    = errors.New("index already exists - double issuance on immutable batch")
-	ErrOverwriteNew = errors.New("index already exists with newer timestamp - double issuance on batch")
+	ErrOverwriteImmutable = errors.New("index already exists - double issuance on immutable batch")
+	ErrOverwrite          = errors.New("index already exists with newer timestamp - double issuance on batch")
 )
 
 // Put stores Chunks to database and depending
@@ -255,12 +255,12 @@ func (db *DB) checkAndRemoveStampIndex(
 		return 0, fmt.Errorf("failed reading postageIndexIndex: %w", err)
 	}
 	if item.Immutable {
-		return 0, ErrOverwrite
+		return 0, ErrOverwriteImmutable
 	}
 	// if a chunk is found with the same postage stamp index,
 	// replace it with the new one only if timestamp is later
 	if !later(previous, item) {
-		return 0, ErrOverwriteNew
+		return 0, ErrOverwrite
 	}
 
 	// remove older chunk

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -273,6 +273,7 @@ func (db *DB) checkAndRemoveStampIndex(
 			// currently there are stale postageIndexIndex entries in the localstore
 			// due to a bug found recently. This error is mainly ignored as the
 			// chunk is already gone and the index is overwritten.
+			db.logger.Debug("old postage stamp index missing", "Address", swarm.NewAddress(previous.Address))
 			return 0, nil
 		}
 		return 0, fmt.Errorf("could not fetch previous item: %w", err)

--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -124,6 +124,9 @@ func (db *DB) put(ctx context.Context, mode storage.ModePut, chs ...swarm.Chunk)
 			}
 			committedLocations = append(committedLocations, l)
 			item.Location, err = l.MarshalBinary()
+			if err != nil {
+				return false, 0, fmt.Errorf("failed serializing sharky location: %w", err)
+			}
 
 			gcChangeNew, err := putOp(item, false)
 			return false, gcChangeNew + gcChange, err
@@ -271,12 +274,12 @@ func (db *DB) checkAndRemoveStampIndex(
 
 	gcSizeChange, err := db.setRemove(batch, previousIdx, true)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("setRemove on double issuance: %w", err)
 	}
 
 	l, err := sharky.LocationFromBinary(previousIdx.Location)
 	if err != nil {
-		return 0, fmt.Errorf("failed getting localtion: %w", err)
+		return 0, fmt.Errorf("failed getting location: %w", err)
 	}
 	loc.add(l)
 

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -46,7 +46,7 @@ var putModes = []storage.ModePut{
 
 // TestModePutRequest validates ModePutRequest index values on the provided DB.
 func TestModePutRequest(t *testing.T) {
-	t.Cleanup(setWithinRadiusFunc(func(_ *DB, _ shed.Item) bool { return false }))
+	t.Cleanup(setWithinRadiusFunc(func(_ *DB, _ shed.Item) bool { return true }))
 	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := newTestDB(t, nil)
@@ -77,7 +77,7 @@ func TestModePutRequest(t *testing.T) {
 					newRetrieveIndexesTestWithAccess(db, ch, wantTimestamp, wantTimestamp)(t)
 				}
 
-				newItemsCountTest(db.gcIndex, tc.count)(t)
+				newItemsCountTest(db.gcIndex, 0)(t)
 				newItemsCountTest(db.pullIndex, tc.count)(t)
 				newItemsCountTest(db.postageIndexIndex, tc.count)(t)
 				newIndexGCSizeTest(db)(t)
@@ -98,7 +98,7 @@ func TestModePutRequest(t *testing.T) {
 					newRetrieveIndexesTestWithAccess(db, ch, storeTimestamp, storeTimestamp)(t)
 				}
 
-				newItemsCountTest(db.gcIndex, tc.count)(t)
+				newItemsCountTest(db.gcIndex, 0)(t)
 				newItemsCountTest(db.pullIndex, tc.count)(t)
 				newItemsCountTest(db.postageIndexIndex, tc.count)(t)
 				newIndexGCSizeTest(db)(t)
@@ -215,13 +215,13 @@ func TestModePutSync(t *testing.T) {
 				binIDs[po]++
 
 				newRetrieveIndexesTestWithAccess(db, ch, wantTimestamp, wantTimestamp)(t)
-				newPullIndexTest(db, ch, binIDs[po], leveldb.ErrNotFound)(t)
-				newPinIndexTest(db, ch, leveldb.ErrNotFound)(t)
+				newPullIndexTest(db, ch, binIDs[po], nil)(t)
+				newPinIndexTest(db, ch, nil)(t)
 				newIndexGCSizeTest(db)(t)
 			}
 			newItemsCountTest(db.postageChunksIndex, tc.count)(t)
 			newItemsCountTest(db.postageIndexIndex, tc.count)(t)
-			newItemsCountTest(db.gcIndex, tc.count)(t)
+			newItemsCountTest(db.gcIndex, 0)(t)
 			newIndexGCSizeTest(db)(t)
 		})
 	}

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -336,10 +336,11 @@ func TestModePutSyncUpload_SameIndex(t *testing.T) {
 	}
 
 	newItemsCountTest(db.retrievalDataIndex, 1)(t)
-	newPullIndexTest(db, chunks[1], binIDs[db.po(chunks[1].Address())], nil)(t)
+	newPullIndexTest(db, chunks[1], binIDs[db.po(chunks[1].Address())], leveldb.ErrNotFound)(t)
 	newPinIndexTest(db, chunks[0], leveldb.ErrNotFound)(t)
-	newPinIndexTest(db, chunks[1], nil)(t)
-	newItemsCountTest(db.pullIndex, 1)(t)
+	newPinIndexTest(db, chunks[1], leveldb.ErrNotFound)(t)
+	newItemsCountTest(db.pullIndex, 0)(t)
+	newItemsCountTest(db.pushIndex, 0)(t)
 	newItemsCountTest(db.postageIndexIndex, 1)(t)
 	newIndexGCSizeTest(db)(t)
 }

--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -79,15 +79,15 @@ func (db *DB) set(ctx context.Context, mode storage.ModeSet, addrs ...swarm.Addr
 	case storage.ModeSetRemove:
 		for _, addr := range addrs {
 			item := addressToItem(addr)
-			item, err = db.retrievalDataIndex.Get(item)
+			storedItem, err := db.retrievalDataIndex.Get(item)
 			if err != nil {
 				return err
 			}
-			c, err := db.setRemove(batch, item, true)
+			c, err := db.setRemove(batch, storedItem, true)
 			if err != nil {
 				return err
 			}
-			l, err := sharky.LocationFromBinary(item.Location)
+			l, err := sharky.LocationFromBinary(storedItem.Location)
 			if err != nil {
 				return err
 			}

--- a/pkg/localstore/mode_set.go
+++ b/pkg/localstore/mode_set.go
@@ -217,7 +217,7 @@ func (db *DB) setSync(batch *leveldb.Batch, addr swarm.Address) (gcSizeChange in
 	} else {
 		item.AccessTimestamp = i1.AccessTimestamp
 	}
-	return db.preserveOrCache(batch, item, false, false)
+	return db.addToCache(batch, item)
 }
 
 // setRemove removes the chunk by updating indexes:

--- a/pkg/localstore/pin_test.go
+++ b/pkg/localstore/pin_test.go
@@ -214,6 +214,13 @@ func TestPinIndexesPutSync(t *testing.T) {
 	}
 	runCountsTest(t, "putSync", db, 1, 1, 0, 1, 1, 0)
 
+	// duplicates should have no effect
+	_, err = db.Put(ctx, storage.ModePutSync, ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "putSync", db, 1, 1, 0, 1, 1, 0)
+
 	err = db.Set(ctx, storage.ModeSetPin, addr)
 	if err != nil {
 		t.Fatal(err)
@@ -249,6 +256,13 @@ func TestPinIndexesPutRequest(t *testing.T) {
 
 	addr := ch.Address()
 	_, err := db.Put(ctx, storage.ModePutRequest, ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCountsTest(t, "putRequest", db, 1, 1, 0, 1, 1, 0)
+
+	// duplicate should have no effect
+	_, err = db.Put(ctx, storage.ModePutRequest, ch)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -194,10 +194,11 @@ func (db *DB) ComputeReserveSize(startPO uint8) (uint64, error) {
 // depthmonitor using the updated storage depth
 func (db *DB) setReserveSize(size uint64) error {
 	err := db.reserveSize.Put(size)
-	if err == nil {
-		if size > db.reserveCapacity {
-			db.triggerReserveEviction()
-		}
+	if err != nil {
+		return fmt.Errorf("failed updating reserve size: %w", err)
 	}
-	return err
+	if size > db.reserveCapacity {
+		db.triggerReserveEviction()
+	}
+	return nil
 }

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -139,11 +139,6 @@ func (db *DB) unpinBatchChunks(id []byte, bin uint8) (uint64, error) {
 				return 0, err
 			}
 		}
-		if reserveSizeChange > 0 {
-			if err := db.incReserveSizeInBatch(batch, -int64(reserveSizeChange)); err != nil {
-				return 0, err
-			}
-		}
 		if err := db.shed.WriteBatch(batch); err != nil {
 			return 0, err
 		}

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -178,3 +178,15 @@ func (db *DB) ComputeReserveSize(startPO uint8) (uint64, error) {
 
 	return count, err
 }
+
+// SetReserveSize will update the localstore reserve size as calculated by the
+// depthmonitor using the updated storage depth
+func (db *DB) SetReserveSize(size uint64) error {
+	err := db.reserveSize.Put(size)
+	if err == nil {
+		if size > db.reserveCapacity {
+			db.triggerReserveEviction()
+		}
+	}
+	return err
+}

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -284,11 +284,6 @@ func TestDB_ReserveGC_Unreserve(t *testing.T) {
 
 	t.Run("reserve size", reserveSizeTest(db, uint64(chunkCount), 2))
 
-	err := db.SetReserveSize(uint64(chunkCount))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var evicted uint64
 	for {
 		select {
@@ -316,11 +311,6 @@ func TestDB_ReserveGC_Unreserve(t *testing.T) {
 	}
 
 	t.Run("reserve size", reserveSizeTest(db, 180, 2))
-
-	err = db.SetReserveSize(uint64(180))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	evicted = 0
 	for {
@@ -472,11 +462,6 @@ func TestDB_ReserveGC_EvictMaxPO(t *testing.T) {
 
 	t.Run("reserve size", reserveSizeTest(db, 100, 2))
 
-	err := db.SetReserveSize(uint64(100))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var evicted uint64
 	for {
 		select {
@@ -512,11 +497,6 @@ func TestDB_ReserveGC_EvictMaxPO(t *testing.T) {
 	}
 
 	t.Run("reserve size", reserveSizeTest(db, 180, 2))
-
-	err = db.SetReserveSize(uint64(180))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	evicted = 0
 	for {
@@ -653,11 +633,9 @@ func TestReserveSize(t *testing.T) {
 				Capacity:        100,
 				ReserveCapacity: 100,
 			})
-			chs []swarm.Chunk
 		)
 		for i := 0; i < chunkCount; i++ {
 			ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
-			chs = append(chs, ch)
 			_, err := db.Put(context.Background(), storage.ModePutRequest, ch)
 			if err != nil {
 				t.Fatal(err)
@@ -764,12 +742,7 @@ func TestDB_ReserveGC_BatchedUnreserve(t *testing.T) {
 		}
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, 0, 100))
-
-	err := db.SetReserveSize(100)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("reserve size", reserveSizeTest(db, 100, 0))
 
 	select {
 	case <-testHookEvictChan:

--- a/pkg/localstore/sampler_test.go
+++ b/pkg/localstore/sampler_test.go
@@ -43,7 +43,7 @@ func TestReserveSampler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, chunkCountPerPO*maxPO))
+	t.Run("reserve size", reserveSizeTest(db, chunkCountPerPO*maxPO, 0))
 
 	var sample1 storage.Sample
 
@@ -80,7 +80,7 @@ func TestReserveSampler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("reserve size", reserveSizeTest(db, 2*chunkCountPerPO*maxPO))
+	t.Run("reserve size", reserveSizeTest(db, 2*chunkCountPerPO*maxPO, 0))
 
 	// Now we generate another sample with the older timestamp. This should give us
 	// the exact same sample, ensuring that none of the later chunks were considered.

--- a/pkg/localstore/subscription_pull_test.go
+++ b/pkg/localstore/subscription_pull_test.go
@@ -192,7 +192,7 @@ func TestDB_SubscribePull_since(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -270,7 +270,7 @@ func TestDB_SubscribePull_until(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -348,7 +348,7 @@ func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -439,7 +439,7 @@ func TestDB_SubscribePull_rangeOnRemovedChunks(t *testing.T) {
 	for i := 0; i < chunkCount; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -529,7 +529,7 @@ func uploadRandomChunksBin(t *testing.T, db *DB, addrs map[uint8][]swarm.Address
 	for i := 0; i < count; i++ {
 		ch := generateTestRandomChunk()
 
-		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -627,7 +627,7 @@ func TestDB_LastPullSubscriptionBinID(t *testing.T) {
 		for i := 0; i < count; i++ {
 			ch := generateTestRandomChunk()
 
-			_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
+			_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -658,9 +658,6 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 		WriteBufferSize:        o.DBWriteBufferSize,
 		DisableSeeksCompaction: o.DBDisableSeeksCompaction,
 		ValidStamp:             validStamp,
-		RadiusFunc: func() uint8 {
-			return batchStore.GetReserveState().StorageRadius
-		},
 	}
 
 	storer, err := localstore.New(path, swarmAddress.Bytes(), stateStore, lo, logger)

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -302,7 +302,7 @@ func TestIntervalChunks_Localstore(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			_, err := db.Put(ctx, storage.ModePutUpload, chunks...)
+			_, err := db.Put(ctx, storage.ModePutSync, chunks...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -239,10 +239,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		defer cancel()
 
 		if err := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				return topmost, fmt.Errorf("delivery put: %w", err)
-			}
-			s.logger.Debug("delivery put", "error", err)
+			return topmost, fmt.Errorf("delivery put: %w", err)
 		}
 	}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
During the recent storage incentives changes, we found that the reserve size calculation in the localstore was off. A bunch of efforts has already been made to understand and fix this, but due to the dynamic nature of storage depth, it seems like it is not possible to have a static count of reserve size stored in the localstore, which can represent the current reserve size.

The reserve size is now synonymous with the pullIndex as this is the index we use to generate the sample. This index will now be used to represent the reserve chunks in the localstore. So if chunks are put into GC index, which represents the cache, we should remove them from pullIndex as they are no longer part of the reserve. This change will make the addition of pullIndex more strict and only allow syncing related contexts to add the pullIndex.

As the reserve size calculation is now completely removed, there are a lot of simplifications in the mode_put file.

Reserve evictions will now be triggered if we are above reserve capacity as computed with the depth seen by the depthmonitor. This is periodic and will only happen if we are above capacity. Localstore will only trigger GC evictions from now.

All the unit tests are adjusted to now verify the new expected values in the indexes.

A bug related to postageIndex collisions is also fixed. During GC, we were not deleting the postageIndexIndex entry, which led to us searching for a chunk that is not present in the localstore. #3039 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3579)
<!-- Reviewable:end -->
