### PR TITLE
fix: nuke statestore to remove sync intervals

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -383,7 +383,7 @@ func (p *Puller) getOrCreateInterval(peer swarm.Address, bin uint8) (*intervalst
 }
 
 func peerIntervalKey(peer swarm.Address, bin uint8) string {
-	k := fmt.Sprintf("%s|%d", peer.String(), bin)
+	k := fmt.Sprintf("sync|%s|%d", peer.ByteString(), bin)
 	return k
 }
 

--- a/pkg/statestore/leveldb/migration.go
+++ b/pkg/statestore/leveldb/migration.go
@@ -45,10 +45,11 @@ const (
 	dBSchemaBatchStoreV2    = "batchstoreV2"
 	dBSchemaBatchStoreV3    = "batchstoreV3"
 	dBSchemaBatchStoreV4    = "batchstoreV4"
+	dBSchemaInterval        = "interval"
 )
 
 var (
-	dbSchemaCurrent = dBSchemaBatchStoreV4
+	dbSchemaCurrent = dBSchemaInterval
 )
 
 type migration struct {
@@ -70,6 +71,11 @@ var schemaMigrations = []migration{
 	{name: dBSchemaBatchStoreV2, fn: migrateBatchstoreV2},
 	{name: dBSchemaBatchStoreV3, fn: migrateBatchstore},
 	{name: dBSchemaBatchStoreV4, fn: migrateBatchstore},
+	{name: dBSchemaInterval, fn: nuke},
+}
+
+func nuke(s *Store) error {
+	return s.Nuke(false)
 }
 
 func migrateFB(s *Store) error {
@@ -332,14 +338,14 @@ func deleteKeys(s *Store, keys []string) error {
 
 // Nuke the store so that only the bare essential entries are
 // left. Careful!
-func (s *Store) Nuke(forgetStamps bool) error {
+func (s *Store) Nuke(removeStamps bool) error {
 	var (
 		keys               []string
 		prefixesToPreserve = []string{"accounting", "pseudosettle", "swap", "non-mineable-overlay", "overlayV2_nonce"}
 		err                error
 	)
 
-	if !forgetStamps {
+	if !removeStamps {
 		prefixesToPreserve = append(prefixesToPreserve, "postage")
 	}
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
At the moment testnet is "broken", storage radiuses and reserve content are not consistent.
As a result, the nodes need to resync chunks, which is possible by resetting all sync intervals.

This is a good exercise, because we will need to reset the sync intervals on the mainnet as well .

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3590)
<!-- Reviewable:end -->
