### PR TITLE
fix(batchstore): allow depthmonitor only to reduce the storage radius

### DIFF
--- a/pkg/postage/batchstore/reserve.go
+++ b/pkg/postage/batchstore/reserve.go
@@ -159,14 +159,6 @@ func (s *store) computeRadius() error {
 		s.rs.Radius = uint8(math.Ceil(math.Log2(float64(totalCommitment) / float64(Capacity))))
 	}
 
-	// in the edge case that the new radius is lower because total commitment has decreased, the global storage radius has to be readjusted
-	if s.rs.Radius < s.rs.StorageRadius {
-		s.rs.StorageRadius = s.rs.Radius
-		if err := s.setBatchStorageRadius(); err != nil {
-			s.logger.Error(err, "batchstore: lower batch storage radius")
-		}
-	}
-
 	return s.store.Put(reserveStateKey, s.rs)
 }
 

--- a/pkg/postage/batchstore/reserve_test.go
+++ b/pkg/postage/batchstore/reserve_test.go
@@ -302,7 +302,7 @@ func TestUnreserveAndLowerStorageRadius(t *testing.T) {
 		radiusAfterFirstBatches  = 5 // radius after three batches
 		radiusAfterSecondBatches = 6 // radius after two more batches
 		radiusAfterChainUpdate   = 5 // radius after expiring two batches with the chain update
-		storageRadiusAfterUpdate = 5 // storage radius after chain update
+		storageRadiusAfterUpdate = 6 // storage radius after chain update
 	)
 
 	store := setupBatchStore(t)

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -102,21 +102,17 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration, freshNode boo
 	// wire up batchstore to start reporting storage radius to kademlia
 	s.bs.SetStorageRadiusSetter(s.topology)
 
-	// if it's a new fresh node, then we set the storage radius to the reserve radius
-	// to prevent syncing from starting at radius zero.
-	if freshNode {
-		reserveRadius := s.bs.GetReserveState().Radius
+	reserveRadius := s.bs.GetReserveState().Radius
 
-		err := s.bs.SetStorageRadius(func(radius uint8) uint8 {
-			// if we are starting from scratch, we can use the reserve radius.
-			if radius == 0 {
-				radius = reserveRadius
-			}
-			return radius
-		})
-		if err != nil {
-			s.logger.Error(err, "depthmonitor: batchstore set storage radius")
+	err := s.bs.SetStorageRadius(func(radius uint8) uint8 {
+		// if we are starting from scratch, we can use the reserve radius.
+		if radius == 0 {
+			radius = reserveRadius
 		}
+		return radius
+	})
+	if err != nil {
+		s.logger.Error(err, "depthmonitor: batchstore set storage radius")
 	}
 
 	// wait for warmup

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -78,18 +78,6 @@ func TestDepthMonitorService_FLAKY(t *testing.T) {
 		}
 	})
 
-	t.Run("old nodes starts at previous radius", func(t *testing.T) {
-		t.Parallel()
-
-		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3, StorageRadius: 0}))
-		svc := newTestSvc(nil, nil, nil, nil, bs, 0, depthmonitor.DefaultWakeupInterval, false)
-		waitForDepth(t, svc, 0)
-		err := svc.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
 	t.Run("start with radius", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
It was discovered on the dev-bee-gateway cluster that the storage radius may drop to zero if the the rpc endpoint is faulty.
This removes the logic from batchstore that lowers the storage radius, since we already have a mechanism (depthmonitor) that takes care of this anyways.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
