### PR TITLE
feat(storageincentives): persisting agent data between rounds

### DIFF
--- a/pkg/storageincentives/agent.go
+++ b/pkg/storageincentives/agent.go
@@ -10,9 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/settlement/swap/erc20"
@@ -111,15 +111,8 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 	defer a.wg.Done()
 
 	var (
-		mtx            sync.Mutex
-		sampleRound    uint64 = math.MaxUint64
-		commitRound    uint64 = math.MaxUint64
-		revealRound    uint64 = math.MaxUint64
-		round          uint64
-		reserveSample  []byte
-		obfuscationKey []byte
-		storageRadius  uint8
-		phaseEvents    = newEvents()
+		currRound   atomic.Uint64
+		phaseEvents = newEvents()
 	)
 	// cancel all possible running phases
 	defer phaseEvents.Close()
@@ -127,24 +120,25 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 	commitF := func(ctx context.Context) {
 		phaseEvents.Cancel(claim)
 
-		mtx.Lock()
-		round := round
-		sampleRound := sampleRound
-		storageRadius := storageRadius
-		reserveSample := reserveSample
-		mtx.Unlock()
+		round := currRound.Load()
 
-		if round-1 == sampleRound { // the sample has to come from previous round to be able to commit it
-			obf, err := a.commit(ctx, storageRadius, reserveSample, round)
-			if err != nil {
-				a.logger.Error(err, "commit")
-			} else {
-				mtx.Lock()
-				obfuscationKey = obf
-				commitRound = round
-				mtx.Unlock()
-				a.logger.Debug("committed the reserve sample and radius")
+		// the sample has to come from previous round to be able to commit it
+		sample, err := getSample(a.state.stateStore, round-1)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				// In absence of sample, phase is skipped
+				return
 			}
+
+			a.logger.Error(err, "getSample for commit phase")
+			return
+		}
+
+		err = a.commit(ctx, sample, round)
+		if err != nil {
+			a.logger.Error(err, "commit")
+		} else {
+			a.logger.Debug("committed the reserve sample and radius")
 		}
 	}
 
@@ -166,60 +160,65 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 		// cancel previous executions of the commit and sample phases
 		phaseEvents.Cancel(commit, sample, sampleEnd)
 
-		mtx.Lock()
-		round := round
-		commitRound := commitRound
-		storageRadius := storageRadius
-		reserveSample := reserveSample
-		obfuscationKey := obfuscationKey
-		mtx.Unlock()
+		round := currRound.Load()
 
-		if round == commitRound { // reveal requires the obfuscationKey from the same round
-			err := a.reveal(ctx, storageRadius, reserveSample, obfuscationKey)
-			if err != nil {
-				a.logger.Error(err, "reveal")
-			} else {
-				mtx.Lock()
-				revealRound = round
-				mtx.Unlock()
-				a.logger.Debug("revealed the sample with the obfuscation key")
+		// reveal requires the commitKey from the same round
+		commitKey, err := getCommitKey(a.state.stateStore, round)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				// In absence of commitKey, phase is skipped
+				return
 			}
+
+			a.logger.Error(err, "getCommitKey for reveal phase")
+			return
+		}
+
+		// reveal requires sample from previous round
+		sample, err := getSample(a.state.stateStore, round-1)
+		if err != nil {
+			// Sample must have been saved so far
+			a.logger.Error(err, "getSample for reveal phase")
+			return
+		}
+
+		err = a.reveal(ctx, sample, commitKey, round)
+		if err != nil {
+			a.logger.Error(err, "reveal")
+		} else {
+			a.logger.Debug("revealed the sample with the obfuscation key")
 		}
 	})
 
 	phaseEvents.On(claim, func(ctx context.Context, _ PhaseType) {
-
 		phaseEvents.Cancel(reveal)
 
-		mtx.Lock()
-		round := round
-		revealRound := revealRound
-		mtx.Unlock()
+		round := currRound.Load()
 
-		if round == revealRound { // to claim, previous reveal must've happened in the same round
-			err := a.claim(ctx, round)
-			if err != nil {
-				a.logger.Error(err, "claim")
+		err := getRevealRound(a.state.stateStore, round)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				// In absence of reval round, phase is skipped
+				return
 			}
+
+			a.logger.Error(err, "getRevealRound for claim phase")
+			return
+		}
+
+		if err := a.claim(ctx, round); err != nil {
+			a.logger.Error(err, "claim")
 		}
 	})
 
 	phaseEvents.On(sample, func(ctx context.Context, _ PhaseType) {
+		round := currRound.Load()
 
-		mtx.Lock()
-		round := round
-		mtx.Unlock()
-
-		sr, smpl, err := a.play(ctx, round)
+		shouldPlayRound, err := a.play(ctx, round)
 		if err != nil {
 			a.logger.Error(err, "make sample")
-		} else if smpl != nil {
-			mtx.Lock()
-			sampleRound = round
-			reserveSample = smpl
-			storageRadius = sr
+		} else if shouldPlayRound {
 			a.logger.Info("produced reserve sample", "round", round)
-			mtx.Unlock()
 		}
 
 		phaseEvents.Publish(sampleEnd)
@@ -254,8 +253,9 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 			continue
 		}
 
-		mtx.Lock()
-		round = block / blocksPerRound
+		round := block / blocksPerRound
+		currRound.Store(round)
+
 		a.metrics.Round.Set(float64(round))
 
 		p := block % blocksPerRound
@@ -292,18 +292,23 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 		prevPhase = currentPhase
 
 		cancel()
-		mtx.Unlock()
 	}
 }
 
-func (a *Agent) reveal(ctx context.Context, storageRadius uint8, sample, obfuscationKey []byte) error {
+func (a *Agent) reveal(ctx context.Context, sample Sample, obfuscationKey []byte, round uint64) error {
 	a.metrics.RevealPhase.Inc()
-	txHash, err := a.contract.Reveal(ctx, storageRadius, sample, obfuscationKey)
+	sampleBytes := sample.ReserveSample.Hash.Bytes()
+	txHash, err := a.contract.Reveal(ctx, sample.StorageRadius, sampleBytes, obfuscationKey)
 	if err != nil {
 		a.metrics.ErrReveal.Inc()
 		return err
 	}
 	a.state.AddFee(ctx, txHash)
+
+	if err := saveRevealRound(a.state.stateStore, round); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -352,21 +357,20 @@ func (a *Agent) claim(ctx context.Context, round uint64) error {
 	return nil
 }
 
-func (a *Agent) play(ctx context.Context, round uint64) (uint8, []byte, error) {
-
+func (a *Agent) play(ctx context.Context, round uint64) (bool, error) {
 	status, err := a.state.Status()
 	if err != nil {
-		return 0, nil, err
+		return false, err
 	}
 
 	if !status.IsFullySynced {
 		a.logger.Info("skipping round because node is not fully synced", "round", round)
-		return 0, nil, nil
+		return false, nil
 	}
 
 	if status.IsFrozen {
 		a.logger.Info("skipping round because node is frozen", "round", round)
-		return 0, nil, nil
+		return false, nil
 	}
 
 	storageRadius := a.radius.StorageRadius()
@@ -374,47 +378,65 @@ func (a *Agent) play(ctx context.Context, round uint64) (uint8, []byte, error) {
 	isPlaying, err := a.contract.IsPlaying(ctx, storageRadius)
 	if err != nil {
 		a.metrics.ErrCheckIsPlaying.Inc()
-		return 0, nil, err
+		return false, err
 	}
 	if !isPlaying {
-		return 0, nil, nil
+		return false, nil
 	}
 
 	hasFunds, err := a.HasEnoughFundsToPlay(ctx)
 	if err != nil {
 		a.logger.Error(err, "agent HasEnoughFundsToPlay failed")
-		return 0, nil, nil
+		return false, nil
 	}
 
 	if !hasFunds {
 		a.logger.Info("insufficient funds to participate in next round", "round", round)
 		a.metrics.InsufficientFundsToPlay.Inc()
-		return 0, nil, nil
+		return false, nil
 	}
 
 	a.state.SetLastPlayedRound(round)
 	a.logger.Info("neighbourhood chosen", "round", round)
 	a.metrics.NeighborhoodSelected.Inc()
 
-	salt, err := a.contract.ReserveSalt(ctx)
+	sample, err := a.makeSample(ctx, round, storageRadius)
 	if err != nil {
-		return 0, nil, err
+		return false, err
 	}
 
-	t := time.Now()
+	err = saveSample(a.state.stateStore, sample, round)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (a *Agent) makeSample(ctx context.Context, round uint64, storageRadius uint8) (Sample, error) {
+	salt, err := a.contract.ReserveSalt(ctx)
+	if err != nil {
+		return Sample{}, err
+	}
 
 	timeLimiter, err := a.getPreviousRoundTime(ctx)
 	if err != nil {
-		return 0, nil, err
+		return Sample{}, err
 	}
 
-	sample, err := a.sampler.ReserveSample(ctx, salt, storageRadius, uint64(timeLimiter))
+	t := time.Now()
+	rSample, err := a.sampler.ReserveSample(ctx, salt, storageRadius, uint64(timeLimiter))
 	if err != nil {
-		return 0, nil, err
+		return Sample{}, err
 	}
 	a.metrics.SampleDuration.Set(time.Since(t).Seconds())
 
-	return storageRadius, sample.Hash.Bytes(), nil
+	sample := Sample{
+		ReserveSample: rSample,
+		StorageRadius: storageRadius,
+	}
+
+	return sample, nil
 }
 
 func (a *Agent) getPreviousRoundTime(ctx context.Context) (time.Duration, error) {
@@ -438,26 +460,33 @@ func (a *Agent) getPreviousRoundTime(ctx context.Context) (time.Duration, error)
 	return time.Duration(timeLimiterBlock.Time) * time.Second / time.Nanosecond, nil
 }
 
-func (a *Agent) commit(ctx context.Context, storageRadius uint8, sample []byte, round uint64) ([]byte, error) {
+func (a *Agent) commit(ctx context.Context, sample Sample, round uint64) error {
 	a.metrics.CommitPhase.Inc()
 
 	key := make([]byte, swarm.HashSize)
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {
-		return nil, err
+		return err
 	}
 
-	obfuscatedHash, err := a.wrapCommit(storageRadius, sample, key)
+	sampleBytes := sample.ReserveSample.Hash.Bytes()
+	obfuscatedHash, err := a.wrapCommit(sample.StorageRadius, sampleBytes, key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	txHash, err := a.contract.Commit(ctx, obfuscatedHash, big.NewInt(int64(round)))
 	if err != nil {
 		a.metrics.ErrCommit.Inc()
-		return nil, err
+		return err
 	}
 	a.state.AddFee(ctx, txHash)
-	return key, nil
+
+	err = saveCommitKey(a.state.stateStore, key, round)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (a *Agent) Close() error {

--- a/pkg/storageincentives/export_test.go
+++ b/pkg/storageincentives/export_test.go
@@ -4,4 +4,12 @@
 
 package storageincentives
 
-var NewEvents = newEvents
+var (
+	NewEvents       = newEvents
+	SaveSample      = saveSample
+	GetSample       = getSample
+	SaveCommitKey   = saveCommitKey
+	GetCommitKey    = getCommitKey
+	SaveRevealRound = saveRevealRound
+	GetRevealRound  = getRevealRound
+)

--- a/pkg/storageincentives/stored_values.go
+++ b/pkg/storageincentives/stored_values.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storageincentives
+
+import (
+	"strconv"
+
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+const (
+	sampleStorageKeyPrefix      = "storage_incentives_sample_"
+	commitKeyStorageKeyPrefix   = "storage_incentives_commit_key_"
+	revealRoundStorageKeyPrefix = "storage_incentives_reveal_round_"
+)
+
+type Sample struct {
+	ReserveSample storage.Sample
+	StorageRadius uint8
+}
+
+func saveSample(store storage.StateStorer, sample Sample, round uint64) error {
+	key := sampleStorageKey(round)
+	return store.Put(key, sample)
+}
+
+func getSample(store storage.StateStorer, round uint64) (Sample, error) {
+	key := sampleStorageKey(round)
+	sample := &Sample{}
+	err := store.Get(key, sample)
+
+	return *sample, err
+}
+
+func saveCommitKey(store storage.StateStorer, commitKey []byte, round uint64) error {
+	key := commitKeyStorageKey(round)
+	return store.Put(key, commitKey)
+}
+
+func getCommitKey(store storage.StateStorer, round uint64) ([]byte, error) {
+	key := commitKeyStorageKey(round)
+	commitKey := make([]byte, swarm.HashSize)
+	err := store.Get(key, &commitKey)
+
+	return commitKey, err
+}
+
+func saveRevealRound(store storage.StateStorer, round uint64) error {
+	key := revealRoundStorageKey(round)
+	return store.Put(key, true)
+}
+
+func getRevealRound(store storage.StateStorer, round uint64) error {
+	key := revealRoundStorageKey(round)
+	value := false
+	err := store.Get(key, &value)
+
+	return err
+}
+
+func sampleStorageKey(round uint64) string {
+	return sampleStorageKeyPrefix + strconv.FormatUint(round, 10)
+}
+
+func commitKeyStorageKey(round uint64) string {
+	return commitKeyStorageKeyPrefix + strconv.FormatUint(round, 10)
+}
+
+func revealRoundStorageKey(round uint64) string {
+	return revealRoundStorageKeyPrefix + strconv.FormatUint(round, 10)
+}

--- a/pkg/storageincentives/stored_values_test.go
+++ b/pkg/storageincentives/stored_values_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storageincentives_test
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	statestore "github.com/ethersphere/bee/pkg/statestore/mock"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storageincentives"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/util/testutil"
+)
+
+func TestStorage_Sample(t *testing.T) {
+	t.Parallel()
+
+	s := statestore.NewStateStore()
+
+	_, err := storageincentives.GetSample(s, 1)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Error("expected error")
+	}
+
+	savedSample := storageincentives.Sample{
+		ReserveSample: storage.Sample{
+			Hash: swarm.RandAddress(t),
+		},
+		StorageRadius: 3,
+	}
+	err = storageincentives.SaveSample(s, savedSample, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	sample, err := storageincentives.GetSample(s, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(savedSample, sample) {
+		t.Errorf("sample does not match saved sample")
+	}
+}
+
+func TestStorage_CommitKey(t *testing.T) {
+	t.Parallel()
+
+	s := statestore.NewStateStore()
+
+	_, err := storageincentives.GetCommitKey(s, 1)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Error("expected error")
+	}
+
+	savedKey := testutil.RandBytes(t, swarm.HashSize)
+	err = storageincentives.SaveCommitKey(s, savedKey, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	key, err := storageincentives.GetCommitKey(s, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(savedKey, key) {
+		t.Errorf("key does not match saved key")
+	}
+}
+
+func TestStorage_RevealRound(t *testing.T) {
+	t.Parallel()
+
+	s := statestore.NewStateStore()
+
+	err := storageincentives.GetRevealRound(s, 1)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Error("expected error")
+	}
+
+	err = storageincentives.SaveRevealRound(s, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = storageincentives.GetRevealRound(s, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In this change storage incentives agent will persist data between round.