### PR TITLE
perf(pushsync, retrieval): skiplist prunes items internally on expiration 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.uber.org/atomic v1.10.0
 	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.4.0
+	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
 	golang.org/x/net v0.4.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.3.0
@@ -160,7 +161,6 @@ require (
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	golang.org/x/tools v0.3.0 // indirect

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -187,10 +187,11 @@ func bootstrapNode(
 
 	storer := inmemstore.New()
 
-	retrieve := retrieval.New(swarmAddress, storer, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching, noopValidStamp)
+	retrieve, cleanup := retrieval.New(swarmAddress, storer, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching, noopValidStamp)
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}
+	defer cleanup()
 
 	ns := netstore.New(storer, noopValidStamp, retrieve, logger)
 

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -187,11 +187,11 @@ func bootstrapNode(
 
 	storer := inmemstore.New()
 
-	retrieve, cleanup := retrieval.New(swarmAddress, storer, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching, noopValidStamp)
+	retrieve := retrieval.New(swarmAddress, storer, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching, noopValidStamp)
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}
-	defer cleanup()
+	b.retrievalCloser = retrieve
 
 	ns := netstore.New(storer, noopValidStamp, retrieve, logger)
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -330,8 +330,6 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 	span, logger, ctx := ps.tracer.StartSpanFromContext(ctx, "push-closest", ps.logger, opentracing.Tag{Key: "address", Value: ch.Address().String()})
 	defer span.Finish()
 
-	ps.skipList.PruneExpiresAfter(0)
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -342,7 +340,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 		inflight         int
 		skip             = skippeers.NewList()
 	)
-	defer skip.Reset()
+	defer skip.Close()
 
 	if origin {
 		ticker := time.NewTicker(preemptiveInterval)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -400,7 +400,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 
 			// no peers left
 			if errors.Is(err, topology.ErrNotFound) {
-				if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
+				if skip.PruneExpiresAfter(ch.Address(), overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
 					if inflight == 0 {
 						ps.logger.Debug("no peers left", "chunk_address", ch.Address(), "error", err)
 						return nil, err

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -791,7 +791,10 @@ func createPushSyncNodeWithAccounting(t *testing.T, addr swarm.Address, prices p
 
 	bs := bsMock.New()
 
-	return pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil, -1), storer, mtag
+	ps, cleanup := pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil, -1)
+	t.Cleanup(cleanup)
+
+	return ps, storer, mtag
 }
 
 func waitOnRecordAndTest(t *testing.T, peer swarm.Address, recorder *streamtest.Recorder, add swarm.Address, data []byte) {

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -791,8 +791,8 @@ func createPushSyncNodeWithAccounting(t *testing.T, addr swarm.Address, prices p
 
 	bs := bsMock.New()
 
-	ps, cleanup := pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil, -1)
-	t.Cleanup(cleanup)
+	ps := pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil, -1)
+	t.Cleanup(func() { ps.Close() })
 
 	return ps, storer, mtag
 }

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -218,7 +218,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 
 				// no peers left
 				if errors.Is(res.err, topology.ErrNotFound) {
-					if skip.PruneExpiresAfter(overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
+					if skip.PruneExpiresAfter(chunkAddr, overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
 						if inflight == 0 {
 							loggerV1.Debug("no peers left", "chunk_address", chunkAddr, "error", res.err)
 							return nil, res.err

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -145,9 +145,7 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 	v, _, err := s.singleflight.Do(topCtx, flightRoute, func(ctx context.Context) (interface{}, error) {
 
 		skip := skippeers.NewList()
-		defer skip.Reset()
-
-		s.errSkip.PruneExpiresAfter(0)
+		defer skip.Close()
 
 		var preemptiveTicker <-chan time.Time
 

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -658,7 +658,7 @@ func TestClosestPeer(t *testing.T) {
 }
 
 func createRetrieval(t *testing.T, addr swarm.Address, storer storage.Storer, streamer p2p.Streamer, chunkPeerer topology.ClosestPeerer, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, tracer *tracing.Tracer, forwarderCaching bool, validStamp postage.ValidStampFn) *retrieval.Service {
-
+	t.Helper()
 	ret, cleanup := retrieval.New(addr, storer, streamer, chunkPeerer, log.Noop, accounting, pricer, tracer, forwarderCaching, validStamp)
 	t.Cleanup(cleanup)
 	return ret

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -14,10 +14,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethersphere/bee/pkg/accounting"
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
 	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/pricer"
 	"github.com/ethersphere/bee/pkg/spinlock"
 	"github.com/ethersphere/bee/pkg/topology"
+	"github.com/ethersphere/bee/pkg/tracing"
 
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p/protobuf"
@@ -65,7 +69,7 @@ func TestDelivery(t *testing.T) {
 	}
 
 	// create the server that will handle the request and will serve the response
-	server := retrieval.New(swarm.MustParseHexAddress("0034"), mockStorer, nil, nil, logger, serverMockAccounting, pricerMock, nil, false, noopStampValidator)
+	server := createRetrieval(t, swarm.MustParseHexAddress("0034"), mockStorer, nil, nil, logger, serverMockAccounting, pricerMock, nil, false, noopStampValidator)
 	recorder := streamtest.New(
 		streamtest.WithProtocols(server.Protocol()),
 		streamtest.WithBaseAddr(clientAddr),
@@ -79,7 +83,7 @@ func TestDelivery(t *testing.T) {
 
 	mt := topologymock.NewTopologyDriver(topologymock.WithClosestPeer(serverAddr))
 
-	client := retrieval.New(clientAddr, clientMockStorer, recorder, mt, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
+	client := createRetrieval(t, clientAddr, clientMockStorer, recorder, mt, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 	v, err := client.RetrieveChunk(ctx, chunk.Address(), swarm.ZeroAddress)
@@ -183,9 +187,9 @@ func TestWaitForInflight(t *testing.T) {
 	}
 
 	// create the server that will handle the request and will serve the response
-	server := retrieval.New(serverAddr, mockStorer, nil, nil, logger, serverMockAccounting, pricerMock, nil, false, noopStampValidator)
+	server := createRetrieval(t, serverAddr, mockStorer, nil, nil, logger, serverMockAccounting, pricerMock, nil, false, noopStampValidator)
 
-	badServer := retrieval.New(badServerAddr, badMockStorer, nil, nil, logger, badServerMockAccounting, pricerMock, nil, false, noopStampValidator)
+	badServer := createRetrieval(t, badServerAddr, badMockStorer, nil, nil, logger, badServerMockAccounting, pricerMock, nil, false, noopStampValidator)
 
 	var fail = true
 	var lock sync.Mutex
@@ -218,7 +222,7 @@ func TestWaitForInflight(t *testing.T) {
 
 	mt := topologymock.NewTopologyDriver(topologymock.WithPeers(badServerAddr, serverAddr))
 
-	client := retrieval.New(clientAddr, clientMockStorer, recorder, mt, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
+	client := createRetrieval(t, clientAddr, clientMockStorer, recorder, mt, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
 	defer cancel()
@@ -264,12 +268,12 @@ func TestRetrieveChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server := retrieval.New(serverAddress, serverStorer, nil, nil, logger, accountingmock.NewAccounting(), pricer, nil, false, noopStampValidator)
+		server := createRetrieval(t, serverAddress, serverStorer, nil, nil, logger, accountingmock.NewAccounting(), pricer, nil, false, noopStampValidator)
 		recorder := streamtest.New(streamtest.WithProtocols(server.Protocol()))
 
 		mt := topologymock.NewTopologyDriver(topologymock.WithClosestPeer(serverAddress))
 
-		client := retrieval.New(clientAddress, nil, recorder, mt, logger, accountingmock.NewAccounting(), pricer, nil, false, noopStampValidator)
+		client := createRetrieval(t, clientAddress, nil, recorder, mt, logger, accountingmock.NewAccounting(), pricer, nil, false, noopStampValidator)
 
 		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), swarm.ZeroAddress)
 		if err != nil {
@@ -295,7 +299,7 @@ func TestRetrieveChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server := retrieval.New(
+		server := createRetrieval(t,
 			serverAddress,
 			serverStorer, // chunk is in server's store
 			nil,
@@ -310,7 +314,7 @@ func TestRetrieveChunk(t *testing.T) {
 
 		forwarderStore := storemock.NewStorer()
 
-		forwarder := retrieval.New(
+		forwarder := createRetrieval(t,
 			forwarderAddress,
 			forwarderStore, // no chunk in forwarder's store
 			streamtest.New(streamtest.WithProtocols(server.Protocol())), // connect to server
@@ -323,7 +327,7 @@ func TestRetrieveChunk(t *testing.T) {
 			noopStampValidator,
 		)
 
-		client := retrieval.New(
+		client := createRetrieval(t,
 			clientAddress,
 			storemock.NewStorer(), // no chunk in clients's store
 			streamtest.New(streamtest.WithProtocols(forwarder.Protocol())), // connect to forwarder
@@ -394,8 +398,8 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 	noClosestPeer := topologymock.NewTopologyDriver()
 	closetPeers := topologymock.NewTopologyDriver(topologymock.WithPeers(peers...))
 
-	server1 := retrieval.New(serverAddress1, serverStorer1, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
-	server2 := retrieval.New(serverAddress2, serverStorer2, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+	server1 := createRetrieval(t, serverAddress1, serverStorer1, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+	server2 := createRetrieval(t, serverAddress2, serverStorer2, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
 
 	t.Run("peer not reachable", func(t *testing.T) {
 		t.Parallel()
@@ -425,7 +429,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 			streamtest.WithBaseAddr(clientAddress),
 		)
 
-		client := retrieval.New(clientAddress, nil, recorder, closetPeers, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+		client := createRetrieval(t, clientAddress, nil, recorder, closetPeers, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
 
 		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), swarm.ZeroAddress)
 		if err != nil {
@@ -463,7 +467,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 			),
 		)
 
-		client := retrieval.New(clientAddress, nil, recorder, closetPeers, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+		client := createRetrieval(t, clientAddress, nil, recorder, closetPeers, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
 
 		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), swarm.ZeroAddress)
 		if err != nil {
@@ -494,8 +498,8 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 		server1MockAccounting := accountingmock.NewAccounting()
 		server2MockAccounting := accountingmock.NewAccounting()
 
-		server1 := retrieval.New(serverAddress1, serverStorer1, nil, noClosestPeer, logger, server1MockAccounting, pricerMock, nil, false, noopStampValidator)
-		server2 := retrieval.New(serverAddress2, serverStorer2, nil, noClosestPeer, logger, server2MockAccounting, pricerMock, nil, false, noopStampValidator)
+		server1 := createRetrieval(t, serverAddress1, serverStorer1, nil, noClosestPeer, logger, server1MockAccounting, pricerMock, nil, false, noopStampValidator)
+		server2 := createRetrieval(t, serverAddress2, serverStorer2, nil, noClosestPeer, logger, server2MockAccounting, pricerMock, nil, false, noopStampValidator)
 
 		// NOTE: must be more than retry duration
 		// (here one second more)
@@ -530,7 +534,7 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 
 		clientMockAccounting := accountingmock.NewAccounting()
 
-		client := retrieval.New(clientAddress, nil, recorder, closetPeers, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
+		client := createRetrieval(t, clientAddress, nil, recorder, closetPeers, logger, clientMockAccounting, pricerMock, nil, false, noopStampValidator)
 
 		got, err := client.RetrieveChunk(context.Background(), chunk.Address(), swarm.ZeroAddress)
 		if err != nil {
@@ -570,21 +574,21 @@ func TestRetrievePreemptiveRetry(t *testing.T) {
 		t.Parallel()
 
 		// server 2 has the chunk
-		server2 := retrieval.New(serverAddress2, serverStorer2, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+		server2 := createRetrieval(t, serverAddress2, serverStorer2, nil, noClosestPeer, logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
 
 		server1Recorder := streamtest.New(
 			streamtest.WithProtocols(server2.Protocol()),
 		)
 
 		// server 1 will forward request to server 2
-		server1 := retrieval.New(serverAddress1, serverStorer1, server1Recorder, topologymock.NewTopologyDriver(topologymock.WithPeers(serverAddress2)), logger, accountingmock.NewAccounting(), pricerMock, nil, true, noopStampValidator)
+		server1 := createRetrieval(t, serverAddress1, serverStorer1, server1Recorder, topologymock.NewTopologyDriver(topologymock.WithPeers(serverAddress2)), logger, accountingmock.NewAccounting(), pricerMock, nil, true, noopStampValidator)
 
 		clientRecorder := streamtest.New(
 			streamtest.WithProtocols(server1.Protocol()),
 		)
 
 		// client only knows about server 1
-		client := retrieval.New(clientAddress, nil, clientRecorder, topologymock.NewTopologyDriver(topologymock.WithPeers(serverAddress1)), logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
+		client := createRetrieval(t, clientAddress, nil, clientRecorder, topologymock.NewTopologyDriver(topologymock.WithPeers(serverAddress1)), logger, accountingmock.NewAccounting(), pricerMock, nil, false, noopStampValidator)
 
 		if got, _ := serverStorer1.Has(context.Background(), chunk.Address()); got {
 			t.Fatalf("forwarder node already has chunk")
@@ -617,7 +621,7 @@ func TestClosestPeer(t *testing.T) {
 	addr2 := swarm.MustParseHexAddress("0300000000000000000000000000000000000000000000000000000000000000")
 	addr3 := swarm.MustParseHexAddress("0400000000000000000000000000000000000000000000000000000000000000")
 
-	ret := retrieval.New(srvAd, nil, nil, topologymock.NewTopologyDriver(topologymock.WithPeers(addr1, addr2, addr3)), log.Noop, nil, nil, nil, false, nil)
+	ret := createRetrieval(t, srvAd, nil, nil, topologymock.NewTopologyDriver(topologymock.WithPeers(addr1, addr2, addr3)), log.Noop, nil, nil, nil, false, nil)
 
 	t.Run("closest", func(t *testing.T) {
 		t.Parallel()
@@ -651,6 +655,13 @@ func TestClosestPeer(t *testing.T) {
 			t.Fatal("closest peer", err)
 		}
 	})
+}
+
+func createRetrieval(t *testing.T, addr swarm.Address, storer storage.Storer, streamer p2p.Streamer, chunkPeerer topology.ClosestPeerer, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, tracer *tracing.Tracer, forwarderCaching bool, validStamp postage.ValidStampFn) *retrieval.Service {
+
+	ret, cleanup := retrieval.New(addr, storer, streamer, chunkPeerer, log.Noop, accounting, pricer, tracer, forwarderCaching, validStamp)
+	t.Cleanup(cleanup)
+	return ret
 }
 
 var noopStampValidator = func(chunk swarm.Chunk, stampBytes []byte) (swarm.Chunk, error) {

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -659,8 +659,8 @@ func TestClosestPeer(t *testing.T) {
 
 func createRetrieval(t *testing.T, addr swarm.Address, storer storage.Storer, streamer p2p.Streamer, chunkPeerer topology.ClosestPeerer, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, tracer *tracing.Tracer, forwarderCaching bool, validStamp postage.ValidStampFn) *retrieval.Service {
 	t.Helper()
-	ret, cleanup := retrieval.New(addr, storer, streamer, chunkPeerer, log.Noop, accounting, pricer, tracer, forwarderCaching, validStamp)
-	t.Cleanup(cleanup)
+	ret := retrieval.New(addr, storer, streamer, chunkPeerer, log.Noop, accounting, pricer, tracer, forwarderCaching, validStamp)
+	t.Cleanup(func() { ret.Close() })
 	return ret
 }
 

--- a/pkg/skippeers/main_test.go
+++ b/pkg/skippeers/main_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package skippeers_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/skippeers/main_test.go
+++ b/pkg/skippeers/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Swarm Authors. All rights reserved.
+// Copyright 2023 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/skippeers/skippeers.go
+++ b/pkg/skippeers/skippeers.go
@@ -6,11 +6,14 @@ package skippeers
 
 import (
 	"container/heap"
+	"math"
 	"sync"
 	"time"
 
 	"github.com/ethersphere/bee/pkg/swarm"
 )
+
+const maxDuration int64 = math.MaxInt64
 
 type List struct {
 	mtx sync.Mutex
@@ -22,6 +25,8 @@ type List struct {
 	quit         chan struct{}
 	// key is chunk address, value is map of peer address to expiration
 	skip map[string]map[string]int64
+
+	wg sync.WaitGroup
 }
 
 func NewList() *List {
@@ -32,12 +37,15 @@ func NewList() *List {
 		quit:    make(chan struct{}),
 	}
 
+	l.wg.Add(1)
 	go l.worker()
 
 	return l
 }
 
 func (l *List) worker() {
+
+	defer l.wg.Done()
 
 	var (
 		timer  *time.Timer
@@ -90,6 +98,19 @@ func (l *List) Add(chunk, peer swarm.Address, expire time.Duration) {
 	l.skip[chunk.ByteString()][peer.ByteString()] = t
 }
 
+func (l *List) AddForever(chunk, peer swarm.Address) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	heap.Push(l.minHeap, maxDuration)
+
+	if _, ok := l.skip[chunk.ByteString()]; !ok {
+		l.skip[chunk.ByteString()] = make(map[string]int64)
+	}
+
+	l.skip[chunk.ByteString()][peer.ByteString()] = maxDuration
+}
+
 func (l *List) ChunkPeers(ch swarm.Address) (peers []swarm.Address) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
@@ -113,7 +134,7 @@ func (l *List) PruneExpiresAfter(d time.Duration) int {
 	now := time.Now().Add(d).UnixNano()
 	count := 0
 
-	if (*l.minHeap)[0] <= now {
+	if len(*l.minHeap) > 0 && (*l.minHeap)[0] <= now {
 		heap.Pop(l.minHeap)
 		if len(*l.minHeap) > 0 {
 			l.smallestTime = (*l.minHeap)[0]
@@ -139,12 +160,14 @@ func (l *List) PruneExpiresAfter(d time.Duration) int {
 }
 
 func (l *List) Close() {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
 	close(l.quit)
+	l.wg.Wait()
+
+	l.mtx.Lock()
 	for k := range l.skip {
 		delete(l.skip, k)
 	}
+	l.mtx.Unlock()
 }
 
 // An IntHeap is a min-heap of ints.

--- a/pkg/skippeers/skippeers.go
+++ b/pkg/skippeers/skippeers.go
@@ -126,14 +126,7 @@ func (l *List) PruneExpiresAfter(ch swarm.Address, d time.Duration) int {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	expiresNano := time.Now().Add(d).UnixNano()
-	count := 0
-
-	for k := range l.skip {
-		count += l.pruneChunk(k, expiresNano)
-	}
-
-	return count
+	return l.pruneChunk(ch.ByteString(), time.Now().Add(d).UnixNano())
 }
 
 func (l *List) prune() {

--- a/pkg/skippeers/skippeers.go
+++ b/pkg/skippeers/skippeers.go
@@ -86,7 +86,7 @@ func (l *List) Add(chunk, peer swarm.Address, expire time.Duration) {
 	heap.Push(l.minHeap, t)
 	min := l.minHeap.First()
 
-	if t < min || l.minHeap.Length() == 1 {
+	if t == min { // pushed the most recent expiration
 		select {
 		case l.durC <- time.Until(time.Unix(0, min)):
 		case <-l.quit:

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -16,6 +16,7 @@ func TestPruneExpiresAfter(t *testing.T) {
 	t.Parallel()
 
 	skipList := skippeers.NewList()
+	t.Cleanup(skipList.Close)
 
 	chunk := swarm.RandAddress(t)
 	peer1 := swarm.RandAddress(t)
@@ -49,6 +50,7 @@ func TestPeerWait(t *testing.T) {
 	t.Parallel()
 
 	skipList := skippeers.NewList()
+	t.Cleanup(skipList.Close)
 
 	chunk1 := swarm.RandAddress(t)
 	chunk2 := swarm.RandAddress(t)

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -28,16 +28,16 @@ func TestPruneExpiresAfter(t *testing.T) {
 	}
 
 	skipList.Add(chunk, peer2, time.Millisecond*10)
-	if skipList.PruneExpiresAfter(time.Millisecond) > 0 {
+	if skipList.PruneExpiresAfter(chunk, time.Millisecond) > 0 {
 		t.Fatal("entry should NOT be pruned")
 	}
 
-	skipList.PruneExpiresAfter(time.Millisecond)
+	skipList.PruneExpiresAfter(chunk, time.Millisecond)
 	if len(skipList.ChunkPeers(chunk)) == 0 {
 		t.Fatal("entry should NOT be pruned")
 	}
 
-	if skipList.PruneExpiresAfter(time.Millisecond*10) == 0 {
+	if skipList.PruneExpiresAfter(chunk, time.Millisecond*10) == 0 {
 		t.Fatal("entry should be pruned")
 	}
 

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -37,12 +37,20 @@ func TestPruneExpiresAfter(t *testing.T) {
 		t.Fatal("entry should NOT be pruned")
 	}
 
+	if len(skipList.ChunkPeers(swarm.RandAddress(t))) != 0 {
+		t.Fatal("there should be now entry")
+	}
+
 	if skipList.PruneExpiresAfter(chunk, time.Millisecond*10) == 0 {
 		t.Fatal("entry should be pruned")
 	}
 
 	if len(skipList.ChunkPeers(chunk)) != 0 {
 		t.Fatal("entry should be pruned")
+	}
+
+	if len(skipList.ChunkPeers(swarm.RandAddress(t))) != 0 {
+		t.Fatal("there should be now entry")
 	}
 }
 

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -16,7 +16,7 @@ func TestPruneExpiresAfter(t *testing.T) {
 	t.Parallel()
 
 	skipList := skippeers.NewList()
-	t.Cleanup(skipList.Close)
+	t.Cleanup(func() { skipList.Close() })
 
 	chunk := swarm.RandAddress(t)
 	peer1 := swarm.RandAddress(t)
@@ -50,7 +50,7 @@ func TestPeerWait(t *testing.T) {
 	t.Parallel()
 
 	skipList := skippeers.NewList()
-	t.Cleanup(skipList.Close)
+	t.Cleanup(func() { skipList.Close() })
 
 	chunk1 := swarm.RandAddress(t)
 	chunk2 := swarm.RandAddress(t)

--- a/pkg/skippeers/skippeers_test.go
+++ b/pkg/skippeers/skippeers_test.go
@@ -12,28 +12,27 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-func TestPeerSkipList(t *testing.T) {
+func TestPruneExpiresAfter(t *testing.T) {
 	t.Parallel()
+
 	skipList := skippeers.NewList()
 
-	addr1 := swarm.RandAddress(t)
-	addr2 := swarm.RandAddress(t)
-	addr3 := swarm.RandAddress(t)
+	chunk := swarm.RandAddress(t)
+	peer1 := swarm.RandAddress(t)
+	peer2 := swarm.RandAddress(t)
 
-	skipList.Add(addr1, addr2, time.Millisecond*10)
-
-	if !skipList.ChunkPeers(addr1)[0].Equal(addr2) {
-		t.Fatal("peer should be skipped")
+	skipList.Add(chunk, peer1, time.Millisecond*10)
+	if !swarm.ContainsAddress(skipList.ChunkPeers(chunk), peer1) {
+		t.Fatal("peer should be in skiplist")
 	}
 
-	skipList.Add(addr1, addr3, time.Millisecond*10)
-
+	skipList.Add(chunk, peer2, time.Millisecond*10)
 	if skipList.PruneExpiresAfter(time.Millisecond) > 0 {
 		t.Fatal("entry should NOT be pruned")
 	}
 
 	skipList.PruneExpiresAfter(time.Millisecond)
-	if len(skipList.ChunkPeers(addr1)) == 0 {
+	if len(skipList.ChunkPeers(chunk)) == 0 {
 		t.Fatal("entry should NOT be pruned")
 	}
 
@@ -41,7 +40,57 @@ func TestPeerSkipList(t *testing.T) {
 		t.Fatal("entry should be pruned")
 	}
 
-	if len(skipList.ChunkPeers(addr1)) != 0 {
+	if len(skipList.ChunkPeers(chunk)) != 0 {
+		t.Fatal("entry should be pruned")
+	}
+}
+
+func TestPeerWait(t *testing.T) {
+	t.Parallel()
+
+	skipList := skippeers.NewList()
+
+	chunk1 := swarm.RandAddress(t)
+	chunk2 := swarm.RandAddress(t)
+	peer1 := swarm.RandAddress(t)
+	peer2 := swarm.RandAddress(t)
+	peer3 := swarm.RandAddress(t)
+
+	skipList.Add(chunk1, peer1, time.Millisecond*100)
+	if !swarm.ContainsAddress(skipList.ChunkPeers(chunk1), peer1) {
+		t.Fatal("peer should be in skiplist")
+	}
+
+	skipList.Add(chunk2, peer1, time.Millisecond*150)
+	if !swarm.ContainsAddress(skipList.ChunkPeers(chunk2), peer1) {
+		t.Fatal("peer should be in skiplist")
+	}
+
+	skipList.Add(chunk1, peer2, time.Millisecond*50)
+	if !swarm.ContainsAddress(skipList.ChunkPeers(chunk1), peer2) {
+		t.Fatal("peer should be in skiplist")
+	}
+
+	skipList.Add(chunk1, peer3, -time.Millisecond*50)
+	if swarm.ContainsAddress(skipList.ChunkPeers(chunk1), peer3) {
+		t.Fatal("peer should NOT be in skiplist")
+	}
+
+	time.Sleep(time.Millisecond * 60)
+
+	if len(skipList.ChunkPeers(chunk1)) != 1 || !swarm.ContainsAddress(skipList.ChunkPeers(chunk1), peer1) {
+		t.Fatal("peer should be in skiplist")
+	}
+
+	time.Sleep(time.Millisecond * 60)
+
+	if len(skipList.ChunkPeers(chunk1)) != 0 {
+		t.Fatal("entry should be pruned")
+	}
+
+	time.Sleep(time.Millisecond * 60)
+
+	if len(skipList.ChunkPeers(chunk2)) != 0 {
 		t.Fatal("entry should be pruned")
 	}
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It was identified in a testing session that during uploads, most CPU cycles are wasted on pruning the skiplist.
With this change, the prune call is no longer needed before every push/retrieval.
The clean up call of items is done once at the time of expiration.
Internally, the skiplist now uses a minimum heap to wake up at the time of the closest expiration. 

### Before
![localhost-profile](https://user-images.githubusercontent.com/14264581/231318324-360a662c-ec75-4b6d-9d06-b65ed2a5a2a0.png)

### After
![localhost-heap](https://user-images.githubusercontent.com/14264581/231319258-973e87b3-4515-461a-90e8-be5c981a59aa.png)


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
