### PR TITLE
ci: public deb and rpm packages to gemfury repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_PAT: ${{ secrets.GHA_PAT_BASIC }}
           SCOOP_PAT: ${{ secrets.GHA_PAT_BASIC }}
+          GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
           BEE_API_VERSION: ${{ env.BEE_API_VERSION }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -172,6 +172,8 @@ archives:
 nfpms:
   - file_name_template: "{{ tolower .ProjectName }}_{{ tolower .Version }}_{{ tolower .Arch }}"
 
+    id: packages
+
     vendor: Swarm Foundation
 
     homepage: https://www.ethswarm.org
@@ -229,6 +231,13 @@ nfpms:
           postremove: ./packaging/rpm/postun
 
     bindir: /usr/bin
+
+publishers:
+  - name: gemfury
+    ids:
+      - packages
+    dir: "{{ dir .ArtifactPath }}"
+    cmd: bash -c "if [[ \"{{ .Prerelease }}\" == \"\" ]]; then curl -F package=@{{ .ArtifactName }} https://{{ .Env.GEMFURY_TOKEN }}@push.fury.io/ethersphere/; else echo SKIPPING PRERELEASE!; fi"
 
 scoop:
   url_template: "https://github.com/ethersphere/bee/releases/download/{{ .Tag }}/{{ .ArtifactName }}"


### PR DESCRIPTION
Slowly we will migrate deb and rpm repos from self-hosted github to [gemfury](https://gemfury.com/ethersphere)
It will not push rc' to the gemfury repo