### PR TITLE
fix: isFullySynced needs to be check frequently

### DIFF
--- a/pkg/storageincentives/agent.go
+++ b/pkg/storageincentives/agent.go
@@ -272,8 +272,8 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 		}
 
 		prevPhase = currentPhase
+		a.state.IsFullySynced(a.monitor.IsFullySynced())
 		mtx.Unlock()
-
 	}
 }
 
@@ -337,7 +337,6 @@ func (a *Agent) play(ctx context.Context, round uint64) (uint8, []byte, error) {
 
 	// get depthmonitor fully synced indicator
 	ready := a.monitor.IsFullySynced()
-	a.state.IsFullySynced(ready)
 	if !ready {
 		return 0, nil, nil
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
IsFullySynced property should be set frequently instead of only when the neighbourhood is selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3758)
<!-- Reviewable:end -->
