### PR TITLE
fix(retrieve, pushsync): wait for overdraft peers to refresh

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -403,7 +403,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 
 			// no peers left
 			if errors.Is(err, topology.ErrNotFound) {
-				if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no peers would be removed, we have depleted ALL peers
+				if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
 					if inflight == 0 {
 						ps.logger.Debug("no peers left", "chunk_address", ch.Address(), "error", err)
 						return nil, err
@@ -427,7 +427,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			}
 
 			if err != nil {
-				if inflight == 0 {
+				if inflight > 0 {
 					continue
 				} else {
 					return nil, fmt.Errorf("get closest for address %s, allow upstream %v: %w", ch, origin, err)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -45,7 +45,7 @@ const (
 	preemptiveInterval               = 5 * time.Second  // P90 request time to live
 	sanctionWait                     = 5 * time.Minute
 	replicationTTL                   = 5 * time.Second // time to live for neighborhood replication
-	overDraftRefresh                 = time.Millisecond * 600
+	overDraftRefresh                 = time.Second
 	maxDuration        time.Duration = 1<<63 - 1
 )
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -405,7 +405,8 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			if errors.Is(err, topology.ErrNotFound) {
 				if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no peers would be removed, we have depleted ALL peers
 					if inflight == 0 {
-						return nil, storage.ErrNotFound
+						ps.logger.Debug("no peers left", "chunk_address", ch.Address(), "error", err)
+						return nil, err
 					} else {
 						continue // there is still an inflight request, wait for it's result
 					}

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -412,7 +412,8 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 					}
 				}
 
-				// there are some overdraft peers, wait for refresh
+				ps.logger.Debug("sleeping to refresh overdraft balanced", "chunk_address", ch.Address())
+
 				select {
 				case <-time.After(overDraftRefresh):
 					retry()

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -46,7 +47,7 @@ const (
 	sanctionWait                     = 5 * time.Minute
 	replicationTTL                   = 5 * time.Second // time to live for neighborhood replication
 	overDraftRefresh                 = time.Second
-	maxDuration        time.Duration = 1<<63 - 1
+	maxDuration        time.Duration = math.MaxInt64
 )
 
 const (

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -429,10 +429,10 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			}
 
 			if err != nil {
-				if inflight > 0 {
-					continue
-				} else {
+				if inflight == 0 {
 					return nil, fmt.Errorf("get closest for address %s, allow upstream %v: %w", ch, origin, err)
+				} else {
+					continue
 				}
 			}
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -223,7 +223,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 
 				// no peers left
 				if errors.Is(res.err, topology.ErrNotFound) {
-					if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no peers would be removed, we have depleted ALL peers
+					if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
 						if inflight == 0 {
 							loggerV1.Debug("no peers left", "chunk_address", chunkAddr, "error", res.err)
 							return nil, res.err

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -200,9 +200,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 					ctx := tracing.WithContext(context.Background(), tracing.FromContext(topCtx))
 					span, _, ctx := s.tracer.StartSpanFromContext(ctx, "retrieve-chunk", s.logger, opentracing.Tag{Key: "address", Value: chunkAddr.String()})
 					defer span.Finish()
-					ctx, cancel := context.WithTimeout(ctx, retrieveChunkTimeout)
-					defer cancel()
-
 					s.retrieveChunk(ctx, chunkAddr, skip, done, resultC, origin)
 				}()
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -108,7 +108,7 @@ func (s *Service) Protocol() p2p.ProtocolSpec {
 const (
 	retrieveChunkTimeout = time.Second * 10
 	preemptiveInterval   = time.Second
-	overDraftRefresh     = time.Millisecond * 600
+	overDraftRefresh     = time.Second
 	skiplistDur          = time.Minute
 	maxRetrievedErrors   = 32
 	originSuffix         = "_origin"

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -72,7 +72,7 @@ type Service struct {
 	tracer        *tracing.Tracer
 	caching       bool
 	validStamp    postage.ValidStampFn
-	skippeers     *skippeers.List
+	errSkip       *skippeers.List
 }
 
 func New(addr swarm.Address, storer storage.Storer, streamer p2p.Streamer, chunkPeerer topology.ClosestPeerer, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, tracer *tracing.Tracer, forwarderCaching bool, validStamp postage.ValidStampFn) *Service {
@@ -88,7 +88,7 @@ func New(addr swarm.Address, storer storage.Storer, streamer p2p.Streamer, chunk
 		tracer:        tracer,
 		caching:       forwarderCaching,
 		validStamp:    validStamp,
-		skippeers:     skippeers.NewList(),
+		errSkip:       skippeers.NewList(),
 	}
 }
 
@@ -106,17 +106,20 @@ func (s *Service) Protocol() p2p.ProtocolSpec {
 }
 
 const (
-	retrieveChunkTimeout = 10 * time.Second
+	retrieveChunkTimeout = time.Second * 10
 	preemptiveInterval   = time.Second
+	overDraftRefresh     = time.Millisecond * 600
 	skiplistDur          = time.Minute
 	maxRetrievedErrors   = 32
 	originSuffix         = "_origin"
+
+	maxDuration time.Duration = 1<<63 - 1
 )
 
 func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr swarm.Address) (swarm.Chunk, error) {
 	loggerV1 := s.logger.V(1).Register()
 
-	defer s.skippeers.PruneExpired()
+	s.errSkip.PruneExpiresAfter(0)
 
 	s.metrics.RequestCounter.Inc()
 
@@ -136,6 +139,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 	defer func() {
 		s.metrics.RequestDurationTime.Observe(time.Since(requestStartTime).Seconds())
 		s.metrics.RequestAttempts.Observe(float64(totalRetrieveAttempts))
+		s.logger.Debug("retrieval duration", fmt.Sprintf("%0.2f", time.Since(requestStartTime).Seconds()))
 	}()
 
 	// topCtx is passing the tracing span to the first singleflight call
@@ -143,11 +147,13 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 
 	v, _, err := s.singleflight.Do(topCtx, flightRoute, func(ctx context.Context) (interface{}, error) {
 
-		var skip []swarm.Address
+		skip := skippeers.NewList()
+		defer skip.Reset()
+
 		var preemptiveTicker <-chan time.Time
 
 		if !sourcePeerAddr.IsZero() {
-			skip = append(skip, sourcePeerAddr)
+			skip.Add(chunkAddr, sourcePeerAddr, maxDuration)
 		}
 
 		sentErrorsLeft := 1
@@ -188,16 +194,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 				totalRetrieveAttempts++
 				s.metrics.PeerRequestCounter.Inc()
 
-				peer, err := s.closestPeer(chunkAddr, append(skip, s.skippeers.ChunkPeers(chunkAddr)...), origin)
-				if err != nil {
-					if inflight == 0 {
-						loggerV1.Debug("no peers left to retry", "chunk_address", chunkAddr)
-						return nil, fmt.Errorf("get closest for address %s, allow upstream %v: %w", chunkAddr, origin, err)
-					}
-					continue
-				}
-				skip = append(skip, peer)
-
 				inflight++
 
 				go func() {
@@ -206,7 +202,8 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 					defer span.Finish()
 					ctx, cancel := context.WithTimeout(ctx, retrieveChunkTimeout)
 					defer cancel()
-					s.retrieveChunk(ctx, peer, done, resultC, chunkAddr, origin)
+
+					s.retrieveChunk(ctx, chunkAddr, skip, done, resultC, origin)
 				}()
 
 			case res := <-resultC:
@@ -218,11 +215,37 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 					return res.chunk, nil
 				}
 
+				// peer is overdrafted, skip to next result
+				if errors.Is(res.err, accounting.ErrOverdraft) {
+					retry()
+					continue
+				}
+
+				// no peers left
+				if errors.Is(res.err, topology.ErrNotFound) {
+					if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no peers would be removed, we have depleted ALL peers
+						if inflight == 0 {
+							return nil, storage.ErrNotFound
+						} else {
+							continue // there is still an inflight request, wait for it's result
+						}
+					}
+
+					// there are some overdraft peers, wait for refresh
+					select {
+					case <-time.After(overDraftRefresh):
+						retry()
+						continue
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				}
+
 				loggerV1.Debug("failed to get chunk", "chunk_address", chunkAddr, "peer_address", res.peer, "error", res.err)
 
 				if res.sent {
 					sentErrorsLeft--
-					s.skippeers.Add(chunkAddr, res.peer, skiplistDur)
+					s.errSkip.Add(chunkAddr, res.peer, skiplistDur)
 				}
 
 				retry()
@@ -243,13 +266,14 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 	return v.(swarm.Chunk), nil
 }
 
-func (s *Service) retrieveChunk(ctx context.Context, peer swarm.Address, done chan struct{}, result chan retrievalResult, addr swarm.Address, isOrigin bool) {
+func (s *Service) retrieveChunk(ctx context.Context, addr swarm.Address, skip *skippeers.List, done chan struct{}, result chan retrievalResult, isOrigin bool) {
 
 	var (
 		startTime = time.Now()
 		err       error
 		sent      bool
 		chunk     swarm.Chunk
+		peer      swarm.Address
 	)
 
 	defer func() {
@@ -263,6 +287,14 @@ func (s *Service) retrieveChunk(ctx context.Context, peer swarm.Address, done ch
 		}
 	}()
 
+	fullSkip := append(skip.ChunkPeers(addr), s.errSkip.ChunkPeers(addr)...)
+
+	peer, err = s.closestPeer(addr, fullSkip, isOrigin)
+	if err != nil {
+		err = fmt.Errorf("get closest for address %s, allow upstream %v: %w", addr, isOrigin, err)
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, retrieveChunkTimeout)
 	defer cancel()
 
@@ -275,9 +307,12 @@ func (s *Service) retrieveChunk(ctx context.Context, peer swarm.Address, done ch
 	// Reserve to see whether we can request the chunk
 	creditAction, err := s.accounting.PrepareCredit(creditCtx, peer, chunkPrice, isOrigin)
 	if err != nil {
+		skip.Add(addr, peer, overDraftRefresh)
 		return
 	}
 	defer creditAction.Cleanup()
+
+	skip.Add(addr, peer, maxDuration)
 
 	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -225,7 +225,8 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 				if errors.Is(res.err, topology.ErrNotFound) {
 					if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no peers would be removed, we have depleted ALL peers
 						if inflight == 0 {
-							return nil, storage.ErrNotFound
+							loggerV1.Debug("no peers left", "chunk_address", chunkAddr, "error", res.err)
+							return nil, res.err
 						} else {
 							continue // there is still an inflight request, wait for it's result
 						}
@@ -252,7 +253,6 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 			}
 		}
 
-		loggerV1.Debug("no attempts left", "chunk_address", chunkAddr)
 		return nil, storage.ErrNotFound
 	})
 	if err != nil {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -230,7 +230,8 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 						}
 					}
 
-					// there are some overdraft peers, wait for refresh
+					loggerV1.Debug("sleeping to refresh overdraft balanced", "chunk_address", chunkAddr)
+
 					select {
 					case <-time.After(overDraftRefresh):
 						retry()

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/accounting"
@@ -113,7 +114,7 @@ const (
 	maxRetrievedErrors   = 32
 	originSuffix         = "_origin"
 
-	maxDuration time.Duration = 1<<63 - 1
+	maxDuration time.Duration = math.MaxInt64
 )
 
 func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr swarm.Address) (swarm.Chunk, error) {

--- a/pkg/skippeers/skippeers.go
+++ b/pkg/skippeers/skippeers.go
@@ -51,23 +51,6 @@ func (l *List) ChunkPeers(ch swarm.Address) (peers []swarm.Address) {
 	return peers
 }
 
-func (l *List) ChunkPeersLength(ch swarm.Address) int {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
-
-	now := time.Now().UnixMilli()
-	count := 0
-
-	if p, ok := l.skip[ch.ByteString()]; ok {
-		for _, exp := range p {
-			if exp > now {
-				count++
-			}
-		}
-	}
-	return count
-}
-
 func (l *List) PruneExpiresAfter(d time.Duration) int {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()

--- a/pkg/skippeers/skippeers.go
+++ b/pkg/skippeers/skippeers.go
@@ -51,17 +51,36 @@ func (l *List) ChunkPeers(ch swarm.Address) (peers []swarm.Address) {
 	return peers
 }
 
-func (l *List) PruneExpired() {
+func (l *List) ChunkPeersLength(ch swarm.Address) int {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
 	now := time.Now().UnixMilli()
+	count := 0
+
+	if p, ok := l.skip[ch.ByteString()]; ok {
+		for _, exp := range p {
+			if exp > now {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func (l *List) PruneExpiresAfter(d time.Duration) int {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	now := time.Now().Add(d).UnixMilli()
+	count := 0
 
 	for k, chunkPeers := range l.skip {
 		chunkPeersLen := len(chunkPeers)
 		for peer, exp := range chunkPeers {
-			if exp < now {
+			if exp <= now {
 				delete(chunkPeers, peer)
+				count++
 				chunkPeersLen--
 			}
 		}
@@ -69,5 +88,16 @@ func (l *List) PruneExpired() {
 		if chunkPeersLen == 0 {
 			delete(l.skip, k)
 		}
+	}
+
+	return count
+}
+
+func (l *List) Reset() {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	for k := range l.skip {
+		delete(l.skip, k)
 	}
 }

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -28,9 +28,12 @@ func TestPeerSkipList(t *testing.T) {
 
 	skipList.Add(addr1, addr3, time.Millisecond*10)
 
-	time.Sleep(time.Millisecond * 11)
+	skipList.PruneExpiresAfter(time.Millisecond)
+	if len(skipList.ChunkPeers(addr1)) == 0 {
+		t.Fatal("entry should NOT be pruned")
+	}
 
-	skipList.PruneExpired()
+	skipList.PruneExpiresAfter(time.Millisecond * 10)
 
 	if len(skipList.ChunkPeers(addr1)) != 0 {
 		t.Fatal("entry should be pruned")

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -28,12 +28,18 @@ func TestPeerSkipList(t *testing.T) {
 
 	skipList.Add(addr1, addr3, time.Millisecond*10)
 
+	if skipList.PruneExpiresAfter(time.Millisecond) > 0 {
+		t.Fatal("entry should NOT be pruned")
+	}
+
 	skipList.PruneExpiresAfter(time.Millisecond)
 	if len(skipList.ChunkPeers(addr1)) == 0 {
 		t.Fatal("entry should NOT be pruned")
 	}
 
-	skipList.PruneExpiresAfter(time.Millisecond * 10)
+	if skipList.PruneExpiresAfter(time.Millisecond*10) == 0 {
+		t.Fatal("entry should be pruned")
+	}
 
 	if len(skipList.ChunkPeers(addr1)) != 0 {
 		t.Fatal("entry should be pruned")


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
