### PR TITLE
refactor: improve underlying goroutine termination of timeout reader

### DIFF
--- a/pkg/util/ioutil/ioutil_test.go
+++ b/pkg/util/ioutil/ioutil_test.go
@@ -24,7 +24,7 @@ func TestTimeoutReader(t *testing.T) {
 		call := uint64(0)
 		read := uint64(0)
 		data := "0123456789"
-		timeout := 100 * time.Millisecond
+		timeout := 200 * time.Millisecond
 		cancelFn := func(u uint64) {
 			atomic.StoreUint64(&call, 1)
 			atomic.StoreUint64(&read, u)
@@ -64,7 +64,7 @@ func TestTimeoutReader(t *testing.T) {
 		call := uint64(0)
 		read := uint64(0)
 		data := "0123456789"
-		timeout := 100 * time.Millisecond
+		timeout := 200 * time.Millisecond
 		cancelFn := func(u uint64) {
 			atomic.StoreUint64(&call, 1)
 			atomic.StoreUint64(&read, u)
@@ -93,7 +93,7 @@ func TestTimeoutReader(t *testing.T) {
 
 		call := uint64(0)
 		read := uint64(0)
-		timeout := 100 * time.Millisecond
+		timeout := 200 * time.Millisecond
 		cancelFn := func(u uint64) {
 			atomic.StoreUint64(&call, 1)
 			atomic.StoreUint64(&read, u)
@@ -133,7 +133,7 @@ func TestTimeoutReader(t *testing.T) {
 
 		call := uint64(0)
 		read := uint64(0)
-		timeout := 100 * time.Millisecond
+		timeout := 200 * time.Millisecond
 		cancelFn := func(u uint64) {
 			atomic.StoreUint64(&call, 1)
 			atomic.StoreUint64(&read, u)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Improve timeout reader:
- don't terminate the underlying goroutine when zero bytes are read
- terminate underlying goroutine on any error encounter