### PR TITLE
fix: simplify gc size calculation

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -306,6 +306,7 @@ func (db *DB) reserveEvictionWorker() {
 			if err != nil {
 				db.logger.Error(err, "evict reserve failed")
 			}
+			db.metrics.EvictReserveCollectedCounter.Add(float64(evictedCount))
 
 			if !done {
 				db.triggerReserveEviction()

--- a/pkg/localstore/metrics.go
+++ b/pkg/localstore/metrics.go
@@ -61,10 +61,11 @@ type metrics struct {
 	GCStoreTimeStamps       prometheus.Gauge
 	GCStoreAccessTimeStamps prometheus.Gauge
 
-	ReserveSize              prometheus.Gauge
-	EvictReserveCounter      prometheus.Counter
-	EvictReserveErrorCounter prometheus.Counter
-	TotalTimeEvictReserve    prometheus.Counter
+	ReserveSize                  prometheus.Gauge
+	EvictReserveCounter          prometheus.Counter
+	EvictReserveErrorCounter     prometheus.Counter
+	EvictReserveCollectedCounter prometheus.Counter
+	TotalTimeEvictReserve        prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -372,6 +373,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "evict_reserve_err_count",
 			Help:      "number of times evict reserve got an error",
+		}),
+		EvictReserveCollectedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "evict_reserve_collected_count",
+			Help:      "number of chunks that have been evicted from reserve",
 		}),
 		TotalTimeEvictReserve: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This is a minor change to use the gcSizeChange as the number for eviction count and not use the separate reserveSize calculation which was recently removed.

Also, added a new metric to show the eviction count.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3591)
<!-- Reviewable:end -->
