### PR TITLE
fix: reset sync interval for the new lower bin

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -126,7 +126,10 @@ func (p *Puller) manage(ctx context.Context, warmupTime time.Duration) {
 
 			// if the radius decreases, we must fully resync the bin
 			if syncRadius < prevRadius {
-				p.resetInterval(syncRadius)
+				err := p.resetInterval(syncRadius)
+				if err != nil {
+					p.logger.Error(err, "reset lower sync radius")
+				}
 			}
 			prevRadius = syncRadius
 

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -366,11 +366,11 @@ func TestBinReset(t *testing.T) {
 	kad.Trigger()
 	time.Sleep(100 * time.Millisecond)
 
-	if err := s.Get(fmt.Sprintf("sync|1|%s", addr.ByteString()), nil); err == storage.ErrNotFound {
+	if err := s.Get(fmt.Sprintf("sync|1|%s", addr.ByteString()), nil); errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("got error %v, want %v", err, storage.ErrNotFound)
 	}
 
-	if err := s.Get(fmt.Sprintf("sync|0|%s", addr.ByteString()), nil); err != storage.ErrNotFound {
+	if err := s.Get(fmt.Sprintf("sync|0|%s", addr.ByteString()), nil); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("got error %v, want %v", err, storage.ErrNotFound)
 	}
 }


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
When the storage radius decreases, to completely resync the bin, the bin sync interval must be reset.
  
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3600)
<!-- Reviewable:end -->
