### PR TITLE
fix: duplicate trace id in logs

### DIFF
--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -281,7 +281,6 @@ func (s *Service) bzzDownloadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathVar string, w http.ResponseWriter, r *http.Request) {
-	logger = tracing.NewLoggerWithTraceID(r.Context(), logger)
 	loggerV1 := logger.V(1).Build()
 
 	ls := loadsave.NewReadonly(s.storer)


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
Fixes
```
"msg"="bzz download: invalid path" "traceID"="c58e21a191226be" "traceID"="c58e21a191226be"
```