### PR TITLE
chore(storageincentives): removed sample end phase/event

### DIFF
--- a/pkg/storageincentives/events.go
+++ b/pkg/storageincentives/events.go
@@ -34,13 +34,12 @@ func (p PhaseType) String() string {
 }
 
 type events struct {
-	mtx      sync.Mutex
-	previous PhaseType
-	ev       map[PhaseType]*event
+	mtx sync.Mutex
+	ev  map[PhaseType]*event
 }
 
 type event struct {
-	funcs  []func(context.Context, PhaseType)
+	funcs  []func(context.Context)
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -51,7 +50,7 @@ func newEvents() *events {
 	}
 }
 
-func (e *events) On(phase PhaseType, f func(context.Context, PhaseType)) {
+func (e *events) On(phase PhaseType, f func(context.Context)) {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
@@ -69,10 +68,9 @@ func (e *events) Publish(phase PhaseType) {
 
 	if ev, ok := e.ev[phase]; ok {
 		for _, v := range ev.funcs {
-			go v(ev.ctx, e.previous)
+			go v(ev.ctx)
 		}
 	}
-	e.previous = phase
 }
 
 func (e *events) Cancel(phases ...PhaseType) {

--- a/pkg/storageincentives/events.go
+++ b/pkg/storageincentives/events.go
@@ -16,7 +16,6 @@ const (
 	reveal
 	claim
 	sample
-	sampleEnd
 )
 
 func (p PhaseType) String() string {
@@ -29,8 +28,6 @@ func (p PhaseType) String() string {
 		return "claim"
 	case sample:
 		return "sample"
-	case sampleEnd:
-		return "sampleEnd"
 	default:
 		return "unknown"
 	}

--- a/pkg/storageincentives/redistributionstate.go
+++ b/pkg/storageincentives/redistributionstate.go
@@ -180,3 +180,9 @@ func (r *RedistributionState) save() {
 		r.logger.Error(err, "saving redistribution status")
 	}
 }
+
+func (r *RedistributionState) currentRoundAndPhase() (uint64, PhaseType) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.status.Round, r.status.Phase
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Removing sample end phase/event because it appears to be unnecessary and introduces confusion because it is not valid phase.
Logic of old sample end event was added to sample handler where it suits more. 

Additional, minor change, was cleaning up commit handler. It now follows same handler convention of previous PR. Also previous phase type event check was removed because handler will be able to know if phase could be played or not based on stored information.