### PR TITLE
fix(pusher): move stamp validation just before pushing

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -113,13 +113,9 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 	// inflight.set handles the backpressure for the maximum amount of inflight chunks
 	// and duplicate handling.
 	chunks, repeat, unsubscribe := s.storer.SubscribePush(ctx, s.inflight.set)
-	go func() {
-		<-s.quit
+	defer func() {
 		unsubscribe()
 		cancel()
-		if !timer.Stop() {
-			<-timer.C
-		}
 	}()
 
 	ctxLogger := func() (context.Context, log.Logger) {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -136,13 +136,16 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 
 		if err := s.valid(op.Chunk); err != nil {
 			logger.Warning("stamp with is no longer valid, skipping syncing for chunk", "batch_id", hex.EncodeToString(op.Chunk.Stamp().BatchID()), "chunk_address", op.Chunk.Address(), "error", err)
-			ctx, cancel := context.WithTimeout(ctx, chunkStoreTimeout)
-			defer cancel()
-			if err = s.storer.Set(ctx, storage.ModeSetSync, op.Chunk.Address()); err != nil {
-				s.logger.Error(err, "set sync failed")
-			}
-			if op.Err != nil {
-				op.Err <- err
+			if op.Direct {
+				if op.Err != nil {
+					op.Err <- err
+				}
+			} else {
+				ctx, cancel := context.WithTimeout(ctx, chunkStoreTimeout)
+				defer cancel()
+				if err = s.storer.Set(ctx, storage.ModeSetSync, op.Chunk.Address()); err != nil {
+					s.logger.Error(err, "set sync failed")
+				}
 			}
 			return
 		}

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -135,7 +135,7 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 		startTime := time.Now()
 
 		if err := s.valid(op.Chunk); err != nil {
-			logger.Warning("stamp with is no longer valid, skipping syncing for chunk", "batch_id", hex.EncodeToString(op.Chunk.Stamp().BatchID()), "chunk_address", op.Chunk.Address(), "error", err)
+			logger.Warning("stamp with is no longer valid, skipping syncing for chunk", "batch_id", hex.EncodeToString(op.Chunk.Stamp().BatchID()), "direct_upload", op.Direct, "chunk_address", op.Chunk.Address(), "error", err)
 			if op.Direct {
 				if op.Err != nil {
 					op.Err <- err

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -378,13 +378,13 @@ func TestChunkWithInvalidStampSkipped(t *testing.T) {
 		return receipt, nil
 	})
 
+	chunk := testingc.GenerateTestRandomChunk()
+
 	validStamp := func(ch swarm.Chunk, stamp []byte) (swarm.Chunk, error) {
-		return nil, errors.New("valid stamp error")
+		return chunk, nil
 	}
 
 	_, _, storer := createPusher(t, triggerPeer, pushSyncService, validStamp, mock.WithClosestPeer(closestPeer), mock.WithNeighborhoodDepth(0))
-
-	chunk := testingc.GenerateTestRandomChunk()
 
 	_, err := storer.Put(context.Background(), storage.ModePutUpload, chunk)
 	if err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Because pusher does stamp validation before the semaphore acquire, under extreme heavy loads (as seen in the testnet), the pusher could be overwhelmed and batches that originally passed the validation may become expired while waiting in the queue to be pushed.

The fix is to move the validation to just before pushing the chunk.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3760)
<!-- Reviewable:end -->
