### PR TITLE
chore: set TestSnapshot and TestAnnounceBgBroadcast as flaky

### DIFF
--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1565,7 +1565,7 @@ func TestBootnodeProtectedNodes(t *testing.T) {
 	}
 }
 
-func TestAnnounceBgBroadcast(t *testing.T) {
+func TestAnnounceBgBroadcast_FLAKY(t *testing.T) {
 	t.Parallel()
 
 	var (

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1230,7 +1230,7 @@ func TestKademlia_SubscribeTopologyChange(t *testing.T) {
 	})
 }
 
-func TestSnapshot(t *testing.T) {
+func TestSnapshot_FLAKY(t *testing.T) {
 	t.Parallel()
 
 	var conns = new(int32)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
marking `TestSnapshot` and `TestAnnounceBgBroadcast` as flaky, issue #3834 #3836

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3835)
<!-- Reviewable:end -->
