### PR TITLE
chore: switch to mainnet abi in unit tests

### DIFF
--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -32,7 +32,7 @@ var (
 
 var (
 	postageStampContractAddress = common.HexToAddress("eeee")
-	postageStampContractABI     = abiutil.MustParseABI(chaincfg.Testnet.PostageStampABI)
+	postageStampContractABI     = abiutil.MustParseABI(chaincfg.Mainnet.PostageStampABI)
 )
 
 const (

--- a/pkg/postage/postagecontract/contract_test.go
+++ b/pkg/postage/postagecontract/contract_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethersphere/bee/pkg/util/abiutil"
 )
 
-var postageStampContractABI = abiutil.MustParseABI(chaincfg.Testnet.PostageStampABI)
+var postageStampContractABI = abiutil.MustParseABI(chaincfg.Mainnet.PostageStampABI)
 
 func TestCreateBatch(t *testing.T) {
 	defer func(b uint8) {

--- a/pkg/storageincentives/redistribution/redistribution_test.go
+++ b/pkg/storageincentives/redistribution/redistribution_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethersphere/bee/pkg/util/testutil"
 )
 
-var redistributionContractABI = abiutil.MustParseABI(chaincfg.Testnet.RedistributionABI)
+var redistributionContractABI = abiutil.MustParseABI(chaincfg.Mainnet.RedistributionABI)
 
 func TestRedistribution(t *testing.T) {
 	t.Parallel()

--- a/pkg/storageincentives/staking/contract_test.go
+++ b/pkg/storageincentives/staking/contract_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethersphere/bee/pkg/util/abiutil"
 )
 
-var stakingContractABI = abiutil.MustParseABI(chaincfg.Testnet.StakingABI)
+var stakingContractABI = abiutil.MustParseABI(chaincfg.Mainnet.StakingABI)
 
 func TestDepositStake(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Changing ABIs used in unit tests from testnet to mainnet. 
From the standpoint of tests both should work, but using mainnet ABIs adds more value because those are more important to testnet's. 