### PR TITLE
feat(salud): new health service

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -321,6 +321,10 @@ components:
         latencyEWMA:
           type: integer
           nullable: false
+        reachability:
+          type: string
+        healthy:
+          type: boolean
 
     Peers:
       type: object

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -747,7 +747,7 @@ func createRedistributionAgentService(t *testing.T, addr swarm.Address, storer s
 	}))
 	contract := &mockContract{}
 
-	return storageincentives.New(addr, common.Address{}, backend, log.Noop, &mockMonitor{}, contract, postageContract, stakingContract, mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{StorageRadius: 0})), &mockSampler{t: t}, time.Millisecond*10, blocksPerRound, blocksPerPhase, storer, erc20Service, tranService)
+	return storageincentives.New(addr, common.Address{}, backend, &mockMonitor{}, contract, postageContract, stakingContract, mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{StorageRadius: 0})), &mockSampler{t: t}, time.Millisecond*10, blocksPerRound, blocksPerPhase, storer, erc20Service, tranService, &mockHealth{}, log.Noop)
 }
 
 type contractCall int
@@ -834,3 +834,7 @@ func (m *mockSampler) ReserveSample(context.Context, []byte, uint8, uint64) (sto
 		Hash: swarm.RandAddress(m.t),
 	}, nil
 }
+
+type mockHealth struct{}
+
+func (m *mockHealth) IsHealthy() bool { return true }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -972,7 +972,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	saludService := salud.New(nodeStatus, kad, batchStore, logger, warmupTime, salud.DefaultMinPeersPerBin)
+	saludService := salud.New(nodeStatus, kad, batchStore, logger, warmupTime, api.FullMode.String(), salud.DefaultMinPeersPerBin)
 	b.saludCloser = saludService
 
 	var (

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -909,7 +909,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 
 	pinningService := pinning.NewService(storer, stateStore, traversalService)
 
-	pushSyncProtocol := pushsync.New(swarmAddress, nonce, p2ps, storer, kad, batchStore, tagService, o.FullNodeMode, pssService.TryUnwrap, validStamp, logger, acc, pricer, signer, tracer)
+	pushSyncProtocol := pushsync.New(swarmAddress, nonce, p2ps, storer, kad, batchStore, tagService, o.FullNodeMode, pssService.TryUnwrap, validStamp, logger, acc, pricer, signer, tracer, warmupTime)
 	b.pushSyncCloser = pushSyncProtocol
 
 	// set the pushSyncer in the PSS
@@ -972,7 +972,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	saludService := salud.New(nodeStatus, kad, batchStore, logger, o.WarmupTime)
+	saludService := salud.New(nodeStatus, kad, batchStore, logger, o.WarmupTime, salud.DefaultMinPeersPerBin)
 	b.saludCloser = saludService
 
 	var (

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1035,8 +1035,8 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	s := salud.New(nodeStatus, kad, p2ps, logger, o.WarmupTime)
-	b.saludCloser = s
+	saludService := salud.New(nodeStatus, kad, logger, o.WarmupTime)
+	b.saludCloser = saludService
 
 	extraOpts := api.ExtraOptions{
 		Pingpong:         pingPong,
@@ -1116,6 +1116,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		debugService.MustRegisterMetrics(acc.Metrics()...)
 		debugService.MustRegisterMetrics(storer.Metrics()...)
 		debugService.MustRegisterMetrics(kad.Metrics()...)
+		debugService.MustRegisterMetrics(saludService.Metrics()...)
 
 		if pullerService != nil {
 			debugService.MustRegisterMetrics(pullerService.Metrics()...)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1035,7 +1035,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	saludService := salud.New(nodeStatus, kad, logger, o.WarmupTime)
+	saludService := salud.New(nodeStatus, kad, batchStore, logger, o.WarmupTime)
 	b.saludCloser = saludService
 
 	extraOpts := api.ExtraOptions{

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -972,7 +972,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	saludService := salud.New(nodeStatus, kad, batchStore, logger, o.WarmupTime, salud.DefaultMinPeersPerBin)
+	saludService := salud.New(nodeStatus, kad, batchStore, logger, warmupTime, salud.DefaultMinPeersPerBin)
 	b.saludCloser = saludService
 
 	var (

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1035,10 +1035,8 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	if o.FullNodeMode && !o.BootnodeMode {
-		s := salud.New(nodeStatus, kad, p2ps, logger, o.WarmupTime)
-		b.saludCloser = s
-	}
+	s := salud.New(nodeStatus, kad, p2ps, logger, o.WarmupTime)
+	b.saludCloser = s
 
 	extraOpts := api.ExtraOptions{
 		Pingpong:         pingPong,

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -310,7 +310,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			// If no peer can be found from an origin peer, the origin peer may store the chunk.
 			// Non-origin peers store the chunk if the chunk is within depth.
 			// For non-origin peers, if the chunk is not within depth, they may store the chunk if they are the closest peer to the chunk.
-			peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), ps.fullNode && !origin, topology.Filter{Reachable: true}, ps.skipList.ChunkPeers(ch.Address())...)
+			peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), ps.fullNode && !origin, topology.Filter{Reachable: true, Healthy: true}, ps.skipList.ChunkPeers(ch.Address())...)
 
 			if errors.Is(err, topology.ErrNotFound) {
 				if ps.skipList.PruneExpiresAfter(ch.Address(), overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -86,6 +86,7 @@ type PushSync struct {
 	signer         crypto.Signer
 	fullNode       bool
 	skipList       *skippeers.List
+	warmupPeriod   time.Time
 }
 
 type receiptResult struct {
@@ -95,7 +96,7 @@ type receiptResult struct {
 	err      error
 }
 
-func New(address swarm.Address, nonce []byte, streamer p2p.StreamerDisconnecter, storer storage.Putter, topology topology.Driver, rs postage.Radius, tagger *tags.Tags, fullNode bool, unwrap func(swarm.Chunk), validStamp postage.ValidStampFn, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, signer crypto.Signer, tracer *tracing.Tracer) *PushSync {
+func New(address swarm.Address, nonce []byte, streamer p2p.StreamerDisconnecter, storer storage.Putter, topology topology.Driver, rs postage.Radius, tagger *tags.Tags, fullNode bool, unwrap func(swarm.Chunk), validStamp postage.ValidStampFn, logger log.Logger, accounting accounting.Interface, pricer pricer.Interface, signer crypto.Signer, tracer *tracing.Tracer, warmupTime time.Duration) *PushSync {
 	ps := &PushSync{
 		address:        address,
 		nonce:          nonce,
@@ -113,6 +114,7 @@ func New(address swarm.Address, nonce []byte, streamer p2p.StreamerDisconnecter,
 		tracer:         tracer,
 		signer:         signer,
 		skipList:       skippeers.NewList(),
+		warmupPeriod:   time.Now().Add(warmupTime),
 	}
 
 	ps.validStamp = ps.validStampWrapper(validStamp)
@@ -264,6 +266,10 @@ func (ps *PushSync) PushChunkToClosest(ctx context.Context, ch swarm.Chunk) (*Re
 
 // pushToClosest attempts to push the chunk into the network.
 func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bool) (*pb.Receipt, error) {
+
+	if !ps.warmedUp() {
+		return nil, ErrWarmup
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -515,4 +521,8 @@ func (ps *PushSync) validStampWrapper(f postage.ValidStampFn) postage.ValidStamp
 
 func (s *PushSync) Close() error {
 	return s.skipList.Close()
+}
+
+func (ps *PushSync) warmedUp() bool {
+	return time.Now().After(ps.warmupPeriod)
 }

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -773,7 +773,7 @@ func createPushSyncNodeWithAccounting(t *testing.T, addr swarm.Address, prices p
 		bs = bsMock.New(bsMock.WithIsWithinStorageRadius(false))
 	}
 
-	ps := pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil)
+	ps := pushsync.New(addr, blockHash.Bytes(), recorderDisconnecter, storer, mockTopology, bs, mtag, true, unwrap, validStamp, logger, acct, mockPricer, signer, nil, -1)
 	t.Cleanup(func() { ps.Close() })
 
 	return ps, storer, mtag

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Swarm Authors. All rights reserved.
+// Copyright 2023 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -10,7 +10,8 @@ import (
 )
 
 type metrics struct {
-	Dur         prometheus.Gauge
+	AvgDur      prometheus.Gauge
+	PDur        prometheus.Gauge
 	Radius      prometheus.Gauge
 	Blocklisted prometheus.Counter
 }
@@ -19,11 +20,17 @@ func newMetrics() metrics {
 	subsystem := "pushsync"
 
 	return metrics{
-		Dur: prometheus.NewGauge(prometheus.GaugeOpts{
+		AvgDur: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "dur",
 			Help:      "Average duration for snapshot response.",
+		}),
+		PDur: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "pdur",
+			Help:      "P99 duration for snapshot response.",
 		}),
 		Radius: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.Namespace,

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -10,12 +10,13 @@ import (
 )
 
 type metrics struct {
-	AvgDur    prometheus.Gauge
-	PDur      prometheus.Gauge
-	PConns    prometheus.Gauge
-	Radius    prometheus.Gauge
-	Healthy   prometheus.Gauge
-	Unhealthy prometheus.Gauge
+	AvgDur             prometheus.Gauge
+	PDur               prometheus.Gauge
+	PConns             prometheus.Gauge
+	NetworkRadius      prometheus.Gauge
+	NeighborhoodRadius prometheus.Gauge
+	Healthy            prometheus.Gauge
+	Unhealthy          prometheus.Gauge
 }
 
 func newMetrics() metrics {
@@ -40,10 +41,16 @@ func newMetrics() metrics {
 			Name:      "pconns",
 			Help:      "Percentile of connections counts.",
 		}),
-		Radius: prometheus.NewGauge(prometheus.GaugeOpts{
+		NetworkRadius: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "radius",
+			Name:      "network_radius",
+			Help:      "Most common radius across the connected peers.",
+		}),
+		NeighborhoodRadius: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "neighborhood_radius",
 			Help:      "Most common radius across the connected peers.",
 		}),
 		Healthy: prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package salud
+
+import (
+	m "github.com/ethersphere/bee/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	Dur         prometheus.Gauge
+	Radius      prometheus.Gauge
+	Blocklisted prometheus.Counter
+}
+
+func newMetrics() metrics {
+	subsystem := "pushsync"
+
+	return metrics{
+		Dur: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "dur",
+			Help:      "Average duration for snapshot response.",
+		}),
+		Radius: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "radius",
+			Help:      "Most common radius across the connected peers.",
+		}),
+		Blocklisted: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "blocklisted",
+			Help:      "Total number of blocklisted peers.",
+		}),
+	}
+}
+
+func (s *service) Metrics() []prometheus.Collector {
+	return m.PrometheusCollectorsFromFields(s.metrics)
+}

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -15,8 +15,9 @@ type metrics struct {
 	PConns             prometheus.Gauge
 	NetworkRadius      prometheus.Gauge
 	NeighborhoodRadius prometheus.Gauge
-	Healthy            prometheus.Gauge
-	Unhealthy          prometheus.Gauge
+	Commitment         prometheus.Gauge
+	Healthy            prometheus.Counter
+	Unhealthy          prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -53,17 +54,23 @@ func newMetrics() metrics {
 			Name:      "neighborhood_radius",
 			Help:      "Most common radius across the connected peers.",
 		}),
-		Healthy: prometheus.NewGauge(prometheus.GaugeOpts{
+		Healthy: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "healthy",
 			Help:      "Count of healthy peers.",
 		}),
-		Unhealthy: prometheus.NewGauge(prometheus.GaugeOpts{
+		Unhealthy: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "unhealthy",
 			Help:      "Count of unhealthy peers.",
+		}),
+		Commitment: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "batch_commitment",
+			Help:      "Most common batch commitment.",
 		}),
 	}
 }

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -14,11 +14,11 @@ type metrics struct {
 	PDur    prometheus.Gauge
 	PConns  prometheus.Gauge
 	Radius  prometheus.Gauge
-	Healthy *prometheus.GaugeVec
+	Healthy *prometheus.CounterVec
 }
 
 func newMetrics() metrics {
-	subsystem := "pushsync"
+	subsystem := "salud"
 
 	return metrics{
 		AvgDur: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -45,8 +45,8 @@ func newMetrics() metrics {
 			Name:      "radius",
 			Help:      "Most common radius across the connected peers.",
 		}),
-		Healthy: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
+		Healthy: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
 				Name:      "healthy",

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -10,11 +10,12 @@ import (
 )
 
 type metrics struct {
-	AvgDur  prometheus.Gauge
-	PDur    prometheus.Gauge
-	PConns  prometheus.Gauge
-	Radius  prometheus.Gauge
-	Healthy *prometheus.CounterVec
+	AvgDur    prometheus.Gauge
+	PDur      prometheus.Gauge
+	PConns    prometheus.Gauge
+	Radius    prometheus.Gauge
+	Healthy   prometheus.Gauge
+	Unhealthy prometheus.Gauge
 }
 
 func newMetrics() metrics {
@@ -45,15 +46,18 @@ func newMetrics() metrics {
 			Name:      "radius",
 			Help:      "Most common radius across the connected peers.",
 		}),
-		Healthy: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "healthy",
-				Help:      "Count of current healthy and unhealthy peers.",
-			},
-			[]string{"healthy"},
-		),
+		Healthy: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "healthy",
+			Help:      "Count of healthy peers.",
+		}),
+		Unhealthy: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "unhealthy",
+			Help:      "Count of unhealthy peers.",
+		}),
 	}
 }
 

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -10,10 +10,11 @@ import (
 )
 
 type metrics struct {
-	AvgDur      prometheus.Gauge
-	PDur        prometheus.Gauge
-	Radius      prometheus.Gauge
-	Blocklisted prometheus.Counter
+	AvgDur  prometheus.Gauge
+	PDur    prometheus.Gauge
+	PConns  prometheus.Gauge
+	Radius  prometheus.Gauge
+	Healthy *prometheus.GaugeVec
 }
 
 func newMetrics() metrics {
@@ -30,7 +31,13 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "pdur",
-			Help:      "P99 duration for snapshot response.",
+			Help:      "Percentile of durations for snapshot response.",
+		}),
+		PConns: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "pconns",
+			Help:      "Percentile of connections counts.",
 		}),
 		Radius: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.Namespace,
@@ -38,12 +45,15 @@ func newMetrics() metrics {
 			Name:      "radius",
 			Help:      "Most common radius across the connected peers.",
 		}),
-		Blocklisted: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "blocklisted",
-			Help:      "Total number of blocklisted peers.",
-		}),
+		Healthy: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "healthy",
+				Help:      "Count of current healthy and unhealthy peers.",
+			},
+			[]string{"healthy"},
+		),
 	}
 }
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -144,7 +144,8 @@ func (s *service) salud() {
 	avgDur := totaldur / float64(len(peers))
 	pDur := percantile(peers, .99)
 
-	s.metrics.Dur.Set(avgDur)
+	s.metrics.AvgDur.Set(avgDur)
+	s.metrics.PDur.Set(pDur)
 	s.metrics.Radius.Set(float64(radius))
 
 	s.logger.Debug("computed", "average", avgDur, "p99", pDur, "radius", radius)

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -206,7 +206,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	}
 
 	if neighbors > 0 {
-		s.isSelfHealthy.Store(s.rs.StorageRadius() == nHoodRadius)
+		s.isSelfHealthy.Store(s.rs.StorageRadius() == networkRadius)
 	}
 }
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -139,6 +139,10 @@ func (s *service) salud() {
 
 	wg.Wait()
 
+	if len(peers) == 0 {
+		return
+	}
+
 	radius := radius(peers)
 	avgDur := totaldur / float64(len(peers))
 	pDur := percentileDur(peers, .95)

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -255,8 +255,8 @@ func (s *service) radius(peers []peer) (uint8, uint8) {
 		}
 	}
 
-	networkR := highestCollisions(networkRadius[:])
-	hoodR := highestCollisions(nHoodRadius[:])
+	networkR := maxIndex(networkRadius[:])
+	hoodR := maxIndex(nHoodRadius[:])
 
 	return uint8(networkR), uint8(hoodR)
 }
@@ -285,7 +285,7 @@ func commitment(peers []peer) uint64 {
 	return maxCommitment
 }
 
-func highestCollisions(n []int) int {
+func maxIndex(n []int) int {
 
 	maxValue := 0
 	index := 0

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -8,7 +8,6 @@ package salud
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -171,13 +170,11 @@ func (s *service) salud(minPeersPerbin int) {
 	s.metrics.NetworkRadius.Set(float64(networkRadius))
 	s.metrics.NeighborhoodRadius.Set(float64(nHoodRadius))
 
-	fmt.Println("computed", "average", avgDur, "percentile", percentile, "pDur", pDur, "pConns", pConns, "network_radius", networkRadius, "neighborhood_radius", nHoodRadius)
+	s.logger.Debug("computed", "average", avgDur, "percentile", percentile, "pDur", pDur, "pConns", pConns, "network_radius", networkRadius, "neighborhood_radius", nHoodRadius)
 
 	for _, peer := range peers {
 
 		var healthy bool
-
-		fmt.Println(peer.bin, bins[peer.bin])
 
 		// every bin should have at least some peers, healthy or not
 		if bins[peer.bin] <= minPeersPerbin {
@@ -185,11 +182,11 @@ func (s *service) salud(minPeersPerbin int) {
 		}
 
 		if networkRadius > 0 && peer.status.StorageRadius < uint32(networkRadius-1) {
-			fmt.Println("radius health failure", "radius", peer.status.StorageRadius, "peer_address", peer.addr)
+			s.logger.Debug("radius health failure", "radius", peer.status.StorageRadius, "peer_address", peer.addr)
 		} else if peer.dur > pDur {
-			fmt.Println("dur health failure", "dur", peer.dur, "peer_address", peer.addr)
+			s.logger.Debug("dur health failure", "dur", peer.dur, "peer_address", peer.addr)
 		} else if peer.status.ConnectedPeers < pConns {
-			fmt.Println("connections health failure", "connections", peer.status.ConnectedPeers, "peer_address", peer.addr)
+			s.logger.Debug("connections health failure", "connections", peer.status.ConnectedPeers, "peer_address", peer.addr)
 		} else {
 			healthy = true
 		}

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -149,6 +149,7 @@ func (s *service) salud() {
 
 	s.metrics.AvgDur.Set(avgDur)
 	s.metrics.PDur.Set(pDur)
+	s.metrics.PConns.Set(float64(pConns))
 	s.metrics.Radius.Set(float64(radius))
 
 	s.logger.Debug("computed", "average", avgDur, "p80Dur", pDur, "p80Conns", pConns, "radius", radius)

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -178,6 +178,7 @@ func (s *service) salud(minPeersPerbin int) {
 
 		// every bin should have at least some peers, healthy or not
 		if bins[peer.bin] <= minPeersPerbin {
+			s.topology.UpdatePeerHealth(peer.addr, true)
 			continue
 		}
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -21,8 +21,9 @@ import (
 // metrics
 
 const (
-	DefaultWakeup       = time.Minute
-	DefaultBlocklistDur = time.Minute * 5
+	DefaultWakeup         = time.Minute
+	DefaultBlocklistDur   = time.Minute * 5
+	DefaultRequestTimeout = time.Second * 10
 )
 
 type service struct {
@@ -97,7 +98,7 @@ func (s *service) salud() {
 		go func() {
 			defer wg.Done()
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			ctx, cancel := context.WithTimeout(context.Background(), DefaultRequestTimeout)
 			defer cancel()
 
 			start := time.Now()
@@ -105,6 +106,7 @@ func (s *service) salud() {
 			snapshot, err := s.status.PeerSnapshot(ctx, addr)
 			if err != nil {
 				// log and blocklist
+				s.p2p.Blocklist(addr, DefaultBlocklistDur, "salud status snapshop failure")
 				return
 			}
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -155,7 +155,7 @@ func (s *service) salud() {
 
 	for _, peer := range peers {
 
-		var health bool
+		var healthy bool
 
 		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {
 			s.logger.Debug("radius health failure", "radius", peer.status.StorageRadius, "peer_address", peer.addr)
@@ -164,11 +164,11 @@ func (s *service) salud() {
 		} else if peer.status.ConnectedPeers < pConns {
 			s.logger.Debug("connections health failure", "connections", peer.status.ConnectedPeers, "peer_address", peer.addr)
 		} else {
-			health = true
+			healthy = true
 		}
 
-		s.topology.UpdatePeerHealth(peer.addr, health)
-		if health {
+		s.topology.UpdatePeerHealth(peer.addr, healthy)
+		if healthy {
 			s.metrics.Healthy.Inc()
 		} else {
 			s.metrics.Unhealthy.Inc()

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -75,11 +75,13 @@ func (s *service) worker(warmup time.Duration) {
 	}
 
 	for {
+
+		s.salud()
+
 		select {
 		case <-s.quit:
 			return
 		case <-time.After(DefaultWakeup):
-			s.salud()
 		}
 	}
 }
@@ -146,7 +148,7 @@ func (s *service) salud() {
 	s.metrics.PDur.Set(pDur)
 	s.metrics.Radius.Set(float64(radius))
 
-	s.logger.Debug("computed", "average", avgDur, "p99", pDur, "radius", radius)
+	s.logger.Debug("computed", "average", avgDur, "p95Dur", pDur, "p95Conns", pConns, "radius", radius)
 
 	for _, peer := range peers {
 		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -205,9 +205,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 		}
 	}
 
-	if neighbors > 0 {
-		s.isSelfHealthy.Store(s.rs.StorageRadius() == networkRadius)
-	}
+	s.isSelfHealthy.Store(s.rs.StorageRadius() == networkRadius)
 }
 
 func (s *service) IsHealthy() bool {

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -2,11 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package salud monitors the storage radius and request reponse duration of peers
+// and blocklists peers to maintain network salud (health).
 package salud
 
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -17,12 +20,8 @@ import (
 	"github.com/ethersphere/bee/pkg/topology"
 )
 
-// TODO:
-// logs
-// metrics
-
 // loggerName is the tree path name of the logger for this package.
-const loggerName = "pushsync"
+const loggerName = "salud"
 
 const (
 	DefaultWakeup         = time.Minute
@@ -35,12 +34,12 @@ type service struct {
 	quit        chan struct{}
 	logger      log.Logger
 	topology    topology.Driver
-	status      status.Service
+	status      *status.Service
 	metrics     metrics
 	blocklister func() p2p.Blocklister
 }
 
-func New(status status.Service, topology topology.Driver, blocklister p2p.Blocklister, logger log.Logger, warmup time.Duration) *service {
+func New(status *status.Service, topology topology.Driver, blocklister p2p.Blocklister, logger log.Logger, warmup time.Duration) *service {
 
 	metrics := newMetrics()
 
@@ -88,23 +87,22 @@ func (s *service) Close() error {
 	return nil
 }
 
+type peer struct {
+	status *status.Snapshot
+	dur    float64
+	addr   swarm.Address
+}
+
 // salud acquires the status snapshot of every peer and computes an avg response duration
 // and the most common storage radius and based on these values, it blocklist peers that fall beyond
 // some allowed threshold.
 func (s *service) salud() {
-
-	type peer struct {
-		status *status.Snapshot
-		dur    float64
-		addr   swarm.Address
-	}
 
 	var (
 		mtx sync.Mutex
 		wg  sync.WaitGroup
 
 		totaldur float64
-		radiuses [swarm.MaxBins]int
 		peers    []peer
 	)
 
@@ -124,18 +122,67 @@ func (s *service) salud() {
 				return
 			}
 
+			if snapshot.BeeMode != "full" {
+				return
+			}
+
 			dur := time.Since(start).Seconds()
+
+			// s.logger.Debug("status", "radius", snapshot.StorageRadius, "dur", dur, "mode", snapshot.BeeMode, "peer", addr)
 
 			mtx.Lock()
 			totaldur += dur
-			radiuses[snapshot.StorageRadius]++
 			peers = append(peers, peer{status: snapshot, dur: dur, addr: addr})
 			mtx.Unlock()
 		}()
 		return false, false, nil
-	}, topology.Filter{Reachable: true})
+	}, topology.Filter{})
 
 	wg.Wait()
+
+	radius := radius(peers)
+	avgDur := totaldur / float64(len(peers))
+	pDur := percantile(peers, .99)
+
+	s.metrics.Dur.Set(avgDur)
+	s.metrics.Radius.Set(float64(radius))
+
+	s.logger.Debug("computed", "average", avgDur, "p99", pDur, "radius", radius)
+
+	for _, peer := range peers {
+
+		// radius check
+		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {
+			s.blocklister().Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud radius failure, radius %d", peer.status.StorageRadius))
+		}
+
+		// duration check
+		if peer.dur > pDur {
+			s.blocklister().Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud duration exceeded, duration %0.1f", peer.dur))
+		}
+	}
+}
+
+func percantile(peers []peer, p float64) float64 {
+
+	index := int(float64(len(peers)) * p)
+
+	sort.Slice(peers, func(i, j int) bool {
+		return peers[i].dur < peers[j].dur
+	})
+
+	return peers[index].dur
+}
+
+func radius(peers []peer) uint8 {
+
+	var radiuses [swarm.MaxBins]int
+
+	for _, peer := range peers {
+		if peer.status.StorageRadius < uint32(swarm.MaxBins) {
+			radiuses[peer.status.StorageRadius]++
+		}
+	}
 
 	maxValue := 0
 	radius := 0
@@ -146,23 +193,5 @@ func (s *service) salud() {
 		}
 	}
 
-	avgDur := totaldur / float64(len(peers))
-
-	s.metrics.Dur.Set(avgDur)
-	s.metrics.Radius.Set(float64(radius))
-
-	s.logger.Debug("computed", "average", fmt.Sprintf("%.2f", avgDur), "radius", radius)
-
-	for _, peer := range peers {
-
-		// radius check
-		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {
-			s.blocklister().Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud radius failure, radius %d", peer.status.StorageRadius))
-		}
-
-		// duration check
-		if peer.dur > avgDur*2 {
-			s.blocklister().Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud duration exceeded, duration %0.1f", peer.dur))
-		}
-	}
+	return uint8(radius)
 }

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -1,0 +1,151 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package salud
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/p2p"
+	"github.com/ethersphere/bee/pkg/status"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/ethersphere/bee/pkg/topology"
+)
+
+// TODO:
+// logs
+// metrics
+
+const (
+	DefaultWakeup       = time.Minute
+	DefaultBlocklistDur = time.Minute * 5
+)
+
+type service struct {
+	wg   sync.WaitGroup
+	quit chan struct{}
+
+	topology topology.Driver
+	status   status.Service
+	p2p      p2p.Blocklister
+}
+
+func New(warmup time.Duration) *service {
+
+	s := &service{
+		quit: make(chan struct{}),
+	}
+
+	s.wg.Add(1)
+	go s.worker(warmup)
+
+	return s
+
+}
+
+func (s *service) worker(warmup time.Duration) {
+	defer s.wg.Done()
+
+	select {
+	case <-s.quit:
+		return
+	case <-time.After(warmup):
+	}
+
+	for {
+		select {
+		case <-s.quit:
+			return
+		case <-time.After(DefaultWakeup):
+			s.salud()
+		}
+	}
+}
+
+func (s *service) Close() error {
+	close(s.quit)
+	s.wg.Wait()
+	return nil
+}
+
+// salud acquires the status snapshot of every peer and computes an avg response duration
+// and the most common storage radius and based on these values, it blocklist peers that fall beyond
+// some allowed threshold.
+func (s *service) salud() {
+
+	type peer struct {
+		status *status.Snapshot
+		dur    float64
+		addr   swarm.Address
+	}
+
+	var (
+		mtx sync.Mutex
+		wg  sync.WaitGroup
+
+		totaldur float64
+		radiuses [swarm.MaxBins]int
+		peers    []peer
+	)
+
+	_ = s.topology.EachConnectedPeer(func(addr swarm.Address, _ uint8) (stop bool, jumpToNext bool, err error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			start := time.Now()
+
+			snapshot, err := s.status.PeerSnapshot(ctx, addr)
+			if err != nil {
+				// log and blocklist
+				return
+			}
+
+			dur := time.Since(start).Seconds()
+
+			mtx.Lock()
+			totaldur += dur
+			radiuses[snapshot.StorageRadius]++
+			peers = append(peers, peer{status: snapshot, dur: dur, addr: addr})
+			mtx.Unlock()
+		}()
+		return false, false, nil
+	}, topology.Filter{Reachable: true})
+
+	wg.Wait()
+
+	maxValue := 0
+	radius := 0
+	for i, c := range radiuses {
+		if c > maxValue {
+			maxValue = c
+			radius = i
+		}
+	}
+
+	avgDur := totaldur / float64(len(peers))
+
+	// log average dur and radius
+
+	for _, peer := range peers {
+
+		// radius check
+		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {
+			s.p2p.Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud radius failure, radius %d", peer.status.StorageRadius))
+			// log and blocklist
+		}
+
+		// duration check
+		if peer.dur > avgDur*2 {
+			s.p2p.Blocklist(peer.addr, DefaultBlocklistDur, fmt.Sprintf("salud radius failure, duration %0.1f", peer.dur))
+			// log and blocklist
+		}
+	}
+}

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -23,7 +23,7 @@ import (
 const loggerName = "salud"
 
 const (
-	DefaultWakeup         = time.Minute * 5
+	DefaultWakeup         = time.Minute
 	DefaultRequestTimeout = time.Second * 10
 )
 
@@ -145,14 +145,14 @@ func (s *service) salud() {
 
 	radius := radius(peers)
 	avgDur := totaldur / float64(len(peers))
-	pDur := percentileDur(peers, .95)
-	pConns := percentileConns(peers, .95)
+	pDur := percentileDur(peers, .80)
+	pConns := percentileConns(peers, .80)
 
 	s.metrics.AvgDur.Set(avgDur)
 	s.metrics.PDur.Set(pDur)
 	s.metrics.Radius.Set(float64(radius))
 
-	s.logger.Debug("computed", "average", avgDur, "p95Dur", pDur, "p95Conns", pConns, "radius", radius)
+	s.logger.Debug("computed", "average", avgDur, "p80Dur", pDur, "p80Conns", pConns, "radius", radius)
 
 	for _, peer := range peers {
 		if radius > 0 && peer.status.StorageRadius < uint32(radius-1) {

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -35,6 +35,7 @@ func TestSalud(t *testing.T) {
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
 
 		// healthy since radius >= most common radius -  1
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7}, 1, true},

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -87,8 +87,8 @@ func TestSelfUnhealthSalud(t *testing.T) {
 	t.Parallel()
 	peers := []peer{
 		// fully healhy
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 0, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 0, true},
 	}
 
 	statusM := &statusMock{make(map[string]peer)}
@@ -122,7 +122,7 @@ type statusMock struct {
 
 func (p *statusMock) PeerSnapshot(ctx context.Context, peer swarm.Address) (*status.Snapshot, error) {
 	if peer, ok := p.peers[peer.ByteString()]; ok {
-		time.Sleep(time.Duration(peer.waitDur) * time.Second)
+		time.Sleep(time.Duration(peer.waitDur) * time.Millisecond * 100)
 		return peer.status, nil
 	}
 	return nil, errors.New("peer not found")

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -66,7 +66,7 @@ func TestSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 8}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, -1, 0)
+	service := salud.New(statusM, topM, bs, log.Noop, -1, "full", 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)
@@ -105,7 +105,7 @@ func TestSelfUnhealthSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 7}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, -1, 0)
+	service := salud.New(statusM, topM, bs, log.Noop, -1, "full", 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -46,12 +46,13 @@ func TestSalud(t *testing.T) {
 
 		// dur too long
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 2, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 2, false},
 
 		// connections not enough
 		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, false},
 
 		// commitment wrong
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 350}, 1, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 350}, 1, false},
 	}
 
 	statusM := &statusMock{make(map[string]peer)}

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -31,24 +31,27 @@ func TestSalud(t *testing.T) {
 	t.Parallel()
 	peers := []peer{
 		// fully healhy
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
 
 		// healthy since radius >= most common radius -  1
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7, BeeMode: "full"}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7, BeeMode: "full", BatchCommitment: 500}, 1, true},
 
-		// not healthy radius too low
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 6, BeeMode: "full"}, 1, false},
+		// radius too low
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 6, BeeMode: "full", BatchCommitment: 500}, 1, false},
 
 		// dur too long
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full"}, 2, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 2, false},
 
 		// connections not enough
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full"}, 1, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, false},
+
+		// commitment wrong
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 350}, 1, false},
 	}
 
 	statusM := &statusMock{make(map[string]peer)}

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package salud_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/log"
+	"github.com/ethersphere/bee/pkg/salud"
+	"github.com/ethersphere/bee/pkg/spinlock"
+	"github.com/ethersphere/bee/pkg/status"
+	"github.com/ethersphere/bee/pkg/swarm"
+	topMock "github.com/ethersphere/bee/pkg/topology/mock"
+)
+
+type peer struct {
+	addr    swarm.Address
+	status  *status.Snapshot
+	waitDur time.Duration
+	health  bool
+}
+
+func TestSalud(t *testing.T) {
+
+	peers := []peer{
+		// fully healhy
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 1, true},
+
+		// healthy since radius >= most common radius -  1
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7}, 1, true},
+
+		// not healthy radius too low
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 6}, 1, false},
+
+		// dur too long
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8}, 2, false},
+
+		// connections not enough
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8}, 1, false},
+	}
+
+	statusM := &statusMock{make(map[string]peer)}
+
+	var addrs []swarm.Address
+	for _, p := range peers {
+		addrs = append(addrs, p.addr)
+		statusM.peers[p.addr.ByteString()] = p
+	}
+
+	topM := topMock.NewTopologyDriver(topMock.WithPeers(addrs...))
+
+	_ = salud.New(statusM, topM, log.Noop, 0)
+
+	spinlock.Wait(time.Minute, func() bool {
+		return len(topM.PeersHealth()) == len(peers)
+	})
+
+	for _, p := range peers {
+		if want, got := p.health, topM.PeersHealth()[p.addr.ByteString()]; want != got {
+			t.Fatalf("got health %v, want %v for peer %s, %v", got, want, p.addr, p.status)
+		}
+	}
+}
+
+type statusMock struct {
+	peers map[string]peer
+}
+
+func (p *statusMock) PeerSnapshot(ctx context.Context, peer swarm.Address) (*status.Snapshot, error) {
+	if peer, ok := p.peers[peer.ByteString()]; ok {
+		time.Sleep(peer.waitDur * time.Second)
+		return peer.status, nil
+	}
+	return nil, errors.New("peer not found")
+}

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -63,7 +63,7 @@ func TestSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 8}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, 0)
+	service := salud.New(statusM, topM, bs, log.Noop, -1, 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)
@@ -102,7 +102,7 @@ func TestSelfUnhealthSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 7}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, 0)
+	service := salud.New(statusM, topM, bs, log.Noop, -1, 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)

--- a/pkg/storageincentives/agent_test.go
+++ b/pkg/storageincentives/agent_test.go
@@ -167,7 +167,7 @@ func createService(
 		return false, nil
 	}))
 
-	return storageincentives.New(addr, common.Address{}, backend, log.Noop, &mockMonitor{}, contract, postageContract, stakingContract, mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{StorageRadius: 0})), &mockSampler{t: t}, time.Millisecond*10, blocksPerRound, blocksPerPhase, statestore.NewStateStore(), erc20mock.New(), transactionmock.New())
+	return storageincentives.New(addr, common.Address{}, backend, &mockMonitor{}, contract, postageContract, stakingContract, mockbatchstore.New(mockbatchstore.WithReserveState(&postage.ReserveState{StorageRadius: 0})), &mockSampler{t: t}, time.Millisecond*10, blocksPerRound, blocksPerPhase, statestore.NewStateStore(), erc20mock.New(), transactionmock.New(), &mockHealth{}, log.Noop)
 }
 
 type mockchainBackend struct {
@@ -291,3 +291,7 @@ func (m *mockSampler) ReserveSample(context.Context, []byte, uint8, uint64) (sto
 		Hash: swarm.RandAddress(m.t),
 	}, nil
 }
+
+type mockHealth struct{}
+
+func (m *mockHealth) IsHealthy() bool { return true }

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -24,6 +24,7 @@ const (
 )
 
 type PeerFilterFunc = peerFilterFunc
+type FilterFunc = filtersFunc
 
 func (k *Kad) IsWithinDepth(addr swarm.Address) bool {
 	return swarm.Proximity(k.base.Bytes(), addr.Bytes()) >= k.NeighborhoodDepth()

--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -115,8 +115,16 @@ func PeerReachability(s p2p.ReachabilityStatus) RecordOp {
 	return func(cs *Counters) {
 		cs.Lock()
 		defer cs.Unlock()
-
 		cs.ReachabilityStatus = s
+	}
+}
+
+// PeerHealth updates the last health status of a peers
+func PeerHealth(h bool) RecordOp {
+	return func(cs *Counters) {
+		cs.Lock()
+		defer cs.Unlock()
+		cs.Healthy = h
 	}
 }
 
@@ -129,6 +137,7 @@ type Snapshot struct {
 	SessionConnectionDirection PeerConnectionDirection
 	LatencyEWMA                time.Duration
 	Reachability               p2p.ReachabilityStatus
+	Healthy                    bool
 }
 
 // HasAtMaxOneConnectionAttempt returns true if the snapshot represents a new
@@ -162,6 +171,7 @@ type Counters struct {
 	sessionConnDirection PeerConnectionDirection
 	latencyEWMA          time.Duration
 	ReachabilityStatus   p2p.ReachabilityStatus
+	Healthy              bool
 }
 
 // UnmarshalJSON unmarshal just the persistent counters.
@@ -210,6 +220,7 @@ func (cs *Counters) snapshot(t time.Time) *Snapshot {
 		SessionConnectionDirection: cs.sessionConnDirection,
 		LatencyEWMA:                cs.latencyEWMA,
 		Reachability:               cs.ReachabilityStatus,
+		Healthy:                    cs.Healthy,
 	}
 }
 
@@ -299,6 +310,39 @@ func (c *Collector) IsUnreachable(addr swarm.Address) bool {
 	defer cs.Unlock()
 
 	return cs.ReachabilityStatus != p2p.ReachabilityStatusPublic
+}
+
+type FilterOp func(*Counters) bool
+
+func Unreachable() FilterOp {
+	return func(cs *Counters) bool {
+		return cs.ReachabilityStatus != p2p.ReachabilityStatusPublic
+	}
+}
+
+func Unhealthy() FilterOp {
+	return func(cs *Counters) bool {
+		return !cs.Healthy
+	}
+}
+
+// Filter returns true if the addr does not pass any filter operation.
+func (c *Collector) Filter(addr swarm.Address, fop ...FilterOp) bool {
+	val, ok := c.counters.Load(addr.ByteString())
+	if !ok {
+		return true
+	}
+	cs := val.(*Counters)
+	cs.Lock()
+	defer cs.Unlock()
+
+	for _, f := range fop {
+		if f(cs) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Inspect allows inspecting current snapshot for the given

--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -124,7 +124,7 @@ func PeerHealth(h bool) RecordOp {
 	return func(cs *Counters) {
 		cs.Lock()
 		defer cs.Unlock()
-		cs.Healthy = h
+		cs.Unhealthy = !h
 	}
 }
 
@@ -137,7 +137,7 @@ type Snapshot struct {
 	SessionConnectionDirection PeerConnectionDirection
 	LatencyEWMA                time.Duration
 	Reachability               p2p.ReachabilityStatus
-	Healthy                    bool
+	Unhealthy                  bool
 }
 
 // HasAtMaxOneConnectionAttempt returns true if the snapshot represents a new
@@ -171,7 +171,7 @@ type Counters struct {
 	sessionConnDirection PeerConnectionDirection
 	latencyEWMA          time.Duration
 	ReachabilityStatus   p2p.ReachabilityStatus
-	Healthy              bool
+	Unhealthy            bool
 }
 
 // UnmarshalJSON unmarshal just the persistent counters.
@@ -220,7 +220,7 @@ func (cs *Counters) snapshot(t time.Time) *Snapshot {
 		SessionConnectionDirection: cs.sessionConnDirection,
 		LatencyEWMA:                cs.latencyEWMA,
 		Reachability:               cs.ReachabilityStatus,
-		Healthy:                    cs.Healthy,
+		Unhealthy:                  cs.Unhealthy,
 	}
 }
 
@@ -322,7 +322,7 @@ func Unreachable() FilterOp {
 
 func Unhealthy() FilterOp {
 	return func(cs *Counters) bool {
-		return !cs.Healthy
+		return cs.Unhealthy
 	}
 }
 

--- a/pkg/topology/kademlia/internal/metrics/metrics_test.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics_test.go
@@ -141,17 +141,17 @@ func TestPeerMetricsCollector(t *testing.T) {
 
 	// Health.
 	ss = snapshot(t, mc, t2, addr)
-	if have, want := ss.Unhealthy, false; have != want {
+	if have, want := ss.Healthy, false; have != want {
 		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
 	}
 	mc.Record(addr, metrics.PeerHealth(true))
 	ss = snapshot(t, mc, t2, addr)
-	if have, want := ss.Unhealthy, false; have != want {
+	if have, want := ss.Healthy, true; have != want {
 		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
 	}
 	mc.Record(addr, metrics.PeerHealth(false))
 	ss = snapshot(t, mc, t2, addr)
-	if have, want := ss.Unhealthy, true; have != want {
+	if have, want := ss.Healthy, false; have != want {
 		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
 	}
 

--- a/pkg/topology/kademlia/internal/metrics/metrics_test.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics_test.go
@@ -141,12 +141,17 @@ func TestPeerMetricsCollector(t *testing.T) {
 
 	// Health.
 	ss = snapshot(t, mc, t2, addr)
-	if have, want := ss.Healthy, false; have != want {
+	if have, want := ss.Unhealthy, false; have != want {
 		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
 	}
 	mc.Record(addr, metrics.PeerHealth(true))
 	ss = snapshot(t, mc, t2, addr)
-	if have, want := ss.Healthy, true; have != want {
+	if have, want := ss.Unhealthy, false; have != want {
+		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
+	}
+	mc.Record(addr, metrics.PeerHealth(false))
+	ss = snapshot(t, mc, t2, addr)
+	if have, want := ss.Unhealthy, true; have != want {
 		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
 	}
 

--- a/pkg/topology/kademlia/internal/metrics/metrics_test.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics_test.go
@@ -139,6 +139,17 @@ func TestPeerMetricsCollector(t *testing.T) {
 		t.Fatalf("Snapshot(%q, ...): has reachability status mismatch: have %q; want %q", addr, have, want)
 	}
 
+	// Health.
+	ss = snapshot(t, mc, t2, addr)
+	if have, want := ss.Healthy, false; have != want {
+		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
+	}
+	mc.Record(addr, metrics.PeerHealth(true))
+	ss = snapshot(t, mc, t2, addr)
+	if have, want := ss.Healthy, true; have != want {
+		t.Fatalf("Snapshot(%q, ...): has health status mismatch: have %v; want %v", addr, have, want)
+	}
+
 	// Inspect.
 	have := mc.Inspect(addr)
 	want := ss

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1653,6 +1653,7 @@ func createMetricsSnapshotView(ss *im.Snapshot) *topology.MetricSnapshotView {
 		SessionConnectionDirection: string(ss.SessionConnectionDirection),
 		LatencyEWMA:                ss.LatencyEWMA.Milliseconds(),
 		Reachability:               ss.Reachability.String(),
+		Healthy:                    ss.Healthy,
 	}
 }
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -894,7 +894,7 @@ func (k *Kad) recalcDepth() {
 
 	var (
 		peers                 = k.connectedPeers
-		filter                = k.opt.FilterFunc(im.Unreachable())
+		filter                = k.opt.FilterFunc(im.Reachability(false))
 		binCount              = 0
 		shallowestUnsaturated = uint8(0)
 		depth                 uint8
@@ -1129,7 +1129,7 @@ func (k *Kad) Pick(peer p2p.Peer) bool {
 		return true
 	}
 	po := swarm.Proximity(k.base.Bytes(), peer.Address.Bytes())
-	oversaturated := k.opt.SaturationFunc(po, k.knownPeers, k.connectedPeers, k.opt.FilterFunc(im.Unreachable()))
+	oversaturated := k.opt.SaturationFunc(po, k.knownPeers, k.connectedPeers, k.opt.FilterFunc(im.Reachability(false)))
 	// pick the peer if we are not oversaturated
 	if !oversaturated {
 		return true
@@ -1177,7 +1177,7 @@ func (k *Kad) Connected(ctx context.Context, peer p2p.Peer, forceConnection bool
 	address := peer.Address
 	po := swarm.Proximity(k.base.Bytes(), address.Bytes())
 
-	if overSaturated := k.opt.SaturationFunc(po, k.knownPeers, k.connectedPeers, k.opt.FilterFunc(im.Unreachable())); overSaturated {
+	if overSaturated := k.opt.SaturationFunc(po, k.knownPeers, k.connectedPeers, k.opt.FilterFunc(im.Reachability(false))); overSaturated {
 		if k.bootnode {
 			randPeer, err := k.randomPeer(po)
 			if err != nil {
@@ -1405,10 +1405,10 @@ func filterOps(filter topology.Filter) []im.FilterOp {
 	ops := make([]im.FilterOp, 0, 2)
 
 	if filter.Reachable {
-		ops = append(ops, im.Unreachable())
+		ops = append(ops, im.Reachability(false))
 	}
 	if filter.Healthy {
-		ops = append(ops, im.Unhealthy())
+		ops = append(ops, im.Health(false))
 	}
 
 	return ops

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1367,7 +1367,7 @@ func (k *Kad) UpdateReachability(status p2p.ReachabilityStatus) {
 // UpdateReachability updates node reachability status.
 // The status will be updated only once. Updates to status
 // p2p.ReachabilityStatusUnknown are ignored.
-func (k *Kad) PeerHealth(peer swarm.Address, health bool) {
+func (k *Kad) UpdatePeerHealth(peer swarm.Address, health bool) {
 	k.collector.Record(peer, im.PeerHealth(health))
 	// k.logger.Debug("health of peer updated", "peer_address", peer, "health", health)
 }

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 	"github.com/ethersphere/bee/pkg/topology"
 	"github.com/ethersphere/bee/pkg/topology/kademlia"
+	im "github.com/ethersphere/bee/pkg/topology/kademlia/internal/metrics"
 	"github.com/ethersphere/bee/pkg/topology/pslice"
 	"github.com/ethersphere/bee/pkg/util/testutil"
 )
@@ -39,6 +40,9 @@ import (
 const spinLockWaitTime = time.Second * 3
 
 var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA")
+var defaultFilterFunc kademlia.FilterFunc = func(...im.FilterOp) kademlia.PeerFilterFunc {
+	return func(swarm.Address) bool { return false }
+}
 
 // TestNeighborhoodDepth tests that the kademlia depth changes correctly
 // according to the change to known peers slice. This inadvertently tests
@@ -52,8 +56,8 @@ func TestNeighborhoodDepth(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			SaturationPeers:  ptrInt(4),
-			ReachabilityFunc: func(_ swarm.Address) bool { return false },
+			SaturationPeers: ptrInt(4),
+			FilterFunc:      defaultFilterFunc,
 		})
 	)
 
@@ -377,8 +381,8 @@ func TestManage(t *testing.T) {
 		conns                    int32 // how many connect calls were made to the p2p mock
 		saturation               = kademlia.DefaultSaturationPeers
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			BitSuffixLength:  ptrInt(-1),
-			ReachabilityFunc: func(_ swarm.Address) bool { return false },
+			BitSuffixLength: ptrInt(-1),
+			FilterFunc:      defaultFilterFunc,
 		})
 	)
 
@@ -424,10 +428,10 @@ func TestManageWithBalancing(t *testing.T) {
 			return f(bin, peers, connected, filter)
 		}
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			SaturationFunc:   saturationFunc,
-			SaturationPeers:  ptrInt(4),
-			BitSuffixLength:  ptrInt(2),
-			ReachabilityFunc: func(_ swarm.Address) bool { return false },
+			SaturationFunc:  saturationFunc,
+			SaturationPeers: ptrInt(4),
+			BitSuffixLength: ptrInt(2),
+			FilterFunc:      defaultFilterFunc,
 		})
 	)
 
@@ -471,9 +475,9 @@ func TestBinSaturation(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			SaturationPeers:  ptrInt(2),
-			BitSuffixLength:  ptrInt(-1),
-			ReachabilityFunc: func(_ swarm.Address) bool { return false },
+			SaturationPeers: ptrInt(2),
+			BitSuffixLength: ptrInt(-1),
+			FilterFunc:      defaultFilterFunc,
 		})
 	)
 
@@ -522,7 +526,7 @@ func TestOversaturation(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			ReachabilityFunc: func(_ swarm.Address) bool { return false },
+			FilterFunc: defaultFilterFunc,
 		})
 	)
 
@@ -574,7 +578,7 @@ func TestOversaturationBootnode(t *testing.T) {
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			SaturationPeers:     ptrInt(4),
 			BootnodeMode:        true,
-			ReachabilityFunc:    func(_ swarm.Address) bool { return false },
+			FilterFunc:          defaultFilterFunc,
 		})
 	)
 
@@ -632,7 +636,7 @@ func TestBootnodeMaxConnections(t *testing.T) {
 			BootnodeOverSaturationPeers: ptrInt(bootnodeOverSaturationPeers),
 			SaturationPeers:             ptrInt(4),
 			BootnodeMode:                true,
-			ReachabilityFunc:            func(_ swarm.Address) bool { return false },
+			FilterFunc:                  defaultFilterFunc,
 		})
 	)
 
@@ -723,7 +727,7 @@ func TestDiscoveryHooks(t *testing.T) {
 	var (
 		conns                    int32
 		_, kad, ab, disc, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			ReachabilityFunc: func(peer swarm.Address) bool { return false },
+			FilterFunc: defaultFilterFunc,
 		})
 		p1, p2, p3 = swarm.RandAddress(t), swarm.RandAddress(t), swarm.RandAddress(t)
 	)
@@ -1293,7 +1297,7 @@ func TestOutofDepthPrune(t *testing.T) {
 			SaturationPeers:     ptrInt(saturationPeers),
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			PruneFunc:           pruneFunc,
-			ReachabilityFunc:    func(_ swarm.Address) bool { return false },
+			FilterFunc:          defaultFilterFunc,
 		})
 	)
 
@@ -1437,7 +1441,7 @@ func TestBootnodeProtectedNodes(t *testing.T) {
 			LowWaterMark:                ptrInt(0),
 			BootnodeMode:                true,
 			StaticNodes:                 protected,
-			ReachabilityFunc:            func(_ swarm.Address) bool { return false },
+			FilterFunc:                  defaultFilterFunc,
 		})
 	)
 
@@ -1527,7 +1531,7 @@ func TestAnnounceBgBroadcast_FLAKY(t *testing.T) {
 			}),
 		)
 		_, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			ReachabilityFunc: func(swarm.Address) bool { return false },
+			FilterFunc: defaultFilterFunc,
 		})
 	)
 
@@ -1596,7 +1600,7 @@ func TestAnnounceNeighborhoodToNeighbor(t *testing.T) {
 			}),
 		)
 		base, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			ReachabilityFunc:    func(swarm.Address) bool { return false },
+			FilterFunc:          defaultFilterFunc,
 			OverSaturationPeers: ptrInt(4),
 			SaturationPeers:     ptrInt(4),
 		})
@@ -1669,12 +1673,20 @@ func TestIteratorOpts(t *testing.T) {
 
 	// randomly mark some nodes as reachable
 	totalReachable := 0
+	totalHealthy := 0
 	reachable := make(map[string]struct{})
+	healthy := make(map[string]struct{})
+
 	_ = kad.EachConnectedPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
 		if randBool.Bool() {
 			kad.Reachable(addr, p2p.ReachabilityStatusPublic)
 			reachable[addr.ByteString()] = struct{}{}
 			totalReachable++
+		}
+		if randBool.Bool() {
+			kad.PeerHealth(addr, true)
+			healthy[addr.ByteString()] = struct{}{}
+			totalHealthy++
 		}
 		return false, false, nil
 	}, topology.Filter{})
@@ -1698,6 +1710,41 @@ func TestIteratorOpts(t *testing.T) {
 		}
 	})
 
+	t.Run("EachConnectedPeer healthy", func(t *testing.T) {
+		t.Parallel()
+
+		count := 0
+		err := kad.EachConnectedPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			if _, exists := healthy[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			count++
+			return false, false, nil
+		}, topology.Filter{Healthy: true})
+		if err != nil {
+			t.Fatal("iterator returned error")
+		}
+		if count != totalHealthy {
+			t.Fatal("iterator returned incorrect no of peers", count, "expected", totalHealthy)
+		}
+	})
+
+	t.Run("EachConnectedPeer reachable healthy", func(t *testing.T) {
+		t.Parallel()
+		err := kad.EachConnectedPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			if _, exists := reachable[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			if _, exists := healthy[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			return false, false, nil
+		}, topology.Filter{Reachable: true, Healthy: true})
+		if err != nil {
+			t.Fatal("iterator returned error")
+		}
+	})
+
 	t.Run("EachConnectedPeerRev reachable", func(t *testing.T) {
 		t.Parallel()
 
@@ -1714,6 +1761,41 @@ func TestIteratorOpts(t *testing.T) {
 		}
 		if count != totalReachable {
 			t.Fatal("iterator returned incorrect no of peers", count, "expected", totalReachable)
+		}
+	})
+
+	t.Run("EachConnectedPeerRev healthy", func(t *testing.T) {
+		t.Parallel()
+
+		count := 0
+		err := kad.EachConnectedPeerRev(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			if _, exists := healthy[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			count++
+			return false, false, nil
+		}, topology.Filter{Healthy: true})
+		if err != nil {
+			t.Fatal("iterator returned error")
+		}
+		if count != totalHealthy {
+			t.Fatal("iterator returned incorrect no of peers", count, "expected", totalHealthy)
+		}
+	})
+
+	t.Run("EachConnectedPeerRev reachable healthy", func(t *testing.T) {
+		t.Parallel()
+		err := kad.EachConnectedPeerRev(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			if _, exists := reachable[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			if _, exists := healthy[addr.ByteString()]; !exists {
+				t.Fatal("iterator returned incorrect peer")
+			}
+			return false, false, nil
+		}, topology.Filter{Reachable: true, Healthy: true})
+		if err != nil {
+			t.Fatal("iterator returned error")
 		}
 	})
 }

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1684,7 +1684,8 @@ func TestIteratorOpts(t *testing.T) {
 			totalReachable++
 		}
 		if randBool.Bool() {
-			kad.PeerHealth(addr, true)
+			kad.PeerHealth(addr, false)
+		} else {
 			healthy[addr.ByteString()] = struct{}{}
 			totalHealthy++
 		}

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1686,7 +1686,7 @@ func TestIteratorOpts(t *testing.T) {
 		if randBool.Bool() {
 			healthy[addr.ByteString()] = struct{}{}
 			totalHealthy++
-			kad.PeerHealth(addr, true)
+			kad.UpdatePeerHealth(addr, true)
 		}
 		return false, false, nil
 	}, topology.Filter{})

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1684,10 +1684,9 @@ func TestIteratorOpts(t *testing.T) {
 			totalReachable++
 		}
 		if randBool.Bool() {
-			kad.PeerHealth(addr, false)
-		} else {
 			healthy[addr.ByteString()] = struct{}{}
 			totalHealthy++
+			kad.PeerHealth(addr, true)
 		}
 		return false, false, nil
 	}, topology.Filter{})

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -77,6 +77,10 @@ func (m *Mock) EachNeighborRev(topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
+func (m *Mock) UpdatePeerHealth(swarm.Address, bool) {
+	panic("not implemented") // TODO: Implement
+}
+
 // PeerIterator iterates from closest bin to farthest
 func (m *Mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) error {
 	m.mtx.Lock()

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -187,14 +187,6 @@ func (m *mock) NeighborhoodDepth() uint8 {
 	return m.depth
 }
 
-func (m *mock) EachNeighbor(f topology.EachPeerFunc) error {
-	return m.EachConnectedPeer(f, topology.Filter{})
-}
-
-func (*mock) EachNeighborRev(_ topology.EachPeerFunc) error {
-	panic("not implemented") // TODO: Implement
-}
-
 // EachConnectedPeer implements topology.PeerIterator interface.
 func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) (err error) {
 	d.mtx.Lock()

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -60,6 +60,7 @@ type PeerIterator interface {
 // Filter defines the different filters that can be used with the Peer iterators
 type Filter struct {
 	Reachable bool
+	Healthy   bool
 }
 
 // EachPeerFunc is a callback that is called with a peer and its PO

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -82,6 +82,7 @@ type MetricSnapshotView struct {
 	SessionConnectionDirection string  `json:"sessionConnectionDirection"`
 	LatencyEWMA                int64   `json:"latencyEWMA"`
 	Reachability               string  `json:"reachability"`
+	Healthy                    bool    `json:"healthy"`
 }
 
 type BinInfo struct {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -32,6 +32,7 @@ type Driver interface {
 	Halter
 	Snapshot() *KadParams
 	IsReachable() bool
+	UpdatePeerHealth(addr swarm.Address, h bool)
 }
 
 type PeerAdder interface {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The salud service utilizes the status protocol and marks a peer as unhealthy if it does not pass certain checks.


The checks are:

1. Calculate 80th percentile of response durations from each peer and marks peers above the percentile as unhealthy
2. Calculate the most common storage radius and marks peers that have a different radius.
3. Calculate the most common batch commitment and marks peers that have a different commitment. 
4. Calculate 80th percentile of connected peers count and marks peers lower than the percentile. 

5. The agent stops the node from playing a round if the peer's radius is different from it's peers. 
### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
some logs 
```
"msg"="radius check failure" "radius"=0 "peer_address"="***"
"msg"="dur check failure" "dur"=4.9897606 "peer_address"="***"
"msg"="dur check failure" "dur"=5.2893351 "peer_address"="***"
"msg"="connections check failure" "connections"=15 "peer_address"="***"
"msg"="connections check failure" "connections"=8 "peer_address"="***"
"msg"="dur check failure" "dur"=0.8584196 "peer_address"="***"
"msg"="radius check failure" "radius"=0 "peer_address"="***"
```
