### PR TITLE
perf: delay out of depth syncing for some time

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -958,7 +958,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 	)
 
 	if o.FullNodeMode && !o.BootnodeMode {
-		pullerService = puller.New(stateStore, kad, batchStore, pullSyncProtocol, p2ps, logger, puller.Options{SyncSleepDur: puller.DefaultSyncErrorSleepDur}, warmupTime)
+		pullerService = puller.New(stateStore, kad, batchStore, pullSyncProtocol, p2ps, logger, puller.Options{SyncSleepDur: puller.DefaultSyncErrorSleepDur, ShallowBinsWarmupDur: puller.DefaultShallowBinsWarmupDur}, warmupTime)
 		b.pullerCloser = pullerService
 
 		depthMonitor := depthmonitor.New(kad, pullSyncProtocol, storer, batchStore, logger, warmupTime, depthmonitor.DefaultWakeupInterval, !batchStoreExists)

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -34,15 +34,17 @@ var errCursorsLength = errors.New("cursors length mismatch")
 const (
 	intervalPrefix = "sync_interval"
 
-	DefaultSyncErrorSleepDur = time.Minute
-	recalcPeersDur           = time.Minute * 5
-	histSyncTimeout          = time.Minute * 10
-	histSyncTimeoutBlockList = time.Hour * 24
+	DefaultSyncErrorSleepDur    = time.Minute
+	recalcPeersDur              = time.Minute * 5
+	histSyncTimeout             = time.Minute * 10
+	histSyncTimeoutBlockList    = time.Hour * 24
+	DefaultShallowBinsWarmupDur = time.Hour * 24
 )
 
 type Options struct {
-	Bins         uint8
-	SyncSleepDur time.Duration
+	Bins                 uint8
+	SyncSleepDur         time.Duration
+	ShallowBinsWarmupDur time.Duration
 }
 
 type Puller struct {
@@ -62,7 +64,8 @@ type Puller struct {
 
 	wg sync.WaitGroup
 
-	syncErrorSleepDur time.Duration
+	syncErrorSleepDur     time.Duration
+	shallowBinsWarmupTime time.Time
 
 	bins uint8 // how many bins do we support
 
@@ -94,6 +97,8 @@ func New(stateStore storage.StateStorer, topology topology.Driver, reserveState 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 
+	p.shallowBinsWarmupTime = time.Now().Add(o.ShallowBinsWarmupDur)
+
 	p.wg.Add(1)
 	go p.manage(ctx, warmupTime)
 	return p
@@ -103,14 +108,14 @@ func (p *Puller) ActiveHistoricalSyncing() uint64 {
 	return p.activeHistoricalSyncing.Load()
 }
 
-func (p *Puller) manage(ctx context.Context, warmupTime time.Duration) {
+func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 	defer p.wg.Done()
 
 	c, unsubscribe := p.topology.SubscribeTopologyChange()
 	defer unsubscribe()
 
 	select {
-	case <-time.After(warmupTime):
+	case <-time.After(warmupDur):
 	case <-ctx.Done():
 		return
 	}
@@ -216,22 +221,12 @@ func (p *Puller) syncPeer(ctx context.Context, peer *syncPeer, storageRadius uin
 
 	/*
 		The syncing behavior diverges for peers outside and winthin the storage radius.
-		For peers with PO lower than the storage radius, we must sync ONLY the bin that is the PO.
 		For neighbor peers, we sync ALL bins greater than or equal to the storage radius.
+		For peers with PO lower than the storage radius, we must sync ONLY the bin that is the PO.
 	*/
 
-	if peer.po < storageRadius {
-		// cancel all non-po bins, if any
-		for bin := uint8(0); bin < p.bins; bin++ {
-			if bin != peer.po {
-				peer.cancelBin(bin)
-			}
-		}
-		// sync PO bin only
-		if !peer.isBinSyncing(peer.po) {
-			p.syncPeerBin(ctx, peer, peer.po, peer.cursors[peer.po])
-		}
-	} else {
+	if peer.po >= storageRadius {
+
 		// cancel all bins lower than the storage radius
 		for bin := uint8(0); bin < storageRadius; bin++ {
 			peer.cancelBin(bin)
@@ -243,6 +238,20 @@ func (p *Puller) syncPeer(ctx context.Context, peer *syncPeer, storageRadius uin
 				p.syncPeerBin(ctx, peer, uint8(bin), cur)
 			}
 		}
+
+	} else if time.Now().After(p.shallowBinsWarmupTime) {
+
+		// cancel all non-po bins, if any
+		for bin := uint8(0); bin < p.bins; bin++ {
+			if bin != peer.po {
+				peer.cancelBin(bin)
+			}
+		}
+		// sync PO bin only
+		if !peer.isBinSyncing(peer.po) {
+			p.syncPeerBin(ctx, peer, peer.po, peer.cursors[peer.po])
+		}
+
 	}
 
 	return nil

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -35,10 +35,11 @@ const (
 	intervalPrefix = "sync_interval"
 
 	DefaultSyncErrorSleepDur    = time.Minute
-	recalcPeersDur              = time.Minute * 5
-	histSyncTimeout             = time.Minute * 10
-	histSyncTimeoutBlockList    = time.Hour * 24
 	DefaultShallowBinsWarmupDur = time.Hour * 24
+
+	recalcPeersDur           = time.Minute * 5
+	histSyncTimeout          = time.Minute * 20
+	histSyncTimeoutBlockList = time.Hour * 24
 )
 
 type Options struct {

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -51,7 +51,7 @@ var (
 
 const (
 	storagePutTimeout = 5 * time.Second
-	makeOfferTimeout  = 5 * time.Minute
+	makeOfferTimeout  = 15 * time.Minute
 )
 
 // how many maximum chunks in a batch

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -50,8 +50,8 @@ var (
 )
 
 const (
-	storagePutTimeout = 5 * time.Second
-	makeOfferTimeout  = 15 * time.Minute
+	storagePutTimeout = time.Second * 15
+	makeOfferTimeout  = time.Minute * 15
 )
 
 // how many maximum chunks in a batch


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
There are two groups of pullsyncing: neighbors and non-neighbors. For fresh nodes especially, each time we lower the storage radius, all previous intervals below the radius are reset, meaning syncing starts from scratch for those bins. For peers that is within the radius, no resyncing occurs because the reset radiuses are below the storage radius, but for the out of depth peers, syncing has to be done from scratch. 

To prevent too much resyscing, we delay the the start of the out of depth syncing until after 24 hours of running, which should be enough time for the storage radius to stabilize.  

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
