### PR TITLE
fix(depthmonitor): change threshold back to 50 percent

### DIFF
--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -124,7 +124,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration, freshNode boo
 
 	s.logger.Info("depthmonitor: warmup period complete, starting worker", "radius", s.bs.StorageRadius())
 
-	targetSize := s.reserve.ReserveCapacity() * 4 / 10 // 40% of the capacity
+	targetSize := s.reserve.ReserveCapacity() * 5 / 10 // 50% of the capacity
 
 	for {
 		select {
@@ -147,7 +147,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration, freshNode boo
 		rate := s.syncer.SyncRate()
 		s.logger.Info("depthmonitor: state", "size", currentSize, "radius", radius, "sync_rate", fmt.Sprintf("%.2f ch/s", rate))
 
-		if currentSize > targetSize {
+		if currentSize >= targetSize {
 			continue
 		}
 

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -95,7 +95,7 @@ func TestDepthMonitorService_FLAKY(t *testing.T) {
 
 		topo := &mockTopology{peers: 1}
 		// >40% utilized reserve
-		reserve := &mockReserve{size: 20001, capacity: 50000}
+		reserve := &mockReserve{size: 25001, capacity: 50000}
 
 		bs := mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{Radius: 3}))
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
as the reserve size gets near the tipping point of over filling and causing the radius to increase, it was discovered that the threshold of 40% is too low that fresh nodes may linger at a storage radius one higher than the rest of network. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
