### PR TITLE
feat(file): use new storagev2 interfaces

### DIFF
--- a/pkg/encryption/store/decrypt_store.go
+++ b/pkg/encryption/store/decrypt_store.go
@@ -9,7 +9,7 @@ import (
 	"encoding/binary"
 
 	"github.com/ethersphere/bee/pkg/encryption"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"golang.org/x/crypto/sha3"
 )
@@ -22,17 +22,17 @@ func New(s storage.Getter) storage.Getter {
 	return &decryptingStore{s}
 }
 
-func (s *decryptingStore) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address) (ch swarm.Chunk, err error) {
+func (s *decryptingStore) Get(ctx context.Context, addr swarm.Address) (ch swarm.Chunk, err error) {
 	switch l := len(addr.Bytes()); l {
 	case swarm.HashSize:
 		// normal, unencrypted content
-		return s.Getter.Get(ctx, mode, addr)
+		return s.Getter.Get(ctx, addr)
 
 	case encryption.ReferenceSize:
 		// encrypted reference
 		ref := addr.Bytes()
 		address := swarm.NewAddress(ref[:swarm.HashSize])
-		ch, err := s.Getter.Get(ctx, mode, address)
+		ch, err := s.Getter.Get(ctx, address)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/feeds/epochs/finder.go
+++ b/pkg/feeds/epochs/finder.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 
 	"github.com/ethersphere/bee/pkg/feeds"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 

--- a/pkg/feeds/epochs/lookup_benchmark_test.go
+++ b/pkg/feeds/epochs/lookup_benchmark_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/feeds/epochs"
 	feedstesting "github.com/ethersphere/bee/pkg/feeds/testing"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 )
 
 func BenchmarkFinder(b *testing.B) {
 	for _, i := range []int{0, 8, 30} {
 		for _, prefill := range []int64{1, 50} {
 			after := int64(50)
-			storer := &feedstesting.Timeout{Storer: mock.NewStorer()}
+			storer := &feedstesting.Timeout{ChunkStore: inmemchunkstore.New()}
 			topicStr := "testtopic"
 			topic, err := crypto.LegacyKeccak256([]byte(topicStr))
 			if err != nil {

--- a/pkg/feeds/epochs/lookup_test.go
+++ b/pkg/feeds/epochs/lookup_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/feeds/epochs"
 	feedstesting "github.com/ethersphere/bee/pkg/feeds/testing"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 )
 
 func TestFinder(t *testing.T) {

--- a/pkg/feeds/epochs/updater.go
+++ b/pkg/feeds/epochs/updater.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 )
 
 var _ feeds.Updater = (*updater)(nil)

--- a/pkg/feeds/factory/factory.go
+++ b/pkg/feeds/factory/factory.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/feeds/epochs"
 	"github.com/ethersphere/bee/pkg/feeds/sequence"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 )
 
 type factory struct {

--- a/pkg/feeds/getter.go
+++ b/pkg/feeds/getter.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/pkg/soc"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -46,7 +46,7 @@ func (f *Getter) Get(ctx context.Context, i Index) (swarm.Chunk, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f.getter.Get(ctx, storage.ModeGetRequest, addr)
+	return f.getter.Get(ctx, addr)
 }
 
 // FromChunk parses out the timestamp and the payload

--- a/pkg/feeds/putter.go
+++ b/pkg/feeds/putter.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/cac"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/soc"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -53,8 +53,7 @@ func (u *Putter) Put(ctx context.Context, i Index, at int64, payload []byte) err
 	if err != nil {
 		return err
 	}
-	_, err = u.putter.Put(ctx, storage.ModePutUpload, ch)
-	return err
+	return u.putter.Put(ctx, ch)
 }
 
 func toChunk(at uint64, payload []byte) (swarm.Chunk, error) {

--- a/pkg/feeds/sequence/lookup_benchmark_test.go
+++ b/pkg/feeds/sequence/lookup_benchmark_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/feeds/sequence"
 	feedstesting "github.com/ethersphere/bee/pkg/feeds/testing"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 )
 
 func BenchmarkFinder(b *testing.B) {
 	for _, prefill := range []int64{1, 100, 1000, 5000} {
-		storer := &feedstesting.Timeout{Storer: mock.NewStorer()}
+		storer := &feedstesting.Timeout{ChunkStore: inmemchunkstore.New()}
 		topicStr := "testtopic"
 		topic, err := crypto.LegacyKeccak256([]byte(topicStr))
 		if err != nil {

--- a/pkg/feeds/sequence/lookup_test.go
+++ b/pkg/feeds/sequence/lookup_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethersphere/bee/pkg/feeds"
 	"github.com/ethersphere/bee/pkg/feeds/sequence"
 	feedstesting "github.com/ethersphere/bee/pkg/feeds/testing"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 )
 
 func TestFinder(t *testing.T) {

--- a/pkg/feeds/sequence/sequence.go
+++ b/pkg/feeds/sequence/sequence.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 

--- a/pkg/feeds/testing/lookup.go
+++ b/pkg/feeds/testing/lookup.go
@@ -17,20 +17,20 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 type Timeout struct {
-	storage.Storer
+	storage.ChunkStore
 }
 
 var searchTimeout = 30 * time.Millisecond
 
 // Get overrides the mock storer and introduces latency
-func (t *Timeout) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address) (swarm.Chunk, error) {
-	ch, err := t.Storer.Get(ctx, mode, addr)
+func (t *Timeout) Get(ctx context.Context, addr swarm.Address) (swarm.Chunk, error) {
+	ch, err := t.ChunkStore.Get(ctx, addr)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			time.Sleep(searchTimeout)
@@ -45,7 +45,7 @@ func (t *Timeout) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Addr
 func TestFinderBasic(t *testing.T, finderf func(storage.Getter, *feeds.Feed) feeds.Lookup, updaterf func(putter storage.Putter, signer crypto.Signer, topic []byte) (feeds.Updater, error)) {
 	t.Parallel()
 
-	storer := &Timeout{mock.NewStorer()}
+	storer := &Timeout{inmemchunkstore.New()}
 	topicStr := "testtopic"
 	topic, err := crypto.LegacyKeccak256([]byte(topicStr))
 	if err != nil {
@@ -119,7 +119,7 @@ func TestFinderFixIntervals(t *testing.T, nextf func() (bool, int64), finderf fu
 
 func TestFinderIntervals(t *testing.T, nextf func() (bool, int64), finderf func(storage.Getter, *feeds.Feed) feeds.Lookup, updaterf func(putter storage.Putter, signer crypto.Signer, topic []byte) (feeds.Updater, error)) {
 
-	storer := &Timeout{mock.NewStorer()}
+	storer := &Timeout{inmemchunkstore.New()}
 	topicStr := "testtopic"
 	topic, err := crypto.LegacyKeccak256([]byte(topicStr))
 	if err != nil {

--- a/pkg/file/addresses/addresses_getter.go
+++ b/pkg/file/addresses/addresses_getter.go
@@ -7,7 +7,7 @@ package addresses
 import (
 	"context"
 
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -22,8 +22,8 @@ func NewGetter(getter storage.Getter, fn swarm.AddressIterFunc) storage.Getter {
 	return &addressesGetterStore{getter, fn}
 }
 
-func (s *addressesGetterStore) Get(ctx context.Context, mode storage.ModeGet, addr swarm.Address) (swarm.Chunk, error) {
-	ch, err := s.getter.Get(ctx, mode, addr)
+func (s *addressesGetterStore) Get(ctx context.Context, addr swarm.Address) (swarm.Chunk, error) {
+	ch, err := s.getter.Get(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/file/addresses/addresses_getter_test.go
+++ b/pkg/file/addresses/addresses_getter_test.go
@@ -29,21 +29,21 @@ func TestAddressesGetterIterateChunkAddresses(t *testing.T) {
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/addresses/addresses_getter_test.go
+++ b/pkg/file/addresses/addresses_getter_test.go
@@ -15,36 +15,35 @@ import (
 	"github.com/ethersphere/bee/pkg/file/addresses"
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	filetest "github.com/ethersphere/bee/pkg/file/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestAddressesGetterIterateChunkAddresses(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -48,7 +48,7 @@ func testSplitThenJoin(t *testing.T) {
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
 		store       = inmemchunkstore.New()
-		p           = builder.NewPipelineBuilder(context.TODO(), store, false)
+		p           = builder.NewPipelineBuilder(context.Background(), store, false)
 		data, _     = test.GetVector(t, int(dataIdx))
 	)
 

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	test "github.com/ethersphere/bee/pkg/file/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -48,8 +47,8 @@ func testSplitThenJoin(t *testing.T) {
 	var (
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
-		store       = mock.NewStorer()
-		p           = builder.NewPipelineBuilder(context.Background(), store, storage.ModePutUpload, false)
+		store       = inmemchunkstore.New()
+		p           = builder.NewPipelineBuilder(context.TODO(), store, false)
 		data, _     = test.GetVector(t, int(dataIdx))
 	)
 

--- a/pkg/file/joiner/joiner.go
+++ b/pkg/file/joiner/joiner.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ethersphere/bee/pkg/encryption"
 	"github.com/ethersphere/bee/pkg/encryption/store"
 	"github.com/ethersphere/bee/pkg/file"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"golang.org/x/sync/errgroup"
 )
@@ -36,7 +36,7 @@ type joiner struct {
 func New(ctx context.Context, getter storage.Getter, address swarm.Address) (file.Joiner, int64, error) {
 	getter = store.New(getter)
 	// retrieve the root chunk to read the total data length the be retrieved
-	rootChunk, err := getter.Get(ctx, storage.ModeGetRequest, address)
+	rootChunk, err := getter.Get(ctx, address)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -139,7 +139,7 @@ func (j *joiner) readAtOffset(b, data []byte, cur, subTrieSize, off, bufferOffse
 
 		func(address swarm.Address, b []byte, cur, subTrieSize, off, bufferOffset, bytesToRead, subtrieSpanLimit int64) {
 			eg.Go(func() error {
-				ch, err := j.getter.Get(j.ctx, storage.ModeGetRequest, address)
+				ch, err := j.getter.Get(j.ctx, address)
 				if err != nil {
 					return err
 				}
@@ -273,7 +273,7 @@ func (j *joiner) processChunkAddresses(ctx context.Context, fn swarm.AddressIter
 			eg.Go(func() error {
 				defer wg.Done()
 
-				ch, err := j.getter.Get(ectx, storage.ModeGetRequest, address)
+				ch, err := j.getter.Get(ectx, address)
 				if err != nil {
 					return err
 				}

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/file/splitter"
 	filetest "github.com/ethersphere/bee/pkg/file/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
 	testingc "github.com/ethersphere/bee/pkg/storage/testing"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"gitlab.com/nolash/go-mockbytes"
 )
@@ -32,7 +32,7 @@ import (
 func TestJoiner_ErrReferenceLength(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 	_, _, err := joiner.New(context.Background(), store, swarm.ZeroAddress)
 
 	if !errors.Is(err, storage.ErrReferenceLength) {
@@ -45,7 +45,7 @@ func TestJoiner_ErrReferenceLength(t *testing.T) {
 func TestJoinerSingleChunk(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,7 +57,7 @@ func TestJoinerSingleChunk(t *testing.T) {
 	mockDataLengthBytes := make([]byte, 8)
 	mockDataLengthBytes[0] = 0x03
 	mockChunk := swarm.NewChunk(mockAddr, append(mockDataLengthBytes, mockData...))
-	_, err := store.Put(ctx, storage.ModePutUpload, mockChunk)
+	_, err := store.Put(ctx, mockChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestJoinerSingleChunk(t *testing.T) {
 func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 	t.Parallel()
 
-	st := mock.NewStorer()
+	st := inmemchunkstore.New()
 	store := store.New(st)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -97,7 +97,7 @@ func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 	mockDataLengthBytes := make([]byte, 8)
 	mockDataLengthBytes[0] = 0x03
 	mockChunk := swarm.NewChunk(mockAddr, append(mockDataLengthBytes, mockData...))
-	_, err := st.Put(ctx, storage.ModePutUpload, mockChunk)
+	_, err := st.Put(ctx, mockChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,28 +124,28 @@ func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 func TestJoinerWithReference(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// create root chunk and two data chunks referenced in the root chunk
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,17 +175,17 @@ func TestJoinerWithReference(t *testing.T) {
 func TestJoinerMalformed(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	subTrie := []byte{8085: 1}
-	pb := builder.NewPipelineBuilder(ctx, store, storage.ModePutUpload, false)
+	pb := builder.NewPipelineBuilder(ctx, store, false)
 	c1addr, _ := builder.FeedPipeline(ctx, pb, bytes.NewReader(subTrie))
 
 	chunk2 := testingc.GenerateTestRandomChunk()
-	_, err := store.Put(ctx, storage.ModePutUpload, chunk2)
+	_, err := store.Put(ctx, chunk2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestJoinerMalformed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err = store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.Run(fmt.Sprintf("Encrypt %d bytes", tt.chunkLength), func(t *testing.T) {
 			t.Parallel()
 
-			store := mock.NewStorer()
+			store := inmemchunkstore.New()
 
 			g := mockbytes.New(0, mockbytes.MockTypeStandard).WithModulus(255)
 			testData, err := g.SequentialBytes(tt.chunkLength)
@@ -247,7 +247,7 @@ func TestEncryptDecrypt(t *testing.T) {
 				t.Fatal(err)
 			}
 			ctx := context.Background()
-			pipe := builder.NewPipelineBuilder(ctx, store, storage.ModePutUpload, true)
+			pipe := builder.NewPipelineBuilder(ctx, store, true)
 			testDataReader := bytes.NewReader(testData)
 			resultAddress, err := builder.FeedPipeline(ctx, pipe, testDataReader)
 			if err != nil {
@@ -330,8 +330,7 @@ func TestSeek(t *testing.T) {
 
 			ctx := context.Background()
 
-			store := mock.NewStorer()
-			defer store.Close()
+			store := inmemchunkstore.New()
 
 			r := mrand.New(mrand.NewSource(seed))
 			data, err := io.ReadAll(io.LimitReader(r, tc.size))
@@ -339,7 +338,7 @@ func TestSeek(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
+			s := splitter.NewSimpleSplitter(store)
 			addr, err := s.Split(ctx, io.NopCloser(bytes.NewReader(data)), tc.size, false)
 			if err != nil {
 				t.Fatal(err)
@@ -612,8 +611,7 @@ func TestPrefetch(t *testing.T) {
 
 			ctx := context.Background()
 
-			store := mock.NewStorer()
-			defer store.Close()
+			store := inmemchunkstore.New()
 
 			r := mrand.New(mrand.NewSource(seed))
 			data, err := io.ReadAll(io.LimitReader(r, tc.size))
@@ -621,7 +619,7 @@ func TestPrefetch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
+			s := splitter.NewSimpleSplitter(store)
 			addr, err := s.Split(ctx, io.NopCloser(bytes.NewReader(data)), tc.size, false)
 			if err != nil {
 				t.Fatal(err)
@@ -650,28 +648,28 @@ func TestPrefetch(t *testing.T) {
 func TestJoinerReadAt(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -697,28 +695,28 @@ func TestJoinerReadAt(t *testing.T) {
 func TestJoinerOneLevel(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -771,28 +769,28 @@ func TestJoinerOneLevel(t *testing.T) {
 func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	// create root chunk with 2 references and two intermediate chunks with references
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*swarm.Branches+42, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize*swarm.Branches, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, 42, swarm.SectionSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -803,7 +801,7 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 		chunkAddressBytes := firstChunk.Data()[cursor : cursor+swarm.SectionSize]
 		chunkAddress := swarm.NewAddress(chunkAddressBytes)
 		ch := filetest.GenerateTestRandomFileChunk(chunkAddress, swarm.ChunkSize, swarm.ChunkSize)
-		_, err := store.Put(ctx, storage.ModePutUpload, ch)
+		_, err := store.Put(ctx, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -812,7 +810,7 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 	chunkAddressBytes := secondChunk.Data()[8:]
 	chunkAddress := swarm.NewAddress(chunkAddressBytes)
 	ch := filetest.GenerateTestRandomFileChunk(chunkAddress, 42, 42)
-	_, err = store.Put(ctx, storage.ModePutUpload, ch)
+	_, err = store.Put(ctx, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,28 +843,28 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 func TestJoinerIterateChunkAddresses(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, storage.ModePutUpload, rootChunk)
+	_, err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, firstChunk)
+	_, err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, storage.ModePutUpload, secondChunk)
+	_, err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -912,7 +910,7 @@ func TestJoinerIterateChunkAddresses(t *testing.T) {
 func TestJoinerIterateChunkAddresses_Encrypted(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 
 	g := mockbytes.New(0, mockbytes.MockTypeStandard).WithModulus(255)
 	testData, err := g.SequentialBytes(10000)
@@ -920,7 +918,7 @@ func TestJoinerIterateChunkAddresses_Encrypted(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	pipe := builder.NewPipelineBuilder(ctx, store, storage.ModePutUpload, true)
+	pipe := builder.NewPipelineBuilder(ctx, store, true)
 	testDataReader := bytes.NewReader(testData)
 	resultAddress, err := builder.FeedPipeline(ctx, pipe, testDataReader)
 	if err != nil {

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -57,7 +57,7 @@ func TestJoinerSingleChunk(t *testing.T) {
 	mockDataLengthBytes := make([]byte, 8)
 	mockDataLengthBytes[0] = 0x03
 	mockChunk := swarm.NewChunk(mockAddr, append(mockDataLengthBytes, mockData...))
-	_, err := store.Put(ctx, mockChunk)
+	err := store.Put(ctx, mockChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestJoinerDecryptingStore_NormalChunk(t *testing.T) {
 	mockDataLengthBytes := make([]byte, 8)
 	mockDataLengthBytes[0] = 0x03
 	mockChunk := swarm.NewChunk(mockAddr, append(mockDataLengthBytes, mockData...))
-	_, err := st.Put(ctx, mockChunk)
+	err := st.Put(ctx, mockChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,21 +131,21 @@ func TestJoinerWithReference(t *testing.T) {
 
 	// create root chunk and two data chunks referenced in the root chunk
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestJoinerMalformed(t *testing.T) {
 	c1addr, _ := builder.FeedPipeline(ctx, pb, bytes.NewReader(subTrie))
 
 	chunk2 := testingc.GenerateTestRandomChunk()
-	_, err := store.Put(ctx, chunk2)
+	err := store.Put(ctx, chunk2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestJoinerMalformed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = store.Put(ctx, rootChunk)
+	err = store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,21 +655,21 @@ func TestJoinerReadAt(t *testing.T) {
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -702,21 +702,21 @@ func TestJoinerOneLevel(t *testing.T) {
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -776,21 +776,21 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 
 	// create root chunk with 2 references and two intermediate chunks with references
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*swarm.Branches+42, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize*swarm.Branches, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, 42, swarm.SectionSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -801,7 +801,7 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 		chunkAddressBytes := firstChunk.Data()[cursor : cursor+swarm.SectionSize]
 		chunkAddress := swarm.NewAddress(chunkAddressBytes)
 		ch := filetest.GenerateTestRandomFileChunk(chunkAddress, swarm.ChunkSize, swarm.ChunkSize)
-		_, err := store.Put(ctx, ch)
+		err := store.Put(ctx, ch)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -810,7 +810,7 @@ func TestJoinerTwoLevelsAcrossChunk(t *testing.T) {
 	chunkAddressBytes := secondChunk.Data()[8:]
 	chunkAddress := swarm.NewAddress(chunkAddressBytes)
 	ch := filetest.GenerateTestRandomFileChunk(chunkAddress, 42, 42)
-	_, err = store.Put(ctx, ch)
+	err = store.Put(ctx, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -850,21 +850,21 @@ func TestJoinerIterateChunkAddresses(t *testing.T) {
 
 	// create root chunk with 2 references and the referenced data chunks
 	rootChunk := filetest.GenerateTestRandomFileChunk(swarm.ZeroAddress, swarm.ChunkSize*2, swarm.SectionSize*2)
-	_, err := store.Put(ctx, rootChunk)
+	err := store.Put(ctx, rootChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	firstAddress := swarm.NewAddress(rootChunk.Data()[8 : swarm.SectionSize+8])
 	firstChunk := filetest.GenerateTestRandomFileChunk(firstAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, firstChunk)
+	err = store.Put(ctx, firstChunk)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	secondAddress := swarm.NewAddress(rootChunk.Data()[swarm.SectionSize+8:])
 	secondChunk := filetest.GenerateTestRandomFileChunk(secondAddress, swarm.ChunkSize, swarm.ChunkSize)
-	_, err = store.Put(ctx, secondChunk)
+	err = store.Put(ctx, secondChunk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/loadsave/loadsave.go
+++ b/pkg/file/loadsave/loadsave.go
@@ -15,44 +15,39 @@ import (
 	"github.com/ethersphere/bee/pkg/file/joiner"
 	"github.com/ethersphere/bee/pkg/file/pipeline"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 var errReadonlyLoadSave = errors.New("readonly manifest loadsaver")
-
-type PutGetter interface {
-	storage.Putter
-	storage.Getter
-}
 
 // loadSave is needed for manifest operations and provides
 // simple wrapping over load and save operations using file
 // package abstractions. use with caution since Loader will
 // load all of the subtrie of a given hash in memory.
 type loadSave struct {
-	storer     PutGetter
+	getter     storage.Getter
 	pipelineFn func() pipeline.Interface
 }
 
 // New returns a new read-write load-saver.
-func New(storer PutGetter, pipelineFn func() pipeline.Interface) file.LoadSaver {
+func New(getter storage.Getter, pipelineFn func() pipeline.Interface) file.LoadSaver {
 	return &loadSave{
-		storer:     storer,
+		getter:     getter,
 		pipelineFn: pipelineFn,
 	}
 }
 
 // NewReadonly returns a new read-only load-saver
 // which will error on write.
-func NewReadonly(storer PutGetter) file.LoadSaver {
+func NewReadonly(getter storage.Getter) file.LoadSaver {
 	return &loadSave{
-		storer: storer,
+		getter: getter,
 	}
 }
 
 func (ls *loadSave) Load(ctx context.Context, ref []byte) ([]byte, error) {
-	j, _, err := joiner.New(ctx, ls.storer, swarm.NewAddress(ref))
+	j, _, err := joiner.New(ctx, ls.getter, swarm.NewAddress(ref))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/file/loadsave/loadsave_test.go
+++ b/pkg/file/loadsave/loadsave_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ethersphere/bee/pkg/file/loadsave"
 	"github.com/ethersphere/bee/pkg/file/pipeline"
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -27,7 +27,7 @@ var (
 func TestLoadSave(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 	ls := loadsave.New(store, pipelineFn(store))
 	ref, err := ls.Save(context.Background(), data)
 
@@ -49,7 +49,7 @@ func TestLoadSave(t *testing.T) {
 func TestReadonlyLoadSave(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 	factory := pipelineFn(store)
 	ls := loadsave.NewReadonly(store)
 	_, err := ls.Save(context.Background(), data)
@@ -71,8 +71,8 @@ func TestReadonlyLoadSave(t *testing.T) {
 	}
 }
 
-func pipelineFn(s storage.Storer) func() pipeline.Interface {
+func pipelineFn(s storage.Putter) func() pipeline.Interface {
 	return func() pipeline.Interface {
-		return builder.NewPipelineBuilder(context.Background(), s, storage.ModePutRequest, false)
+		return builder.NewPipelineBuilder(context.Background(), s, false)
 	}
 }

--- a/pkg/file/pipeline/builder/builder.go
+++ b/pkg/file/pipeline/builder/builder.go
@@ -17,33 +17,33 @@ import (
 	"github.com/ethersphere/bee/pkg/file/pipeline/feeder"
 	"github.com/ethersphere/bee/pkg/file/pipeline/hashtrie"
 	"github.com/ethersphere/bee/pkg/file/pipeline/store"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // NewPipelineBuilder returns the appropriate pipeline according to the specified parameters
-func NewPipelineBuilder(ctx context.Context, s storage.Putter, mode storage.ModePut, encrypt bool) pipeline.Interface {
+func NewPipelineBuilder(ctx context.Context, s storage.Putter, encrypt bool) pipeline.Interface {
 	if encrypt {
-		return newEncryptionPipeline(ctx, s, mode)
+		return newEncryptionPipeline(ctx, s)
 	}
-	return newPipeline(ctx, s, mode)
+	return newPipeline(ctx, s)
 }
 
 // newPipeline creates a standard pipeline that only hashes content with BMT to create
 // a merkle-tree of hashes that represent the given arbitrary size byte stream. Partial
 // writes are supported. The pipeline flow is: Data -> Feeder -> BMT -> Storage -> HashTrie.
-func newPipeline(ctx context.Context, s storage.Putter, mode storage.ModePut) pipeline.Interface {
-	tw := hashtrie.NewHashTrieWriter(swarm.ChunkSize, swarm.Branches, swarm.HashSize, newShortPipelineFunc(ctx, s, mode))
-	lsw := store.NewStoreWriter(ctx, s, mode, tw)
+func newPipeline(ctx context.Context, s storage.Putter) pipeline.Interface {
+	tw := hashtrie.NewHashTrieWriter(swarm.ChunkSize, swarm.Branches, swarm.HashSize, newShortPipelineFunc(ctx, s))
+	lsw := store.NewStoreWriter(ctx, s, tw)
 	b := bmt.NewBmtWriter(lsw)
 	return feeder.NewChunkFeederWriter(swarm.ChunkSize, b)
 }
 
 // newShortPipelineFunc returns a constructor function for an ephemeral hashing pipeline
 // needed by the hashTrieWriter.
-func newShortPipelineFunc(ctx context.Context, s storage.Putter, mode storage.ModePut) func() pipeline.ChainWriter {
+func newShortPipelineFunc(ctx context.Context, s storage.Putter) func() pipeline.ChainWriter {
 	return func() pipeline.ChainWriter {
-		lsw := store.NewStoreWriter(ctx, s, mode, nil)
+		lsw := store.NewStoreWriter(ctx, s, nil)
 		return bmt.NewBmtWriter(lsw)
 	}
 }
@@ -53,9 +53,9 @@ func newShortPipelineFunc(ctx context.Context, s storage.Putter, mode storage.Mo
 // writes are supported. The pipeline flow is: Data -> Feeder -> Encryption -> BMT -> Storage -> HashTrie.
 // Note that the encryption writer will mutate the data to contain the encrypted span, but the span field
 // with the unencrypted span is preserved.
-func newEncryptionPipeline(ctx context.Context, s storage.Putter, mode storage.ModePut) pipeline.Interface {
-	tw := hashtrie.NewHashTrieWriter(swarm.ChunkSize, 64, swarm.HashSize+encryption.KeyLength, newShortEncryptionPipelineFunc(ctx, s, mode))
-	lsw := store.NewStoreWriter(ctx, s, mode, tw)
+func newEncryptionPipeline(ctx context.Context, s storage.Putter) pipeline.Interface {
+	tw := hashtrie.NewHashTrieWriter(swarm.ChunkSize, 64, swarm.HashSize+encryption.KeyLength, newShortEncryptionPipelineFunc(ctx, s))
+	lsw := store.NewStoreWriter(ctx, s, tw)
 	b := bmt.NewBmtWriter(lsw)
 	enc := enc.NewEncryptionWriter(encryption.NewChunkEncrypter(), b)
 	return feeder.NewChunkFeederWriter(swarm.ChunkSize, enc)
@@ -63,9 +63,9 @@ func newEncryptionPipeline(ctx context.Context, s storage.Putter, mode storage.M
 
 // newShortEncryptionPipelineFunc returns a constructor function for an ephemeral hashing pipeline
 // needed by the hashTrieWriter.
-func newShortEncryptionPipelineFunc(ctx context.Context, s storage.Putter, mode storage.ModePut) func() pipeline.ChainWriter {
+func newShortEncryptionPipelineFunc(ctx context.Context, s storage.Putter) func() pipeline.ChainWriter {
 	return func() pipeline.ChainWriter {
-		lsw := store.NewStoreWriter(ctx, s, mode, nil)
+		lsw := store.NewStoreWriter(ctx, s, nil)
 		b := bmt.NewBmtWriter(lsw)
 		return enc.NewEncryptionWriter(encryption.NewChunkEncrypter(), b)
 	}

--- a/pkg/file/pipeline/builder/builder_test.go
+++ b/pkg/file/pipeline/builder/builder_test.go
@@ -23,7 +23,7 @@ func TestPartialWrites(t *testing.T) {
 	t.Parallel()
 
 	m := inmemchunkstore.New()
-	p := builder.NewPipelineBuilder(context.TODO(), m, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, false)
 	_, _ = p.Write([]byte("hello "))
 	_, _ = p.Write([]byte("world"))
 
@@ -41,7 +41,7 @@ func TestHelloWorld(t *testing.T) {
 	t.Parallel()
 
 	m := inmemchunkstore.New()
-	p := builder.NewPipelineBuilder(context.TODO(), m, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, false)
 
 	data := []byte("hello world")
 	_, err := p.Write(data)
@@ -92,7 +92,7 @@ func TestAllVectors(t *testing.T) {
 			t.Parallel()
 
 			m := inmemchunkstore.New()
-			p := builder.NewPipelineBuilder(context.TODO(), m, false)
+			p := builder.NewPipelineBuilder(context.Background(), m, false)
 
 			_, err := p.Write(data)
 			if err != nil {
@@ -154,7 +154,7 @@ func benchmarkPipeline(b *testing.B, count int) {
 	b.StopTimer()
 
 	m := inmemchunkstore.New()
-	p := builder.NewPipelineBuilder(context.TODO(), m, false)
+	p := builder.NewPipelineBuilder(context.Background(), m, false)
 	data := make([]byte, count)
 	_, err := rand.Read(data)
 	if err != nil {

--- a/pkg/file/pipeline/builder/builder_test.go
+++ b/pkg/file/pipeline/builder/builder_test.go
@@ -15,16 +15,15 @@ import (
 
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	test "github.com/ethersphere/bee/pkg/file/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestPartialWrites(t *testing.T) {
 	t.Parallel()
 
-	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	m := inmemchunkstore.New()
+	p := builder.NewPipelineBuilder(context.TODO(), m, false)
 	_, _ = p.Write([]byte("hello "))
 	_, _ = p.Write([]byte("world"))
 
@@ -41,8 +40,8 @@ func TestPartialWrites(t *testing.T) {
 func TestHelloWorld(t *testing.T) {
 	t.Parallel()
 
-	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	m := inmemchunkstore.New()
+	p := builder.NewPipelineBuilder(context.TODO(), m, false)
 
 	data := []byte("hello world")
 	_, err := p.Write(data)
@@ -64,8 +63,8 @@ func TestHelloWorld(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 
-	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	m := inmemchunkstore.New()
+	p := builder.NewPipelineBuilder(context.Background(), m, false)
 
 	data := []byte{}
 	_, err := p.Write(data)
@@ -92,8 +91,8 @@ func TestAllVectors(t *testing.T) {
 		t.Run(fmt.Sprintf("data length %d, vector %d", len(data), i), func(t *testing.T) {
 			t.Parallel()
 
-			m := mock.NewStorer()
-			p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+			m := inmemchunkstore.New()
+			p := builder.NewPipelineBuilder(context.TODO(), m, false)
 
 			_, err := p.Write(data)
 			if err != nil {
@@ -154,8 +153,8 @@ func benchmarkPipeline(b *testing.B, count int) {
 
 	b.StopTimer()
 
-	m := mock.NewStorer()
-	p := builder.NewPipelineBuilder(context.Background(), m, storage.ModePutUpload, false)
+	m := inmemchunkstore.New()
+	p := builder.NewPipelineBuilder(context.TODO(), m, false)
 	data := make([]byte, count)
 	_, err := rand.Read(data)
 	if err != nil {

--- a/pkg/file/pipeline/hashtrie/hashtrie_test.go
+++ b/pkg/file/pipeline/hashtrie/hashtrie_test.go
@@ -14,8 +14,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/pipeline/bmt"
 	"github.com/ethersphere/bee/pkg/file/pipeline/hashtrie"
 	"github.com/ethersphere/bee/pkg/file/pipeline/store"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -23,7 +22,6 @@ var (
 	addr swarm.Address
 	span []byte
 	ctx  = context.Background()
-	mode = storage.ModePutUpload
 )
 
 // nolint:gochecknoinits
@@ -96,9 +94,9 @@ func TestLevels(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			s := mock.NewStorer()
+			s := inmemchunkstore.New()
 			pf := func() pipeline.ChainWriter {
-				lsw := store.NewStoreWriter(ctx, s, mode, nil)
+				lsw := store.NewStoreWriter(ctx, s, nil)
 				return bmt.NewBmtWriter(lsw)
 			}
 
@@ -117,7 +115,7 @@ func TestLevels(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rootch, err := s.Get(ctx, storage.ModeGetRequest, swarm.NewAddress(ref))
+			rootch, err := s.Get(ctx, swarm.NewAddress(ref))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -139,9 +137,9 @@ func TestLevels_TrieFull(t *testing.T) {
 		chunkSize = 128
 		hashSize  = 32
 		writes    = 16384 // this is to get a balanced trie
-		s         = mock.NewStorer()
+		s         = inmemchunkstore.New()
 		pf        = func() pipeline.ChainWriter {
-			lsw := store.NewStoreWriter(ctx, s, mode, nil)
+			lsw := store.NewStoreWriter(ctx, s, nil)
 			return bmt.NewBmtWriter(lsw)
 		}
 
@@ -183,9 +181,9 @@ func TestRegression(t *testing.T) {
 		hashSize  = 32
 		writes    = 67100000 / 4096
 		span      = make([]byte, 8)
-		s         = mock.NewStorer()
+		s         = inmemchunkstore.New()
 		pf        = func() pipeline.ChainWriter {
-			lsw := store.NewStoreWriter(ctx, s, mode, nil)
+			lsw := store.NewStoreWriter(ctx, s, nil)
 			return bmt.NewBmtWriter(lsw)
 		}
 		ht = hashtrie.NewHashTrieWriter(chunkSize, branching, hashSize, pf)
@@ -205,7 +203,7 @@ func TestRegression(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootch, err := s.Get(ctx, storage.ModeGetRequest, swarm.NewAddress(ref))
+	rootch, err := s.Get(ctx, swarm.NewAddress(ref))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/pipeline/store/store.go
+++ b/pkg/file/pipeline/store/store.go
@@ -9,64 +9,37 @@ import (
 	"errors"
 
 	"github.com/ethersphere/bee/pkg/file/pipeline"
-	"github.com/ethersphere/bee/pkg/sctx"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/tags"
 )
 
 var errInvalidData = errors.New("store: invalid data")
 
 type storeWriter struct {
 	l    storage.Putter
-	mode storage.ModePut
 	ctx  context.Context
 	next pipeline.ChainWriter
 }
 
 // NewStoreWriter returns a storeWriter. It just writes the given data
 // to a given storage.Putter.
-func NewStoreWriter(ctx context.Context, l storage.Putter, mode storage.ModePut, next pipeline.ChainWriter) pipeline.ChainWriter {
-	return &storeWriter{ctx: ctx, l: l, mode: mode, next: next}
+func NewStoreWriter(ctx context.Context, l storage.Putter, next pipeline.ChainWriter) pipeline.ChainWriter {
+	return &storeWriter{ctx: ctx, l: l, next: next}
 }
 
 func (w *storeWriter) ChainWrite(p *pipeline.PipeWriteArgs) error {
 	if p.Ref == nil || p.Data == nil {
 		return errInvalidData
 	}
-	tag := sctx.GetTag(w.ctx)
-	var c swarm.Chunk
-	if tag != nil {
-		err := tag.Inc(tags.StateSplit)
-		if err != nil {
-			return err
-		}
-		c = swarm.NewChunk(swarm.NewAddress(p.Ref), p.Data).WithTagID(tag.Uid)
-	} else {
-		c = swarm.NewChunk(swarm.NewAddress(p.Ref), p.Data)
-	}
-	seen, err := w.l.Put(w.ctx, w.mode, c)
+	err := w.l.Put(w.ctx, swarm.NewChunk(swarm.NewAddress(p.Ref), p.Data))
 	if err != nil {
 		return err
-	}
-	if tag != nil {
-		err := tag.Inc(tags.StateStored)
-		if err != nil {
-			return err
-		}
-		if seen[0] {
-			err := tag.Inc(tags.StateSeen)
-			if err != nil {
-				return err
-			}
-		}
 	}
 	if w.next == nil {
 		return nil
 	}
 
 	return w.next.ChainWrite(p)
-
 }
 
 func (w *storeWriter) Sum() ([]byte, error) {

--- a/pkg/file/pipeline/store/store_test.go
+++ b/pkg/file/pipeline/store/store_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/ethersphere/bee/pkg/file/pipeline"
 	mock "github.com/ethersphere/bee/pkg/file/pipeline/mock"
 	"github.com/ethersphere/bee/pkg/file/pipeline/store"
-	"github.com/ethersphere/bee/pkg/storage"
-	storer "github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -22,10 +21,10 @@ import (
 func TestStoreWriter(t *testing.T) {
 	t.Parallel()
 
-	mockStore := storer.NewStorer()
+	mockStore := inmemchunkstore.New()
 	mockChainWriter := mock.NewChainWriter()
 	ctx := context.Background()
-	writer := store.NewStoreWriter(ctx, mockStore, storage.ModePutUpload, mockChainWriter)
+	writer := store.NewStoreWriter(ctx, mockStore, mockChainWriter)
 
 	for _, tc := range []struct {
 		name   string
@@ -54,7 +53,7 @@ func TestStoreWriter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		d, err := mockStore.Get(ctx, storage.ModeGetRequest, swarm.NewAddress(tc.ref))
+		d, err := mockStore.Get(ctx, swarm.NewAddress(tc.ref))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +72,7 @@ func TestSum(t *testing.T) {
 
 	mockChainWriter := mock.NewChainWriter()
 	ctx := context.Background()
-	writer := store.NewStoreWriter(ctx, nil, storage.ModePutUpload, mockChainWriter)
+	writer := store.NewStoreWriter(ctx, nil, mockChainWriter)
 	_, err := writer.Sum()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/file/splitter/internal/job.go
+++ b/pkg/file/splitter/internal/job.go
@@ -13,15 +13,10 @@ import (
 	"github.com/ethersphere/bee/pkg/cac"
 	"github.com/ethersphere/bee/pkg/encryption"
 	"github.com/ethersphere/bee/pkg/file"
-	"github.com/ethersphere/bee/pkg/sctx"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/tags"
 	"golang.org/x/crypto/sha3"
 )
-
-type Putter interface {
-	Put(context.Context, swarm.Chunk) ([]bool, error)
-}
 
 // maximum amount of file tree levels this file hasher component can handle
 // (128 ^ (9 - 1)) * 4096 = 295147905179352825856 bytes
@@ -38,21 +33,20 @@ const levelBufferLimit = 9
 // error and will may result in undefined result.
 type SimpleSplitterJob struct {
 	ctx        context.Context
-	putter     Putter
+	putter     storage.Putter
 	spanLength int64  // target length of data
 	length     int64  // number of bytes written to the data level of the hasher
 	sumCounts  []int  // number of sums performed, indexed per level
 	cursors    []int  // section write position, indexed per level
 	buffer     []byte // keeps data and hashes, indexed by cursors
-	tag        *tags.Tag
-	toEncrypt  bool // to encryrpt the chunks or not
+	toEncrypt  bool   // to encryrpt the chunks or not
 	refSize    int64
 }
 
 // NewSimpleSplitterJob creates a new SimpleSplitterJob.
 //
 // The spanLength is the length of the data that will be written.
-func NewSimpleSplitterJob(ctx context.Context, putter Putter, spanLength int64, toEncrypt bool) *SimpleSplitterJob {
+func NewSimpleSplitterJob(ctx context.Context, putter storage.Putter, spanLength int64, toEncrypt bool) *SimpleSplitterJob {
 	hashSize := swarm.HashSize
 	refSize := int64(hashSize)
 	if toEncrypt {
@@ -66,7 +60,6 @@ func NewSimpleSplitterJob(ctx context.Context, putter Putter, spanLength int64, 
 		sumCounts:  make([]int, levelBufferLimit),
 		cursors:    make([]int, levelBufferLimit),
 		buffer:     make([]byte, swarm.ChunkWithSpanSize*levelBufferLimit*2), // double size as temp workaround for weak calculation of needed buffer space
-		tag:        sctx.GetTag(ctx),
 		toEncrypt:  toEncrypt,
 		refSize:    refSize,
 	}
@@ -141,10 +134,6 @@ func (s *SimpleSplitterJob) sumLevel(lvl int) ([]byte, error) {
 	binary.LittleEndian.PutUint64(head, uint64(span))
 	tail := s.buffer[s.cursors[lvl+1]:s.cursors[lvl]]
 	chunkData = append(head, tail...)
-	err := s.incrTag(tags.StateSplit)
-	if err != nil {
-		return nil, err
-	}
 	c := chunkData
 	var encryptionKey encryption.Key
 
@@ -161,22 +150,7 @@ func (s *SimpleSplitterJob) sumLevel(lvl int) ([]byte, error) {
 		return nil, err
 	}
 
-	// Add tag to the chunk if tag is valid
-	if s.tag != nil {
-		ch = ch.WithTagID(s.tag.Uid)
-	}
-
-	seen, err := s.putter.Put(s.ctx, ch)
-	if err != nil {
-		return nil, err
-	} else if len(seen) > 0 && seen[0] {
-		err = s.incrTag(tags.StateSeen)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = s.incrTag(tags.StateStored)
+	err = s.putter.Put(s.ctx, ch)
 	if err != nil {
 		return nil, err
 	}
@@ -297,11 +271,4 @@ func (s *SimpleSplitterJob) newSpanEncryption(key encryption.Key) encryption.Int
 
 func (s *SimpleSplitterJob) newDataEncryption(key encryption.Key) encryption.Interface {
 	return encryption.New(key, int(swarm.ChunkSize), 0, sha3.NewLegacyKeccak256)
-}
-
-func (s *SimpleSplitterJob) incrTag(state tags.State) error {
-	if s.tag != nil {
-		return s.tag.Inc(state)
-	}
-	return nil
 }

--- a/pkg/file/splitter/internal/job_test.go
+++ b/pkg/file/splitter/internal/job_test.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/file/splitter/internal"
 	test "github.com/ethersphere/bee/pkg/file/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -22,32 +21,19 @@ var (
 	end   = test.GetVectorCount()
 )
 
-type putWrapper struct {
-	putter func(context.Context, swarm.Chunk) ([]bool, error)
-}
-
-func (p putWrapper) Put(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
-	return p.putter(ctx, ch)
-}
-
 // TestSplitterJobPartialSingleChunk passes sub-chunk length data to the splitter,
 // verifies the correct hash is returned, and that write after Sum/complete Write
 // returns error.
 func TestSplitterJobPartialSingleChunk(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
-	putter := putWrapper{
-		putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
-			return store.Put(ctx, storage.ModePutUpload, ch)
-		},
-	}
+	store := inmemchunkstore.New()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	data := []byte("foo")
-	j := internal.NewSimpleSplitterJob(ctx, putter, int64(len(data)), false)
+	j := internal.NewSimpleSplitterJob(ctx, store, int64(len(data)), false)
 
 	c, err := j.Write(data)
 	if err != nil {
@@ -88,18 +74,13 @@ func testSplitterJobVector(t *testing.T) {
 	var (
 		paramstring = strings.Split(t.Name(), "/")
 		dataIdx, _  = strconv.ParseInt(paramstring[1], 10, 0)
-		store       = mock.NewStorer()
-		putter      = putWrapper{
-			putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
-				return store.Put(ctx, storage.ModePutUpload, ch)
-			},
-		}
+		store       = inmemchunkstore.New()
 	)
 
 	data, expect := test.GetVector(t, int(dataIdx))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	j := internal.NewSimpleSplitterJob(ctx, putter, int64(len(data)), false)
+	j := internal.NewSimpleSplitterJob(ctx, store, int64(len(data)), false)
 
 	for i := 0; i < len(data); i += swarm.ChunkSize {
 		l := swarm.ChunkSize

--- a/pkg/file/splitter/splitter.go
+++ b/pkg/file/splitter/splitter.go
@@ -13,31 +13,19 @@ import (
 
 	"github.com/ethersphere/bee/pkg/file"
 	"github.com/ethersphere/bee/pkg/file/splitter/internal"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-type putWrapper struct {
-	putter func(context.Context, swarm.Chunk) ([]bool, error)
-}
-
-func (p putWrapper) Put(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
-	return p.putter(ctx, ch)
-}
-
 // simpleSplitter wraps a non-optimized implementation of file.Splitter
 type simpleSplitter struct {
-	putter internal.Putter
+	putter storage.Putter
 }
 
 // NewSimpleSplitter creates a new SimpleSplitter
-func NewSimpleSplitter(storePutter storage.Putter, mode storage.ModePut) file.Splitter {
+func NewSimpleSplitter(storePutter storage.Putter) file.Splitter {
 	return &simpleSplitter{
-		putter: putWrapper{
-			putter: func(ctx context.Context, ch swarm.Chunk) ([]bool, error) {
-				return storePutter.Put(ctx, mode, ch)
-			},
-		},
+		putter: storePutter,
 	}
 }
 

--- a/pkg/file/splitter/splitter_test.go
+++ b/pkg/file/splitter/splitter_test.go
@@ -61,7 +61,7 @@ func TestSplitSingleChunk(t *testing.T) {
 		t.Fatalf("expected %v, got %v", testHashAddress, resultAddress)
 	}
 
-	_, err = store.Get(context.TODO(), resultAddress)
+	_, err = store.Get(context.Background(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,12 +95,12 @@ func TestSplitThreeLevels(t *testing.T) {
 		t.Fatalf("expected %v, got %v", testHashAddress, resultAddress)
 	}
 
-	_, err = store.Get(context.TODO(), resultAddress)
+	_, err = store.Get(context.Background(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rootChunk, err := store.Get(context.TODO(), resultAddress)
+	rootChunk, err := store.Get(context.Background(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestSplitThreeLevels(t *testing.T) {
 	for i := 0; i < swarm.ChunkSize; i += swarm.SectionSize {
 		dataAddressBytes := rootData[i : i+swarm.SectionSize]
 		dataAddress := swarm.NewAddress(dataAddressBytes)
-		_, err := store.Get(context.TODO(), dataAddress)
+		_, err := store.Get(context.Background(), dataAddress)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/file/splitter/splitter_test.go
+++ b/pkg/file/splitter/splitter_test.go
@@ -14,8 +14,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/file"
 	"github.com/ethersphere/bee/pkg/file/splitter"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 	mockbytes "gitlab.com/nolash/go-mockbytes"
 )
@@ -26,8 +25,8 @@ func TestSplitIncomplete(t *testing.T) {
 	t.Parallel()
 
 	testData := make([]byte, 42)
-	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
+	store := inmemchunkstore.New()
+	s := splitter.NewSimpleSplitter(store)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	_, err := s.Split(context.Background(), testDataReader, 41, false)
@@ -47,8 +46,8 @@ func TestSplitSingleChunk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
+	store := inmemchunkstore.New()
+	s := splitter.NewSimpleSplitter(store)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	resultAddress, err := s.Split(context.Background(), testDataReader, int64(len(testData)), false)
@@ -62,7 +61,7 @@ func TestSplitSingleChunk(t *testing.T) {
 		t.Fatalf("expected %v, got %v", testHashAddress, resultAddress)
 	}
 
-	_, err = store.Get(context.Background(), storage.ModeGetRequest, resultAddress)
+	_, err = store.Get(context.TODO(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,8 +80,8 @@ func TestSplitThreeLevels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(store, storage.ModePutUpload)
+	store := inmemchunkstore.New()
+	s := splitter.NewSimpleSplitter(store)
 
 	testDataReader := file.NewSimpleReadCloser(testData)
 	resultAddress, err := s.Split(context.Background(), testDataReader, int64(len(testData)), false)
@@ -96,12 +95,12 @@ func TestSplitThreeLevels(t *testing.T) {
 		t.Fatalf("expected %v, got %v", testHashAddress, resultAddress)
 	}
 
-	_, err = store.Get(context.Background(), storage.ModeGetRequest, resultAddress)
+	_, err = store.Get(context.TODO(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rootChunk, err := store.Get(context.Background(), storage.ModeGetRequest, resultAddress)
+	rootChunk, err := store.Get(context.TODO(), resultAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +109,7 @@ func TestSplitThreeLevels(t *testing.T) {
 	for i := 0; i < swarm.ChunkSize; i += swarm.SectionSize {
 		dataAddressBytes := rootData[i : i+swarm.SectionSize]
 		dataAddress := swarm.NewAddress(dataAddressBytes)
-		_, err := store.Get(context.Background(), storage.ModeGetRequest, dataAddress)
+		_, err := store.Get(context.TODO(), dataAddress)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -123,8 +122,8 @@ func TestUnalignedSplit(t *testing.T) {
 	t.Parallel()
 
 	var (
-		storer    storage.Storer = mock.NewStorer()
-		chunkPipe                = file.NewChunkPipe()
+		storer    = inmemchunkstore.New()
+		chunkPipe = file.NewChunkPipe()
 	)
 
 	// test vector taken from pkg/file/testing/vector.go
@@ -141,7 +140,7 @@ func TestUnalignedSplit(t *testing.T) {
 	}
 
 	// perform the split in a separate thread
-	sp := splitter.NewSimpleSplitter(storer, storage.ModePutUpload)
+	sp := splitter.NewSimpleSplitter(storer)
 	ctx := context.Background()
 	doneC := make(chan swarm.Address)
 	errC := make(chan error)
@@ -236,8 +235,8 @@ func benchmarkSplitter(b *testing.B, count int) {
 
 	b.StopTimer()
 
-	m := mock.NewStorer()
-	s := splitter.NewSimpleSplitter(m, storage.ModePutUpload)
+	m := inmemchunkstore.New()
+	s := splitter.NewSimpleSplitter(m)
 	data := make([]byte, count)
 	_, err := rand.Read(data)
 	if err != nil {

--- a/pkg/storagev2/storage.go
+++ b/pkg/storagev2/storage.go
@@ -61,11 +61,13 @@ const (
 )
 
 // ErrInvalidQuery indicates that the query is not a valid query.
-var ErrInvalidQuery = errors.New("storage: invalid query")
+var (
+	ErrInvalidQuery = errors.New("storage: invalid query")
 
-var ErrNotFound = errors.New("storage: not found")
+	ErrNotFound = errors.New("storage: not found")
 
-var ErrReferenceLength = errors.New("invalid reference length")
+	ErrReferenceLength = errors.New("storage: invalid reference length")
+)
 
 // Query denotes the iteration attributes.
 type Query struct {

--- a/pkg/storagev2/storage.go
+++ b/pkg/storagev2/storage.go
@@ -65,6 +65,8 @@ var ErrInvalidQuery = errors.New("storage: invalid query")
 
 var ErrNotFound = errors.New("storage: not found")
 
+var ErrReferenceLength = errors.New("invalid reference length")
+
 // Query denotes the iteration attributes.
 type Query struct {
 	// Factory is a constructor passed by client

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethersphere/bee/pkg/manifest"
 	"github.com/ethersphere/bee/pkg/manifest/mantaray"
 	"github.com/ethersphere/bee/pkg/soc"
-	"github.com/ethersphere/bee/pkg/storage"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -28,19 +28,14 @@ type Traverser interface {
 	Traverse(context.Context, swarm.Address, swarm.AddressIterFunc) error
 }
 
-type PutGetter interface {
-	storage.Putter
-	storage.Getter
-}
-
 // New constructs for a new Traverser.
-func New(store PutGetter) Traverser {
+func New(store storage.Getter) Traverser {
 	return &service{store: store}
 }
 
 // service is implementation of Traverser using storage.Storer as its storage.
 type service struct {
-	store PutGetter
+	store storage.Getter
 }
 
 // Traverse implements Traverser.Traverse method.
@@ -57,7 +52,7 @@ func (s *service) Traverse(ctx context.Context, addr swarm.Address, iterFn swarm
 		return nil
 	}
 
-	ch, err := s.store.Get(ctx, storage.ModeGetRequest, addr)
+	ch, err := s.store.Get(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("traversal: failed to get root chunk %s: %w", addr.String(), err)
 	}

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -480,7 +480,7 @@ func TestTraversalSOC(t *testing.T) {
 	store := inmemchunkstore.New()
 	iter := newAddressIterator(false)
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	s := testingsoc.GenerateMockSOC(t, generateSample(swarm.ChunkSize))
 	sch := s.Chunk()
@@ -506,6 +506,6 @@ func TestTraversalSOC(t *testing.T) {
 
 func pipelineFactory(s storage.Putter, encrypt bool) func() pipeline.Interface {
 	return func() pipeline.Interface {
-		return builder.NewPipelineBuilder(context.TODO(), s, encrypt)
+		return builder.NewPipelineBuilder(context.Background(), s, encrypt)
 	}
 }

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/pkg/manifest"
 	testingsoc "github.com/ethersphere/bee/pkg/soc/testing"
-	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/mock"
+	storage "github.com/ethersphere/bee/pkg/storagev2"
+	"github.com/ethersphere/bee/pkg/storagev2/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/traversal"
 )
@@ -155,13 +155,13 @@ func TestTraversalBytes(t *testing.T) {
 			var (
 				data       = generateSample(tc.dataSize)
 				iter       = newAddressIterator(tc.ignoreDuplicateHashes)
-				storerMock = mock.NewStorer()
+				storerMock = inmemchunkstore.New()
 			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			pipe := builder.NewPipelineBuilder(ctx, storerMock, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, storerMock, false)
 			address, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data))
 			if err != nil {
 				t.Fatal(err)
@@ -250,19 +250,19 @@ func TestTraversalFiles(t *testing.T) {
 			var (
 				data       = generateSample(tc.filesSize)
 				iter       = newAddressIterator(tc.ignoreDuplicateHashes)
-				storerMock = mock.NewStorer()
+				storerMock = inmemchunkstore.New()
 			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			pipe := builder.NewPipelineBuilder(ctx, storerMock, storage.ModePutUpload, false)
+			pipe := builder.NewPipelineBuilder(ctx, storerMock, false)
 			fr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			ls := loadsave.New(storerMock, pipelineFactory(storerMock, storage.ModePutRequest, false))
+			ls := loadsave.New(storerMock, pipelineFactory(storerMock, false))
 			fManifest, err := manifest.NewDefaultManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -408,7 +408,7 @@ func TestTraversalManifest(t *testing.T) {
 			t.Parallel()
 
 			var (
-				storerMock = mock.NewStorer()
+				storerMock = inmemchunkstore.New()
 				iter       = newAddressIterator(tc.ignoreDuplicateHashes)
 			)
 
@@ -421,7 +421,7 @@ func TestTraversalManifest(t *testing.T) {
 			}
 			wantHashes = append(wantHashes, tc.manifestHashes...)
 
-			ls := loadsave.New(storerMock, pipelineFactory(storerMock, storage.ModePutRequest, false))
+			ls := loadsave.New(storerMock, pipelineFactory(storerMock, false))
 			dirManifest, err := manifest.NewMantarayManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -430,7 +430,7 @@ func TestTraversalManifest(t *testing.T) {
 			for _, f := range tc.files {
 				data := generateSample(f.size)
 
-				pipe := builder.NewPipelineBuilder(ctx, storerMock, storage.ModePutUpload, false)
+				pipe := builder.NewPipelineBuilder(ctx, storerMock, false)
 				fr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data))
 				if err != nil {
 					t.Fatal(err)
@@ -477,16 +477,15 @@ func TestTraversalManifest(t *testing.T) {
 func TestTraversalSOC(t *testing.T) {
 	t.Parallel()
 
-	store := mock.NewStorer()
+	store := inmemchunkstore.New()
 	iter := newAddressIterator(false)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	s := testingsoc.GenerateMockSOC(t, generateSample(swarm.ChunkSize))
 	sch := s.Chunk()
 
-	_, err := store.Put(ctx, storage.ModePutUploadPin, sch)
+	err := store.Put(ctx, sch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,8 +504,8 @@ func TestTraversalSOC(t *testing.T) {
 	}
 }
 
-func pipelineFactory(s storage.Putter, mode storage.ModePut, encrypt bool) func() pipeline.Interface {
+func pipelineFactory(s storage.Putter, encrypt bool) func() pipeline.Interface {
 	return func() pipeline.Interface {
-		return builder.NewPipelineBuilder(context.Background(), s, mode, encrypt)
+		return builder.NewPipelineBuilder(context.TODO(), s, encrypt)
 	}
 }


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Use the new storagev2 interfaces in the file package. This PR will be part of a series of PRs for the integration. So CI will not be green till we merge everything. As this is for the file pkg:

❯ go test ./pkg/file/...
ok  	github.com/ethersphere/bee/pkg/file	0.124s
ok  	github.com/ethersphere/bee/pkg/file/addresses	0.005s
ok  	github.com/ethersphere/bee/pkg/file/joiner	1.120s
ok  	github.com/ethersphere/bee/pkg/file/loadsave	0.008s
?   	github.com/ethersphere/bee/pkg/file/pipeline	[no test files]
ok  	github.com/ethersphere/bee/pkg/file/pipeline/bmt	0.007s
ok  	github.com/ethersphere/bee/pkg/file/pipeline/builder	1.803s
ok  	github.com/ethersphere/bee/pkg/file/pipeline/encryption	0.006s
ok  	github.com/ethersphere/bee/pkg/file/pipeline/feeder	0.005s
ok  	github.com/ethersphere/bee/pkg/file/pipeline/hashtrie	0.141s
?   	github.com/ethersphere/bee/pkg/file/pipeline/mock	[no test files]
ok  	github.com/ethersphere/bee/pkg/file/pipeline/store	0.006s
ok  	github.com/ethersphere/bee/pkg/file/splitter	0.029s
ok  	github.com/ethersphere/bee/pkg/file/splitter/internal	0.038s
?   	github.com/ethersphere/bee/pkg/file/testing	[no test files]

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3787)
<!-- Reviewable:end -->
