### PR TITLE
fix(kademlia): new prune log, oversaturation check fix, and more aggressive balance connector

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -719,15 +719,19 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 		}
 
 		binPeersCount := k.connectedPeers.BinSize(uint8(i))
-		if binPeersCount < k.opt.OverSaturationPeers {
+		if binPeersCount <= k.opt.OverSaturationPeers {
 			continue
 		}
 
 		binPeers := k.connectedPeers.BinPeers(uint8(i))
 
-		peersToRemove := binPeersCount - k.opt.OverSaturationPeers
+		k.logger.Debug("starting pruning", "bin", i, "binSize", binPeersCount)
 
-		for j := 0; peersToRemove > 0 && j < len(k.commonBinPrefixes[i]); j++ {
+		for j := 0; j < len(k.commonBinPrefixes[i]); j++ {
+
+			if k.connectedPeers.BinSize(uint8(i)) <= k.opt.OverSaturationPeers {
+				break
+			}
 
 			pseudoAddr := k.commonBinPrefixes[i][j]
 			peers := k.balancedSlotPeers(pseudoAddr, binPeers, i)
@@ -753,7 +757,6 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 			if err != nil {
 				k.logger.Debug("prune disconnect failed", "error", err)
 			}
-			peersToRemove--
 		}
 	}
 }

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -337,6 +337,7 @@ func (k *Kad) connectBalanced(wg *sync.WaitGroup, peerConnChan chan<- *peerConnI
 				continue
 			}
 
+			wg.Add(1)
 			select {
 			case <-k.quit:
 				return
@@ -382,6 +383,7 @@ func (k *Kad) connectNeighbours(wg *sync.WaitGroup, peerConnChan chan<- *peerCon
 			return false, false, nil
 		}
 
+		wg.Add(1)
 		select {
 		case <-k.quit:
 			return true, false, nil
@@ -469,7 +471,6 @@ func (k *Kad) connectionAttemptsHandler(ctx context.Context, wg *sync.WaitGroup,
 			case <-k.quit:
 				return
 			case peer := <-peerConnChan:
-				wg.Add(1)
 				addr := peer.addr.String()
 
 				if k.waitNext.Waiting(peer.addr) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
In some cases, the balanced connector is not sufficient, causing the depth to fluctuate when a shallow bin count goes below 8 peers:
ex: 
````
 "bins": {
    "bin_0": {
      "population": 2103,
      "connected": 9
    },
    "bin_1": {
      "population": 970,
      "connected": 7
    },
    "bin_2": {
      "population": 483,
      "connected": 19
    },
    "bin_3": {
      "population": 227,
      "connected": 40
    },
    "bin_4": {
      "population": 118,
      "connected": 41
    },

```
 
after change
 
 ```
 {
  "depth": 8,
  "reachability": "Private",
  "networkAvailability": "Available",
  "bins": {
    "bin_0": {
      "population": 1996,
      "connected": 17
    },
    "bin_1": {
      "population": 822,
      "connected": 14
    },
    "bin_2": {
      "population": 455,
      "connected": 16
    },
    "bin_3": {
      "population": 234,
      "connected": 16
    },
    "bin_4": {
      "population": 110,
      "connected": 18
    },
    
```