### PR TITLE
fix: use correct page size for pullsync

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -55,7 +55,7 @@ const (
 )
 
 // how many maximum chunks in a batch
-var maxPage = 250
+var maxPage = 32
 
 // Interface is the PullSync interface.
 type Interface interface {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Currently 128KB is the max message size for our P2P layer. We increased the max page size without looking at these limits. Also, on research it seems like smaller protobuf message size is a better solution. This was tested and verified before and in order to change this we need more research and proof that this improves the situation.