### PR TITLE
chore(swarm): proximity utilities to use Address type

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/localstore"
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
+	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +66,7 @@ func dbIndicesCmd(cmd *cobra.Command) {
 
 			path := filepath.Join(dataDir, "localstore")
 
-			storer, err := localstore.New(path, nil, nil, nil, logger)
+			storer, err := localstore.New(path, swarm.ZeroAddress, nil, nil, logger)
 			if err != nil {
 				return fmt.Errorf("localstore: %w", err)
 			}
@@ -119,7 +120,7 @@ func dbExportCmd(cmd *cobra.Command) {
 
 			path := filepath.Join(dataDir, "localstore")
 
-			storer, err := localstore.New(path, nil, nil, nil, logger)
+			storer, err := localstore.New(path, swarm.ZeroAddress, nil, nil, logger)
 			if err != nil {
 				return fmt.Errorf("localstore: %w", err)
 			}
@@ -179,7 +180,7 @@ func dbImportCmd(cmd *cobra.Command) {
 
 			path := filepath.Join(dataDir, "localstore")
 
-			storer, err := localstore.New(path, nil, nil, nil, logger)
+			storer, err := localstore.New(path, swarm.ZeroAddress, nil, nil, logger)
 			if err != nil {
 				return fmt.Errorf("localstore: %w", err)
 			}

--- a/pkg/localstore/disaster_recovery_test.go
+++ b/pkg/localstore/disaster_recovery_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestRecovery(t *testing.T) {
@@ -27,7 +26,7 @@ func TestRecovery(t *testing.T) {
 	}
 
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(5, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(5, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutUpload, ch)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/localstore/gc_test.go
+++ b/pkg/localstore/gc_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/ethersphere/bee/pkg/util/testutil"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -483,10 +482,10 @@ func TestDB_collectGarbageWorker_withRequests(t *testing.T) {
 // database is initialized with existing data.
 func TestDB_gcSize(t *testing.T) {
 	dir := t.TempDir()
-	baseKey := testutil.RandBytes(t, 32)
+	baseAddr := swarm.RandAddress(t)
 
 	logger := log.Noop
-	db, err := New(dir, baseKey, nil, nil, logger)
+	db, err := New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +513,7 @@ func TestDB_gcSize(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	db, err = New(dir, baseKey, nil, nil, logger)
+	db, err = New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1069,7 +1068,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 	// insert 11 chunks that fall into the reserve, then
 	// expect one to be evicted
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -1114,7 +1113,7 @@ func TestReserveEvictionWorker(t *testing.T) {
 	})
 
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 3).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 3).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/localstore/index_test.go
+++ b/pkg/localstore/index_test.go
@@ -57,8 +57,8 @@ func TestDB_pullIndex(t *testing.T) {
 	}
 
 	testItemsOrder(t, db.pullIndex, chunks, func(i, j int) (less bool) {
-		poi := swarm.Proximity(db.baseKey, chunks[i].Address().Bytes())
-		poj := swarm.Proximity(db.baseKey, chunks[j].Address().Bytes())
+		poi := swarm.Proximity(db.baseAddr, chunks[i].Address())
+		poj := swarm.Proximity(db.baseAddr, chunks[j].Address())
 		if poi < poj {
 			return true
 		}

--- a/pkg/localstore/localstore.go
+++ b/pkg/localstore/localstore.go
@@ -171,8 +171,8 @@ type DB struct {
 	// are done before closing the database
 	updateGCWG sync.WaitGroup
 
-	// baseKey is the overlay address
-	baseKey []byte
+	// baseAddr is the overlay address
+	baseAddr swarm.Address
 
 	lock *multex.Multex
 
@@ -261,7 +261,7 @@ func (d *dirFS) Open(path string) (fs.File, error) {
 // New returns a new DB.  All fields and indexes are initialized
 // and possible conflicts with schema from existing database is checked.
 // One goroutine for writing batches is created.
-func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger log.Logger) (db *DB, err error) {
+func New(path string, baseAddr swarm.Address, ss storage.StateStorer, o *Options, logger log.Logger) (db *DB, err error) {
 	if o == nil {
 		// default options
 		o = &Options{
@@ -277,7 +277,7 @@ func New(path string, baseKey []byte, ss storage.StateStorer, o *Options, logger
 		cacheCapacity:   o.Capacity,
 		reserveCapacity: o.ReserveCapacity,
 		unreserveFunc:   o.UnreserveFunc,
-		baseKey:         baseKey,
+		baseAddr:        baseAddr,
 		tags:            o.Tags,
 		ctx:             ctx,
 		cancel:          cancel,
@@ -742,7 +742,7 @@ func (db *DB) Close() error {
 // po computes the proximity order between the address
 // and database base key.
 func (db *DB) po(addr swarm.Address) (bin uint8) {
-	return swarm.Proximity(db.baseKey, addr.Bytes())
+	return swarm.Proximity(db.baseAddr, addr)
 }
 
 // DebugIndices returns the index sizes for all indexes in localstore

--- a/pkg/localstore/localstore_test.go
+++ b/pkg/localstore/localstore_test.go
@@ -230,10 +230,7 @@ func TestParallelPutAndGet(t *testing.T) {
 func newTestDB(tb testing.TB, o *Options) *DB {
 	tb.Helper()
 
-	baseKey := make([]byte, 32)
-	if _, err := rand.Read(baseKey); err != nil {
-		tb.Fatal(err)
-	}
+	baseAddr := swarm.RandAddress(tb)
 	if o == nil {
 		o = &Options{}
 	}
@@ -248,7 +245,7 @@ func newTestDB(tb testing.TB, o *Options) *DB {
 		}
 	}
 	logger := log.Noop
-	db, err := New("", baseKey, nil, o, logger)
+	db, err := New("", baseAddr, nil, o, logger)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/pkg/localstore/migration_test.go
+++ b/pkg/localstore/migration_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/ethersphere/bee/pkg/log"
-	"github.com/ethersphere/bee/pkg/util/testutil"
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 func TestOneMigration(t *testing.T) {
@@ -48,7 +48,7 @@ func TestOneMigration(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	baseKey := testutil.RandBytes(t, 32)
+	baseKey := swarm.RandAddress(t)
 	logger := log.Noop
 
 	// start the fresh localstore with the sanctuary schema name
@@ -128,11 +128,11 @@ func TestManyMigrations(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	baseKey := testutil.RandBytes(t, 32)
+	baseAddr := swarm.RandAddress(t)
 	logger := log.Noop
 
 	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, nil, logger)
+	db, err := New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestManyMigrations(t *testing.T) {
 	DBSchemaCurrent = "salvation"
 
 	// start the existing localstore and expect the migration to run
-	db, err = New(dir, baseKey, nil, nil, logger)
+	db, err = New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,11 +201,11 @@ func TestMigrationErrorFrom(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	baseKey := testutil.RandBytes(t, 32)
+	baseAddr := swarm.RandAddress(t)
 	logger := log.Noop
 
 	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, nil, logger)
+	db, err := New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestMigrationErrorFrom(t *testing.T) {
 	DBSchemaCurrent = "foo"
 
 	// start the existing localstore and expect the migration to run
-	_, err = New(dir, baseKey, nil, nil, logger)
+	_, err = New(dir, baseAddr, nil, nil, logger)
 	if !strings.Contains(err.Error(), errMissingCurrentSchema.Error()) {
 		t.Fatalf("expected errCannotFindSchema but got %v", err)
 	}
@@ -254,12 +254,12 @@ func TestMigrationErrorTo(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	baseKey := testutil.RandBytes(t, 32)
+	baseAddr := swarm.RandAddress(t)
 
 	logger := log.Noop
 
 	// start the fresh localstore with the sanctuary schema name
-	db, err := New(dir, baseKey, nil, nil, logger)
+	db, err := New(dir, baseAddr, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +272,7 @@ func TestMigrationErrorTo(t *testing.T) {
 	DBSchemaCurrent = "foo"
 
 	// start the existing localstore and expect the migration to run
-	_, err = New(dir, baseKey, nil, nil, logger)
+	_, err = New(dir, baseAddr, nil, nil, logger)
 	if !strings.Contains(err.Error(), errMissingTargetSchema.Error()) {
 		t.Fatalf("expected errMissingTargetSchema but got %v", err)
 	}

--- a/pkg/localstore/mode_put_test.go
+++ b/pkg/localstore/mode_put_test.go
@@ -153,7 +153,7 @@ func TestModePutRequestCache(t *testing.T) {
 			db := newTestDB(t, nil)
 			var chunks []swarm.Chunk
 			for i := 0; i < tc.count; i++ {
-				chunk := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2)
+				chunk := generateTestRandomChunkAt(t, db.baseAddr, 2)
 				chunks = append(chunks, chunk)
 			}
 			// call unreserve on the batch with radius 0 so that

--- a/pkg/localstore/mode_set_test.go
+++ b/pkg/localstore/mode_set_test.go
@@ -70,7 +70,7 @@ func TestModeSetRemove_WithSync(t *testing.T) {
 			db := newTestDB(t, nil)
 			var chs []swarm.Chunk
 			for i := 0; i < tc.count; i++ {
-				ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+				ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 				_, err := db.unreserveBatch(ch.Stamp().BatchID(), 2)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/localstore/reserve_test.go
+++ b/pkg/localstore/reserve_test.go
@@ -43,7 +43,7 @@ func TestDB_ReserveGC_AllOutOfRadius(t *testing.T) {
 	addrs := make([]swarm.Address, 0)
 
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(5, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(5, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutRequest, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -158,7 +158,7 @@ func TestDB_ReserveGC_AllWithinRadius(t *testing.T) {
 	addrs := make([]swarm.Address, 0)
 
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -271,7 +271,7 @@ func TestDB_ReserveGC_Unreserve(t *testing.T) {
 	// will cause reserve eviction of 10 chunks into
 	// the cache. gc of the cache is still not triggered
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -299,7 +299,7 @@ func TestDB_ReserveGC_Unreserve(t *testing.T) {
 
 	// insert another 90, this will trigger gc
 	for i := 0; i < 90; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -449,7 +449,7 @@ func TestDB_ReserveGC_EvictMaxPO(t *testing.T) {
 
 	// put the first chunkCount chunks within radius
 	for i := 0; i < chunkCount; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -485,7 +485,7 @@ func TestDB_ReserveGC_EvictMaxPO(t *testing.T) {
 	t.Run("postage radius index count", newItemsCountTest(db.postageRadiusIndex, 0))
 
 	for i := 0; i < 90; i++ {
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 		_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 		if err != nil {
 			t.Fatal(err)
@@ -572,7 +572,7 @@ func TestReserveSize(t *testing.T) {
 			chs []swarm.Chunk
 		)
 		for i := 0; i < chunkCount; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 			chs = append(chs, ch)
 		}
 		_, err := db.Put(context.Background(), storage.ModePutSync, chs...)
@@ -592,7 +592,7 @@ func TestReserveSize(t *testing.T) {
 			addrs []swarm.Address
 		)
 		for i := 0; i < chunkCount; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 			chs = append(chs, ch)
 			addrs = append(addrs, ch.Address())
 		}
@@ -617,7 +617,7 @@ func TestReserveSize(t *testing.T) {
 			})
 		)
 		for i := 0; i < chunkCount; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 			_, err := db.Put(context.Background(), storage.ModePutSync, ch)
 			if err != nil {
 				t.Fatal(err)
@@ -635,7 +635,7 @@ func TestReserveSize(t *testing.T) {
 			})
 		)
 		for i := 0; i < chunkCount; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, 2).WithBatch(2, 3, 2, false)
 			_, err := db.Put(context.Background(), storage.ModePutRequest, ch)
 			if err != nil {
 				t.Fatal(err)
@@ -657,7 +657,7 @@ func TestComputeReserveSize(t *testing.T) {
 
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, po).WithBatch(0, 3, 2, false)
 			chs = append(chs, ch)
 		}
 	}
@@ -728,7 +728,7 @@ func TestDB_ReserveGC_BatchedUnreserve(t *testing.T) {
 	// generate chunks with the same batch and depth to trigger larger eviction
 	genChunk := func() swarm.Chunk {
 		newStamp := postagetesting.MustNewBatchStamp(stamp.BatchID())
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2)
 		return ch.WithBatch(2, 3, 2, false).WithStamp(newStamp)
 	}
 
@@ -801,7 +801,7 @@ func TestDB_ReserveGC_EvictBatch(t *testing.T) {
 	// generate chunks with the same batch and depth to trigger larger eviction
 	genChunk := func() swarm.Chunk {
 		newStamp := postagetesting.MustNewBatchStamp(stamp.BatchID())
-		ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), 2)
+		ch := generateTestRandomChunkAt(t, db.baseAddr, 2)
 		return ch.WithBatch(2, 3, 2, false).WithStamp(newStamp)
 	}
 

--- a/pkg/localstore/sampler_test.go
+++ b/pkg/localstore/sampler_test.go
@@ -37,7 +37,7 @@ func TestReserveSampler(t *testing.T) {
 
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, po).WithBatch(0, 3, 2, false)
 			// override stamp timestamp to be before the consensus timestamp
 			ch = ch.WithStamp(postagetesting.MustNewStampWithTimestamp(timeVar - 1))
 			chs = append(chs, ch)
@@ -74,7 +74,7 @@ func TestReserveSampler(t *testing.T) {
 	// some of them should definitely make it to the sample based on lex ordering.
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), po).WithBatch(0, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, po).WithBatch(0, 3, 2, false)
 			// override stamp timestamp to be after the consensus timestamp
 			ch = ch.WithStamp(postagetesting.MustNewStampWithTimestamp(timeVar + 1))
 			chs = append(chs, ch)
@@ -168,7 +168,7 @@ func TestReserveSamplerStop_FLAKY(t *testing.T) {
 
 	for po := 0; po < maxPO; po++ {
 		for i := 0; i < chunkCountPerPO; i++ {
-			ch := generateTestRandomChunkAt(t, swarm.NewAddress(db.baseKey), po).WithBatch(2, 3, 2, false)
+			ch := generateTestRandomChunkAt(t, db.baseAddr, po).WithBatch(2, 3, 2, false)
 			mtx.Lock()
 			chs = append(chs, ch)
 			batchIDs = append(batchIDs, ch.Stamp().BatchID())

--- a/pkg/localstore/subscription_pull.go
+++ b/pkg/localstore/subscription_pull.go
@@ -220,7 +220,7 @@ func (db *DB) triggerPullSubscriptions(bin uint8) {
 // addressInBin returns an address that is in a specific
 // proximity order bin from database base key.
 func (db *DB) addressInBin(bin uint8) swarm.Address {
-	addr := append([]byte(nil), db.baseKey...)
+	addr := append([]byte(nil), db.baseAddr.Bytes()...)
 	b := bin / 8
 	addr[b] = addr[b] ^ (1 << (7 - bin%8))
 	return swarm.NewAddress(addr)

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -241,7 +241,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		},
 	}
 
-	storer, err := localstore.New("", swarmAddress.Bytes(), stateStore, lo, logger)
+	storer, err := localstore.New("", swarmAddress, stateStore, lo, logger)
 	if err != nil {
 		return nil, fmt.Errorf("localstore: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -630,7 +630,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		ValidStamp:             validStamp,
 	}
 
-	storer, err := localstore.New(path, swarmAddress.Bytes(), stateStore, lo, logger)
+	storer, err := localstore.New(path, swarmAddress, stateStore, lo, logger)
 	if err != nil {
 		return nil, fmt.Errorf("localstore: %w", err)
 	}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -105,7 +105,7 @@ func (s *store) IsWithinStorageRadius(addr swarm.Address) bool {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
-	po := swarm.Proximity(addr.Bytes(), s.base.Bytes())
+	po := swarm.Proximity(addr, s.base)
 	return po >= s.rs.StorageRadius
 }
 

--- a/pkg/pricer/pricer.go
+++ b/pkg/pricer/pricer.go
@@ -32,7 +32,7 @@ func NewFixedPricer(overlay swarm.Address, poPrice uint64) *FixedPricer {
 
 // PeerPrice implements Pricer.
 func (pricer *FixedPricer) PeerPrice(peer, chunk swarm.Address) uint64 {
-	return uint64(swarm.MaxPO-swarm.Proximity(peer.Bytes(), chunk.Bytes())+1) * pricer.poPrice
+	return uint64(swarm.MaxPO-swarm.Proximity(peer, chunk)+1) * pricer.poPrice
 }
 
 // Price implements Pricer.

--- a/pkg/pullsync/pullstorage/pullstorage_test.go
+++ b/pkg/pullsync/pullstorage/pullstorage_test.go
@@ -291,7 +291,7 @@ func TestIntervalChunks_Localstore(t *testing.T) {
 
 			for i := 1; i <= tc.chunks; {
 				c := stesting.GenerateTestRandomChunk()
-				po := swarm.Proximity(c.Address().Bytes(), base)
+				po := swarm.Proximity(c.Address(), base)
 				if po == 1 {
 					chunks = append(chunks, c)
 					i++
@@ -570,20 +570,20 @@ func newPullStorage(t *testing.T, o ...mock.Option) (pullstorage.Storer, *mock.M
 	return ps, db
 }
 
-func newTestDB(t *testing.T, o *localstore.Options) (baseKey []byte, db *localstore.DB) {
+func newTestDB(t *testing.T, o *localstore.Options) (base swarm.Address, db *localstore.DB) {
 	t.Helper()
 
-	baseKey = testutil.RandBytes(t, 32)
+	base = swarm.RandAddress(t)
 
 	createLocalstoreLock.Lock()
 	defer createLocalstoreLock.Unlock()
-	db, err := localstore.New("", baseKey, nil, o, log.Noop)
+	db, err := localstore.New("", base, nil, o, log.Noop)
 	if err != nil {
 		t.Fatal(err)
 	}
 	testutil.CleanupCloser(t, db)
 
-	return baseKey, db
+	return base, db
 }
 
 // check that every a exists in b

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -185,7 +185,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		}
 		s.metrics.Offered.Inc()
 		s.metrics.DbOps.Inc()
-		po := swarm.Proximity(a.Bytes(), s.overlayAddress.Bytes())
+		po := swarm.Proximity(a, s.overlayAddress)
 		if po >= s.radius.StorageRadius() {
 			have, err = s.storage.Has(ctx, a)
 			if err != nil {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -309,7 +309,7 @@ func (s *Service) checkReceipt(receipt *pushsync.Receipt) error {
 		return fmt.Errorf("pusher: receipt storer address: %w", err)
 	}
 
-	po := swarm.Proximity(addr.Bytes(), peer.Bytes())
+	po := swarm.Proximity(addr, peer)
 
 	// Ideally the storage radius should be checked here, but because light nodes do not maintain a storage radius,
 	// we go with the best alternative - the kademlia neighborhood depth

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -411,7 +411,7 @@ func createPusherWithRetryCount(t *testing.T, addr swarm.Address, pushSyncServic
 	logger := log.Noop
 
 	createLocalstoreLock.Lock()
-	storer, err := localstore.New("", addr.Bytes(), nil, nil, logger)
+	storer, err := localstore.New("", addr, nil, nil, logger)
 	if err != nil {
 		createLocalstoreLock.Unlock()
 		t.Fatal(err)

--- a/pkg/storage/mock/storer.go
+++ b/pkg/storage/mock/storer.go
@@ -25,7 +25,7 @@ type MockStorer struct {
 	morePull        chan struct{}
 	mtx             sync.Mutex
 	quit            chan struct{}
-	baseAddress     []byte
+	baseAddress     swarm.Address
 	bins            []uint64
 	subPullCalls    int
 }
@@ -39,7 +39,7 @@ func WithSubscribePullChunks(chs ...storage.Descriptor) Option {
 
 func WithBaseAddress(a swarm.Address) Option {
 	return optionFunc(func(m *MockStorer) {
-		m.baseAddress = a.Bytes()
+		m.baseAddress = a
 	})
 }
 
@@ -88,7 +88,7 @@ func (m *MockStorer) Put(ctx context.Context, mode storage.ModePut, chs ...swarm
 			return exist, err
 		}
 		if !exist[i] {
-			po := swarm.Proximity(ch.Address().Bytes(), m.baseAddress)
+			po := swarm.Proximity(ch.Address(), m.baseAddress)
 			m.bins[po]++
 		}
 		// this is needed since the chunk feeder shares memory across calls

--- a/pkg/storage/testing/chunk.go
+++ b/pkg/storage/testing/chunk.go
@@ -79,7 +79,7 @@ func GenerateValidRandomChunkAt(target swarm.Address, po int) swarm.Chunk {
 		if err != nil {
 			continue
 		}
-		if swarm.Proximity(ch.Address().Bytes(), target.Bytes()) > uint8(po) {
+		if swarm.Proximity(ch.Address(), target) > uint8(po) {
 			break
 		}
 	}

--- a/pkg/swarm/proximity.go
+++ b/pkg/swarm/proximity.go
@@ -17,42 +17,33 @@ package swarm
 // binary representation of the x^y.
 //
 // (0 farthest, 255 closest, 256 self)
-func Proximity(one, other []byte) (ret uint8) {
-	b := MaxPO/8 + 1
-	if l := uint8(len(one)); b > l {
-		b = l
-	}
-	if l := uint8(len(other)); b > l {
-		b = l
-	}
-	var m uint8 = 8
-	for i := uint8(0); i < b; i++ {
-		oxo := one[i] ^ other[i]
-		for j := uint8(0); j < m; j++ {
-			if (oxo>>(7-j))&0x01 != 0 {
-				return i*8 + j
-			}
-		}
-	}
-	return MaxPO
+func Proximity(x, y Address) (ret uint8) {
+	return proximity(MaxPO, x, y)
 }
 
-func ExtendedProximity(one, other []byte) (ret uint8) {
-	b := ExtendedPO/8 + 1
-	if l := uint8(len(one)); b > l {
+func ExtendedProximity(x, y Address) uint8 {
+	return proximity(ExtendedPO, x, y)
+}
+
+func proximity(po uint8, x, y Address) uint8 {
+	xb, yb := x.b, y.b
+
+	b := po/8 + 1
+	if l := uint8(len(xb)); b > l {
 		b = l
 	}
-	if l := uint8(len(other)); b > l {
+	if l := uint8(len(yb)); b > l {
 		b = l
 	}
-	var m uint8 = 8
+
 	for i := uint8(0); i < b; i++ {
-		oxo := one[i] ^ other[i]
-		for j := uint8(0); j < m; j++ {
+		oxo := xb[i] ^ yb[i]
+		for j := uint8(0); j < 8; j++ {
 			if (oxo>>(7-j))&0x01 != 0 {
 				return i*8 + j
 			}
 		}
 	}
-	return ExtendedPO
+
+	return po
 }

--- a/pkg/swarm/proximity_test.go
+++ b/pkg/swarm/proximity_test.go
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package swarm
+package swarm_test
 
 import (
 	"testing"
+
+	"github.com/ethersphere/bee/pkg/swarm"
 )
 
 // TestProximity validates Proximity function with explicit
@@ -26,13 +28,6 @@ import (
 func TestProximity(t *testing.T) {
 	t.Parallel()
 
-	// adjust expected bins in respect to MaxPO
-	limitPO := func(po uint8) uint8 {
-		if po > MaxPO {
-			return MaxPO
-		}
-		return po
-	}
 	base := []byte{0b00000000, 0b00000000, 0b00000000, 0b00000000}
 	for _, tc := range []struct {
 		addr []byte
@@ -40,158 +35,160 @@ func TestProximity(t *testing.T) {
 	}{
 		{
 			addr: base,
-			po:   MaxPO,
+			po:   swarm.MaxPO,
 		},
 		{
 			addr: []byte{0b10000000, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(0),
+			po:   0,
 		},
 		{
 			addr: []byte{0b01000000, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(1),
+			po:   1,
 		},
 		{
 			addr: []byte{0b00100000, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(2),
+			po:   2,
 		},
 		{
 			addr: []byte{0b00010000, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(3),
+			po:   3,
 		},
 		{
 			addr: []byte{0b00001000, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(4),
+			po:   4,
 		},
 		{
 			addr: []byte{0b00000100, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(5),
+			po:   5,
 		},
 		{
 			addr: []byte{0b00000010, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(6),
+			po:   6,
 		},
 		{
 			addr: []byte{0b00000001, 0b00000000, 0b00000000, 0b00000000},
-			po:   limitPO(7),
+			po:   7,
 		},
 		{
 			addr: []byte{0b00000000, 0b10000000, 0b00000000, 0b00000000},
-			po:   limitPO(8),
+			po:   8,
 		},
 		{
 			addr: []byte{0b00000000, 0b01000000, 0b00000000, 0b00000000},
-			po:   limitPO(9),
+			po:   9,
 		},
 		{
 			addr: []byte{0b00000000, 0b00100000, 0b00000000, 0b00000000},
-			po:   limitPO(10),
+			po:   10,
 		},
 		{
 			addr: []byte{0b00000000, 0b00010000, 0b00000000, 0b00000000},
-			po:   limitPO(11),
+			po:   11,
 		},
 		{
 			addr: []byte{0b00000000, 0b00001000, 0b00000000, 0b00000000},
-			po:   limitPO(12),
+			po:   12,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000100, 0b00000000, 0b00000000},
-			po:   limitPO(13),
+			po:   13,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000010, 0b00000000, 0b00000000},
-			po:   limitPO(14),
+			po:   14,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000001, 0b00000000, 0b00000000},
-			po:   limitPO(15),
+			po:   15,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b10000000, 0b00000000},
-			po:   limitPO(16),
+			po:   16,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b01000000, 0b00000000},
-			po:   limitPO(17),
+			po:   17,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00100000, 0b00000000},
-			po:   limitPO(18),
+			po:   18,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00010000, 0b00000000},
-			po:   limitPO(19),
+			po:   19,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00001000, 0b00000000},
-			po:   limitPO(20),
+			po:   20,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000100, 0b00000000},
-			po:   limitPO(21),
+			po:   21,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000010, 0b00000000},
-			po:   limitPO(22),
+			po:   22,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000001, 0b00000000},
-			po:   limitPO(23),
+			po:   23,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b10000000},
-			po:   limitPO(24),
+			po:   24,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b01000000},
-			po:   limitPO(25),
+			po:   25,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00100000},
-			po:   limitPO(26),
+			po:   26,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00010000},
-			po:   limitPO(27),
+			po:   27,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00001000},
-			po:   limitPO(28),
+			po:   28,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000100},
-			po:   limitPO(29),
+			po:   29,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000010},
-			po:   limitPO(30),
+			po:   30,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000001},
-			po:   limitPO(31),
+			po:   31,
 		},
 		{
 			addr: nil,
-			po:   limitPO(31),
+			po:   31,
 		},
 		{
 			addr: []byte{0b00000001},
-			po:   limitPO(7),
+			po:   7,
 		},
 		{
 			addr: []byte{0b00000000},
-			po:   limitPO(31),
+			po:   31,
 		},
 		{
 			addr: []byte{0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000001},
-			po:   limitPO(31),
+			po:   31,
 		},
 	} {
-		got := Proximity(base, tc.addr)
+		x, y := swarm.NewAddress(base), swarm.NewAddress(tc.addr)
+
+		got := swarm.Proximity(x, y)
 		if got != tc.po {
 			t.Errorf("got %v bin, want %v", got, tc.po)
 		}
-		got = Proximity(tc.addr, base)
+		got = swarm.Proximity(y, x)
 		if got != tc.po {
 			t.Errorf("got %v bin, want %v (reverse arguments)", got, tc.po)
 		}

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -26,7 +26,7 @@ const (
 type PeerFilterFunc = peerFilterFunc
 
 func (k *Kad) IsWithinDepth(addr swarm.Address) bool {
-	return swarm.Proximity(k.base.Bytes(), addr.Bytes()) >= k.NeighborhoodDepth()
+	return swarm.Proximity(k.base, addr) >= k.NeighborhoodDepth()
 }
 
 // IsBalanced returns if Kademlia is balanced to bin.
@@ -43,7 +43,7 @@ func (k *Kad) IsBalanced(bin uint8) bool {
 			return false
 		}
 
-		closestConnectedPO := swarm.ExtendedProximity(closestConnectedPeer.Bytes(), pseudoAddr.Bytes())
+		closestConnectedPO := swarm.ExtendedProximity(closestConnectedPeer, pseudoAddr)
 		if int(closestConnectedPO) < int(bin)+k.opt.BitSuffixLength+1 {
 			return false
 		}

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1195,7 +1195,7 @@ func TestSnapshot_FLAKY(t *testing.T) {
 		t.Errorf("expected population %d but got %d", 1, snap.Population)
 	}
 
-	po := swarm.Proximity(sa.Bytes(), a.Bytes())
+	po := swarm.Proximity(sa, a)
 
 	if binP := getBinPopulation(&snap.Bins, po); binP != 1 {
 		t.Errorf("expected bin(%d) to have population %d but got %d", po, 1, snap.Population)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR changes arguments of `swarm.Proximity` and `swarm.ExtendedProximity` utilities from `[]bytes` to `swarm.Address` in order to ensure type safety.

All changes are:
- `pkg/swarm/proximity.go` - change in this file are changing arguments to `swarm.Address`
- changes in other files reflect this change
