### PR TITLE
fix: negative work group counter on shutdown

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1246,7 +1246,7 @@ func (b *Bee) Shutdown() error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(7)
+	wg.Add(9)
 	go func() {
 		defer wg.Done()
 		tryClose(b.chainSyncerCloser, "chain syncer")


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Fixes panic on negative WaitGroup counter:

```
panic: sync: negative WaitGroup counter

goroutine 87 [running]:
sync.(*WaitGroup).Add(0x9f2c7a099b40bc0f?, 0x26d354ac58e15864?)
        sync/waitgroup.go:62 +0xe5
sync.(*WaitGroup).Done(0x2d66c9c4fd2b7fa1?)
        sync/waitgroup.go:87 +0x25
github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown.func11()
        github.com/ethersphere/bee/pkg/node/node.go:1283 +0x8d
created by github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown
        github.com/ethersphere/bee/pkg/node/node.go:1280 +0x714
panic: sync: negative WaitGroup counter

goroutine 90 [running]:
sync.(*WaitGroup).Add(0xf08b306d2c0b7911?, 0x4280c26bdb144bc1?)
        sync/waitgroup.go:62 +0xe5
sync.(*WaitGroup).Done(0xd44234d4b5331c0f?)
        sync/waitgroup.go:87 +0x25
github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown.func14()
        github.com/ethersphere/bee/pkg/node/node.go:1303 +0x8d
created by github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown
        github.com/ethersphere/bee/pkg/node/node.go:1300 +0x8ec
```