### PR TITLE
chore(swarm): distance args to use Address type

### DIFF
--- a/pkg/swarm/distance.go
+++ b/pkg/swarm/distance.go
@@ -11,7 +11,7 @@ import (
 
 // Distance returns the distance between address x and address y as a (comparable) big integer using the distance metric defined in the swarm specification.
 // Fails if not all addresses are of equal length.
-func Distance(x, y []byte) (*big.Int, error) {
+func Distance(x, y Address) (*big.Int, error) {
 	distanceBytes, err := DistanceRaw(x, y)
 	if err != nil {
 		return nil, err
@@ -23,13 +23,15 @@ func Distance(x, y []byte) (*big.Int, error) {
 
 // DistanceRaw returns the distance between address x and address y in big-endian binary format using the distance metric defined in the swarm specification.
 // Fails if not all addresses are of equal length.
-func DistanceRaw(x, y []byte) ([]byte, error) {
-	if len(x) != len(y) {
+func DistanceRaw(x, y Address) ([]byte, error) {
+	xb, yb := x.b, y.b
+
+	if len(xb) != len(yb) {
 		return nil, errors.New("address length must match")
 	}
-	c := make([]byte, len(x))
-	for i, addr := range x {
-		c[i] = addr ^ y[i]
+	c := make([]byte, len(xb))
+	for i, addr := range xb {
+		c[i] = addr ^ yb[i]
 	}
 	return c, nil
 }
@@ -41,14 +43,16 @@ func DistanceRaw(x, y []byte) ([]byte, error) {
 //   - -1 if x is farther from a than y
 //
 // Fails if not all addresses are of equal length.
-func DistanceCmp(a, x, y []byte) (int, error) {
-	if len(a) != len(x) || len(a) != len(y) {
+func DistanceCmp(a, x, y Address) (int, error) {
+	ab, xb, yb := a.b, x.b, y.b
+
+	if len(ab) != len(xb) || len(ab) != len(yb) {
 		return 0, errors.New("address length must match")
 	}
 
-	for i := range a {
-		dx := x[i] ^ a[i]
-		dy := y[i] ^ a[i]
+	for i := range ab {
+		dx := xb[i] ^ ab[i]
+		dy := yb[i] ^ ab[i]
 		if dx == dy {
 			continue
 		} else if dx < dy {

--- a/pkg/swarm/distance_test.go
+++ b/pkg/swarm/distance_test.go
@@ -2,51 +2,53 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package swarm
+package swarm_test
 
 import (
 	"testing"
+
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 type distanceTest struct {
-	x      []byte
-	y      []byte
+	x      swarm.Address
+	y      swarm.Address
 	result string
 }
 
 type distanceCmpTest struct {
-	a      []byte
-	x      []byte
-	y      []byte
+	a      swarm.Address
+	x      swarm.Address
+	y      swarm.Address
 	result int
 }
 
 var (
 	distanceTests = []distanceTest{
 		{
-			x:      MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000").Bytes(),
-			y:      MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000").Bytes(),
+			x:      swarm.MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000"),
+			y:      swarm.MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000"),
 			result: "8593944123082061379093159043613555660984881674403010612303492563087302590464",
 		},
 	}
 
 	distanceCmpTests = []distanceCmpTest{
 		{
-			a:      MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000").Bytes(), // 10010001
-			x:      MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000").Bytes(), // 10000010 xor(0x91,0x82) =	19
-			y:      MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000").Bytes(), // 00010010 xor(0x91,0x12) = 131
+			a:      swarm.MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000"), // 10010001
+			x:      swarm.MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000"), // 10000010 xor(0x91,0x82) =	19
+			y:      swarm.MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000"), // 00010010 xor(0x91,0x12) = 131
 			result: 1,
 		},
 		{
-			a:      MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000").Bytes(),
-			x:      MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000").Bytes(),
-			y:      MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000").Bytes(),
+			a:      swarm.MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000"),
+			x:      swarm.MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000"),
+			y:      swarm.MustParseHexAddress("8200000000000000000000000000000000000000000000000000000000000000"),
 			result: -1,
 		},
 		{
-			a:      MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000").Bytes(),
-			x:      MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000").Bytes(),
-			y:      MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000").Bytes(),
+			a:      swarm.MustParseHexAddress("9100000000000000000000000000000000000000000000000000000000000000"),
+			x:      swarm.MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000"),
+			y:      swarm.MustParseHexAddress("1200000000000000000000000000000000000000000000000000000000000000"),
 			result: 0,
 		},
 	}
@@ -57,7 +59,7 @@ func TestDistance(t *testing.T) {
 	t.Parallel()
 
 	for _, dt := range distanceTests {
-		distance, err := Distance(dt.x, dt.y)
+		distance, err := swarm.Distance(dt.x, dt.y)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +74,7 @@ func TestDistanceCmp(t *testing.T) {
 	t.Parallel()
 
 	for _, dt := range distanceCmpTests {
-		direction, err := DistanceCmp(dt.a, dt.x, dt.y)
+		direction, err := swarm.DistanceCmp(dt.a, dt.x, dt.y)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -119,7 +119,7 @@ func (a Address) MarshalJSON() ([]byte, error) {
 
 // Closer returns if x is closer to a than y
 func (x Address) Closer(a Address, y Address) (bool, error) {
-	cmp, err := DistanceCmp(a.b, x.b, y.b)
+	cmp, err := DistanceCmp(a, x, y)
 	return cmp == 1, err
 }
 


### PR DESCRIPTION
In this PR `swarm.Distance` arguments are changed to `swarm.Address` to enforce better type safety.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3830)
<!-- Reviewable:end -->
