### PR TITLE
feat: dbIndices on debug API

### DIFF
--- a/pkg/api/dbindices.go
+++ b/pkg/api/dbindices.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+)
+
+type StorageIndexDebugger interface {
+	DebugIndices() (map[string]int, error)
+}
+
+func (s *Service) dbIndicesHandler(w http.ResponseWriter, _ *http.Request) {
+	logger := s.logger.WithName("db_indices").Build()
+
+	indexDebugger, ok := s.storer.(StorageIndexDebugger)
+	if !ok {
+		jsonhttp.NotImplemented(w, "storage indices not available")
+		logger.Error(nil, "db indices not implemented")
+		return
+	}
+
+	indices, err := indexDebugger.DebugIndices()
+	if err != nil {
+		jsonhttp.InternalServerError(w, "cannot get storage indices")
+		logger.Debug("db indices failed", "error", err)
+		logger.Error(nil, "db indices failed")
+		return
+	}
+
+	jsonhttp.OK(w, indices)
+}

--- a/pkg/api/dbindices.go
+++ b/pkg/api/dbindices.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package api
 
 import (

--- a/pkg/api/dbindices_test.go
+++ b/pkg/api/dbindices_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package api_test
 
 import (

--- a/pkg/api/dbindices_test.go
+++ b/pkg/api/dbindices_test.go
@@ -1,0 +1,84 @@
+package api_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/jsonhttp"
+	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/mock"
+)
+
+type testStorer struct {
+	storage.Storer
+	indicesFunc func() (map[string]int, error)
+}
+
+func (t *testStorer) DebugIndices() (map[string]int, error) {
+	return t.indicesFunc()
+}
+
+func TestDBIndices(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		expectedIndices := map[string]int{
+			"a": 1,
+			"b": 100,
+			"c": 10000,
+		}
+		testServer, _, _, _ := newTestServer(t, testServerOptions{
+			DebugAPI: true,
+			Storer: &testStorer{
+				Storer:      mock.NewStorer(),
+				indicesFunc: func() (map[string]int, error) { return expectedIndices, nil },
+			},
+		})
+
+		// We expect a list of items unordered by peer:
+		var got map[string]int
+		jsonhttptest.Request(t, testServer, http.MethodGet, "/dbindices", http.StatusOK,
+			jsonhttptest.WithUnmarshalJSONResponse(&got),
+		)
+
+		for k, v := range expectedIndices {
+			if got[k] != v {
+				t.Fatalf("expected index value %s, expected %d found %d", k, v, got[k])
+			}
+		}
+	})
+	t.Run("internal error returned", func(t *testing.T) {
+		t.Parallel()
+		testServer, _, _, _ := newTestServer(t, testServerOptions{
+			DebugAPI: true,
+			Storer: &testStorer{
+				Storer:      mock.NewStorer(),
+				indicesFunc: func() (map[string]int, error) { return nil, errors.New("dummy error") },
+			},
+		})
+
+		jsonhttptest.Request(t, testServer, http.MethodGet, "/dbindices", http.StatusInternalServerError,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "cannot get storage indices",
+				Code:    http.StatusInternalServerError,
+			}),
+		)
+	})
+	t.Run("not implemented error returned", func(t *testing.T) {
+		t.Parallel()
+		testServer, _, _, _ := newTestServer(t, testServerOptions{
+			DebugAPI: true,
+			Storer:   mock.NewStorer(),
+		})
+
+		jsonhttptest.Request(t, testServer, http.MethodGet, "/dbindices", http.StatusNotImplemented,
+			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
+				Message: "storage indices not available",
+				Code:    http.StatusNotImplemented,
+			}),
+		)
+	})
+}

--- a/pkg/api/dbindices_test.go
+++ b/pkg/api/dbindices_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -19,6 +20,8 @@ type testStorer struct {
 	storage.Storer
 	indicesFunc func() (map[string]int, error)
 }
+
+var _ api.StorageIndexDebugger = (*testStorer)(nil)
 
 func (t *testStorer) DebugIndices() (map[string]int, error) {
 	return t.indicesFunc()

--- a/pkg/api/dbindices_test.go
+++ b/pkg/api/dbindices_test.go
@@ -38,7 +38,7 @@ func TestDBIndices(t *testing.T) {
 			},
 		})
 
-		// We expect a list of items unordered by peer:
+		// We expect a list of items unordered
 		var got map[string]int
 		jsonhttptest.Request(t, testServer, http.MethodGet, "/dbindices", http.StatusOK,
 			jsonhttptest.WithUnmarshalJSONResponse(&got),

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -145,6 +145,13 @@ func (s *Service) mountTechnicalDebug() {
 		httpaccess.NewHTTPAccessSuppressLogHandler(),
 		web.FinalHandlerFunc(s.healthHandler),
 	))
+
+	s.router.Handle("/dbindices", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			httpaccess.NewHTTPAccessSuppressLogHandler(),
+			web.FinalHandlerFunc(s.dbIndicesHandler),
+		),
+	})
 }
 
 func (s *Service) mountAPI() {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This change adds a new API endpoint to print out the DebugIndices output of localstore. This gives us the count of items in the different indexes. This API should be used with care as it takes sometime and will count all the items in the localstore. Should be strictly used for debugging.

As such, I am not sure if we should add openapi spec for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3612)
<!-- Reviewable:end -->
