### PR TITLE
feat: tx chunkstore and multiple stamp support

### DIFF
--- a/pkg/localstorev2/internal/chunkstore/chunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/chunkstore.go
@@ -181,6 +181,9 @@ func (c *chunkStampItem) Clone() storage.Item {
 	return clone
 }
 
+// Sharky provides an abstraction for the sharky.Store operations used in the
+// chunkstore. This allows us to be more flexible in passing in the sharky instance
+// to chunkstore. For eg, check the TxChunkStore implementation in this pkg.
 type Sharky interface {
 	Read(context.Context, sharky.Location, []byte) error
 	Write(context.Context, []byte) (sharky.Location, error)

--- a/pkg/localstorev2/internal/chunkstore/chunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/chunkstore.go
@@ -292,10 +292,6 @@ func (c *chunkStoreWrapper) GetWithStamp(
 	return c.get(ctx, addr, batchID)
 }
 
-func (c *chunkStoreWrapper) GetWithStamp(ctx context.Context, addr swarm.Address, batchID []byte) (swarm.Chunk, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
 func (c *chunkStoreWrapper) Has(_ context.Context, addr swarm.Address) (bool, error) {
 	return c.store.Has(&retrievalIndexItem{Address: addr})
 }

--- a/pkg/localstorev2/internal/chunkstore/chunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/chunkstore.go
@@ -5,6 +5,7 @@
 package chunkstore
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -180,9 +181,15 @@ func (c *chunkStampItem) Clone() storage.Item {
 	return clone
 }
 
+type Sharky interface {
+	Read(context.Context, sharky.Location, []byte) error
+	Write(context.Context, []byte) (sharky.Location, error)
+	Release(context.Context, sharky.Location) error
+}
+
 type chunkStoreWrapper struct {
 	store  storage.Store
-	sharky *sharky.Store
+	sharky Sharky
 }
 
 // New returns a chunkStoreWrapper which implements the storage.ChunkStore interface
@@ -199,18 +206,20 @@ type chunkStoreWrapper struct {
 // of some component which will provide the uniqueness guarantee.
 // Due to the refCnt a Delete would only result in an actual Delete operation
 // if the refCnt goes to 0.
-func New(store storage.Store, sharky *sharky.Store) storage.ChunkStore {
+func New(store storage.Store, sharky Sharky) storage.ChunkStore {
 	return &chunkStoreWrapper{store: store, sharky: sharky}
 }
 
-func (c *chunkStoreWrapper) getStamp(addr swarm.Address) (swarm.Stamp, error) {
+func (c *chunkStoreWrapper) getStamp(addr swarm.Address, batchID []byte) (swarm.Stamp, error) {
 	var stamp swarm.Stamp
 	err := c.store.Iterate(storage.Query{
 		Factory: func() storage.Item { return &chunkStampItem{Address: addr} },
 	}, func(res storage.Result) (bool, error) {
-		// Use the first available stamp till we support multiple stamps on chunk.
-		stamp = res.Entry.(*chunkStampItem).Stamp
-		return true, nil
+		if batchID == nil || bytes.Equal(batchID, res.Entry.(*chunkStampItem).Stamp.BatchID()) {
+			stamp = res.Entry.(*chunkStampItem).Stamp
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return nil, err
@@ -240,8 +249,8 @@ func (c *chunkStoreWrapper) removeStamps(addr swarm.Address) error {
 }
 
 // helper to read chunk from retrievalIndex.
-func (c *chunkStoreWrapper) readChunk(ctx context.Context, rIdx *retrievalIndexItem) (swarm.Chunk, error) {
-	stamp, err := c.getStamp(rIdx.Address)
+func (c *chunkStoreWrapper) readChunk(ctx context.Context, rIdx *retrievalIndexItem, batchID []byte) (swarm.Chunk, error) {
+	stamp, err := c.getStamp(rIdx.Address, batchID)
 	if err != nil {
 		return nil, fmt.Errorf("chunk store: failed to read stamp for address %s: %w", rIdx.Address, err)
 	}
@@ -261,14 +270,26 @@ func (c *chunkStoreWrapper) readChunk(ctx context.Context, rIdx *retrievalIndexI
 	return swarm.NewChunk(rIdx.Address, buf).WithStamp(stamp), nil
 }
 
-func (c *chunkStoreWrapper) Get(ctx context.Context, addr swarm.Address) (swarm.Chunk, error) {
+func (c *chunkStoreWrapper) get(ctx context.Context, addr swarm.Address, batchID []byte) (swarm.Chunk, error) {
 	rIdx := &retrievalIndexItem{Address: addr}
 	err := c.store.Get(rIdx)
 	if err != nil {
 		return nil, fmt.Errorf("chunk store: failed reading retrievalIndex for address %s: %w", addr, err)
 	}
 
-	return c.readChunk(ctx, rIdx)
+	return c.readChunk(ctx, rIdx, batchID)
+}
+
+func (c *chunkStoreWrapper) Get(ctx context.Context, addr swarm.Address) (swarm.Chunk, error) {
+	return c.get(ctx, addr, nil)
+}
+
+func (c *chunkStoreWrapper) GetWithStamp(
+	ctx context.Context,
+	addr swarm.Address,
+	batchID []byte,
+) (swarm.Chunk, error) {
+	return c.get(ctx, addr, batchID)
 }
 
 func (c *chunkStoreWrapper) GetWithStamp(ctx context.Context, addr swarm.Address, batchID []byte) (swarm.Chunk, error) {
@@ -369,7 +390,7 @@ func (c *chunkStoreWrapper) Iterate(ctx context.Context, fn storage.IterateChunk
 	return c.store.Iterate(storage.Query{
 		Factory: func() storage.Item { return new(retrievalIndexItem) },
 	}, func(r storage.Result) (bool, error) {
-		ch, err := c.readChunk(ctx, r.Entry.(*retrievalIndexItem))
+		ch, err := c.readChunk(ctx, r.Entry.(*retrievalIndexItem), nil)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/localstorev2/internal/chunkstore/export_test.go
+++ b/pkg/localstorev2/internal/chunkstore/export_test.go
@@ -6,11 +6,11 @@ package chunkstore
 
 import storage "github.com/ethersphere/bee/pkg/storagev2"
 
-type RetrievalIndexItem = retrievalIndexItem
-
-type ChunkStampItem = chunkStampItem
-
-type TxChunkStoreWrapper = txChunkStoreWrapper
+type (
+	RetrievalIndexItem  = retrievalIndexItem
+	ChunkStampItem      = chunkStampItem
+	TxChunkStoreWrapper = txChunkStoreWrapper
+)
 
 var (
 	ErrMarshalInvalidRetrievalIndexItemAddress = errMarshalInvalidRetrievalIndexAddress

--- a/pkg/localstorev2/internal/chunkstore/export_test.go
+++ b/pkg/localstorev2/internal/chunkstore/export_test.go
@@ -4,9 +4,13 @@
 
 package chunkstore
 
+import storage "github.com/ethersphere/bee/pkg/storagev2"
+
 type RetrievalIndexItem = retrievalIndexItem
 
 type ChunkStampItem = chunkStampItem
+
+type TxChunkStoreWrapper = txChunkStoreWrapper
 
 var (
 	ErrMarshalInvalidRetrievalIndexItemAddress = errMarshalInvalidRetrievalIndexAddress
@@ -17,3 +21,7 @@ var (
 	ErrMarshalInvalidChunkStampItemStamp     = errMarshalInvalidChunkStampItemStamp
 	ErrUnmarshalInvalidChunkStampItemSize    = errUnmarshalInvalidChunkStampItemSize
 )
+
+func (t *txChunkStoreWrapper) Store() storage.Store {
+	return t.txStore
+}

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore.go
@@ -1,0 +1,124 @@
+package chunkstore
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethersphere/bee/pkg/sharky"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/hashicorp/go-multierror"
+)
+
+type txSharky struct {
+	Sharky
+
+	opsMu         sync.Mutex
+	releaseOps    []sharky.Location
+	committedLocs []sharky.Location
+}
+
+func (t *txSharky) Write(ctx context.Context, data []byte) (sharky.Location, error) {
+	loc, err := t.Sharky.Write(ctx, data)
+	if err == nil {
+		t.opsMu.Lock()
+		t.committedLocs = append(t.committedLocs, loc)
+		t.opsMu.Unlock()
+	}
+	return loc, err
+}
+
+func (t *txSharky) Release(_ context.Context, loc sharky.Location) error {
+	t.opsMu.Lock()
+	defer t.opsMu.Unlock()
+
+	t.releaseOps = append(t.releaseOps, loc)
+
+	return nil
+}
+
+func (t *txSharky) newTx() *txSharky {
+	return &txSharky{Sharky: t.Sharky}
+}
+
+type txChunkStoreWrapper struct {
+	*storage.TxChunkStoreBase
+
+	txStore storage.TxStore
+	sharky  *txSharky
+	doneMu  sync.Mutex
+}
+
+func (t *txChunkStoreWrapper) Put(ctx context.Context, chunk swarm.Chunk) error {
+	return t.TxChunkStoreBase.Put(ctx, chunk)
+}
+
+func (t *txChunkStoreWrapper) Delete(ctx context.Context, address swarm.Address) error {
+	return t.TxChunkStoreBase.Delete(ctx, address)
+}
+
+func (t *txChunkStoreWrapper) Commit() error {
+	t.doneMu.Lock()
+	defer t.doneMu.Unlock()
+
+	if err := t.IsDone(); err != nil {
+		return err
+	}
+
+	for _, v := range t.sharky.releaseOps {
+		err := t.sharky.Sharky.Release(context.Background(), v)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := t.txStore.Commit(); err != nil {
+		for _, v := range t.sharky.committedLocs {
+			err = multierror.Append(err, t.sharky.Sharky.Release(context.Background(), v))
+		}
+		return err
+	}
+
+	t.TxState.Done()
+	return nil
+}
+
+func (t *txChunkStoreWrapper) Rollback() error {
+	t.doneMu.Lock()
+	defer t.doneMu.Unlock()
+
+	if err := t.IsDone(); err != nil {
+		return err
+	}
+
+	if err := t.txStore.Rollback(); err != nil {
+		return err
+	}
+
+	var err *multierror.Error
+	for _, v := range t.sharky.committedLocs {
+		err = multierror.Append(err, t.sharky.Sharky.Release(context.Background(), v))
+	}
+	return err.ErrorOrNil()
+}
+
+func (t *txChunkStoreWrapper) NewTx(state *storage.TxState) storage.TxChunkStore {
+	txStore := t.txStore.NewTx(storage.NewChildTxState(state))
+	txSharky := t.sharky.newTx()
+	return &txChunkStoreWrapper{
+		TxChunkStoreBase: &storage.TxChunkStoreBase{
+			TxState:    state,
+			ChunkStore: New(txStore, txSharky),
+		},
+		txStore: txStore,
+		sharky:  txSharky,
+	}
+}
+
+func NewTxChunkStore(txStore storage.TxStore, sharky Sharky) storage.TxChunkStore {
+	return &txChunkStoreWrapper{
+		TxChunkStoreBase: &storage.TxChunkStoreBase{ChunkStore: New(txStore, sharky)},
+		txStore:          txStore,
+		sharky:           &txSharky{Sharky: sharky},
+	}
+}

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// txSharky provides a simple txn functionality over the Sharky store.
 type txSharky struct {
 	Sharky
 
@@ -41,9 +42,7 @@ func (t *txSharky) Release(_ context.Context, loc sharky.Location) error {
 	return nil
 }
 
-func (t *txSharky) newTx() *txSharky {
-	return &txSharky{Sharky: t.Sharky}
-}
+func (t *txSharky) newTx() *txSharky { return &txSharky{Sharky: t.Sharky} }
 
 type txChunkStoreWrapper struct {
 	*storage.TxChunkStoreBase

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore.go
@@ -1,3 +1,7 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package chunkstore
 
 import (

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package chunkstore_test
 
 import (
@@ -26,7 +30,9 @@ func TestTxChunkStore(t *testing.T) {
 	storagetest.TestTxChunkStore(t, chunkstore.NewTxChunkStore(inmemstore.NewTxStore(inmemstore.New()), sharky))
 }
 
-func TestMultipleStamps(t *testing.T) {
+// TestMultipleStampsRefCnt tests the behaviour of ref counting along with multiple
+// stamps to ensure transactions work correctly.
+func TestMultipleStampsRefCnt(t *testing.T) {
 	t.Parallel()
 
 	sharky, err := sharky.New(&memFS{Fs: afero.NewMemMapFs()}, 1, swarm.SocMaxChunkSize)

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
@@ -1,10 +1,14 @@
 package chunkstore_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/localstorev2/internal/chunkstore"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 	"github.com/ethersphere/bee/pkg/sharky"
+	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
 	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -14,10 +18,117 @@ import (
 func TestTxChunkStore(t *testing.T) {
 	t.Parallel()
 
-	sharky, err := sharky.New(&memFS{Fs: afero.NewMemMapFs()}, 1, swarm.ChunkSize)
+	sharky, err := sharky.New(&memFS{Fs: afero.NewMemMapFs()}, 1, swarm.SocMaxChunkSize)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	storagetest.TestTxChunkStore(t, chunkstore.NewTxChunkStore(inmemstore.NewTxStore(inmemstore.New()), sharky))
+}
+
+func TestMultipleStamps(t *testing.T) {
+	t.Parallel()
+
+	sharky, err := sharky.New(&memFS{Fs: afero.NewMemMapFs()}, 1, swarm.SocMaxChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chunkStore := chunkstore.NewTxChunkStore(inmemstore.NewTxStore(inmemstore.New()), sharky)
+
+	chunk := chunktest.GenerateTestRandomChunk()
+	stamps := []swarm.Stamp{chunk.Stamp()}
+	for i := 0; i < 2; i++ {
+		stamps = append(stamps, postagetesting.MustNewStamp())
+	}
+
+	verify := func(t *testing.T) {
+		t.Helper()
+
+		rIdx := chunkstore.RetrievalIndexItem{
+			Address: chunk.Address(),
+		}
+
+		has, err := chunkStore.(*chunkstore.TxChunkStoreWrapper).Store().Has(&rIdx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !has {
+			t.Fatalf("retrievalIndex not found %s", chunk.Address())
+		}
+
+		for _, stamp := range stamps {
+			sIdx := chunkstore.ChunkStampItem{
+				Address: chunk.Address(),
+				Stamp:   stamp,
+			}
+
+			has, err := chunkStore.(*chunkstore.TxChunkStoreWrapper).Store().Has(&sIdx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !has {
+				t.Fatalf("chunkStampItem not found %s", chunk.Address())
+			}
+		}
+	}
+
+	t.Run("put with multiple stamps", func(t *testing.T) {
+		cs := chunkStore.NewTx(storage.NewTxState(context.TODO()))
+
+		for _, stamp := range stamps {
+			err := chunkStore.Put(context.TODO(), chunk.WithStamp(stamp))
+			if err != nil {
+				t.Fatalf("failed to put chunk: %v", err)
+			}
+		}
+
+		err := cs.Commit()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		verify(t)
+	})
+
+	t.Run("rollback delete operations", func(t *testing.T) {
+		t.Run("less than refCnt", func(t *testing.T) {
+			cs := chunkStore.NewTx(storage.NewTxState(context.TODO()))
+
+			for i := 0; i < 2; i++ {
+				err := cs.Delete(context.TODO(), chunk.Address())
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := cs.Rollback()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			verify(t)
+		})
+
+		// this should remove all the stamps and hopefully bring them back
+		t.Run("till refCnt", func(t *testing.T) {
+			cs := chunkStore.NewTx(storage.NewTxState(context.TODO()))
+
+			for i := 0; i < 3; i++ {
+				err := cs.Delete(context.TODO(), chunk.Address())
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := cs.Rollback()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			verify(t)
+		})
+	})
 }

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
@@ -40,7 +40,8 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chunkStore := chunkstore.NewTxChunkStore(inmemstore.NewTxStore(inmemstore.New()), sharky)
+	store := inmemstore.New()
+	chunkStore := chunkstore.NewTxChunkStore(inmemstore.NewTxStore(store), sharky)
 
 	chunk := chunktest.GenerateTestRandomChunk()
 	stamps := []swarm.Stamp{chunk.Stamp()}
@@ -48,14 +49,14 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 		stamps = append(stamps, postagetesting.MustNewStamp())
 	}
 
-	verify := func(t *testing.T) {
+	verifyAllIndexes := func(t *testing.T) {
 		t.Helper()
 
 		rIdx := chunkstore.RetrievalIndexItem{
 			Address: chunk.Address(),
 		}
 
-		has, err := chunkStore.(*chunkstore.TxChunkStoreWrapper).Store().Has(&rIdx)
+		has, err := store.Has(&rIdx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -70,7 +71,7 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 				Stamp:   stamp,
 			}
 
-			has, err := chunkStore.(*chunkstore.TxChunkStoreWrapper).Store().Has(&sIdx)
+			has, err := store.Has(&sIdx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -96,7 +97,7 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		verify(t)
+		verifyAllIndexes(t)
 	})
 
 	t.Run("rollback delete operations", func(t *testing.T) {
@@ -115,7 +116,7 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			verify(t)
+			verifyAllIndexes(t)
 		})
 
 		// this should remove all the stamps and hopefully bring them back
@@ -134,7 +135,7 @@ func TestMultipleStampsRefCnt(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			verify(t)
+			verifyAllIndexes(t)
 		})
 	})
 }

--- a/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
+++ b/pkg/localstorev2/internal/chunkstore/txchunkstore_test.go
@@ -1,0 +1,23 @@
+package chunkstore_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/localstorev2/internal/chunkstore"
+	"github.com/ethersphere/bee/pkg/sharky"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemstore"
+	"github.com/ethersphere/bee/pkg/storagev2/storagetest"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/spf13/afero"
+)
+
+func TestTxChunkStore(t *testing.T) {
+	t.Parallel()
+
+	sharky, err := sharky.New(&memFS{Fs: afero.NewMemMapFs()}, 1, swarm.ChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storagetest.TestTxChunkStore(t, chunkstore.NewTxChunkStore(inmemstore.NewTxStore(inmemstore.New()), sharky))
+}

--- a/pkg/localstorev2/localstore.go
+++ b/pkg/localstorev2/localstore.go
@@ -23,3 +23,5 @@ type PinStore interface {
 	HasPin(context.Context) (bool, error)
 	DeletePin(context.Context, swarm.Address) error
 }
+
+type localstore struct{}

--- a/pkg/localstorev2/localstore.go
+++ b/pkg/localstorev2/localstore.go
@@ -23,5 +23,3 @@ type PinStore interface {
 	HasPin(context.Context) (bool, error)
 	DeletePin(context.Context, swarm.Address) error
 }
-
-type localstore struct{}

--- a/pkg/storagev2/inmemstore/transaction.go
+++ b/pkg/storagev2/inmemstore/transaction.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ethersphere/bee/pkg/storagev2"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/pkg/storagev2/storagetest/chunkstore.go
+++ b/pkg/storagev2/storagetest/chunkstore.go
@@ -66,7 +66,7 @@ func TestChunkStore(t *testing.T, st storage.ChunkStore) {
 	t.Run("get chunks with multiple stamps", func(t *testing.T) {
 		st1 := postagetesting.MustNewStamp()
 		st2 := postagetesting.MustNewStamp()
-		ch1 := chunktest.GenerateTestRandomInvalidChunk().WithStamp(st1)
+		ch1 := chunktest.GenerateTestRandomChunk().WithStamp(st1)
 		ch2 := swarm.NewChunk(ch1.Address(), ch1.Data()).WithStamp(st2)
 
 		err := st.Put(context.TODO(), ch1)
@@ -114,7 +114,7 @@ func TestChunkStore(t *testing.T, st storage.ChunkStore) {
 	t.Run("get chunk errors", func(t *testing.T) {
 		nonexistentBatchID := postagetesting.MustNewID()
 		stamp := postagetesting.MustNewStamp()
-		ch := chunktest.GenerateTestRandomInvalidChunk().WithStamp(stamp)
+		ch := chunktest.GenerateTestRandomChunk().WithStamp(stamp)
 
 		err := st.Put(context.TODO(), swarm.NewChunk(ch.Address(), ch.Data()))
 		if err != nil {

--- a/pkg/storagev2/storagetest/transaction.go
+++ b/pkg/storagev2/storagetest/transaction.go
@@ -336,17 +336,17 @@ func checkTxChunkStoreFinishedTxInvariants(t *testing.T, store storage.TxChunkSt
 
 	ctx := context.Background()
 	want := storage.ErrTxDone
-	o007 := chunktest.GenerateTestRandomChunk()
+	randomChunk := chunktest.GenerateTestRandomChunk()
 
-	if chunk, have := store.Get(ctx, o007.Address()); !errors.Is(have, want) || chunk != nil {
+	if chunk, have := store.Get(ctx, randomChunk.Address()); !errors.Is(have, want) || chunk != nil {
 		t.Fatalf("Get(...)\n\thave: %v, %v\n\twant: <nil>, %v", chunk, have, want)
 	}
 
-	if have := store.Put(ctx, o007); !errors.Is(have, want) {
+	if have := store.Put(ctx, randomChunk); !errors.Is(have, want) {
 		t.Fatalf("Put(...):\n\thave: %v\n\twant: %v", have, want)
 	}
 
-	if have := store.Delete(ctx, o007.Address()); !errors.Is(have, want) {
+	if have := store.Delete(ctx, randomChunk.Address()); !errors.Is(have, want) {
 		t.Fatalf("Delete(...):\n\thave: %v\n\twant: %v", have, want)
 	}
 

--- a/pkg/storagev2/storagetest/transaction.go
+++ b/pkg/storagev2/storagetest/transaction.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -404,12 +403,7 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		// chunks := chunktest.GenerateTestRandomChunks(3)
-		chunks := []swarm.Chunk{
-			swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")).WithStamp(postagetesting.MustNewStamp()),
-		}
+		chunks := chunktest.GenerateTestRandomChunks(3)
 
 		t.Run("add new chunks", func(t *testing.T) {
 			tx := store.NewTx(storage.NewTxState(ctx))

--- a/pkg/storagev2/storagetest/transaction.go
+++ b/pkg/storagev2/storagetest/transaction.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/google/go-cmp/cmp"
@@ -337,7 +337,8 @@ func checkTxChunkStoreFinishedTxInvariants(t *testing.T, store storage.TxChunkSt
 
 	ctx := context.Background()
 	want := storage.ErrTxDone
-	o007 := swarm.NewChunk(swarm.NewAddress([]byte("007")), []byte("Hello, World!"))
+	// o007 := swarm.NewChunk(swarm.NewAddress([]byte("007")), []byte("Hello, World!"))
+	o007 := chunktest.GenerateTestRandomChunk()
 
 	if chunk, have := store.Get(ctx, o007.Address()); !errors.Is(have, want) || chunk != nil {
 		t.Fatalf("Get(...)\n\thave: %v, %v\n\twant: <nil>, %v", chunk, have, want)
@@ -404,11 +405,12 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		chunks := []swarm.Chunk{
-			swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")).WithStamp(postagetesting.MustNewStamp()),
-		}
+		// chunks := []swarm.Chunk{
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
+		// }
+		chunks := chunktest.GenerateTestRandomChunks(3)
 
 		t.Run("add new chunks", func(t *testing.T) {
 			tx := store.NewTx(storage.NewTxState(ctx))
@@ -474,11 +476,12 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 
 		tx := store.NewTx(storage.NewTxState(ctx))
 
-		chunks := []swarm.Chunk{
-			swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")).WithStamp(postagetesting.MustNewStamp()),
-		}
+		// chunks := []swarm.Chunk{
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
+		// }
+		chunks := chunktest.GenerateTestRandomChunks(3)
 		initChunkStore(t, tx, chunks...)
 
 		if err := tx.Rollback(); err != nil {
@@ -501,11 +504,12 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		t.Cleanup(cancel)
 
 		tx := store.NewTx(storage.NewTxState(ctx))
-		chunks := []swarm.Chunk{
-			swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")).WithStamp(postagetesting.MustNewStamp()),
-			swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")).WithStamp(postagetesting.MustNewStamp()),
-		}
+		// chunks := []swarm.Chunk{
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
+		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
+		// }
+		chunks := chunktest.GenerateTestRandomChunks(3)
 		initChunkStore(t, tx, chunks...)
 		if err := tx.Commit(); err != nil {
 			t.Fatalf("Commit(): unexpected error: %v", err)

--- a/pkg/storagev2/storagetest/transaction.go
+++ b/pkg/storagev2/storagetest/transaction.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
 	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -403,7 +404,12 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		chunks := chunktest.GenerateTestRandomChunks(3)
+		// chunks := chunktest.GenerateTestRandomChunks(3)
+		chunks := []swarm.Chunk{
+			swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")).WithStamp(postagetesting.MustNewStamp()),
+			swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")).WithStamp(postagetesting.MustNewStamp()),
+			swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")).WithStamp(postagetesting.MustNewStamp()),
+		}
 
 		t.Run("add new chunks", func(t *testing.T) {
 			tx := store.NewTx(storage.NewTxState(ctx))

--- a/pkg/storagev2/storagetest/transaction.go
+++ b/pkg/storagev2/storagetest/transaction.go
@@ -16,7 +16,6 @@ import (
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/google/go-cmp/cmp"
-	//"github.com/ethersphere/bee/pkg/storagev2/leveldbstore"
 )
 
 var _ storage.Item = (*object)(nil)
@@ -337,7 +336,6 @@ func checkTxChunkStoreFinishedTxInvariants(t *testing.T, store storage.TxChunkSt
 
 	ctx := context.Background()
 	want := storage.ErrTxDone
-	// o007 := swarm.NewChunk(swarm.NewAddress([]byte("007")), []byte("Hello, World!"))
 	o007 := chunktest.GenerateTestRandomChunk()
 
 	if chunk, have := store.Get(ctx, o007.Address()); !errors.Is(have, want) || chunk != nil {
@@ -405,11 +403,6 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		// chunks := []swarm.Chunk{
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
-		// }
 		chunks := chunktest.GenerateTestRandomChunks(3)
 
 		t.Run("add new chunks", func(t *testing.T) {
@@ -476,11 +469,6 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 
 		tx := store.NewTx(storage.NewTxState(ctx))
 
-		// chunks := []swarm.Chunk{
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
-		// }
 		chunks := chunktest.GenerateTestRandomChunks(3)
 		initChunkStore(t, tx, chunks...)
 
@@ -504,11 +492,6 @@ func TestTxChunkStore(t *testing.T, store storage.TxChunkStore) {
 		t.Cleanup(cancel)
 
 		tx := store.NewTx(storage.NewTxState(ctx))
-		// chunks := []swarm.Chunk{
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0001")), []byte("data1")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0002")), []byte("data2")),
-		// 	swarm.NewChunk(swarm.NewAddress([]byte("0003")), []byte("data3")),
-		// }
 		chunks := chunktest.GenerateTestRandomChunks(3)
 		initChunkStore(t, tx, chunks...)
 		if err := tx.Commit(); err != nil {

--- a/pkg/storagev2/transaction.go
+++ b/pkg/storagev2/transaction.go
@@ -114,14 +114,16 @@ func (tx *TxState) Done() error {
 	return err
 }
 
-func NewChildTxState(tx *TxState) *TxState {
-	return NewTxState(tx.ctx)
-}
-
 // NewTxState is a convenient constructor for creating instances of TxState.
 func NewTxState(ctx context.Context) *TxState {
 	ctx, cancel := context.WithCancel(ctx)
 	return &TxState{ctx: ctx, cancel: cancel}
+}
+
+// NewChildTxState can be used to initialize a new TxState by deriving the context
+// of the parent TxState. This can be used to potentially chain Txns.
+func NewChildTxState(tx *TxState) *TxState {
+	return NewTxState(tx.ctx)
 }
 
 var _ Store = (*TxStoreBase)(nil)

--- a/pkg/storagev2/transaction.go
+++ b/pkg/storagev2/transaction.go
@@ -114,6 +114,10 @@ func (tx *TxState) Done() error {
 	return err
 }
 
+func NewChildTxState(tx *TxState) *TxState {
+	return NewTxState(tx.ctx)
+}
+
 // NewTxState is a convenient constructor for creating instances of TxState.
 func NewTxState(ctx context.Context) *TxState {
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR adds the TxChunkStore implementation for the localstorev2.ChunkStore. The chunkstore uses the storage.Store as well as Sharky. So implementing a transaction functionality is a little tricky.

The way it is done here is to have a simple transaction functionality over sharky, where released locations are only released on commit, so that they can be rolled back and committed locations are released on rollback to give back the slots to sharky.

Along with this, we use the TxStore internally in the transactions to revert the state of the Store items to their original state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3702)
<!-- Reviewable:end -->
