### PR TITLE
fix(retrieval): added missing select default case for retry func

### DIFF
--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -134,13 +134,10 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 		s.metrics.RequestAttempts.Observe(float64(totalRetrieveAttempts))
 	}()
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	// topCtx is passing the tracing span to the first singleflight call
 	topCtx := ctx
 
-	v, _, err := s.singleflight.Do(ctx, flightRoute, func(ctx context.Context) (interface{}, error) {
+	v, _, err := s.singleflight.Do(topCtx, flightRoute, func(ctx context.Context) (interface{}, error) {
 
 		var skip []swarm.Address
 		var preemptiveTicker <-chan time.Time
@@ -165,9 +162,9 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 
 		retry := func() {
 			select {
-			case retryC <- struct{}{}:
-			case <-done:
 			case <-ctx.Done():
+			case retryC <- struct{}{}:
+			default:
 			}
 		}
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
The main loop on rare edge cases would freeze as the default case for the retry was missing. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
