### PR TITLE
fix: deadlock in localstore batchstore interaction

### DIFF
--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -88,6 +88,12 @@ const (
 	// lockKeySampling is used to synchronize the sampler stopping process if evictions
 	// start during sampling.
 	lockKeySampling string = "sampling"
+	// lockKeyReserveEviction is used to allow only 1 reserve eviction process to run
+	// at a time. This is required as the batch expirations need the GC lock to evict
+	// chunks and if the reserveEvictionWorker is running during this time, it could
+	// be holding the GC lock while waiting on the batchstore lock held by batch
+	// expiration (evictFn).
+	lockKeyReserveEviction string = "reserve-eviction"
 )
 
 // DB is the local store implementation and holds

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -646,8 +646,6 @@ func TestReserveSize(t *testing.T) {
 }
 
 func TestComputeReserveSize(t *testing.T) {
-	t.Parallel()
-
 	const chunkCountPerPO = 10
 	const maxPO = 10
 	var chs []swarm.Chunk


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The current implementation of localstore and batchstore is a little problematic. We assign the localstore.EvictBatch function to batchstore to perform evictions due to batch expirations and batchstore.Unreserve to localstore to free reserve when we go over capacity.

This causes a deadlock situation as reserveEvictionWorker could acquire the GC lock and then wait for batchstore lock which is held by the cleanup function of batchstore which calls evictFn (localstore.EvictBatch), which waits on the GC lock. Solution is to allow only 1 reserve eviction process to start at a time. This is done by adding a new lock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3641)
<!-- Reviewable:end -->
