### PR TITLE
fix: set batch storage radius on global storage radius change

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -249,8 +249,6 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 
 // handler handles an incoming request to sync an interval
 func (s *Syncer) handler(streamCtx context.Context, p p2p.Peer, stream p2p.Stream) (err error) {
-	loggerV2 := s.logger.V(2).Register()
-
 	select {
 	case <-s.quit:
 		return nil
@@ -265,7 +263,6 @@ func (s *Syncer) handler(streamCtx context.Context, p p2p.Peer, stream p2p.Strea
 			_ = stream.FullClose()
 		}
 	}()
-	loggerV2.Debug("peer pulling", "peer_address", p.Address)
 
 	ctx, cancel := context.WithCancel(streamCtx)
 	defer cancel()


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
It could happen that we pushsync chunks of newer batches that are outside our radius of responsibility as we have not seen the batch before. So we consider the current radius of this batch is 0 in localstore and might end up storing chunks for it.

With this fix, we use the initial value of current storage radius for a batch while adding it to batchstore. This would disallow any chunks from lower bins to be replicated by pushsync in the reserve.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3651)
<!-- Reviewable:end -->
