### PR TITLE
refactor: pin store changes

### DIFF
--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -154,13 +154,27 @@ func (w *wrappedStore) Put(i storage.Item) error {
 	return w.Store.Put(i)
 }
 
+func newTestStorage(t *testing.T) *testStorage {
+	t.Helper()
+
+	storg, closer := internal.NewInmemStorage()
+	t.Cleanup(func() {
+		err := closer()
+		if err != nil {
+			t.Errorf("failed closing storage: %v", err)
+		}
+	})
+
+	return &testStorage{Storage: storg}
+}
+
 func TestCache(t *testing.T) {
 	t.Parallel()
 
 	t.Run("fresh new cache", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{Storage: internal.NewTestStorage(t)}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -171,7 +185,7 @@ func TestCache(t *testing.T) {
 	t.Run("putter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{Storage: internal.NewTestStorage(t)}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -232,7 +246,7 @@ func TestCache(t *testing.T) {
 	t.Run("getter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{Storage: internal.NewTestStorage(t)}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -316,7 +330,7 @@ func TestCache(t *testing.T) {
 	t.Run("handle error", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{Storage: internal.NewTestStorage(t)}
+		st := newTestStorage(t)
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/localstorev2/internal/cache/cache_test.go
+++ b/pkg/localstorev2/internal/cache/cache_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ethersphere/bee/pkg/localstorev2/internal/cache"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
-	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
-	inmem "github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/google/go-cmp/cmp"
@@ -136,27 +134,12 @@ func TestCacheEntryItem(t *testing.T) {
 }
 
 type testStorage struct {
-	store   storage.Store
-	chStore *chunkStore
-	putFn   func(storage.Item) error
+	internal.Storage
+	putFn func(storage.Item) error
 }
-
-type chunkStore struct {
-	storage.ChunkStore
-}
-
-func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ []byte) (swarm.Chunk, error) {
-	return c.Get(ctx, address)
-}
-
-func (testStorage) Ctx() context.Context { return context.TODO() }
 
 func (t *testStorage) Store() storage.Store {
-	return &wrappedStore{Store: t.store, putFn: t.putFn}
-}
-
-func (t *testStorage) ChunkStore() internal.ChunkStore {
-	return t.chStore
+	return &wrappedStore{Store: t.Storage.Store(), putFn: t.putFn}
 }
 
 type wrappedStore struct {
@@ -177,10 +160,7 @@ func TestCache(t *testing.T) {
 	t.Run("fresh new cache", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := &testStorage{Storage: internal.NewTestStorage(t)}
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -191,10 +171,7 @@ func TestCache(t *testing.T) {
 	t.Run("putter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := &testStorage{Storage: internal.NewTestStorage(t)}
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -255,10 +232,7 @@ func TestCache(t *testing.T) {
 	t.Run("getter", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := &testStorage{Storage: internal.NewTestStorage(t)}
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -342,10 +316,7 @@ func TestCache(t *testing.T) {
 	t.Run("handle error", func(t *testing.T) {
 		t.Parallel()
 
-		st := &testStorage{
-			store:   inmem.New(),
-			chStore: &chunkStore{inmemchunkstore.New()},
-		}
+		st := &testStorage{Storage: internal.NewTestStorage(t)}
 		c, err := cache.New(st, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -365,7 +336,7 @@ func TestCache(t *testing.T) {
 			if i.Namespace() == "cacheState" {
 				return retErr
 			}
-			return st.store.Put(i)
+			return st.Storage.Store().Put(i)
 		}
 
 		// on error the cache expects the overarching transactions to clean itself up

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -62,7 +62,7 @@ func NewInmemStorage() (Storage, func() error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ts := &testStorage{
+	ts := &inmemRepository{
 		ctx:        ctx,
 		indexStore: inmemstore.New(),
 		chunkStore: &chunkStore{inmemchunkstore.New()},
@@ -74,7 +74,7 @@ func NewInmemStorage() (Storage, func() error) {
 	}
 }
 
-type testStorage struct {
+type inmemRepository struct {
 	ctx        context.Context
 	indexStore storage.Store
 	chunkStore *chunkStore
@@ -89,6 +89,6 @@ func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ 
 	return c.Get(ctx, address)
 }
 
-func (t *testStorage) Ctx() context.Context   { return t.ctx }
-func (t *testStorage) Store() storage.Store   { return t.indexStore }
-func (t *testStorage) ChunkStore() ChunkStore { return t.chunkStore }
+func (t *inmemRepository) Ctx() context.Context   { return t.ctx }
+func (t *inmemRepository) Store() storage.Store   { return t.indexStore }
+func (t *inmemRepository) ChunkStore() ChunkStore { return t.chunkStore }

--- a/pkg/localstorev2/internal/internal.go
+++ b/pkg/localstorev2/internal/internal.go
@@ -7,8 +7,11 @@ package internal
 import (
 	"bytes"
 	"context"
+	"testing"
 
 	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -46,3 +49,48 @@ func AddressBytesOrZero(addr swarm.Address) []byte {
 	}
 	return addr.Bytes()
 }
+
+func NewTestStorage(t *testing.T) Storage {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ts := &testStorage{
+		ctx:        ctx,
+		indexStore: inmemstore.New(),
+		chunkStore: &chunkStore{inmemchunkstore.New()},
+	}
+	t.Cleanup(func() {
+		if err := ts.Store().Close(); err != nil {
+			t.Errorf("Storage().Close(): unexpected error: %v", err)
+		}
+		if err := ts.ChunkStore().Close(); err != nil {
+			t.Errorf("ChunkStore().Close(): unexpected error: %v", err)
+		}
+	})
+
+	return ts
+}
+
+type testStorage struct {
+	ctx        context.Context
+	indexStore storage.Store
+	chunkStore *chunkStore
+}
+
+type chunkStore struct {
+	storage.ChunkStore
+}
+
+func (c *chunkStore) GetWithStamp(ctx context.Context, address swarm.Address, _ []byte) (swarm.Chunk, error) {
+	return c.Get(ctx, address)
+}
+
+func (c *chunkStore) DeleteWithStamp(ctx context.Context, address swarm.Address, _ []byte) error {
+	return c.Delete(ctx, address)
+}
+
+func (t *testStorage) Ctx() context.Context   { return t.ctx }
+func (t *testStorage) Store() storage.Store   { return t.indexStore }
+func (t *testStorage) ChunkStore() ChunkStore { return t.chunkStore }

--- a/pkg/localstorev2/internal/pinning/export_test.go
+++ b/pkg/localstorev2/internal/pinning/export_test.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidPinCollectionItemUUID = errInvalidPinCollectionUUID
 	ErrInvalidPinCollectionItemSize = errInvalidPinCollectionSize
 	ErrPutterAlreadyClosed          = errPutterAlreadyClosed
+	ErrCollectionRootAddressIsZero  = errCollectionRootAddressIsZero
 )
 
 var NewUUID = newUUID

--- a/pkg/localstorev2/internal/pinning/pinning.go
+++ b/pkg/localstorev2/internal/pinning/pinning.go
@@ -34,6 +34,9 @@ var (
 	errInvalidPinCollectionSize = errors.New("unmarshal pinCollectionItem: invalid size")
 	// errPutterAlreadyClosed is returned when trying to use a Putter which is already closed
 	errPutterAlreadyClosed = errors.New("pin store: putter already closed")
+	// errCollectionRootAddressIsZero is returned if the putter is closed with a zero
+	// swarm.Address. Root reference has to be set.
+	errCollectionRootAddressIsZero = errors.New("pin store: collection root address is zero")
 )
 
 // batchSize used for deletion
@@ -179,6 +182,10 @@ func (c *collectionPutter) Put(ctx context.Context, ch swarm.Chunk) error {
 }
 
 func (c *collectionPutter) Close(root swarm.Address) error {
+	if root.IsZero() {
+		return errCollectionRootAddressIsZero
+	}
+
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/pkg/localstorev2/internal/pinning/pinning_test.go
+++ b/pkg/localstorev2/internal/pinning/pinning_test.go
@@ -25,6 +25,20 @@ type pinningCollection struct {
 	dupChunks    []swarm.Chunk
 }
 
+func newTestStorage(t *testing.T) internal.Storage {
+	t.Helper()
+
+	storg, closer := internal.NewInmemStorage()
+	t.Cleanup(func() {
+		err := closer()
+		if err != nil {
+			t.Errorf("failed closing storage: %v", err)
+		}
+	})
+
+	return storg
+}
+
 func TestPinStore(t *testing.T) {
 
 	tests := make([]pinningCollection, 0, 3)
@@ -56,7 +70,7 @@ func TestPinStore(t *testing.T) {
 		tests = append(tests, c)
 	}
 
-	st := internal.NewTestStorage(t)
+	st := newTestStorage(t)
 
 	t.Run("create new collections", func(t *testing.T) {
 		for tCount, tc := range tests {

--- a/pkg/localstorev2/internal/pinning/pinning_test.go
+++ b/pkg/localstorev2/internal/pinning/pinning_test.go
@@ -239,6 +239,22 @@ func TestPinStore(t *testing.T) {
 			t.Fatalf("unexpected error during Put, want: %v, got: %v", pinstore.ErrPutterAlreadyClosed, err)
 		}
 	})
+
+	t.Run("zero address close", func(t *testing.T) {
+		root := chunktest.GenerateTestRandomChunk()
+		putter := pinstore.NewCollection(st)
+
+		err := putter.Put(context.TODO(), root)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = putter.Close(swarm.ZeroAddress)
+		if !errors.Is(err, pinstore.ErrCollectionRootAddressIsZero) {
+			t.Fatalf("unexpected error on close, want: %v, got: %v", pinstore.ErrCollectionRootAddressIsZero, err)
+		}
+
+	})
 }
 
 func TestPinCollectionItem_MarshalAndUnmarshal(t *testing.T) {

--- a/pkg/localstorev2/internal/pinning/pinning_test.go
+++ b/pkg/localstorev2/internal/pinning/pinning_test.go
@@ -11,11 +11,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/localstorev2/internal"
 	pinstore "github.com/ethersphere/bee/pkg/localstorev2/internal/pinning"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
-	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
-	inmem "github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	storagetest "github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -25,17 +24,6 @@ type pinningCollection struct {
 	uniqueChunks []swarm.Chunk
 	dupChunks    []swarm.Chunk
 }
-
-type testStorage struct {
-	store   storage.Store
-	chStore storage.ChunkStore
-}
-
-func (testStorage) Ctx() context.Context { return context.TODO() }
-
-func (t *testStorage) Store() storage.Store { return t.store }
-
-func (t *testStorage) ChunkStore() storage.ChunkStore { return t.chStore }
 
 func TestPinStore(t *testing.T) {
 
@@ -68,18 +56,12 @@ func TestPinStore(t *testing.T) {
 		tests = append(tests, c)
 	}
 
-	st := &testStorage{
-		store:   inmem.New(),
-		chStore: inmemchunkstore.New(),
-	}
+	st := internal.NewTestStorage(t)
 
 	t.Run("create new collections", func(t *testing.T) {
 		for tCount, tc := range tests {
 			t.Run(fmt.Sprintf("create collection %d", tCount), func(t *testing.T) {
-				putter, err := pinstore.NewCollection(st, tc.root.Address())
-				if err != nil {
-					t.Fatal(err)
-				}
+				putter := pinstore.NewCollection(st)
 				for _, ch := range append(tc.uniqueChunks, tc.root) {
 					err := putter.Put(context.TODO(), ch)
 					if err != nil {
@@ -92,7 +74,7 @@ func TestPinStore(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
-				err = putter.Close()
+				err := putter.Close(tc.root.Address())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -226,17 +208,14 @@ func TestPinStore(t *testing.T) {
 
 	t.Run("error after close", func(t *testing.T) {
 		root := chunktest.GenerateTestRandomChunk()
-		putter, err := pinstore.NewCollection(st, root.Address())
+		putter := pinstore.NewCollection(st)
+
+		err := putter.Put(context.TODO(), root)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = putter.Put(context.TODO(), root)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = putter.Close()
+		err = putter.Close(root.Address())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -315,10 +315,24 @@ func TestUploadItem_MarshalAndUnmarshal(t *testing.T) {
 	}
 }
 
+func newTestStorage(t *testing.T) internal.Storage {
+	t.Helper()
+
+	storg, closer := internal.NewInmemStorage()
+	t.Cleanup(func() {
+		err := closer()
+		if err != nil {
+			t.Errorf("failed closing storage: %v", err)
+		}
+	})
+
+	return storg
+}
+
 func TestChunkPutter(t *testing.T) {
 	t.Parallel()
 
-	ts := internal.NewTestStorage(t)
+	ts := newTestStorage(t)
 
 	const tagID = 1
 	putter, err := upload.NewPutter(ts, tagID)
@@ -423,7 +437,7 @@ func TestChunkPutter(t *testing.T) {
 func TestChunkReporter(t *testing.T) {
 	t.Parallel()
 
-	ts := internal.NewTestStorage(t)
+	ts := newTestStorage(t)
 
 	const tagID = 1
 	putter, err := upload.NewPutter(ts, tagID)

--- a/pkg/localstorev2/internal/upload/uploadstore_test.go
+++ b/pkg/localstorev2/internal/upload/uploadstore_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/ethersphere/bee/pkg/localstorev2/internal/upload"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
-	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
-	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
 	swarmtesting "github.com/ethersphere/bee/pkg/swarm/test"
@@ -320,22 +318,7 @@ func TestUploadItem_MarshalAndUnmarshal(t *testing.T) {
 func TestChunkPutter(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	ts := &testStorage{
-		ctx:        ctx,
-		indexStore: inmemstore.New(),
-		chunkStore: &chunkStore{inmemchunkstore.New()},
-	}
-	t.Cleanup(func() {
-		if err := ts.Store().Close(); err != nil {
-			t.Errorf("Storage().Close(): unexpected error: %v", err)
-		}
-		if err := ts.ChunkStore().Close(); err != nil {
-			t.Errorf("ChunkStore().Close(): unexpected error: %v", err)
-		}
-	})
+	ts := internal.NewTestStorage(t)
 
 	const tagID = 1
 	putter, err := upload.NewPutter(ts, tagID)
@@ -440,22 +423,7 @@ func TestChunkPutter(t *testing.T) {
 func TestChunkReporter(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	ts := &testStorage{
-		ctx:        ctx,
-		indexStore: inmemstore.New(),
-		chunkStore: &chunkStore{inmemchunkstore.New()},
-	}
-	t.Cleanup(func() {
-		if err := ts.Store().Close(); err != nil {
-			t.Errorf("Storage().Close(): unexpected error: %v", err)
-		}
-		if err := ts.ChunkStore().Close(); err != nil {
-			t.Errorf("ChunkStore().Close(): unexpected error: %v", err)
-		}
-	})
+	ts := internal.NewTestStorage(t)
 
 	const tagID = 1
 	putter, err := upload.NewPutter(ts, tagID)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Minor changes in the pin store putter implementation. The problem was that the Putter creation initially required a root reference. However, this is available at the end in some cases where we haven't finished splitting the file yet. So now the upload putter will be closed with the reference and the root collection item will only be created at the end.

Also, created a function in the internal package for tests to reduce common code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3693)
<!-- Reviewable:end -->
