### PR TITLE
fix: dbindices API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -136,6 +136,7 @@ type Service struct {
 	probe           *Probe
 	metricsRegistry *prometheus.Registry
 	stakingContract staking.Contract
+	indexDebugger   StorageIndexDebugger
 	Options
 
 	http.Handler
@@ -221,6 +222,7 @@ type ExtraOptions struct {
 	Staking          staking.Contract
 	Steward          steward.Interface
 	SyncStatus       func() (bool, error)
+	IndexDebugger    StorageIndexDebugger
 }
 
 func New(publicKey, pssPublicKey ecdsa.PublicKey, ethereumAddress common.Address, logger log.Logger, transaction transaction.Service, batchStore postage.Storer, beeMode BeeNodeMode, chequebookEnabled bool, swapEnabled bool, chainBackend transaction.Backend, cors []string) *Service {
@@ -283,6 +285,7 @@ func (s *Service) Configure(signer crypto.Signer, auth auth.Authenticator, trace
 	s.postageContract = e.PostageContract
 	s.steward = e.Steward
 	s.stakingContract = e.Staking
+	s.indexDebugger = e.IndexDebugger
 
 	s.pingpong = e.Pingpong
 	s.topologyDriver = e.TopologyDriver

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -103,6 +103,7 @@ type testServerOptions struct {
 	Restricted         bool
 	DirectUpload       bool
 	Probe              *api.Probe
+	IndexDebugger      api.StorageIndexDebugger
 
 	Overlay         swarm.Address
 	PublicKey       ecdsa.PublicKey
@@ -192,6 +193,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		Steward:          o.Steward,
 		SyncStatus:       o.SyncStatus,
 		Staking:          o.StakingContract,
+		IndexDebugger:    o.IndexDebugger,
 	}
 	// by default bee mode is set to full mode
 	if o.beeMode == api.LightMode {

--- a/pkg/api/dbindices.go
+++ b/pkg/api/dbindices.go
@@ -17,14 +17,13 @@ type StorageIndexDebugger interface {
 func (s *Service) dbIndicesHandler(w http.ResponseWriter, _ *http.Request) {
 	logger := s.logger.WithName("db_indices").Build()
 
-	indexDebugger, ok := s.storer.(StorageIndexDebugger)
-	if !ok {
+	if s.indexDebugger == nil {
 		jsonhttp.NotImplemented(w, "storage indices not available")
 		logger.Error(nil, "db indices not implemented")
 		return
 	}
 
-	indices, err := indexDebugger.DebugIndices()
+	indices, err := s.indexDebugger.DebugIndices()
 	if err != nil {
 		jsonhttp.InternalServerError(w, "cannot get storage indices")
 		logger.Debug("db indices failed", "error", err)

--- a/pkg/api/dbindices_test.go
+++ b/pkg/api/dbindices_test.go
@@ -12,18 +12,15 @@ import (
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
 	"github.com/ethersphere/bee/pkg/jsonhttp/jsonhttptest"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
 )
 
-type testStorer struct {
-	storage.Storer
+type testIndexDebugger struct {
 	indicesFunc func() (map[string]int, error)
 }
 
-var _ api.StorageIndexDebugger = (*testStorer)(nil)
+var _ api.StorageIndexDebugger = (*testIndexDebugger)(nil)
 
-func (t *testStorer) DebugIndices() (map[string]int, error) {
+func (t *testIndexDebugger) DebugIndices() (map[string]int, error) {
 	return t.indicesFunc()
 }
 
@@ -39,8 +36,7 @@ func TestDBIndices(t *testing.T) {
 		}
 		testServer, _, _, _ := newTestServer(t, testServerOptions{
 			DebugAPI: true,
-			Storer: &testStorer{
-				Storer:      mock.NewStorer(),
+			IndexDebugger: &testIndexDebugger{
 				indicesFunc: func() (map[string]int, error) { return expectedIndices, nil },
 			},
 		})
@@ -61,8 +57,7 @@ func TestDBIndices(t *testing.T) {
 		t.Parallel()
 		testServer, _, _, _ := newTestServer(t, testServerOptions{
 			DebugAPI: true,
-			Storer: &testStorer{
-				Storer:      mock.NewStorer(),
+			IndexDebugger: &testIndexDebugger{
 				indicesFunc: func() (map[string]int, error) { return nil, errors.New("dummy error") },
 			},
 		})
@@ -78,7 +73,6 @@ func TestDBIndices(t *testing.T) {
 		t.Parallel()
 		testServer, _, _, _ := newTestServer(t, testServerOptions{
 			DebugAPI: true,
-			Storer:   mock.NewStorer(),
 		})
 
 		jsonhttptest.Request(t, testServer, http.MethodGet, "/dbindices", http.StatusNotImplemented,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1043,6 +1043,7 @@ func NewBee(interrupt chan struct{}, sysInterrupt chan os.Signal, addr string, p
 		Staking:          stakingContract,
 		Steward:          steward,
 		SyncStatus:       syncStatusFn,
+		IndexDebugger:    storer,
 	}
 
 	if o.APIAddr != "" {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
The DB Indices API is not working on the node as the API uses a wrapped netstore as Storer.

We will need to explicitly provide the interface from localstore. This time it is tested on a running node.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3622)
<!-- Reviewable:end -->
