### PR TITLE
fix: depthmonitor to track active syncing counter instead of rate

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -991,7 +991,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 	var agent *storageincentives.Agent
 	if o.FullNodeMode {
 
-		depthMonitor := depthmonitor.New(kad, pullSyncProtocol, storer, batchStore, logger, warmupTime, depthmonitor.DefaultWakeupInterval)
+		depthMonitor := depthmonitor.New(kad, pullerService, storer, batchStore, logger, warmupTime, depthmonitor.DefaultWakeupInterval)
 		b.depthMonitorCloser = depthMonitor
 
 		if !o.BootnodeMode && o.EnableStorageIncentives {

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -64,7 +64,7 @@ func TestOneSync(t *testing.T) {
 
 	waitSyncCalled(t, pullsync, addr, false)
 
-	checkHistSyncing(t, puller)
+	checkHistSyncingCount(t, puller, 0)
 }
 
 func TestNoSyncOutsideDepth(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNoSyncOutsideDepth(t *testing.T) {
 	waitSyncCalled(t, pullsync, addr, true)
 	waitSyncCalled(t, pullsync, addr2, true)
 
-	checkHistSyncing(t, puller)
+	checkHistSyncingCount(t, puller, 0)
 }
 
 func TestSyncFlow_PeerWithinDepth_Live(t *testing.T) {
@@ -161,7 +161,7 @@ func TestSyncFlow_PeerWithinDepth_Live(t *testing.T) {
 			// check the intervals
 			checkIntervals(t, st, addr, tc.intervals, 1)
 
-			checkHistSyncing(t, puller)
+			checkHistSyncingCount(t, puller, 0)
 		})
 	}
 }
@@ -245,7 +245,7 @@ func TestSyncFlow_PeerWithinDepth_Historical(t *testing.T) {
 			// check the intervals
 			checkIntervals(t, st, addr, tc.intervals, 1)
 
-			checkHistSyncing(t, puller)
+			checkHistSyncingCount(t, puller, 0)
 		})
 	}
 }
@@ -300,7 +300,7 @@ func TestSyncFlow_PeerWithinDepth_Live2(t *testing.T) {
 			// check the intervals
 			checkIntervals(t, st, addr, tc.intervals, 2)
 
-			checkHistSyncing(t, puller)
+			checkHistSyncingCount(t, puller, 0)
 		})
 	}
 }
@@ -338,7 +338,7 @@ func TestPeerDisconnected(t *testing.T) {
 	if puller.IsSyncing(p, addr) {
 		t.Fatalf("peer is syncing but shouldnt")
 	}
-	checkHistSyncing(t, p)
+	checkHistSyncingCount(t, p, 0)
 }
 
 func TestBinReset(t *testing.T) {
@@ -385,7 +385,7 @@ func TestBinReset(t *testing.T) {
 		t.Fatalf("got error %v, want %v", err, storage.ErrNotFound)
 	}
 
-	checkHistSyncing(t, puller)
+	checkHistSyncingCount(t, puller, 0)
 }
 
 // TestDepthChange tests that puller reacts correctly to
@@ -507,7 +507,7 @@ func TestDepthChange(t *testing.T) {
 				checkNotFound(t, st, addr, b)
 			}
 
-			checkHistSyncing(t, puller)
+			checkHistSyncingCount(t, puller, 0)
 		})
 	}
 }
@@ -598,11 +598,6 @@ func TestPeerGone(t *testing.T) {
 		t.Fatalf("peer is syncing but shouldnt")
 	}
 
-	checkHistSyncing(t, p)
-}
-
-func checkHistSyncing(t *testing.T, p *puller.Puller) {
-	t.Helper()
 	checkHistSyncingCount(t, p, 0)
 }
 

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -38,7 +38,7 @@ type ReserveReporter interface {
 // SyncReporter interface needs to be implemented by the syncing component of the node (pullsync).
 type SyncReporter interface {
 	// Rate of syncing in terms of chunks/sec.
-	Rate() float64
+	ActiveHistoricalSyncing() uint64
 }
 
 // Topology interface encapsulates the functionality required by the topology component
@@ -136,7 +136,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 		// save last calculated reserve size
 		s.lastRSize.Store(currentSize)
 
-		rate := s.syncer.Rate()
+		rate := s.syncer.ActiveHistoricalSyncing()
 		s.logger.Info("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "chunks/sec rate", rate)
 
 		if currentSize > targetSize {
@@ -160,7 +160,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 }
 
 func (s *Service) IsFullySynced() bool {
-	return s.syncer.Rate() == 0 && s.lastRSize.Load() > s.reserve.ReserveCapacity()*4/10
+	return s.syncer.ActiveHistoricalSyncing() == 0 && s.lastRSize.Load() > s.reserve.ReserveCapacity()*4/10
 }
 
 func (s *Service) Close() error {

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -35,9 +35,9 @@ type ReserveReporter interface {
 	ReserveCapacity() uint64
 }
 
-// SyncReporter interface needs to be implemented by the syncing component of the node (pullsync).
+// SyncReporter interface needs to be implemented by the syncing component of the node (puller).
 type SyncReporter interface {
-	// Rate of syncing in terms of chunks/sec.
+	// Number of active historical syncing jobs.
 	ActiveHistoricalSyncing() uint64
 }
 

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -136,15 +136,15 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 		// save last calculated reserve size
 		s.lastRSize.Store(currentSize)
 
-		rate := s.syncer.ActiveHistoricalSyncing()
-		s.logger.Info("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "chunks/sec rate", rate)
+		syncCount := s.syncer.ActiveHistoricalSyncing()
+		s.logger.Info("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "sync_count", syncCount)
 
 		if currentSize > targetSize {
 			continue
 		}
 
 		// if historical syncing rate is at zero, we proactively decrease the storage radius to allow nodes to widen their neighbourhoods
-		if rate == 0 && s.topology.PeersCount(topologyDriver.Filter{}) != 0 {
+		if syncCount == 0 && s.topology.PeersCount(topologyDriver.Filter{}) != 0 {
 			err = s.bs.SetStorageRadius(func(radius uint8) uint8 {
 				if radius > s.minimumRadius {
 					radius--

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -216,10 +216,10 @@ func (m *mockTopology) getStorageDepth() uint8 {
 }
 
 type mockSyncReporter struct {
-	rate float64
+	rate uint64
 }
 
-func (m *mockSyncReporter) Rate() float64 {
+func (m *mockSyncReporter) ActiveHistoricalSyncing() uint64 {
 	return m.rate
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In some cases where the node is using high CPU or disk IO, or pulling intervals with invalid chunks for some, it may appear that the pullsync rate is zero, although there are active historical sync jobs running in the background.


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3680)
<!-- Reviewable:end -->
