### PR TITLE
fix: ignore overwrite errors for syncing

### DIFF
--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -613,7 +613,10 @@ func TestModePut_SameStamp(t *testing.T) {
 						t.Fatal(err)
 					}
 					_, err = db.Put(ctx, modeTc2, tc.discardChunk)
-					if !errors.Is(err, ErrOverwrite) {
+					if modeTc2 != storage.ModePutSync && !errors.Is(err, ErrOverwrite) {
+						t.Fatal(err)
+					}
+					if modeTc2 == storage.ModePutSync && err != nil {
 						t.Fatal(err)
 					}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Ignore Batch overwrite error for syncing context. This was changed as old behaviour was to silently return without returning error. However we should only allow this for syncing. If for upload user tries this, we should still catch this error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3589)
<!-- Reviewable:end -->
