### PR TITLE
fix: log level hooks

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -296,6 +296,6 @@ func WithLogMetrics() Option {
 			return
 		}
 		opts.logMetrics = newLogMetrics()
-		WithLevelHooks(VerbosityAll, opts.logMetrics)
+		WithLevelHooks(VerbosityAll, opts.logMetrics)(opts)
 	}
 }


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
It seems a change in the library led to level hooks not being plugged in properly into the log options and.
As a result the grafana dashboards stopped reporting log counts. This PR should fix that. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethersphere/bee/3848)
<!-- Reviewable:end -->
