### PR TITLE
feat(ci): run flaky test separately

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,8 +13,8 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Build and Test
+  test:
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,12 +31,27 @@ jobs:
       run: make build
     - name: Test with race detector (Ubuntu and MacOS)
       if: matrix.os != 'windows-latest'
-      run: make test-race-ci
+      run: make test-ci-race
     - name: Test without race detector (Windows)
       if: matrix.os == 'windows-latest'
       run: make test-ci
-  golangci-lint:
-    name: GolangCI-Lint
+  test-flaky:
+    name: Test (flaky)
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        cache: true
+        go-version-file: go.mod
+    - name: Run flaky test
+      run: make test-ci-flaky
+      continue-on-error: ${{ github.ref == 'refs/heads/master' }}
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -56,8 +71,11 @@ jobs:
       with:
         skip-cache: false
         version: v1.49
+    - name: Whitespace check
+      run: make check-whitespace
   coverage:
     name: Coverage Report
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -74,10 +92,8 @@ jobs:
           ~/.cache/go-build
           ~/go/pkg/mod
         key: ${{ runner.os }}-go-coverage-${{ hashFiles('**/go.sum') }}
-    - name: Test whitespaces and code coverage
-      run: |
-        make check-whitespace
-        make cover=1 test-ci
+    - name: Test with code coverage
+      run: make cover=1 test-ci
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
@@ -87,7 +103,7 @@ jobs:
   trigger-beekeeper:
     name: Trigger Beekeeper
     runs-on: ubuntu-latest
-    needs: [build, golangci-lint, coverage]
+    needs: [test, lint, coverage]
     if: github.ref == 'refs/heads/master'
     steps:
     - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,6 @@ else
 	$(GO) test -race -failfast -v ./...
 endif
 
-.PHONY: test-race-ci
-test-race-ci:
-ifdef cover
-	$(GO) test -race -coverprofile=cover.out -v ./...
-else
-	$(GO) test -race -v ./...
-endif
-
 .PHONY: test-integration
 test-integration:
 	$(GO) test -tags=integration -v ./...
@@ -129,10 +121,22 @@ endif
 .PHONY: test-ci
 test-ci:
 ifdef cover
-	$(GO) test -coverprofile=cover.out -v ./...
+	$(GO) test -run "[^FLAKY]$$" -v -coverprofile=cover.out ./...
 else
-	$(GO) test -v ./...
+	$(GO) test -run "[^FLAKY]$$" -v ./...
 endif
+
+.PHONY: test-ci-race
+test-ci-race:
+ifdef cover
+	$(GO) test -race -run "[^FLAKY]$$" -v -coverprofile=cover.out ./...
+else
+	$(GO) test -race -run "[^FLAKY]$$" -v ./...
+endif
+
+.PHONY: test-ci-flaky
+test-ci-flaky:
+	$(GO) test -race -run "FLAKY$$" -v ./...
 
 .PHONY: build
 build: export CGO_ENABLED=0

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -567,9 +567,9 @@ func TestOptions(t *testing.T) {
 	}
 }
 
-// TestPostageDirectAndDeferred tests that incorrect postage batch ids
+// TestPostageDirectAndDeferred_FLAKY tests that incorrect postage batch ids
 // provided to the api correct the appropriate error code.
-func TestPostageDirectAndDeferred(t *testing.T) {
+func TestPostageDirectAndDeferred_FLAKY(t *testing.T) {
 	t.Parallel()
 
 	options := testServerOptions{

--- a/pkg/feeds/epochs/lookup_test.go
+++ b/pkg/feeds/epochs/lookup_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ethersphere/bee/pkg/storage"
 )
 
-func TestFinder(t *testing.T) {
+func TestFinder_FLAKY(t *testing.T) {
 	t.Parallel()
-	t.Skip("test flakes")
+
 	testf := func(t *testing.T, finderf func(storage.Getter, *feeds.Feed) feeds.Lookup, updaterf func(putter storage.Putter, signer crypto.Signer, topic []byte) (feeds.Updater, error)) {
 		t.Helper()
 

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -109,7 +109,7 @@ func TestHandlerRateLimit(t *testing.T) {
 	}
 }
 
-func TestBroadcastPeers(t *testing.T) {
+func TestBroadcastPeers_FLAKY(t *testing.T) {
 	t.Parallel()
 
 	logger := log.Noop

--- a/pkg/localstore/sampler_test.go
+++ b/pkg/localstore/sampler_test.go
@@ -102,7 +102,7 @@ func TestReserveSampler(t *testing.T) {
 	})
 }
 
-func TestReserveSamplerStop(t *testing.T) {
+func TestReserveSamplerStop_FLAKY(t *testing.T) {
 	const chunkCountPerPO = 10
 	const maxPO = 10
 	var (

--- a/pkg/p2p/libp2p/connections_test.go
+++ b/pkg/p2p/libp2p/connections_test.go
@@ -947,8 +947,8 @@ func TestWithDisconnectStreams(t *testing.T) {
 
 func TestWithBlocklistStreams(t *testing.T) {
 	t.Parallel()
+	t.Skip("this test always fails")
 
-	t.Skip("test flakes")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -386,7 +386,7 @@ func TestBinReset(t *testing.T) {
 	checkHistSyncingCount(t, puller, 0)
 }
 
-// TestDepthChange tests that puller reacts correctly to
+// TestDepthChange_FLAKY tests that puller reacts correctly to
 // depth changes signalled from kademlia.
 // Due to the fact that the component does goroutine termination
 // and new syncing sessions autonomously, the testing strategy is a bit
@@ -400,7 +400,7 @@ func TestBinReset(t *testing.T) {
 // the bin was synced). This also means that tweaking these tests needs to
 // be done carefully and with the understanding of what each change does to
 // the tested unit.
-func TestDepthChange(t *testing.T) {
+func TestDepthChange_FLAKY(t *testing.T) {
 	t.Parallel()
 	t.Skip()
 

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -386,7 +386,7 @@ func TestBinReset(t *testing.T) {
 	checkHistSyncingCount(t, puller, 0)
 }
 
-// TestDepthChange_FLAKY tests that puller reacts correctly to
+// TestDepthChange tests that puller reacts correctly to
 // depth changes signalled from kademlia.
 // Due to the fact that the component does goroutine termination
 // and new syncing sessions autonomously, the testing strategy is a bit
@@ -400,9 +400,9 @@ func TestBinReset(t *testing.T) {
 // the bin was synced). This also means that tweaking these tests needs to
 // be done carefully and with the understanding of what each change does to
 // the tested unit.
-func TestDepthChange_FLAKY(t *testing.T) {
+func TestDepthChange(t *testing.T) {
 	t.Parallel()
-	t.Skip()
+	t.Skip("this test always panics")
 
 	var (
 		addr     = test.RandomAddress()

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -54,7 +54,7 @@ func newTestSvc(
 	return depthmonitor.New(topo, syncer, reserve, batchStore, log.Noop, warmupTime, wakeupInterval, freshNode)
 }
 
-func TestDepthMonitorService(t *testing.T) {
+func TestDepthMonitorService_FLAKY(t *testing.T) {
 	t.Parallel()
 
 	waitForDepth := func(t *testing.T, svc *depthmonitor.Service, depth uint8) {

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -739,6 +739,7 @@ func TestBootnodeMaxConnections(t *testing.T) {
 func TestNotifierHooks(t *testing.T) {
 	t.Parallel()
 	t.Skip("disabled due to kademlia inconsistencies hotfix")
+
 	var (
 		base, kad, ab, _, signer = newTestKademlia(t, nil, nil, kademlia.Options{})
 		peer                     = test.RandomAddressAt(base, 3)
@@ -992,6 +993,7 @@ func TestAddressBookQuickPrune(t *testing.T) {
 // TestClosestPeer tests that ClosestPeer method returns closest connected peer to a given address.
 func TestClosestPeer(t *testing.T) {
 	t.Parallel()
+	t.Skip("disabled due to kademlia inconsistencies hotfix")
 
 	metricsDB, err := shed.NewDB("", nil)
 	if err != nil {
@@ -1000,7 +1002,6 @@ func TestClosestPeer(t *testing.T) {
 	cleanupCloser(t, metricsDB)
 
 	_ = waitPeers
-	t.Skip("disabled due to kademlia inconsistencies hotfix")
 
 	logger := log.Noop
 	base := swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
@@ -1284,6 +1285,7 @@ func TestStart(t *testing.T) {
 	t.Run("non-empty addressbook", func(t *testing.T) {
 		t.Parallel()
 		t.Skip("test flakes")
+
 		var conns, failedConns int32 // how many connect calls were made to the p2p mock
 		_, kad, ab, _, signer := newTestKademlia(t, &conns, &failedConns, kademlia.Options{Bootnodes: bootnodes})
 


### PR DESCRIPTION
This PR makes changes to CI jobs per proposal #3427.

Changes:
- `Lint` job will now execute `Whitespace check` as additional step. Previously this step was executed as par of `Coverage Report` job.
- `Coverage Report` is now only executed for master branch (there is no need to send coverage reports for commits to PRs)
- `Test (flaky)` job was added which executes unit tests ending with `FLAKY` string. This job will 'continue on error' on master branch (thus not affecting green check marks), but on other branches this job will fail (making red cross mark) giving developers the same level of insight as before this PR. 
- `Test` step of `Test` job was changed so that it runs all unit tests that are not marked as flaky (unit tests which do not end `FLAKY` string)
- Added FLAKY annotation
  - on all flaky tests
  - on some tests which were flaky but were skipped (via `t.Skip()`)
 


After this PR is merged `Test` job could be marked as mandatory (Required). This way all PR will have to be fully functional before merging to master. 


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3806)
<!-- Reviewable:end -->
