### PR TITLE
fix(api): set Content-Length header on download endpoints

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -179,6 +179,6 @@ func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
 		// soc
 		span = int64(len(ch.Data()))
 	}
-	w.Header().Add("Content-Length", strconv.FormatInt(span, 10))
+	w.Header().Set("Content-Length", strconv.FormatInt(span, 10))
 	w.WriteHeader(http.StatusOK) // HEAD requests do not write a body
 }

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -205,6 +205,6 @@ func (s *Service) chunkGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "binary/octet-stream")
-	w.Header().Add("Content-Length", strconv.FormatInt(int64(len(chunk.Data())), 10))
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(chunk.Data())), 10))
 	_, _ = io.Copy(w, bytes.NewReader(chunk.Data()))
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
- disabled compression handler in API for download endpoints; because this handler is always removing `Content-Length` header
- improved API test when asserting response 
  - added assertion of Content-Length header 
  - utilized WithExpectedResponseHeader for other headers

