### PR TITLE
fix: batchstore localstore deadlock

### DIFF
--- a/pkg/localstore/gc.go
+++ b/pkg/localstore/gc.go
@@ -307,7 +307,7 @@ func (db *DB) reserveEvictionWorker() {
 			db.expiredBatches = nil
 			db.lock.Unlock(lockKeyBatchExpiry)
 
-			if expiredBatches != nil && len(expiredBatches) > 0 {
+			if len(expiredBatches) > 0 {
 				for _, batch := range expiredBatches {
 					err := db.evictBatch(batch)
 					if err != nil {

--- a/pkg/localstore/reserve.go
+++ b/pkg/localstore/reserve.go
@@ -18,15 +18,19 @@ import (
 // EvictBatch will evict all chunks associated with the batch from the reserve. This
 // is used by batch store for expirations.
 func (db *DB) EvictBatch(id []byte) error {
+	db.lock.Lock(lockKeyBatchExpiry)
+	defer db.lock.Unlock(lockKeyBatchExpiry)
+
+	db.expiredBatches = append(db.expiredBatches, id)
+	db.triggerReserveEviction()
+	return nil
+}
+
+func (db *DB) evictBatch(id []byte) error {
 	db.metrics.BatchEvictCounter.Inc()
 	defer func(start time.Time) {
 		totalTimeMetric(db.metrics.TotalTimeBatchEvict, start)
 	}(time.Now())
-
-	// Only one reserve eviction process should happen at a time to prevent lock
-	// contention between batchstore and localstore functions.
-	db.lock.Lock(lockKeyReserveEviction)
-	defer db.lock.Unlock(lockKeyReserveEviction)
 
 	// EvictBatch will affect the reserve as well as GC indexes
 	db.lock.Lock(lockKeyGC)

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -821,7 +821,7 @@ func TestDB_ReserveGC_EvictBatch(t *testing.T) {
 	}
 
 	select {
-	case <-testHookCollectGarbageChan:
+	case <-testHookEvictChan:
 	case <-time.After(10 * time.Second):
 		t.Fatal("reserve eviction timeout")
 	}
@@ -832,7 +832,7 @@ func TestDB_ReserveGC_EvictBatch(t *testing.T) {
 
 	for {
 		select {
-		case <-testHookEvictChan:
+		case <-testHookCollectGarbageChan:
 		case <-time.After(10 * time.Second):
 			t.Fatal("gc timeout")
 		}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The previous fix for synchronizing the eviction processes was not the right fix for the goroutine pileup seen on the testnet. The problem happens because of the batchstore.Mutex contention as PutChainState in batchstore can call EvictBatch under the batchstore.Lock which will be waiting for GC lock held by reserveEvictionWorker that could be running simultaneously waiting for the batchstore.Mutex through Unreserve.

Solution is to not have any locking when we call evictFn from batchstore. So now we will register the expiredBatches in localstore when called from the batchstore and trigger the reserveEviction worker. This will enable only 1 flow of eviction and hence prevent any locking problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3644)
<!-- Reviewable:end -->
