### PR TITLE
perf(puller): reduce historical sync workload

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -41,7 +41,7 @@ const (
 	histSyncTimeout          = time.Minute * 15
 	histSyncTimeoutBlockList = time.Hour * 24
 
-	maxHistJobs = swarm.MaxBins * 3
+	maxHistJobs = swarm.MaxBins
 )
 
 type Options struct {

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -41,7 +41,7 @@ const (
 	histSyncTimeout          = time.Minute * 15
 	histSyncTimeoutBlockList = time.Hour * 24
 
-	maxHistSyncsPerBin = 3
+	maxHistSyncs = swarm.MaxBins
 )
 
 type Options struct {
@@ -72,8 +72,8 @@ type Puller struct {
 
 	bins uint8 // how many bins do we support
 
-	histSync        *atomic.Uint64  // current number of gorourines doing historical syncing
-	histSyncLimiter []chan struct{} // historical syncing limiter
+	histSync        *atomic.Uint64 // current number of gorourines doing historical syncing
+	histSyncLimiter chan struct{}  // historical syncing limiter
 }
 
 func New(stateStore storage.StateStorer, topology topology.Driver, reserveState postage.Radius, pullSync pullsync.Interface, blockLister p2p.Blocklister, logger log.Logger, o Options, warmupTime time.Duration) *Puller {
@@ -96,14 +96,8 @@ func New(stateStore storage.StateStorer, topology topology.Driver, reserveState 
 		bins:              bins,
 		histSync:          atomic.NewUint64(0),
 		blockLister:       blockLister,
+		histSyncLimiter:   make(chan struct{}, maxHistSyncs),
 	}
-
-	var binLimiter []chan struct{}
-	for i := 0; i < int(bins); i++ {
-		binLimiter = append(binLimiter, make(chan struct{}, maxHistSyncsPerBin))
-	}
-
-	p.histSyncLimiter = binLimiter
 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
@@ -342,12 +336,12 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		case <-ctx.Done():
 			loggerV2.Debug("histSyncWorker context cancelled", "peer_address", peer, "bin", bin, "cursor", cur)
 			return
-		case p.histSyncLimiter[bin] <- struct{}{}:
+		case p.histSyncLimiter <- struct{}{}:
 		}
 
 		stop := sync()
 
-		<-p.histSyncLimiter[bin]
+		<-p.histSyncLimiter
 
 		if stop {
 			return

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -38,8 +38,10 @@ const (
 	DefaultShallowBinsWarmupDur = time.Hour * 24
 
 	recalcPeersDur           = time.Minute * 5
-	histSyncTimeout          = time.Minute * 20
+	histSyncTimeout          = time.Minute * 15
 	histSyncTimeoutBlockList = time.Hour * 24
+
+	maxHistJobs = swarm.MaxBins * 3
 )
 
 type Options struct {
@@ -71,6 +73,7 @@ type Puller struct {
 	bins uint8 // how many bins do we support
 
 	activeHistoricalSyncing *atomic.Uint64
+	activeHistoricalJobs    chan struct{}
 }
 
 func New(stateStore storage.StateStorer, topology topology.Driver, reserveState postage.Radius, pullSync pullsync.Interface, blockLister p2p.Blocklister, logger log.Logger, o Options, warmupTime time.Duration) *Puller {
@@ -93,6 +96,7 @@ func New(stateStore storage.StateStorer, topology topology.Driver, reserveState 
 		bins:                    bins,
 		activeHistoricalSyncing: atomic.NewUint64(0),
 		blockLister:             blockLister,
+		activeHistoricalJobs:    make(chan struct{}, maxHistJobs),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -280,39 +284,19 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 	defer p.metrics.HistWorkerDoneCounter.Inc()
 	defer p.activeHistoricalSyncing.Dec()
 
-	sleep := false
 	loopStart := time.Now()
 	loggerV2.Debug("histSyncWorker starting", "peer_address", peer, "bin", bin, "cursor", cur)
 
-	for {
-		p.metrics.HistWorkerIterCounter.Inc()
-
-		if sleep {
-			select {
-			case <-ctx.Done():
-				loggerV2.Debug("histSyncWorker context cancelled", "peer_address", peer, "bin", bin, "cursor", cur)
-				return
-			case <-time.After(p.syncErrorSleepDur):
-			}
-			sleep = false
-		}
-
-		select {
-		case <-ctx.Done():
-			loggerV2.Debug("histSyncWorker context cancelled", "peer_address", peer, "bin", bin, "cursor", cur)
-			return
-		default:
-		}
-
+	sync := func() bool {
 		s, _, _, err := p.nextPeerInterval(peer, bin)
 		if err != nil {
 			p.metrics.HistWorkerErrCounter.Inc()
 			p.logger.Error(err, "histSyncWorker nextPeerInterval failed, quitting...")
-			return
+			return true
 		}
 		if s > cur {
 			p.logger.Debug("histSyncWorker syncing finished", "bin", bin, "cursor", cur, "total_duration", time.Since(loopStart), "peer_address", peer)
-			return
+			return true
 		}
 
 		syncStart := time.Now()
@@ -324,24 +308,42 @@ func (p *Puller) histSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 			if err := p.addPeerInterval(peer, bin, s, top); err != nil {
 				p.metrics.HistWorkerErrCounter.Inc()
 				p.logger.Error(err, "histSyncWorker could not persist interval for peer", "peer_address", peer)
-				continue
+				return false
 			}
 			loggerV2.Debug("histSyncWorker pulled", "bin", bin, "start", s, "topmost", top, "duration", time.Since(syncStart), "peer_address", peer)
 		}
 
 		if err != nil {
 			p.metrics.HistWorkerErrCounter.Inc()
-			loggerV2.Debug("histSyncWorker interval failed", "peer_address", peer, "bin", bin, "cursor", cur, "start", s, "topmost", top, "err", err)
+			p.logger.Debug("histSyncWorker interval failed", "peer_address", peer, "bin", bin, "cursor", cur, "start", s, "topmost", top, "err", err)
 			if errors.Is(err, context.DeadlineExceeded) {
 				p.logger.Debug("histSyncWorker interval timeout, exiting", "total_duration", time.Since(loopStart), "peer_address", peer, "error", err)
 				err = p.blockLister.Blocklist(peer, histSyncTimeoutBlockList, "sync interval timeout")
 				if err != nil {
 					p.logger.Debug("histSyncWorker timeout disconnect error", "error", err)
 				}
-				return
+				return true
 			}
-			sleep = true
-			continue
+		}
+
+		return false
+	}
+
+	for {
+		p.metrics.HistWorkerIterCounter.Inc()
+
+		select {
+		case <-ctx.Done():
+			loggerV2.Debug("histSyncWorker context cancelled", "peer_address", peer, "bin", bin, "cursor", cur)
+			return
+		case p.activeHistoricalJobs <- struct{}{}:
+		}
+
+		stop := sync()
+		<-p.activeHistoricalJobs
+
+		if stop {
+			return
 		}
 	}
 }
@@ -353,20 +355,8 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 	loggerV2.Debug("liveSyncWorker starting", "peer_address", peer, "bin", bin, "cursor", cur)
 	from := cur + 1
 
-	sleep := false
-
 	for {
 		p.metrics.LiveWorkerIterCounter.Inc()
-
-		if sleep {
-			select {
-			case <-ctx.Done():
-				loggerV2.Debug("liveSyncWorker context cancelled", "peer_address", peer, "bin", bin, "cursor", cur)
-				return
-			case <-time.After(p.syncErrorSleepDur):
-			}
-			sleep = false
-		}
 
 		select {
 		case <-ctx.Done():
@@ -396,8 +386,6 @@ func (p *Puller) liveSyncWorker(ctx context.Context, peer swarm.Address, bin uin
 		if err != nil {
 			p.metrics.LiveWorkerErrCounter.Inc()
 			p.logger.Debug("liveSyncWorker sync error", "peer_address", peer, "bin", bin, "from", from, "topmost", top, "err", err)
-			sleep = true
-			continue
 		}
 	}
 }

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -524,10 +524,7 @@ func TestContinueSyncing(t *testing.T) {
 
 	checkHistSyncingCount(t, puller, 1)
 
-	// expected calls should ideally be exactly 100,
-	// but we allow some time for the goroutines to run
-	// by reducing the minimum expected calls to 2
-	if len(calls) < 2 || len(calls) > 100 {
+	if len(calls) < 2 {
 		t.Fatalf("unexpected amount of calls, got %d", len(calls))
 	}
 }

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -42,7 +42,7 @@ const (
 
 const (
 	MaxCursor           = math.MaxUint64
-	DefaultRateDuration = time.Minute * 30
+	DefaultRateDuration = time.Minute * 15
 )
 
 var (

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -42,7 +42,7 @@ const (
 
 const (
 	MaxCursor           = math.MaxUint64
-	DefaultRateDuration = time.Minute * 10
+	DefaultRateDuration = time.Minute * 30
 )
 
 var (

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -20,7 +20,7 @@ const loggerName = "depthmonitor"
 
 // DefaultWakeupInterval is the default value
 // for the depth monitor wake-up interval.
-const DefaultWakeupInterval = 5 * time.Minute
+const DefaultWakeupInterval = 15 * time.Minute
 
 // defaultMinimumRadius is the default value
 // for the depth monitor minimum radius.


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

When the neighborhood size is large, node have to sync with many peers that ultimately respond with the same chunks because reserves are identical across neighborhoods. It is wasteful to have to sync with ALL of the neighbors at the SAME time. 

So, we can limit the amount of parallel hist sync jobs and that should reduce the intensity of the initial syncing.

Since reserves are identical across neighborhoods (we get the same chunk from different peers), the time to find a stable storage radius does not get affected. 

This change also propagates through the network because peers now have to respond to fewer sync requests. 

At the end, we still complete historical syncing with every neighbor. 

The depthmonitor wake up interval is also increased.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
