### PR TITLE
feat: increase max page of pullsync requests

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -51,7 +51,7 @@ const (
 )
 
 // how many maximum chunks in a batch
-var maxPage = 50
+var maxPage = 250
 
 // Interface is the PullSync interface.
 type Interface interface {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
PR increases the max page of a pullsync pull request from 
50 chunks (~200kb) to 250 chunks (~1MB)

this will reduce the number of opened and closed streams, and makes skipping unwanted bin intervals quicker.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3754)
<!-- Reviewable:end -->
