### PR TITLE
ci: bump goreleaser and fix deprecated option

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
           echo "BEE_API_VERSION=$(grep '^  version:' openapi/Swarm.yaml | awk '{print $2}')" >> $GITHUB_ENV
           echo "BEE_DEBUG_API_VERSION=$(grep '^  version:' openapi/SwarmDebug.yaml | awk '{print $2}')" >> $GITHUB_ENV
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist --timeout 1h
+          args: release --clean --timeout 1h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_PAT: ${{ secrets.GHA_PAT_BASIC }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,12 +119,12 @@ snapshot:
 signs:
   - artifacts: checksum
     args: [
-    "--pinentry-mode", "loopback",
-    "--passphrase", "{{ .Env.GPG_PASSPHRASE }}",
-    "-u", "{{ .Env.GPG_FINGERPRINT }}",
-    "--output", "${signature}",
-    "--detach-sign", "${artifact}",
-  ]
+      "--pinentry-mode", "loopback",
+      "--passphrase", "{{ .Env.GPG_PASSPHRASE }}",
+      "-u", "{{ .Env.GPG_FINGERPRINT }}",
+      "--output", "${signature}",
+      "--detach-sign", "${artifact}",
+    ]
 
 archives:
   -


### PR DESCRIPTION
Updated goreleaser version and fixed deprecated option

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3770)
<!-- Reviewable:end -->
