### PR TITLE
fix: reduce depthmonitor target size to 40 percent

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -116,7 +116,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 	case <-time.After(warmupTime):
 	}
 
-	halfCapacity := s.reserve.ReserveCapacity() / 2
+	targetSize := s.reserve.ReserveCapacity() * 4 / 10 // 40% of the capacity
 
 	for {
 		select {
@@ -139,8 +139,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 		rate := s.syncer.Rate()
 		s.logger.Info("depthmonitor: state", "current size", currentSize, "radius", reserveState.StorageRadius, "chunks/sec rate", rate)
 
-		// we have crossed 50% utilization
-		if currentSize > halfCapacity {
+		if currentSize > targetSize {
 			continue
 		}
 
@@ -161,7 +160,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration) {
 }
 
 func (s *Service) IsFullySynced() bool {
-	return s.syncer.Rate() == 0 && s.lastRSize.Load() > s.reserve.ReserveCapacity()/2
+	return s.syncer.Rate() == 0 && s.lastRSize.Load() > s.reserve.ReserveCapacity()*4/10
 }
 
 func (s *Service) Close() error {

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -98,8 +98,8 @@ func TestDepthMonitorService(t *testing.T) {
 		t.Parallel()
 
 		topo := &mockTopology{peers: 1}
-		// >50% utilized reserve
-		reserve := &mockReserveReporter{size: 26000, capacity: 50000}
+		// >40% utilized reserve
+		reserve := &mockReserveReporter{size: 20001, capacity: 50000}
 
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
 
@@ -140,8 +140,8 @@ func TestDepthMonitorService(t *testing.T) {
 	t.Run("depth doesnt change for utilized reserve", func(t *testing.T) {
 		t.Parallel()
 
-		// >50% utilized reserve
-		reserve := &mockReserveReporter{size: 25001, capacity: 50000}
+		// >40% utilized reserve
+		reserve := &mockReserveReporter{size: 20001, capacity: 50000}
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
 
 		svc := newTestSvc(nil, nil, reserve, nil, bs, 0, depthMonitorWakeUpInterval)
@@ -162,8 +162,8 @@ func TestDepthMonitorService(t *testing.T) {
 
 		topo := &mockTopology{connDepth: 3}
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
-		// >50% utilized reserve
-		reserve := &mockReserveReporter{size: 25001, capacity: 50000}
+		// >40% utilized reserve
+		reserve := &mockReserveReporter{size: 20001, capacity: 50000}
 
 		svc := newTestSvc(topo, nil, reserve, nil, bs, 0, depthMonitorWakeUpInterval)
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3682)
<!-- Reviewable:end -->
