### PR TITLE
fix: recalc puller peers more periodically

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -29,7 +29,10 @@ const loggerName = "puller"
 
 var errCursorsLength = errors.New("cursors length mismatch")
 
-const DefaultSyncErrorSleepDur = time.Second * 30
+const (
+	DefaultSyncErrorSleepDur = time.Second * 30
+	recalcPeersDur           = time.Minute * 5
+)
 
 type Options struct {
 	Bins         uint8
@@ -143,7 +146,7 @@ func (p *Puller) manage(ctx context.Context, warmupTime time.Duration) {
 		p.syncPeersMtx.Unlock()
 	}
 
-	tick := time.NewTicker(5 * time.Minute)
+	tick := time.NewTicker(recalcPeersDur)
 	defer tick.Stop()
 
 	for {
@@ -153,6 +156,7 @@ func (p *Puller) manage(ctx context.Context, warmupTime time.Duration) {
 		case <-tick.C:
 			onChange()
 		case <-c:
+			tick.Reset(recalcPeersDur)
 			onChange()
 		}
 	}

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -101,51 +101,59 @@ func (p *Puller) manage(ctx context.Context, warmupTime time.Duration) {
 
 	var prevRadius uint8
 
+	onChange := func() {
+		p.syncPeersMtx.Lock()
+
+		// peersDisconnected is used to mark and prune peers that are no longer connected.
+		peersDisconnected := make(map[string]*syncPeer)
+		for _, peer := range p.syncPeers {
+			peersDisconnected[peer.address.ByteString()] = peer
+		}
+
+		neighborhoodDepth := p.topology.NeighborhoodDepth()
+		syncRadius := p.reserveState.GetReserveState().StorageRadius
+
+		// if the radius decreases, we must fully resync the bin
+		if syncRadius < prevRadius {
+			err := p.resetInterval(syncRadius)
+			if err != nil {
+				p.logger.Error(err, "reset lower sync radius")
+			}
+		}
+		prevRadius = syncRadius
+
+		_ = p.topology.EachPeerRev(func(addr swarm.Address, po uint8) (stop, jumpToNext bool, err error) {
+			if po >= neighborhoodDepth {
+				// add peer to sync
+				if _, ok := p.syncPeers[addr.ByteString()]; !ok {
+					p.syncPeers[addr.ByteString()] = newSyncPeer(addr, p.bins)
+				}
+				// remove from disconnected list as the peer is still connected
+				delete(peersDisconnected, addr.ByteString())
+			}
+			return false, false, nil
+		}, topology.Filter{Reachable: true})
+
+		for _, peer := range peersDisconnected {
+			p.disconnectPeer(peer.address)
+		}
+
+		p.recalcPeers(ctx, syncRadius)
+
+		p.syncPeersMtx.Unlock()
+	}
+
+	tick := time.NewTicker(5 * time.Minute)
+	defer tick.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-tick.C:
+			onChange()
 		case <-c:
-
-			p.syncPeersMtx.Lock()
-
-			// peersDisconnected is used to mark and prune peers that are no longer connected.
-			peersDisconnected := make(map[string]*syncPeer)
-			for _, peer := range p.syncPeers {
-				peersDisconnected[peer.address.ByteString()] = peer
-			}
-
-			neighborhoodDepth := p.topology.NeighborhoodDepth()
-			syncRadius := p.reserveState.GetReserveState().StorageRadius
-
-			// if the radius decreases, we must fully resync the bin
-			if syncRadius < prevRadius {
-				err := p.resetInterval(syncRadius)
-				if err != nil {
-					p.logger.Error(err, "reset lower sync radius")
-				}
-			}
-			prevRadius = syncRadius
-
-			_ = p.topology.EachPeerRev(func(addr swarm.Address, po uint8) (stop, jumpToNext bool, err error) {
-				if po >= neighborhoodDepth {
-					// add peer to sync
-					if _, ok := p.syncPeers[addr.ByteString()]; !ok {
-						p.syncPeers[addr.ByteString()] = newSyncPeer(addr, p.bins)
-					}
-					// remove from disconnected list as the peer is still connected
-					delete(peersDisconnected, addr.ByteString())
-				}
-				return false, false, nil
-			}, topology.Filter{Reachable: true})
-
-			for _, peer := range peersDisconnected {
-				p.disconnectPeer(peer.address)
-			}
-
-			p.recalcPeers(ctx, syncRadius)
-
-			p.syncPeersMtx.Unlock()
+			onChange()
 		}
 	}
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
It was observed on the private testnet that no pullsyncing was occurring because the topology change subscription never fired as there were no changes in the topology after the warm up period.


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3643)
<!-- Reviewable:end -->
