### PR TITLE
fix: flaky sampler test

### DIFF
--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -542,6 +542,13 @@ func setWithinRadiusFunc(h func(*DB, shed.Item) bool) (reset func()) {
 	return reset
 }
 
+func setValidChunkFunc(h func(swarm.Chunk) bool) (reset func()) {
+	current := validChunkFn
+	reset = func() { validChunkFn = current }
+	validChunkFn = h
+	return reset
+}
+
 // TestSetTestHookCollectGarbage tests if setTestHookCollectGarbage changes
 // testHookCollectGarbage function correctly and if its reset function
 // resets the original function.

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -319,6 +319,10 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 		withinRadiusFn = withinRadius
 	}
 
+	if validChunkFn == nil {
+		validChunkFn = validChunk
+	}
+
 	db.shed, err = shed.NewDB(path, shedOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -258,10 +258,9 @@ func newTestDB(tb testing.TB, o *Options) *DB {
 }
 
 var (
-	generateTestRandomChunk    = chunktesting.GenerateTestRandomChunk
-	generateTestRandomChunks   = chunktesting.GenerateTestRandomChunks
-	generateTestRandomChunkAt  = chunktesting.GenerateTestRandomChunkAt
-	generateValidRandomChunkAt = chunktesting.GenerateValidRandomChunkAt
+	generateTestRandomChunk   = chunktesting.GenerateTestRandomChunk
+	generateTestRandomChunks  = chunktesting.GenerateTestRandomChunks
+	generateTestRandomChunkAt = chunktesting.GenerateTestRandomChunkAt
 )
 
 // chunkAddresses return chunk addresses of provided chunks.

--- a/pkg/localstore/sampler.go
+++ b/pkg/localstore/sampler.go
@@ -222,7 +222,7 @@ func (db *DB) ReserveSample(
 			}
 			_, err = db.validStamp(chunk, stampData)
 			if err == nil {
-				if !cac.Valid(chunk) && !soc.Valid(chunk) {
+				if !validChunkFn(chunk) {
 					logger.Debug("data invalid for chunk address", "chunk_address", chunk.Address())
 				} else {
 					insert(item.transformedAddress)
@@ -294,4 +294,13 @@ func (db *DB) resetSamplingState() {
 
 	db.samplerStop = nil
 	db.samplerSignal = nil
+}
+
+var validChunkFn func(swarm.Chunk) bool
+
+func validChunk(ch swarm.Chunk) bool {
+	if !cac.Valid(ch) && !soc.Valid(ch) {
+		return false
+	}
+	return true
 }

--- a/pkg/localstore/sampler_test.go
+++ b/pkg/localstore/sampler_test.go
@@ -26,6 +26,8 @@ func TestReserveSampler(t *testing.T) {
 	const maxPO = 10
 	var chs []swarm.Chunk
 
+	t.Cleanup(setValidChunkFunc(func(swarm.Chunk) bool { return true }))
+
 	db := newTestDB(t, &Options{
 		Capacity:        1000,
 		ReserveCapacity: 1000,
@@ -35,7 +37,7 @@ func TestReserveSampler(t *testing.T) {
 
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateValidRandomChunkAt(swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
+			ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
 			// override stamp timestamp to be before the consensus timestamp
 			ch = ch.WithStamp(postagetesting.MustNewStampWithTimestamp(timeVar - 1))
 			chs = append(chs, ch)
@@ -166,7 +168,7 @@ func TestReserveSamplerStop(t *testing.T) {
 
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateValidRandomChunkAt(swarm.NewAddress(db.baseKey), po).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(swarm.NewAddress(db.baseKey), po).WithBatch(2, 3, 2, false)
 			mtx.Lock()
 			chs = append(chs, ch)
 			batchIDs = append(batchIDs, ch.Stamp().BatchID())


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In the sampler test we use the valid chunk checks, so we created a new testing function which mines the chunks to generate valid chunks. This however leads to timeouts in the race tests.

Instead, we will configure a testing validChunk function to skip this for the tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3642)
<!-- Reviewable:end -->
