### PR TITLE
docs: added missing fields to openapi definition

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -701,10 +701,14 @@ components:
     RedistributionStateResponse:
       type: object
       properties:
+        hasSufficientFunds:
+          type: boolean
         isFrozen:
           type: boolean
         isFullySynced:
           type: boolean
+        phase:
+          type: string
         round:
           type: integer
         lastWonRound:


### PR DESCRIPTION
Added missing fields for debug api "phase" and "hasSufficientFunds" to openapi SwarmCommon.yaml file.