### PR TITLE
revert: pusher to check receipt depth with the neighborhood depth, not s…

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -900,7 +900,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 	// set the pushSyncer in the PSS
 	pssService.SetPushSyncer(pushSyncProtocol)
 
-	pusherService := pusher.New(networkID, storer, batchStore, pushSyncProtocol, validStamp, tagService, logger, tracer, warmupTime, pusher.DefaultRetryCount)
+	pusherService := pusher.New(networkID, storer, kad, pushSyncProtocol, validStamp, tagService, logger, tracer, warmupTime, pusher.DefaultRetryCount)
 	b.pusherCloser = pusherService
 
 	pullStorage := pullstorage.New(storer, logger)

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethersphere/bee/pkg/localstore"
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/postage"
-	bsMock "github.com/ethersphere/bee/pkg/postage/batchstore/mock"
 	"github.com/ethersphere/bee/pkg/pusher"
 	"github.com/ethersphere/bee/pkg/pushsync"
 	pushsyncmock "github.com/ethersphere/bee/pkg/pushsync/mock"
@@ -29,6 +28,7 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/tags"
 	"github.com/ethersphere/bee/pkg/topology"
+	"github.com/ethersphere/bee/pkg/topology/mock"
 )
 
 // time to wait for received response from pushsync
@@ -88,6 +88,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	key, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(key)
@@ -102,7 +103,7 @@ func TestSendChunkToSyncWithTag(t *testing.T) {
 		return receipt, nil
 	})
 
-	mtags, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	mtags, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	ta, err := mtags.Create(1)
 	if err != nil {
@@ -137,6 +138,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	key, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(key)
@@ -151,7 +153,7 @@ func TestSendChunkToPushSyncWithoutTag(t *testing.T) {
 		return receipt, nil
 	})
 
-	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -174,6 +176,7 @@ func TestSendChunkToPushSyncViaApiChannel(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	key, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(key)
@@ -188,7 +191,7 @@ func TestSendChunkToPushSyncViaApiChannel(t *testing.T) {
 		return receipt, nil
 	})
 
-	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	_, p, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	apiC := make(chan *pusher.Op)
 	p.AddFeed(apiC)
@@ -211,12 +214,13 @@ func TestSendChunkToPushSyncDirect(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		return nil, topology.ErrWantSelf
 	})
 
-	_, p, _ := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	_, p, _ := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	apiC := make(chan *pusher.Op)
 	p.AddFeed(apiC)
@@ -245,12 +249,13 @@ func TestSendChunkAndReceiveInvalidReceipt(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	pushSyncService := pushsyncmock.New(func(ctx context.Context, chunk swarm.Chunk) (*pushsync.Receipt, error) {
 		return nil, errors.New("invalid receipt")
 	})
 
-	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -275,6 +280,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	key, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(key)
@@ -290,7 +296,7 @@ func TestSendChunkAndTimeoutinReceivingReceipt(t *testing.T) {
 		return receipt, nil
 	})
 
-	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp)
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, defaultMockValidStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {
@@ -330,8 +336,7 @@ func TestPusherRetryShallow(t *testing.T) {
 	// create the pivot peer pusher with depth 31, this makes
 	// sure that virtually any receipt generated by the random
 	// key will be considered too shallow
-	bs := bsMock.New(bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 31}))
-	_, _, storer := createPusherWithRetryCount(t, pivotPeer, pushSyncService, bs, defaultMockValidStamp, retryCount)
+	_, _, storer := createPusherWithRetryCount(t, pivotPeer, pushSyncService, defaultMockValidStamp, retryCount, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(31))
 
 	// generate a chunk at PO 1 with closestPeer, meaning that we get a
 	// receipt which is shallower than the pivot peer's depth, resulting
@@ -358,6 +363,7 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 
 	// create a trigger  and a closestpeer
 	triggerPeer := swarm.MustParseHexAddress("6000000000000000000000000000000000000000000000000000000000000000")
+	closestPeer := swarm.MustParseHexAddress("f000000000000000000000000000000000000000000000000000000000000000")
 
 	key, _ := crypto.GenerateSecp256k1Key()
 	signer := crypto.NewDefaultSigner(key)
@@ -376,7 +382,7 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 		return nil, errors.New("valid stamp error")
 	}
 
-	_, _, storer := createPusher(t, triggerPeer, pushSyncService, validStamp)
+	_, _, storer := createPusher(t, triggerPeer, pushSyncService, validStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
 
 	chunk := testingc.GenerateTestRandomChunk()
 
@@ -393,14 +399,13 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 	}
 }
 
-func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn) (*tags.Tags, *pusher.Service, *Store) {
+func createPusher(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
 	t.Helper()
 
-	bs := bsMock.New()
-	return createPusherWithRetryCount(t, addr, pushSyncService, bs, validStamp, pusher.DefaultRetryCount)
+	return createPusherWithRetryCount(t, addr, pushSyncService, validStamp, pusher.DefaultRetryCount, mockOpts...)
 }
 
-func createPusherWithRetryCount(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, bs postage.Storer, validStamp postage.ValidStampFn, retryCount int) (*tags.Tags, *pusher.Service, *Store) {
+func createPusherWithRetryCount(t *testing.T, addr swarm.Address, pushSyncService pushsync.PushSyncer, validStamp postage.ValidStampFn, retryCount int, mockOpts ...mock.Option) (*tags.Tags, *pusher.Service, *Store) {
 	t.Helper()
 	logger := log.Noop
 
@@ -420,8 +425,9 @@ func createPusherWithRetryCount(t *testing.T, addr swarm.Address, pushSyncServic
 		modeSet:        make(map[string]storage.ModeSet),
 		modeSetMu:      &sync.Mutex{},
 	}
+	peerSuggester := mock.NewTopologyDriver(mockOpts...)
 
-	pusherService := pusher.New(1, pusherStorer, bs, pushSyncService, validStamp, mtags, logger, nil, 0, retryCount)
+	pusherService := pusher.New(1, pusherStorer, peerSuggester, pushSyncService, validStamp, mtags, logger, nil, 0, retryCount)
 
 	t.Cleanup(func() {
 		pusherService.Close()


### PR DESCRIPTION
…torage radius

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Light nodes do not maintain a storage radius so we revert this small change to the pusher back to the neighborhood depth.


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3726)
<!-- Reviewable:end -->
