### PR TITLE
fix: prevent reserve put for out of depth chunks

### DIFF
--- a/pkg/localstore/mode_put.go
+++ b/pkg/localstore/mode_put.go
@@ -451,6 +451,12 @@ func (db *DB) putSync(
 		}
 	}
 
+	// if we try to add a new item at a lesser radius than the last known eviction
+	// radius of the batch, we should not add the chunk to reserve, but to cache
+	if !withinRadius(db, item) {
+		return db.addToCache(batch, item)
+	}
+
 	found, err := db.pullIndex.Has(item)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
In ModePutSync, if we get a chunk with radius lesser than the last known eviction radius of the batch, we force it to cache and not add it to reserve.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3627)
<!-- Reviewable:end -->
