### PR TITLE
fix(goleak): ignore libp2p goroutine

### DIFF
--- a/pkg/p2p/libp2p/main_test.go
+++ b/pkg/p2p/libp2p/main_test.go
@@ -15,9 +15,11 @@ func TestMain(m *testing.M) {
 		m,
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 		goleak.IgnoreTopFunction("sync.runtime_Semacquire"),
+		goleak.IgnoreTopFunction("net.ParseCIDR"),
 		goleak.IgnoreTopFunction("github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine"),
 		goleak.IgnoreTopFunction("github.com/huin/goupnp/httpu.(*MultiClient).Do.func2"),
 		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),
 		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger.(*prefixTrie).insert"),
+		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger.newPathprefixTrie"),
 	)
 }

--- a/pkg/p2p/libp2p/main_test.go
+++ b/pkg/p2p/libp2p/main_test.go
@@ -21,5 +21,8 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),
 		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger.(*prefixTrie).insert"),
 		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger.newPathprefixTrie"),
+		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger/net.NetworkNumber.LeastCommonBitPosition"),
+		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger/net.NewNetwork"),
+		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger/net.Network.LeastCommonBitPosition"),
 	)
 }

--- a/pkg/p2p/libp2p/main_test.go
+++ b/pkg/p2p/libp2p/main_test.go
@@ -18,5 +18,6 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine"),
 		goleak.IgnoreTopFunction("github.com/huin/goupnp/httpu.(*MultiClient).Do.func2"),
 		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),
+		goleak.IgnoreTopFunction("github.com/libp2p/go-cidranger.(*prefixTrie).insert"),
 	)
 }

--- a/pkg/pss/main_test.go
+++ b/pkg/pss/main_test.go
@@ -11,8 +11,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(
-		m,
-		goleak.IgnoreTopFunction("sync.runtime_Semacquire"),
-	)
+	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
- Ignoring one more libp2p goroutine
- Removed unnecessary goleak ignore from pss package

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3807)
<!-- Reviewable:end -->
