### PR TITLE
refactor: upload store with tags

### DIFF
--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ethersphere/bee/pkg/localstorev2/internal/cache"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
-	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
-	inmem "github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/google/go-cmp/cmp"
@@ -136,27 +134,12 @@ func TestCacheEntryItem(t *testing.T) {
 }
 
 type testStorage struct {
-	store   storage.Store
-	chStore *chunkStore
-	putFn   func(storage.Item) error
+	internal.Storage
+	putFn func(storage.Item) error
 }
-
-type chunkStore struct {
-	storage.ChunkStore
-}
-
-func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ []byte) (swarm.Chunk, error) {
-	return c.Get(ctx, address)
-}
-
-func (testStorage) Ctx() context.Context { return context.TODO() }
 
 func (t *testStorage) Store() storage.Store {
-	return &wrappedStore{Store: t.store, putFn: t.putFn}
-}
-
-func (t *testStorage) ChunkStore() internal.ChunkStore {
-	return t.chStore
+	return &wrappedStore{Store: t.Storage.Store(), putFn: t.putFn}
 }
 
 type wrappedStore struct {
@@ -171,16 +154,27 @@ func (w *wrappedStore) Put(i storage.Item) error {
 	return w.Store.Put(i)
 }
 
+func newTestStorage(t *testing.T) *testStorage {
+	t.Helper()
+
+	storg, closer := internal.NewInmemStorage()
+	t.Cleanup(func() {
+		err := closer()
+		if err != nil {
+			t.Errorf("failed closing storage: %v", err)
+		}
+	})
+
+	return &testStorage{Storage: storg}
+}
+
 func TestCache(t *testing.T) {
 	t.Parallel()
 
 	t.Run("fresh new cache", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -191,10 +185,7 @@ func TestCache(t *testing.T) {
 	t.Run("putter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -255,10 +246,7 @@ func TestCache(t *testing.T) {
 	t.Run("getter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -342,10 +330,7 @@ func TestCache(t *testing.T) {
 	t.Run("handle error", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -365,7 +350,7 @@ func TestCache(t *testing.T) {
 			if i.Namespace() == "cacheState" {
 				return retErr
 			}
-			return st.store.Put(i)
+			return st.Storage.Store().Put(i)
 		}
 
 		// on error the cache expects the overarching transactions to clean itself up

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -149,10 +149,6 @@ func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ 
 	return c.Get(ctx, address)
 }
 
-func (c *chunkStore) DeleteWithStamp(ctx context.Context, address swarm.Address, _ []byte) error {
-	return c.Delete(ctx, address)
-}
-
 func (testStorage) Ctx() context.Context { return context.TODO() }
 
 func (t *testStorage) Store() storage.Store {

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -22,7 +22,6 @@ type Storage interface {
 type ChunkStore interface {
 	storage.ChunkStore
 	storage.GetterWithStamp
-	storage.DeleterWithStamp
 }
 
 // PutterCloserWithReference provides a Putter which can be closed with a root

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -9,7 +9,10 @@ import (
 	"context"
 
 	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/hashicorp/go-multierror"
 )
 
 // Storage groups the storage.Store and storage.ChunkStore interfaces with context..
@@ -33,6 +36,9 @@ type PutterCloserWithReference interface {
 
 var emptyAddr = make([]byte, swarm.HashSize)
 
+// AddressOrZero returns swarm.ZeroAddress if the buf is of zero bytes. The Zero byte
+// buffer is used by the items to serialize their contents and if valid swarm.ZeroAddress
+// entries are allowed.
 func AddressOrZero(buf []byte) swarm.Address {
 	if bytes.Equal(buf, emptyAddr) {
 		return swarm.ZeroAddress
@@ -40,9 +46,49 @@ func AddressOrZero(buf []byte) swarm.Address {
 	return swarm.NewAddress(append(make([]byte, 0, swarm.HashSize), buf...))
 }
 
+// AddressBytesOrZero is a helper which creates a zero buffer of swarm.HashSize. This
+// is required during storing the items in the Store as their serialization formats
+// are strict.
 func AddressBytesOrZero(addr swarm.Address) []byte {
 	if addr.IsZero() {
 		return make([]byte, swarm.HashSize)
 	}
 	return addr.Bytes()
 }
+
+// NewInmemStorage constructs a inmem Storage implementation which can be used
+// for the tests in the internal packages.
+func NewInmemStorage() (Storage, func() error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ts := &inmemRepository{
+		ctx:        ctx,
+		indexStore: inmemstore.New(),
+		chunkStore: &chunkStore{inmemchunkstore.New()},
+	}
+
+	return ts, func() error {
+		cancel()
+		return multierror.Append(ts.indexStore.Close(), ts.chunkStore.Close()).ErrorOrNil()
+	}
+}
+
+type inmemRepository struct {
+	ctx        context.Context
+	indexStore storage.Store
+	chunkStore *chunkStore
+}
+
+type chunkStore struct {
+	storage.ChunkStore
+}
+
+// Once the inmemchunkstore supports this, we can remove this.
+func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ []byte) (swarm.Chunk, error) {
+	return c.Get(ctx, address)
+}
+
+func (t *inmemRepository) Ctx() context.Context   { return t.ctx }
+func (t *inmemRepository) Store() storage.Store   { return t.indexStore }
+func (t *inmemRepository) ChunkStore() ChunkStore { return t.chunkStore }

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -16,7 +16,13 @@ import (
 type Storage interface {
 	Ctx() context.Context
 	Store() storage.Store
-	ChunkStore() storage.ChunkStore
+	ChunkStore() ChunkStore
+}
+
+type ChunkStore interface {
+	storage.ChunkStore
+	storage.GetterWithStamp
+	storage.DeleterWithStamp
 }
 
 // PutterCloserWithReference provides a Putter which can be closed with a root

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -5,6 +5,7 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 
 	storage "github.com/ethersphere/bee/pkg/storagev2"
@@ -23,4 +24,20 @@ type Storage interface {
 type PutterCloserWithReference interface {
 	storage.Putter
 	Close(swarm.Address) error
+}
+
+var emptyAddr = make([]byte, swarm.HashSize)
+
+func AddressOrZero(buf []byte) swarm.Address {
+	if bytes.Equal(buf, emptyAddr) {
+		return swarm.ZeroAddress
+	}
+	return swarm.NewAddress(append(make([]byte, 0, swarm.HashSize), buf...))
+}
+
+func AddressBytesOrZero(addr swarm.Address) []byte {
+	if addr.IsZero() {
+		return make([]byte, swarm.HashSize)
+	}
+	return addr.Bytes()
 }

--- a/pkg/localstorev2/internal/pinning/export_test.go
+++ b/pkg/localstorev2/internal/pinning/export_test.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidPinCollectionItemUUID = errInvalidPinCollectionUUID
 	ErrInvalidPinCollectionItemSize = errInvalidPinCollectionSize
 	ErrPutterAlreadyClosed          = errPutterAlreadyClosed
+	ErrCollectionRootAddressIsZero  = errCollectionRootAddressIsZero
 )
 
 var NewUUID = newUUID

--- a/pkg/localstorev2/internal/pinning/pinning.go
+++ b/pkg/localstorev2/internal/pinning/pinning.go
@@ -9,9 +9,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"sync"
 
+	"github.com/ethersphere/bee/pkg/localstorev2/internal"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/google/uuid"
@@ -34,6 +34,9 @@ var (
 	errInvalidPinCollectionSize = errors.New("unmarshal pinCollectionItem: invalid size")
 	// errPutterAlreadyClosed is returned when trying to use a Putter which is already closed
 	errPutterAlreadyClosed = errors.New("pin store: putter already closed")
+	// errCollectionRootAddressIsZero is returned if the putter is closed with a zero
+	// swarm.Address. Root reference has to be set.
+	errCollectionRootAddressIsZero = errors.New("pin store: collection root address is zero")
 )
 
 // batchSize used for deletion
@@ -120,45 +123,22 @@ func (p *pinChunkItem) Unmarshal(_ []byte) error {
 	return nil
 }
 
-// PutterCloser implements the storage.Putter as well as an io.Closer. The Putter
-// should be closed for a successful operation.
-type PutterCloser interface {
-	storage.Putter
-	io.Closer
-}
-
-// Storage interface is the functionality required from the underlying storage to
-// achieve the pinstore functionality. This allows us to do stateless operations
-// here.
-type Storage interface {
-	Ctx() context.Context
-	Store() storage.Store
-	ChunkStore() storage.ChunkStore
-}
-
 // NewCollection returns a putter wrapped around the passed storage.
 // The putter will add the chunk to Chunk store if it doesnt exists within this collection.
 // It will create a new UUID for the collection which can be used to iterate on all the chunks
 // that are part of this collection. The root pin is only updated on successful close of this
 // Putter.
-func NewCollection(st Storage, root swarm.Address) (PutterCloser, error) {
-
-	collection := &pinCollectionItem{Addr: root, UUID: newUUID()}
-	found, err := st.Store().Has(collection)
-	if err != nil {
-		return nil, fmt.Errorf("pin store: failed checking collection: %w", err)
+func NewCollection(st internal.Storage) internal.PutterCloserWithReference {
+	return &collectionPutter{
+		collection: &pinCollectionItem{UUID: newUUID()},
+		st:         st,
 	}
-	if found {
-		return nil, fmt.Errorf("pin store: root %s already exists", root)
-	}
-
-	return &collectionPutter{collection: collection, st: st}, nil
 }
 
 type collectionPutter struct {
 	mtx        sync.Mutex
 	collection *pinCollectionItem
-	st         Storage
+	st         internal.Storage
 	closed     bool
 }
 
@@ -201,11 +181,16 @@ func (c *collectionPutter) Put(ctx context.Context, ch swarm.Chunk) error {
 	return nil
 }
 
-func (c *collectionPutter) Close() error {
+func (c *collectionPutter) Close(root swarm.Address) error {
+	if root.IsZero() {
+		return errCollectionRootAddressIsZero
+	}
+
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
 	// Save the root pin reference.
+	c.collection.Addr = root
 	err := c.st.Store().Put(c.collection)
 	if err != nil {
 		return fmt.Errorf("pin store: failed updating collection: %w", err)
@@ -245,7 +230,7 @@ func Pins(st storage.Store) ([]swarm.Address, error) {
 
 // DeletePin will delete the root pin and all the chunks that are part of this
 // collection.
-func DeletePin(st Storage, root swarm.Address) error {
+func DeletePin(st internal.Storage, root swarm.Address) error {
 	collection := &pinCollectionItem{Addr: root}
 	err := st.Store().Get(collection)
 	if err != nil {

--- a/pkg/localstorev2/internal/upload/export_test.go
+++ b/pkg/localstorev2/internal/upload/export_test.go
@@ -16,6 +16,8 @@ var (
 	ErrUploadItemMarshalAddressIsZero = errUploadItemMarshalAddressIsZero
 	ErrUploadItemMarshalBatchInvalid  = errUploadItemMarshalBatchInvalid
 	ErrUploadItemUnmarshalInvalidSize = errUploadItemUnmarshalInvalidSize
+
+	ErrPutterAlreadyClosed = errPutterAlreadyClosed
 )
 
 type (

--- a/pkg/localstorev2/internal/upload/export_test.go
+++ b/pkg/localstorev2/internal/upload/export_test.go
@@ -7,16 +7,21 @@ package upload
 import "time"
 
 var (
-	ErrTagIDAddressItemMarshalAddressIsZero = errTagIDAddressItemMarshalAddressIsZero
-	ErrTagIDAddressItemUnmarshalInvalidSize = errTagIDAddressItemUnmarshalInvalidSize
-
 	ErrPushItemMarshalAddressIsZero = errPushItemMarshalAddressIsZero
+	ErrPushItemMarshalBatchInvalid  = errPushItemMarshalBatchInvalid
 	ErrPushItemUnmarshalInvalidSize = errPushItemUnmarshalInvalidSize
+
+	ErrTagItemUnmarshalInvalidSize = errTagItemUnmarshalInvalidSize
+
+	ErrUploadItemMarshalAddressIsZero = errUploadItemMarshalAddressIsZero
+	ErrUploadItemMarshalBatchInvalid  = errUploadItemMarshalBatchInvalid
+	ErrUploadItemUnmarshalInvalidSize = errUploadItemUnmarshalInvalidSize
 )
 
 type (
-	TagIDAddressItem = tagIDAddressItem
-	PushItem         = pushItem
+	PushItem   = pushItem
+	TagItem    = tagItem
+	UploadItem = uploadItem
 )
 
 func ReplaceTimeNow(fn func() time.Time) { now = fn }

--- a/pkg/localstorev2/internal/upload/uploadstore.go
+++ b/pkg/localstorev2/internal/upload/uploadstore.go
@@ -394,7 +394,7 @@ func (p *pushReporter) Report(
 			return fmt.Errorf("failed deleting pushItem %s: %w", pi, err)
 		}
 
-		err = p.s.ChunkStore().DeleteWithStamp(ctx, chunk.Address(), chunk.Stamp().BatchID())
+		err = p.s.ChunkStore().Delete(ctx, chunk.Address())
 		if err != nil {
 			return fmt.Errorf("failed deleting chunk %s: %w", chunk.Address(), err)
 		}

--- a/pkg/localstorev2/internal/upload/uploadstore.go
+++ b/pkg/localstorev2/internal/upload/uploadstore.go
@@ -262,11 +262,11 @@ func NewPutter(s internal.Storage, tagId uint64) (internal.PutterCloserWithRefer
 }
 
 // Put operation will do the following:
-// 1. If upload store has already seen this chunk, it will update the tag and return
-// 2. For a new chunk it will add:
-//    a. uploadItem entry to keep track of this chunk.
-//    b. pushItem entry to make it available for PushSubscriber
-//    c. add chunk to the chunkstore till it is synced
+// 1.If upload store has already seen this chunk, it will update the tag and return
+// 2.For a new chunk it will add:
+// - uploadItem entry to keep track of this chunk.
+// - b.pushItem entry to make it available for PushSubscriber
+// - c.add chunk to the chunkstore till it is synced
 func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 	u.mtx.Lock()
 	defer u.mtx.Unlock()

--- a/pkg/localstorev2/internal/upload/uploadstore.go
+++ b/pkg/localstorev2/internal/upload/uploadstore.go
@@ -343,10 +343,13 @@ type pushReporter struct {
 	s internal.Storage
 }
 
+// NewPushReporter returns a new storage.PushReporter which can be used by the
+// pusher component to report chunk state information.
 func NewPushReporter(s internal.Storage) storage.PushReporter {
 	return &pushReporter{s: s}
 }
 
+// Report is the implementation of the PushReporter interface.
 func (p *pushReporter) Report(
 	ctx context.Context,
 	chunk swarm.Chunk,

--- a/pkg/localstorev2/internal/upload/uploadstore.go
+++ b/pkg/localstorev2/internal/upload/uploadstore.go
@@ -40,7 +40,7 @@ const pushItemSize = 8 + 2*swarm.HashSize + 8
 var _ storage.Item = (*pushItem)(nil)
 
 // pushItem is an store.Item that represents data relevant to push.
-// The key is a combination of Timestamp and Address, where the
+// The key is a combination of Timestamp, Address and postage stamp, where the
 // Timestamp provides an order to iterate.
 type pushItem struct {
 	Timestamp int64
@@ -107,7 +107,7 @@ const tagItemSize = swarm.HashSize + 7*8
 
 var _ storage.Item = (*tagItem)(nil)
 
-// tagItem is an store.Item that stores addresses of already seen chunks.
+// tagItem is an store.Item that stores information about a session of upload.
 type tagItem struct {
 	TagID     uint64        // unique identifier for the tag
 	Split     uint64        // total no of chunks processed by the splitter for hashing

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -6,6 +6,7 @@ package upload_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -433,6 +434,13 @@ func TestChunkPutter(t *testing.T) {
 		}
 		if diff := cmp.Diff(wantTI, ti); diff != "" {
 			t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
+		}
+	})
+
+	t.Run("error after close", func(t *testing.T) {
+		err := putter.Put(context.TODO(), chunktest.GenerateTestRandomChunk())
+		if !errors.Is(err, upload.ErrPutterAlreadyClosed) {
+			t.Fatalf("unexpected error, expected: %v, got: %v", upload.ErrPutterAlreadyClosed, err)
 		}
 	})
 }

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -53,10 +53,6 @@ func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ 
 	return c.Get(ctx, address)
 }
 
-func (c *chunkStore) DeleteWithStamp(ctx context.Context, address swarm.Address, _ []byte) error {
-	return c.Delete(ctx, address)
-}
-
 func (t *testStorage) Ctx() context.Context            { return t.ctx }
 func (t *testStorage) Store() storage.Store            { return t.indexStore }
 func (t *testStorage) ChunkStore() internal.ChunkStore { return t.chunkStore }

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -368,14 +368,14 @@ func TestChunkPutter(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Get(...): unexpected error: %v", err)
 				}
-				exp := &upload.UploadItem{
+				wantUI := &upload.UploadItem{
 					Address:  chunk.Address(),
 					BatchID:  chunk.Stamp().BatchID(),
 					TagID:    tagID,
 					Uploaded: now().Unix(),
 				}
 
-				if diff := cmp.Diff(ui, exp); diff != "" {
+				if diff := cmp.Diff(wantUI, ui); diff != "" {
 					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
 				}
 
@@ -388,14 +388,14 @@ func TestChunkPutter(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Get(...): unexpected error: %v", err)
 				}
-				pexp := &upload.PushItem{
+				wantPI := &upload.PushItem{
 					Address:   chunk.Address(),
 					BatchID:   chunk.Stamp().BatchID(),
 					TagID:     tagID,
 					Timestamp: now().Unix(),
 				}
 
-				if diff := cmp.Diff(pi, pexp); diff != "" {
+				if diff := cmp.Diff(wantPI, pi); diff != "" {
 					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
 				}
 
@@ -424,14 +424,14 @@ func TestChunkPutter(t *testing.T) {
 			t.Fatalf("Get(...): unexpected error %v", err)
 		}
 
-		exp := &upload.TagItem{
+		wantTI := &upload.TagItem{
 			TagID:     tagID,
 			Split:     20,
 			Seen:      10,
 			StartedAt: now().Unix(),
 			Address:   addr,
 		}
-		if diff := cmp.Diff(ti, exp); diff != "" {
+		if diff := cmp.Diff(wantTI, ti); diff != "" {
 			t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
 		}
 	})
@@ -502,7 +502,7 @@ func TestChunkReporter(t *testing.T) {
 					t.Fatalf("Get(...): unexpected error: %v", err)
 				}
 				count := uint64(idx + 1)
-				exp := &upload.TagItem{
+				wantTI := &upload.TagItem{
 					TagID:     tagID,
 					StartedAt: now().Unix(),
 					Sent:      count,
@@ -510,7 +510,7 @@ func TestChunkReporter(t *testing.T) {
 					Stored:    count,
 				}
 
-				if diff := cmp.Diff(ti, exp); diff != "" {
+				if diff := cmp.Diff(wantTI, ti); diff != "" {
 					t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
 				}
 
@@ -522,7 +522,7 @@ func TestChunkReporter(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Get(...): unexpected error: %v", err)
 				}
-				uexp := &upload.UploadItem{
+				wantUI := &upload.UploadItem{
 					Address:  chunk.Address(),
 					BatchID:  chunk.Stamp().BatchID(),
 					TagID:    tagID,
@@ -530,7 +530,7 @@ func TestChunkReporter(t *testing.T) {
 					Synced:   now().Unix(),
 				}
 
-				if diff := cmp.Diff(ui, uexp); diff != "" {
+				if diff := cmp.Diff(wantUI, ui); diff != "" {
 					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
 				}
 
@@ -572,7 +572,7 @@ func TestChunkReporter(t *testing.T) {
 			t.Fatalf("Get(...): unexpected error %v", err)
 		}
 
-		exp := &upload.TagItem{
+		wantTI := &upload.TagItem{
 			TagID:     tagID,
 			Split:     10,
 			Seen:      0,
@@ -582,7 +582,7 @@ func TestChunkReporter(t *testing.T) {
 			StartedAt: now().Unix(),
 			Address:   addr,
 		}
-		if diff := cmp.Diff(ti, exp); diff != "" {
+		if diff := cmp.Diff(wantTI, ti); diff != "" {
 			t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
 		}
 	})

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -6,7 +6,6 @@ package upload_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -19,10 +18,11 @@ import (
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
-	inmem "github.com/ethersphere/bee/pkg/storagev2/inmemstore"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
 	swarmtesting "github.com/ethersphere/bee/pkg/swarm/test"
+	"github.com/google/go-cmp/cmp"
 )
 
 // now is a function that returns the current time and replaces time.Now.
@@ -42,84 +42,24 @@ var _ internal.Storage = (*testStorage)(nil)
 type testStorage struct {
 	ctx        context.Context
 	indexStore storage.Store
-	chunkStore storage.ChunkStore
+	chunkStore *chunkStore
 }
 
-func (t *testStorage) Ctx() context.Context           { return t.ctx }
-func (t *testStorage) Store() storage.Store           { return t.indexStore }
-func (t *testStorage) ChunkStore() storage.ChunkStore { return t.chunkStore }
-
-func TestTagIDAddressItem_MarshalAndUnmarshal(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		test *storagetest.ItemMarshalAndUnmarshalTest
-	}{{
-		name: "zero values",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item:       &upload.TagIDAddressItem{},
-			Factory:    func() storage.Item { return new(upload.TagIDAddressItem) },
-			MarshalErr: upload.ErrTagIDAddressItemMarshalAddressIsZero,
-		},
-	}, {
-		name: "zero address",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: &upload.TagIDAddressItem{
-				Address: swarm.ZeroAddress,
-				TagID:   1,
-			},
-			Factory:    func() storage.Item { return new(upload.TagIDAddressItem) },
-			MarshalErr: upload.ErrTagIDAddressItemMarshalAddressIsZero,
-		},
-	}, {
-		name: "min values",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: &upload.TagIDAddressItem{
-				Address: swarm.NewAddress(storagetest.MinAddressBytes[:]),
-				TagID:   0,
-			},
-			Factory: func() storage.Item { return new(upload.TagIDAddressItem) },
-		},
-	}, {
-		name: "max values",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: &upload.TagIDAddressItem{
-				Address: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
-				TagID:   math.MaxUint64,
-			},
-			Factory: func() storage.Item { return new(upload.TagIDAddressItem) },
-		},
-	}, {
-		name: "random values",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: &upload.TagIDAddressItem{
-				Address: swarmtesting.RandomAddress(),
-				TagID:   rand.Uint64(),
-			},
-			Factory: func() storage.Item { return new(upload.TagIDAddressItem) },
-		},
-	}, {
-		name: "invalid size",
-		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: &storagetest.ItemStub{
-				MarshalBuf:   []byte{0xFF},
-				UnmarshalBuf: []byte{0xFF},
-			},
-			Factory:      func() storage.Item { return new(upload.TagIDAddressItem) },
-			UnmarshalErr: upload.ErrTagIDAddressItemUnmarshalInvalidSize,
-		},
-	}}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			storagetest.TestItemMarshalAndUnmarshal(t, tc.test)
-		})
-	}
+type chunkStore struct {
+	storage.ChunkStore
 }
+
+func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ []byte) (swarm.Chunk, error) {
+	return c.Get(ctx, address)
+}
+
+func (c *chunkStore) DeleteWithStamp(ctx context.Context, address swarm.Address, _ []byte) error {
+	return c.Delete(ctx, address)
+}
+
+func (t *testStorage) Ctx() context.Context            { return t.ctx }
+func (t *testStorage) Store() storage.Store            { return t.indexStore }
+func (t *testStorage) ChunkStore() internal.ChunkStore { return t.chunkStore }
 
 func TestPushItem_MarshalAndUnmarshal(t *testing.T) {
 	t.Parallel()
@@ -146,11 +86,23 @@ func TestPushItem_MarshalAndUnmarshal(t *testing.T) {
 			MarshalErr: upload.ErrPushItemMarshalAddressIsZero,
 		},
 	}, {
+		name: "nil stamp",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.PushItem{
+				Timestamp: 1,
+				Address:   swarm.NewAddress(storagetest.MinAddressBytes[:]),
+				TagID:     1,
+			},
+			Factory:    func() storage.Item { return new(upload.PushItem) },
+			MarshalErr: upload.ErrPushItemMarshalBatchInvalid,
+		},
+	}, {
 		name: "min values",
 		test: &storagetest.ItemMarshalAndUnmarshalTest{
 			Item: &upload.PushItem{
 				Timestamp: 0,
 				Address:   swarm.NewAddress(storagetest.MinAddressBytes[:]),
+				BatchID:   storagetest.MinAddressBytes[:],
 				TagID:     0,
 			},
 			Factory: func() storage.Item { return new(upload.PushItem) },
@@ -161,6 +113,7 @@ func TestPushItem_MarshalAndUnmarshal(t *testing.T) {
 			Item: &upload.PushItem{
 				Timestamp: math.MaxInt64,
 				Address:   swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				BatchID:   storagetest.MaxAddressBytes[:],
 				TagID:     math.MaxUint64,
 			},
 			Factory: func() storage.Item { return new(upload.PushItem) },
@@ -171,6 +124,7 @@ func TestPushItem_MarshalAndUnmarshal(t *testing.T) {
 			Item: &upload.PushItem{
 				Timestamp: rand.Int63(),
 				Address:   swarmtesting.RandomAddress(),
+				BatchID:   swarmtesting.RandomAddress().Bytes(),
 				TagID:     rand.Uint64(),
 			},
 			Factory: func() storage.Item { return new(upload.PushItem) },
@@ -197,81 +151,172 @@ func TestPushItem_MarshalAndUnmarshal(t *testing.T) {
 	}
 }
 
-func TestChunkGetterDeleter(t *testing.T) {
+func TestTagItem_MarshalAndUnmarshal(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	tests := []struct {
+		name string
+		test *storagetest.ItemMarshalAndUnmarshalTest
+	}{{
+		name: "zero values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item:    &upload.TagItem{},
+			Factory: func() storage.Item { return new(upload.TagItem) },
+		},
+	}, {
+		name: "max values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.TagItem{
+				TagID:     math.MaxUint64,
+				Split:     math.MaxUint64,
+				Seen:      math.MaxUint64,
+				Stored:    math.MaxUint64,
+				Sent:      math.MaxUint64,
+				Synced:    math.MaxUint64,
+				Address:   swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				StartedAt: math.MaxInt64,
+			},
+			Factory: func() storage.Item { return new(upload.TagItem) },
+		},
+	}, {
+		name: "random values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.TagItem{
+				TagID:     rand.Uint64(),
+				Split:     rand.Uint64(),
+				Seen:      rand.Uint64(),
+				Stored:    rand.Uint64(),
+				Sent:      rand.Uint64(),
+				Synced:    rand.Uint64(),
+				Address:   swarmtesting.RandomAddress(),
+				StartedAt: rand.Int63(),
+			},
+			Factory: func() storage.Item { return new(upload.TagItem) },
+		},
+	}, {
+		name: "invalid size",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &storagetest.ItemStub{
+				MarshalBuf:   []byte{0xFF},
+				UnmarshalBuf: []byte{0xFF},
+			},
+			Factory:      func() storage.Item { return new(upload.TagItem) },
+			UnmarshalErr: upload.ErrTagItemUnmarshalInvalidSize,
+		},
+	}}
 
-	ts := &testStorage{
-		ctx:        ctx,
-		indexStore: inmem.New(),
-		chunkStore: inmemchunkstore.New(),
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			storagetest.TestItemMarshalAndUnmarshal(t, tc.test)
+		})
 	}
-	t.Cleanup(func() {
-		if err := ts.Store().Close(); err != nil {
-			t.Errorf("Storage().Close(): unexpected error: %v", err)
-		}
-		if err := ts.ChunkStore().Close(); err != nil {
-			t.Errorf("ChunkStore().Close(): unexpected error: %v", err)
-		}
-	})
 
-	const tagID = 1
-	putter, err := upload.ChunkPutter(ts, tagID)
-	if err != nil {
-		t.Fatalf("upload.ChunkPutter(...): unexpected error: %v", err)
-	}
+}
 
-	// Initialize the store before the tests.
-	chunks := chunktest.GenerateTestRandomChunks(10)
-	for _, chunk := range chunks {
-		if err := putter.Put(ctx, chunk.WithTagID(uint32(tagID))); err != nil {
-			t.Fatalf("putter.Put(...): unexpected error: %v", err)
-		}
-	}
+func TestUploadItem_MarshalAndUnmarshal(t *testing.T) {
+	t.Parallel()
 
-	store := upload.ChunkGetterDeleter(ts, tagID)
-	for i, chunk := range chunks {
-		t.Run(fmt.Sprintf("chunk %s", chunk.Address()), func(t *testing.T) {
-			t.Run("get existing chunk", func(t *testing.T) {
-				have, err := store.Get(context.TODO(), chunk.Address())
-				if err != nil {
-					t.Fatalf("Get(...): unexpected error: %v", err)
-				}
-				if want := chunk; !want.Equal(have) {
-					t.Fatalf("Get(...): chunk missmatch:\nwant: %x\nhave: %x", want, have)
-				}
-			})
+	randomAddress := swarmtesting.RandomAddress()
+	randomBatchId := swarmtesting.RandomAddress().Bytes()
 
-			t.Run("delete existing chunk", func(t *testing.T) {
-				err := store.Delete(context.TODO(), chunk.Address())
-				if err != nil {
-					t.Fatalf("Put(...): unexpected error: %v", err)
+	tests := []struct {
+		name string
+		test *storagetest.ItemMarshalAndUnmarshalTest
+	}{{
+		name: "zero values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item:       &upload.UploadItem{},
+			Factory:    func() storage.Item { return new(upload.UploadItem) },
+			MarshalErr: upload.ErrUploadItemMarshalAddressIsZero,
+		},
+	}, {
+		name: "zero address",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.UploadItem{
+				Address: swarm.ZeroAddress,
+				BatchID: storagetest.MinAddressBytes[:],
+			},
+			Factory:    func() storage.Item { return new(upload.UploadItem) },
+			MarshalErr: upload.ErrUploadItemMarshalAddressIsZero,
+		},
+	}, {
+		name: "nil stamp",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.UploadItem{
+				Address: swarm.NewAddress(storagetest.MinAddressBytes[:]),
+			},
+			Factory:    func() storage.Item { return new(upload.UploadItem) },
+			MarshalErr: upload.ErrUploadItemMarshalBatchInvalid,
+		},
+	}, {
+		name: "min values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.UploadItem{
+				Address: swarm.NewAddress(storagetest.MinAddressBytes[:]),
+				BatchID: storagetest.MinAddressBytes[:],
+			},
+			Factory: func() storage.Item {
+				return &upload.UploadItem{
+					Address: swarm.NewAddress(storagetest.MinAddressBytes[:]),
+					BatchID: storagetest.MinAddressBytes[:],
 				}
+			},
+		},
+	}, {
+		name: "max values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.UploadItem{
+				Address:  swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+				BatchID:  storagetest.MaxAddressBytes[:],
+				TagID:    math.MaxUint64,
+				Uploaded: math.MaxInt64,
+				Synced:   math.MaxInt64,
+			},
+			Factory: func() storage.Item {
+				return &upload.UploadItem{
+					Address: swarm.NewAddress(storagetest.MaxAddressBytes[:]),
+					BatchID: storagetest.MaxAddressBytes[:],
+				}
+			},
+		},
+	}, {
+		name: "random values",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &upload.UploadItem{
+				Address:  randomAddress,
+				BatchID:  randomBatchId,
+				TagID:    rand.Uint64(),
+				Uploaded: rand.Int63(),
+				Synced:   rand.Int63(),
+			},
+			Factory: func() storage.Item {
+				return &upload.UploadItem{
+					Address: randomAddress,
+					BatchID: randomBatchId,
+				}
+			},
+		},
+	}, {
+		name: "invalid size",
+		test: &storagetest.ItemMarshalAndUnmarshalTest{
+			Item: &storagetest.ItemStub{
+				MarshalBuf:   []byte{0xFF},
+				UnmarshalBuf: []byte{0xFF},
+			},
+			Factory:      func() storage.Item { return new(upload.UploadItem) },
+			UnmarshalErr: upload.ErrUploadItemUnmarshalInvalidSize,
+		},
+	}}
 
-				cnt := 0
-				err = ts.ChunkStore().Iterate(ctx, func(chunk swarm.Chunk) (stop bool, err error) {
-					cnt++
-					return false, nil
-				})
-				if err != nil {
-					t.Fatalf("ChunkStore().Iterate(...): unexpected error: %v", err)
-				}
-				if want, have := len(chunks)-(i+1), cnt; want != have {
-					t.Fatalf("ChunkStore().Iterate(...): chunk count mismatch:\nwant: %d\nhave: %d", want, have)
-				}
-			})
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-			t.Run("get non-existing chunk", func(t *testing.T) {
-				have, err := store.Get(context.TODO(), chunk.Address())
-				if !errors.Is(err, storage.ErrNotFound) {
-					t.Fatalf("Get(...): unexpected error: %v", err)
-				}
-				if want := swarm.Chunk(nil); want != have {
-					t.Fatalf("Get(...): chunk missmatch:\nwant: %x\nhave: %x", want, have)
-				}
-			})
+			storagetest.TestItemMarshalAndUnmarshal(t, tc.test)
 		})
 	}
 }
@@ -284,8 +329,8 @@ func TestChunkPutter(t *testing.T) {
 
 	ts := &testStorage{
 		ctx:        ctx,
-		indexStore: inmem.New(),
-		chunkStore: inmemchunkstore.New(),
+		indexStore: inmemstore.New(),
+		chunkStore: &chunkStore{inmemchunkstore.New()},
 	}
 	t.Cleanup(func() {
 		if err := ts.Store().Close(); err != nil {
@@ -297,9 +342,9 @@ func TestChunkPutter(t *testing.T) {
 	})
 
 	const tagID = 1
-	putter, err := upload.ChunkPutter(ts, tagID)
+	putter, err := upload.NewPutter(ts, tagID)
 	if err != nil {
-		t.Fatalf("upload.ChunkPutter(...): unexpected error: %v", err)
+		t.Fatalf("failed creating putter: %v", err)
 	}
 
 	for _, chunk := range chunktest.GenerateTestRandomChunks(10) {
@@ -319,27 +364,43 @@ func TestChunkPutter(t *testing.T) {
 			})
 
 			t.Run("verify internal state", func(t *testing.T) {
-				has, err := ts.Store().Has(&upload.TagIDAddressItem{
-					TagID:   tagID,
+				ui := &upload.UploadItem{
 					Address: chunk.Address(),
-				})
-				if err != nil {
-					t.Fatalf("Has(...): unexpected error: %v", err)
+					BatchID: chunk.Stamp().BatchID(),
 				}
-				if !has {
-					t.Fatal("Has(...): item not found")
+				err := ts.Store().Get(ui)
+				if err != nil {
+					t.Fatalf("Get(...): unexpected error: %v", err)
+				}
+				exp := &upload.UploadItem{
+					Address:  chunk.Address(),
+					BatchID:  chunk.Stamp().BatchID(),
+					TagID:    tagID,
+					Uploaded: now().Unix(),
 				}
 
-				has, err = ts.Store().Has(&upload.PushItem{
+				if diff := cmp.Diff(ui, exp); diff != "" {
+					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
+				}
+
+				pi := &upload.PushItem{
 					Timestamp: now().Unix(),
 					Address:   chunk.Address(),
-					TagID:     tagID,
-				})
-				if err != nil {
-					t.Fatalf("Has(...): unexpected error: %v", err)
+					BatchID:   chunk.Stamp().BatchID(),
 				}
-				if !has {
-					t.Fatalf("Has(...): item not found")
+				err = ts.Store().Get(pi)
+				if err != nil {
+					t.Fatalf("Get(...): unexpected error: %v", err)
+				}
+				pexp := &upload.PushItem{
+					Address:   chunk.Address(),
+					BatchID:   chunk.Stamp().BatchID(),
+					TagID:     tagID,
+					Timestamp: now().Unix(),
+				}
+
+				if diff := cmp.Diff(pi, pexp); diff != "" {
+					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
 				}
 
 				have, err := ts.ChunkStore().Get(context.TODO(), chunk.Address())
@@ -352,4 +413,181 @@ func TestChunkPutter(t *testing.T) {
 			})
 		})
 	}
+
+	t.Run("close with reference", func(t *testing.T) {
+		addr := swarmtesting.RandomAddress()
+
+		err := putter.Close(addr)
+		if err != nil {
+			t.Fatalf("Close(...): unexpected error %v", err)
+		}
+
+		ti := &upload.TagItem{TagID: tagID}
+		err = ts.Store().Get(ti)
+		if err != nil {
+			t.Fatalf("Get(...): unexpected error %v", err)
+		}
+
+		exp := &upload.TagItem{
+			TagID:     tagID,
+			Split:     20,
+			Seen:      10,
+			StartedAt: now().Unix(),
+			Address:   addr,
+		}
+		if diff := cmp.Diff(ti, exp); diff != "" {
+			t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
+		}
+	})
+}
+
+func TestChunkReporter(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ts := &testStorage{
+		ctx:        ctx,
+		indexStore: inmemstore.New(),
+		chunkStore: &chunkStore{inmemchunkstore.New()},
+	}
+	t.Cleanup(func() {
+		if err := ts.Store().Close(); err != nil {
+			t.Errorf("Storage().Close(): unexpected error: %v", err)
+		}
+		if err := ts.ChunkStore().Close(); err != nil {
+			t.Errorf("ChunkStore().Close(): unexpected error: %v", err)
+		}
+	})
+
+	const tagID = 1
+	putter, err := upload.NewPutter(ts, tagID)
+	if err != nil {
+		t.Fatalf("failed creating putter: %v", err)
+	}
+
+	reporter := upload.NewPushReporter(ts)
+
+	for idx, chunk := range chunktest.GenerateTestRandomChunks(10) {
+		t.Run(fmt.Sprintf("chunk %s", chunk.Address()), func(t *testing.T) {
+			err := putter.Put(context.TODO(), chunk)
+			if err != nil {
+				t.Fatalf("Put(...): unexpected error: %v", err)
+			}
+
+			t.Run("mark sent", func(t *testing.T) {
+				err := reporter.Report(context.TODO(), chunk, storage.ChunkSent)
+				if err != nil {
+					t.Fatalf("Report(...): unexpected error: %v", err)
+				}
+			})
+
+			t.Run("mark stored", func(t *testing.T) {
+				err := reporter.Report(context.TODO(), chunk, storage.ChunkStored)
+				if err != nil {
+					t.Fatalf("Report(...): unexpected error: %v", err)
+				}
+			})
+
+			t.Run("mark synced", func(t *testing.T) {
+				err := reporter.Report(context.TODO(), chunk, storage.ChunkSynced)
+				if err != nil {
+					t.Fatalf("Report(...): unexpected error: %v", err)
+				}
+			})
+
+			t.Run("verify internal state", func(t *testing.T) {
+				ti := &upload.TagItem{
+					TagID: tagID,
+				}
+				err := ts.Store().Get(ti)
+				if err != nil {
+					t.Fatalf("Get(...): unexpected error: %v", err)
+				}
+				count := uint64(idx + 1)
+				exp := &upload.TagItem{
+					TagID:     tagID,
+					StartedAt: now().Unix(),
+					Sent:      count,
+					Synced:    count,
+					Stored:    count,
+				}
+
+				if diff := cmp.Diff(ti, exp); diff != "" {
+					t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
+				}
+
+				ui := &upload.UploadItem{
+					Address: chunk.Address(),
+					BatchID: chunk.Stamp().BatchID(),
+				}
+				err = ts.Store().Get(ui)
+				if err != nil {
+					t.Fatalf("Get(...): unexpected error: %v", err)
+				}
+				uexp := &upload.UploadItem{
+					Address:  chunk.Address(),
+					BatchID:  chunk.Stamp().BatchID(),
+					TagID:    tagID,
+					Uploaded: now().Unix(),
+					Synced:   now().Unix(),
+				}
+
+				if diff := cmp.Diff(ui, uexp); diff != "" {
+					t.Fatalf("Get(...): unexpected UploadItem (-want +have):\n%s", diff)
+				}
+
+				pi := &upload.PushItem{
+					Timestamp: now().Unix(),
+					Address:   chunk.Address(),
+					BatchID:   chunk.Stamp().BatchID(),
+				}
+				has, err := ts.Store().Has(pi)
+				if err != nil {
+					t.Fatalf("Has(...): unexpected error: %v", err)
+				}
+				if has {
+					t.Fatalf("Has(...): expected to not be found: %s", pi)
+				}
+
+				have, err := ts.ChunkStore().Has(context.TODO(), chunk.Address())
+				if err != nil {
+					t.Fatalf("Get(...): unexpected error: %v", err)
+				}
+				if have {
+					t.Fatalf("Get(...): chunk expected to not be found: %s", chunk.Address())
+				}
+			})
+		})
+	}
+
+	t.Run("close with reference", func(t *testing.T) {
+		addr := swarmtesting.RandomAddress()
+
+		err := putter.Close(addr)
+		if err != nil {
+			t.Fatalf("Close(...): unexpected error %v", err)
+		}
+
+		ti := &upload.TagItem{TagID: tagID}
+		err = ts.Store().Get(ti)
+		if err != nil {
+			t.Fatalf("Get(...): unexpected error %v", err)
+		}
+
+		exp := &upload.TagItem{
+			TagID:     tagID,
+			Split:     10,
+			Seen:      0,
+			Stored:    10,
+			Sent:      10,
+			Synced:    10,
+			StartedAt: now().Unix(),
+			Address:   addr,
+		}
+		if diff := cmp.Diff(ti, exp); diff != "" {
+			t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
+		}
+	})
 }

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -19,7 +19,7 @@ type Getter interface {
 	// if the chunk is not found.
 	// If the chunk has multiple stamps, then the first stamp is returned in this
 	// query. In order to deterministically get the stamp, use the GetterWithStamp
-	// interface.
+	// interface. If the chunk is not found storage.ErrNotFound will be returned.
 	Get(context.Context, swarm.Address) (swarm.Chunk, error)
 }
 

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -131,10 +131,11 @@ const (
 	ChunkStored
 	// ChunkSynced is used by the pusher component to notify that the chunk is synced to the
 	// network. This is reported when a valid receipt was received after the chunk was
-	// pushed. Once the chunk is synced, the chunk is deleted from the upload store as
+	// pushed.
 	ChunkSynced
 )
 
+// PushReporter is used to report chunk state.
 type PushReporter interface {
 	Report(context.Context, swarm.Chunk, ChunkState) error
 }

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -17,7 +17,18 @@ type Getter interface {
 	// Get a chunk by its swarm.Address. Returns the chunk associated with
 	// the address alongside with its postage stamp, or a storage.ErrNotFound
 	// if the chunk is not found.
+	// If the chunk has multiple stamps, then the first stamp is returned in this
+	// query. In order to deterministically get the stamp, use the GetterWithStamp
+	// interface.
 	Get(context.Context, swarm.Address) (swarm.Chunk, error)
+}
+
+// GetterWithStamp is the interface that provides a way to specify a postage
+// stamp to filter the Get query. This is required as we will support multiple stamps
+// on a chunk. As a result some components would need to query chunk and provide
+// the stamp to return by using the argument.
+type GetterWithStamp interface {
+	GetWithStamp(context.Context, swarm.Address, []byte) (swarm.Chunk, error)
 }
 
 // Putter is the interface that wraps the basic Put method.
@@ -26,10 +37,20 @@ type Putter interface {
 	Put(context.Context, swarm.Chunk) error
 }
 
-// Deleter is the interface that wraps the basic Delete method.
+// Deleter is the interface that wraps the basic Delete method. This delete will
+// remove all the stamps associated with the chunk. To delete based on stamps,
+// use the DeleterWithStamp interface.
 type Deleter interface {
 	// Delete a chunk by the given swarm.Address.
 	Delete(context.Context, swarm.Address) error
+}
+
+// DeleterWithStamp provides a way to Delete a chunk by specifying the stamp
+// associated with this deletion. If the chunk has other stamps, then it is expected
+// that only the stamp association will be deleted and chunk will be kept in the
+// chunkstore.
+type DeleterWithStamp interface {
+	DeleteWithStamp(context.Context, swarm.Address, []byte) error
 }
 
 // PutterFunc type is an adapter to allow the use of

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -117,3 +117,24 @@ type PullSubscriber interface {
 type PushSubscriber interface {
 	SubscribePush(ctx context.Context, skipFn func([]byte) bool) (c <-chan swarm.Chunk, repeat, stop func())
 }
+
+type ChunkState = int
+
+const (
+	// ChunkSent is used by the pusher component to notify about successful push of chunk from
+	// the node. A chunk could be retried on failure so, this sent count is maintained to
+	// understand how many attempts were made by the node while pushing. The attempts are
+	// registered only when an actual request was sent from this node.
+	ChunkSent ChunkState = iota
+	// ChunkStored is used by the pusher component to notify that the uploader node is
+	// the closest node and has stored the chunk.
+	ChunkStored
+	// ChunkSynced is used by the pusher component to notify that the chunk is synced to the
+	// network. This is reported when a valid receipt was received after the chunk was
+	// pushed. Once the chunk is synced, the chunk is deleted from the upload store as
+	ChunkSynced
+)
+
+type PushReporter interface {
+	Report(context.Context, swarm.Chunk, ChunkState) error
+}

--- a/pkg/storagev2/chunkstore.go
+++ b/pkg/storagev2/chunkstore.go
@@ -37,20 +37,10 @@ type Putter interface {
 	Put(context.Context, swarm.Chunk) error
 }
 
-// Deleter is the interface that wraps the basic Delete method. This delete will
-// remove all the stamps associated with the chunk. To delete based on stamps,
-// use the DeleterWithStamp interface.
+// Deleter is the interface that wraps the basic Delete method.
 type Deleter interface {
 	// Delete a chunk by the given swarm.Address.
 	Delete(context.Context, swarm.Address) error
-}
-
-// DeleterWithStamp provides a way to Delete a chunk by specifying the stamp
-// associated with this deletion. If the chunk has other stamps, then it is expected
-// that only the stamp association will be deleted and chunk will be kept in the
-// chunkstore.
-type DeleterWithStamp interface {
-	DeleteWithStamp(context.Context, swarm.Address, []byte) error
 }
 
 // PutterFunc type is an adapter to allow the use of


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
After discussions within the team, it was agreed that the current tags-related functionality is not ideal. We need to pass the tag around on the chunk and across components using context key-value pairs. This has become pretty ugly. With the new localstore, we have a separate component called upload store which is used to consume uploads. It is possible to clean up all the ugly tag handling now by moving the tag-related logic into the upload store.

This PR refactors the originally envisioned upload store by also adding the tag functionality. Each putter can be assigned a new tag ID and hence serves as a session to upload data and keep track of the information related to this particular session. The Tag IDs can be thought of as file descriptors. They can be monotonically increasing integers that can be reset when they overflow. The new tag feature is compatible with the existing implementation. So this would be transparent to the users mostly.

Along with the tag, we will also maintain chunk information. So we can show the users which chunk was uploaded with which stamp and also the timestamp when it was synced to the network. A separate API can be provided to show this information if required. This information should be cleaned up when the stamps expire as there is no other way to clean up the entries right now.

We will also support uploading chunks with different stamps. These will be separate push requests. Also users will be able to see all the stamps with which a chunk was uploaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3690)
<!-- Reviewable:end -->
