### PR TITLE
ci: fix release tag version sort

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@ project_name: bee
 release:
   prerelease: auto
 
+git:
+  tag_sort: version:refname
+
 builds:
   - id: linux
     main: ./cmd/bee


### PR DESCRIPTION
By default goreleaser sorts tag version in reverse using, sort `-version:refname`
```
❯ git tag --points-at HEAD --sort=-version:refname --format='%(creatordate)%09%(refname)'
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0-rc3
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0
```
With this fix it will produce outcome that we expect `version:refname`
```
❯ git tag --points-at HEAD --sort=version:refname --format='%(creatordate)%09%(refname)'
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0-rc3
```