### PR TITLE
fix(comment-lint): disabled body rules

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get Commit Message
         id: commit
         run: |
-          MSG=$(git log --format=%B -n 1 ${{github.event.after}})
+          MSG=$(git log --format=%s -n 1 ${{github.event.after}})
           echo "msg=${MSG}" >> $GITHUB_OUTPUT
       - name: Build - 0
         run: |

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	rules: {
 		'body-leading-blank': [2, 'always'],
-    	'body-case': [0, 'never'],
+		'body-case': [0, 'never'],
 		'footer-leading-blank': [1, 'always'],
 		'footer-max-line-length': [2, 'always', 72],
 		'header-max-length': [2, 'always', 72],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,12 +1,7 @@
 module.exports = {
 	rules: {
 		'body-leading-blank': [2, 'always'],
-		'body-max-line-length': [2, 'always', 72],
-    'body-case': [
-			2,
-			'never',
-			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
-		],
+    	'body-case': [0, 'never'],
 		'footer-leading-blank': [1, 'always'],
 		'footer-max-line-length': [2, 'always', 72],
 		'header-max-length': [2, 'always', 72],


### PR DESCRIPTION
Currently `bee`'s comment linting rules are vary strict about git commit body. This is causing CI lint job to fail for commits made by dependency bot because it is adding vary descriptive body of git commits. 

This PR:
- relaxes rules of commit body 
- changes `Get Commit Message` task to log short commit format 

Example of dependency bot PR (https://github.com/ethersphere/bee/pull/3827)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3828)
<!-- Reviewable:end -->
