### PR TITLE
feat: add isFullySynced field

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -703,6 +703,8 @@ components:
       properties:
         isFrozen:
           type: boolean
+        isFullySynced:
+          type: boolean
         round:
           type: integer
         lastWonRound:

--- a/pkg/api/redistribution.go
+++ b/pkg/api/redistribution.go
@@ -13,6 +13,7 @@ import (
 
 type nodeStatusResponse struct {
 	IsFrozen        bool           `json:"isFrozen"`
+	IsFullySynced   bool           `json:"isFullySynced"`
 	Phase           string         `json:"phase"`
 	Round           uint64         `json:"round"`
 	LastWonRound    uint64         `json:"lastWonRound"`
@@ -36,6 +37,7 @@ func (s *Service) redistributionStatusHandler(w http.ResponseWriter, r *http.Req
 
 	jsonhttp.OK(w, nodeStatusResponse{
 		IsFrozen:        status.IsFrozen,
+		IsFullySynced:   status.IsFullySynced,
 		Phase:           status.Phase.String(),
 		LastWonRound:    status.LastWonRound,
 		LastPlayedRound: status.LastPlayedRound,

--- a/pkg/storageincentives/agent.go
+++ b/pkg/storageincentives/agent.go
@@ -337,6 +337,7 @@ func (a *Agent) play(ctx context.Context, round uint64) (uint8, []byte, error) {
 
 	// get depthmonitor fully synced indicator
 	ready := a.monitor.IsFullySynced()
+	a.state.IsFullySynced(ready)
 	if !ready {
 		return 0, nil, nil
 	}

--- a/pkg/storageincentives/redistributionstate.go
+++ b/pkg/storageincentives/redistributionstate.go
@@ -41,6 +41,7 @@ type RedistributionState struct {
 type Status struct {
 	Phase           PhaseType
 	IsFrozen        bool
+	IsFullySynced   bool
 	Round           uint64
 	LastWonRound    uint64
 	LastPlayedRound uint64
@@ -103,6 +104,13 @@ func (r *RedistributionState) SetLastWonRound(round uint64) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	r.status.LastWonRound = round
+	r.save()
+}
+
+func (r *RedistributionState) IsFullySynced(isSynced bool) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.status.IsFullySynced = isSynced
 	r.save()
 }
 

--- a/pkg/storageincentives/redistributionstate_test.go
+++ b/pkg/storageincentives/redistributionstate_test.go
@@ -42,7 +42,8 @@ func TestState(t *testing.T) {
 	t.Parallel()
 	input := Status{
 		Phase:           commit,
-		IsFrozen:        false,
+		IsFrozen:        true,
+		IsFullySynced:   true,
 		Round:           2,
 		LastWonRound:    2,
 		LastPlayedRound: 2,
@@ -51,17 +52,19 @@ func TestState(t *testing.T) {
 	}
 	want := Status{
 		Phase:           commit,
-		IsFrozen:        false,
+		IsFrozen:        true,
+		IsFullySynced:   true,
 		Round:           2,
 		LastWonRound:    2,
 		LastPlayedRound: 2,
-		LastFrozenRound: 0,
+		LastFrozenRound: 2,
 		Block:           2,
 		Fees:            big.NewInt(0),
 		Reward:          big.NewInt(0),
 	}
 	state := createRedistribution(t, nil, nil)
 	state.SetCurrentEvent(input.Phase, input.Round, input.Block)
+	state.IsFullySynced(input.IsFullySynced)
 	state.SetLastWonRound(input.LastWonRound)
 	state.SetFrozen(input.IsFrozen, input.LastFrozenRound)
 	state.SetLastPlayedRound(input.LastPlayedRound)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
add isFullySynced field, which indicates that the node is ready to participate in the game

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3751)
<!-- Reviewable:end -->
