### PR TITLE
fix(pushsync): include self in the case no neighbor can be found

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -48,7 +48,7 @@ const (
 )
 
 const (
-	nPeersToReplicate = 3 // number of peers to replicate to as receipt is sent upstream
+	nPeersToReplicate = 2 // number of peers to replicate to as receipt is sent upstream
 	maxPushErrors     = 32
 )
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -306,7 +306,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			retry()
 		case <-retryC:
 
-			// Origin peers should not store the chunk initially so that the chunks is always forwarded into the network.
+			// Origin peers should not store the chunk initially so that the chunk is always forwarded into the network.
 			// If no peer can be found from an origin peer, the origin peer may store the chunk.
 			// Non-origin peers store the chunk if the chunk is within depth.
 			// For non-origin peers, if the chunk is not within depth, they may store the chunk if they are the closest peer to the chunk.


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In the case that no neighbor peer can be found for a chunk, the closest peer should store the chunk.

1. Origin peers should not store the chunk initially so that the chunks is always forwarded into the network, 
2. If no peer can be found from an origin peer, the origin peer may store the chunk.
3. Non-origin peers store the chunk if the chunk is within depth.
4. For non-origin peers, if the chunk is not within depth, they may store the chunk if they are the closest peer to the chunk.

Puller continues to pull chunks from out of depth bins, so that these out of depth chunks eventually find their way into a proper neighborhood.

Pusher continues to check the depth of the receipt so for shallow receipts, the chunk is retried up to 5-6 times.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
