### PR TITLE
fix(pullsync): use parent ctx for storage operations

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -46,8 +46,7 @@ var (
 )
 
 const (
-	storagePutTimeout = 5 * time.Second
-	makeOfferTimeout  = 5 * time.Minute
+	makeOfferTimeout = 5 * time.Minute
 )
 
 // how many maximum chunks in a batch
@@ -234,9 +233,6 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 
 	if len(chunksToPut) > 0 {
 		s.metrics.DbOps.Inc()
-		ctx, cancel := context.WithTimeout(ctx, storagePutTimeout)
-		defer cancel()
-
 		if err := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
 			return topmost, fmt.Errorf("delivery put: %w", err)
 		}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3776)
<!-- Reviewable:end -->
