### PR TITLE
feat(localstorev2): netstore interfaces

### DIFF
--- a/pkg/localstorev2/export_test.go
+++ b/pkg/localstorev2/export_test.go
@@ -83,6 +83,17 @@ func (db *DB) SetRepoStorePutHook(fn func(storage.Item) error) {
 	db.repo = &wrappedRepo{Repository: db.repo, putHook: fn}
 }
 
+func (db *DB) WaitForBgCacheWorkers() (unblock func()) {
+	for i := 0; i < defaultBgCacheWorkers; i++ {
+		db.bgCacheWorkers <- struct{}{}
+	}
+	return func() {
+		for i := 0; i < defaultBgCacheWorkers; i++ {
+			<-db.bgCacheWorkers
+		}
+	}
+}
+
 func DefaultOptions() *Options {
 	return defaultOptions()
 }

--- a/pkg/localstorev2/localstore.go
+++ b/pkg/localstorev2/localstore.go
@@ -93,9 +93,19 @@ type CacheStore interface {
 	Cache() storage.Putter
 }
 
+// NetStore is a logical component of the localstore that deals with network. It will
+// push/retrieve chunks from the network.
 type NetStore interface {
-	DirectUpload() storage.Putter
-	Download(bool) storage.Getter
+	// DirectUpload provides a session which can be used to push chunks directly
+	// to the network.
+	DirectUpload() PutterSession
+	// Download provides a getter which can be used to download data. If the data
+	// is found locally, its returned immediately, otherwise it is retrieved from
+	// the network.
+	Download(pin bool) storage.Getter
+	// PusherFeed is the feed for direct push chunks. This can be used by the
+	// pusher component to push out the chunks.
+	PusherFeed() <-chan *pusher.Op
 }
 
 type memFS struct {

--- a/pkg/localstorev2/localstore_test.go
+++ b/pkg/localstorev2/localstore_test.go
@@ -20,10 +20,9 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-func verifySessionInfo(
+func verifyChunks(
 	t *testing.T,
 	repo storage.Repository,
-	sessionID uint64,
 	chunks []swarm.Chunk,
 	has bool,
 ) {
@@ -39,6 +38,19 @@ func verifySessionInfo(
 			t.Fatalf("unexpected chunk has state: want %t have %t", has, hasFound)
 		}
 	}
+
+}
+
+func verifySessionInfo(
+	t *testing.T,
+	repo storage.Repository,
+	sessionID uint64,
+	chunks []swarm.Chunk,
+	has bool,
+) {
+	t.Helper()
+
+	verifyChunks(t, repo, chunks, has)
 
 	if has {
 		tagInfo, err := upload.GetTagInfo(repo.IndexStore(), sessionID)
@@ -73,16 +85,7 @@ func verifyPinCollection(
 		t.Fatalf("unexpected pin collection state: want %t have %t", has, hasFound)
 	}
 
-	for _, ch := range chunks {
-		hasFound, err := repo.ChunkStore().Has(context.TODO(), ch.Address())
-		if err != nil {
-			t.Fatalf("ChunkStore.Has(...): unexpected error: %v", err)
-		}
-
-		if hasFound != has {
-			t.Fatalf("unexpected chunk state, exp has chunk %t got %t", has, hasFound)
-		}
-	}
+	verifyChunks(t, repo, chunks, has)
 }
 
 func testUploadStore(t *testing.T, newLocalstore func() (*localstore.DB, error)) {

--- a/pkg/localstorev2/localstore_test.go
+++ b/pkg/localstorev2/localstore_test.go
@@ -15,6 +15,7 @@ import (
 	localstore "github.com/ethersphere/bee/pkg/localstorev2"
 	pinstore "github.com/ethersphere/bee/pkg/localstorev2/internal/pinning"
 	"github.com/ethersphere/bee/pkg/localstorev2/internal/upload"
+	"github.com/ethersphere/bee/pkg/log"
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -609,7 +610,10 @@ func TestCacheStore(t *testing.T) {
 		t.Parallel()
 
 		testCacheStore(t, func() (*localstore.DB, error) {
-			return localstore.New("", &localstore.Options{CacheCapacity: 10})
+			return localstore.New("", &localstore.Options{
+				CacheCapacity: 10,
+				Logger:        log.Noop,
+			})
 		})
 	})
 	t.Run("disk", func(t *testing.T) {

--- a/pkg/localstorev2/netstore.go
+++ b/pkg/localstorev2/netstore.go
@@ -1,3 +1,7 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package localstore
 
 import (
@@ -77,7 +81,7 @@ func (db *DB) Download(cache bool) storage.Getter {
 
 						err := db.Cache().Put(ctx, ch)
 						if err != nil {
-							// log error
+							db.logger.Error(err, "failed putting chunk to cache", "chunk_address", ch.Address())
 						}
 					}()
 				}

--- a/pkg/localstorev2/netstore.go
+++ b/pkg/localstorev2/netstore.go
@@ -1,0 +1,44 @@
+package localstore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethersphere/bee/pkg/pusher"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+func (db *DB) DirectUpload() storage.Putter {
+	return storage.PutterFunc(func(ctx context.Context, ch swarm.Chunk) error {
+		op := &pusher.Op{Chunk: ch, Err: make(chan error), Direct: true}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-db.quit:
+			return errors.New("db stopped")
+		case db.pusherFeed <- op:
+			return <-op.Err
+		}
+	})
+}
+
+func (db *DB) Download() storage.Getter {
+	return storage.GetterFunc(func(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
+		ch, err := db.Lookup().Get(ctx, address)
+		switch {
+		case err == nil:
+			return ch, nil
+		case errors.Is(err, storage.ErrNotFound):
+			// if chunk is not found locally, retrieve it from the network
+			ch, err = db.retrieval.RetrieveChunk(ctx, address, swarm.ZeroAddress)
+			if err == nil {
+				_ = db.Cache().Put(ctx, ch)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	})
+}

--- a/pkg/localstorev2/netstore.go
+++ b/pkg/localstorev2/netstore.go
@@ -20,6 +20,7 @@ const (
 
 var errDBStopped = errors.New("db stopped")
 
+// DirectUpload is the implementation of the NetStore.DirectUpload method.
 func (db *DB) DirectUpload() PutterSession {
 	workers := make(chan struct{}, directUploadWorkers)
 	// egCtx will allow early exit of Put operations if we have
@@ -60,6 +61,7 @@ func (db *DB) DirectUpload() PutterSession {
 	}
 }
 
+// Download is the implementation of the NetStore.Download method.
 func (db *DB) Download(cache bool) storage.Getter {
 	return storage.GetterFunc(func(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
 		ch, err := db.Lookup().Get(ctx, address)
@@ -94,6 +96,7 @@ func (db *DB) Download(cache bool) storage.Getter {
 	})
 }
 
+// PusherFeed is the implementation of the NetStore.PusherFeed method.
 func (db *DB) PusherFeed() <-chan *pusher.Op {
 	return db.pusherFeed
 }

--- a/pkg/localstorev2/netstore_test.go
+++ b/pkg/localstorev2/netstore_test.go
@@ -1,0 +1,300 @@
+package localstore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	localstore "github.com/ethersphere/bee/pkg/localstorev2"
+	"github.com/ethersphere/bee/pkg/retrieval"
+	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type testRetrieval struct {
+	fn func(swarm.Address) (swarm.Chunk, error)
+}
+
+func (t *testRetrieval) RetrieveChunk(_ context.Context, address swarm.Address, _ swarm.Address) (swarm.Chunk, error) {
+	return t.fn(address)
+}
+
+func testNetStore(t *testing.T, newLocalstore func(r retrieval.Interface) (*localstore.DB, error)) {
+	t.Helper()
+
+	t.Run("direct upload", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("commit", func(t *testing.T) {
+			t.Parallel()
+
+			chunks := chunktesting.GenerateTestRandomChunks(10)
+
+			lstore, err := newLocalstore(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			session := lstore.DirectUpload()
+
+			count := 0
+			quit := make(chan struct{})
+			t.Cleanup(func() { close(quit) })
+			go func() {
+				for {
+					select {
+					case op := <-lstore.PusherFeed():
+						found := false
+						for _, ch := range chunks {
+							if op.Chunk.Equal(ch) {
+								found = true
+								break
+							}
+						}
+						if !found {
+							t.Fatalf("incorrect chunk for push: have %s", op.Chunk.Address())
+						}
+						count++
+						op.Err <- nil
+					case <-quit:
+						return
+					}
+				}
+			}()
+
+			for _, ch := range chunks {
+				err := session.Put(context.TODO(), ch)
+				if err != nil {
+					t.Fatalf("session.Put(...): unexpected error: %v", err)
+				}
+			}
+
+			err = session.Done(chunks[0].Address())
+			if err != nil {
+				t.Fatalf("session.Done(): unexpected error: %v", err)
+			}
+
+			if count != 10 {
+				t.Fatalf("unexpected no of pusher ops want 10 have %d", count)
+			}
+
+			verifyChunks(t, lstore.Repo(), chunks, false)
+		})
+
+		t.Run("pusher error", func(t *testing.T) {
+			t.Parallel()
+
+			chunks := chunktesting.GenerateTestRandomChunks(10)
+
+			lstore, err := newLocalstore(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			session := lstore.DirectUpload()
+
+			count := 0
+			quit := make(chan struct{})
+			t.Cleanup(func() { close(quit) })
+			wantErr := errors.New("dummy error")
+			go func() {
+				for {
+					select {
+					case op := <-lstore.PusherFeed():
+						found := false
+						for _, ch := range chunks {
+							if op.Chunk.Equal(ch) {
+								found = true
+								break
+							}
+						}
+						if !found {
+							t.Fatalf("incorrect chunk for push: have %s", op.Chunk.Address())
+						}
+						count++
+						if count >= 5 {
+							op.Err <- wantErr
+						} else {
+							op.Err <- nil
+						}
+					case <-quit:
+						return
+					}
+				}
+			}()
+
+			for _, ch := range chunks {
+				err := session.Put(context.TODO(), ch)
+				if err != nil && !errors.Is(err, wantErr) {
+					t.Fatalf("session.Put(...): unexpected error: %v", err)
+				}
+			}
+
+			err = session.Cleanup()
+			if err != nil {
+				t.Fatalf("session.Cleanup(): unexpected error: %v", err)
+			}
+
+			verifyChunks(t, lstore.Repo(), chunks, false)
+		})
+
+		t.Run("context cancellation", func(t *testing.T) {
+			t.Parallel()
+
+			chunks := chunktesting.GenerateTestRandomChunks(10)
+
+			lstore, err := newLocalstore(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			session := lstore.DirectUpload()
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			count := 0
+			go func() {
+				<-lstore.PusherFeed()
+				count++
+				cancel()
+			}()
+
+			for _, ch := range chunks {
+				err := session.Put(ctx, ch)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					t.Fatalf("session.Put(...): unexpected error: have %v", err)
+				}
+			}
+
+			err = session.Cleanup()
+			if err != nil {
+				t.Fatalf("session.Cleanup(): unexpected error: %v", err)
+			}
+
+			if count != 1 {
+				t.Fatalf("unexpected no of pusher ops want 5 have %d", count)
+			}
+
+			verifyChunks(t, lstore.Repo(), chunks, false)
+		})
+	})
+
+	t.Run("download", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with cache", func(t *testing.T) {
+			t.Parallel()
+
+			chunks := chunktesting.GenerateTestRandomChunks(10)
+
+			lstore, err := newLocalstore(&testRetrieval{fn: func(address swarm.Address) (swarm.Chunk, error) {
+				for _, ch := range chunks[5:] {
+					if ch.Address().Equal(address) {
+						return ch, nil
+					}
+				}
+				return nil, storage.ErrNotFound
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Add some chunks to Cache to simulate local retrieval.
+			for idx, ch := range chunks {
+				if idx < 5 {
+					err := lstore.Cache().Put(context.TODO(), ch)
+					if err != nil {
+						t.Fatalf("cache.Put(...): unexpected error: %v", err)
+					}
+				} else {
+					break
+				}
+			}
+
+			getter := lstore.Download(true)
+
+			for idx, ch := range chunks {
+				readCh, err := getter.Get(context.TODO(), ch.Address())
+				if err != nil {
+					t.Fatalf("download.Get(...): unexpected error: %v idx %d", err, idx)
+				}
+				if !readCh.Equal(ch) {
+					t.Fatalf("incorrect chunk read: address %s", readCh.Address())
+				}
+			}
+
+			t.Cleanup(lstore.WaitForBgCacheWorkers())
+
+			// After download is complete all chunks should be in the local storage.
+			verifyChunks(t, lstore.Repo(), chunks, true)
+		})
+
+		t.Run("no cache", func(t *testing.T) {
+			t.Parallel()
+
+			chunks := chunktesting.GenerateTestRandomChunks(10)
+
+			lstore, err := newLocalstore(&testRetrieval{fn: func(address swarm.Address) (swarm.Chunk, error) {
+				for _, ch := range chunks[5:] {
+					if ch.Address().Equal(address) {
+						return ch, nil
+					}
+				}
+				return nil, storage.ErrNotFound
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Add some chunks to Cache to simulate local retrieval.
+			for idx, ch := range chunks {
+				if idx < 5 {
+					err := lstore.Cache().Put(context.TODO(), ch)
+					if err != nil {
+						t.Fatalf("cache.Put(...): unexpected error: %v", err)
+					}
+				} else {
+					break
+				}
+			}
+
+			getter := lstore.Download(false)
+
+			for _, ch := range chunks {
+				readCh, err := getter.Get(context.TODO(), ch.Address())
+				if err != nil {
+					t.Fatalf("download.Get(...): unexpected error: %v", err)
+				}
+				if !readCh.Equal(ch) {
+					t.Fatalf("incorrect chunk read: address %s", readCh.Address())
+				}
+			}
+
+			// only the chunks that were already in cache should be present
+			verifyChunks(t, lstore.Repo(), chunks[:5], true)
+			verifyChunks(t, lstore.Repo(), chunks[5:], false)
+		})
+	})
+}
+
+func TestNetStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inmem", func(t *testing.T) {
+		t.Parallel()
+
+		testNetStore(t, func(r retrieval.Interface) (*localstore.DB, error) {
+			return localstore.New("", &localstore.Options{Retrieval: r, CacheCapacity: 100})
+		})
+	})
+	t.Run("disk", func(t *testing.T) {
+		t.Parallel()
+
+		testNetStore(t, func(r retrieval.Interface) (*localstore.DB, error) {
+			opts := localstore.DefaultOptions()
+			opts.Retrieval = r
+			return diskLocalstore(t, opts)()
+		})
+	})
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR adds the netstore interfaces as specified in the new localstore design. The Netstore is a special storage.Getter and storage.Putter which deals with the network. It will be used for direct upload and download. On direct upload, it will straight away push the chunks to the pusher. On download, it will retrieve the chunk from the network if not found locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3766)
<!-- Reviewable:end -->
