### PR TITLE
refactor: use leveldb in stamper

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ethersphere/bee/pkg/status"
 	"github.com/ethersphere/bee/pkg/steward"
 	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
 	testingc "github.com/ethersphere/bee/pkg/storage/testing"
 	"github.com/ethersphere/bee/pkg/storageincentives"
 	"github.com/ethersphere/bee/pkg/storageincentives/staking"
@@ -204,7 +205,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		o.BeeMode = api.FullMode
 	}
 
-	s := api.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.Logger, transaction, o.BatchStore, o.BeeMode, true, true, backend, o.CORSAllowedOrigins)
+	s := api.New(o.PublicKey, o.PSSPublicKey, o.EthereumAddress, o.Logger, transaction, o.BatchStore, o.BeeMode, true, true, backend, o.CORSAllowedOrigins, inmemstore.New())
 	testutil.CleanupCloser(t, s)
 
 	s.SetP2P(o.P2P)
@@ -389,7 +390,7 @@ func TestParseName(t *testing.T) {
 		pk, _ := crypto.GenerateSecp256k1Key()
 		signer := crypto.NewDefaultSigner(pk)
 
-		s := api.New(pk.PublicKey, pk.PublicKey, common.Address{}, log, nil, nil, 1, false, false, nil, []string{"*"})
+		s := api.New(pk.PublicKey, pk.PublicKey, common.Address{}, log, nil, nil, 1, false, false, nil, []string{"*"}, inmemstore.New())
 		s.Configure(signer, nil, nil, api.Options{}, api.ExtraOptions{Resolver: tC.res}, 1, nil)
 		s.MountAPI()
 

--- a/pkg/api/main_test.go
+++ b/pkg/api/main_test.go
@@ -17,5 +17,10 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/rjeczalik/notify.(*nonrecursiveTree).internal"),
 		goleak.IgnoreTopFunction("github.com/rjeczalik/notify.(*recursiveTree).dispatch"),
 		goleak.IgnoreTopFunction("github.com/rjeczalik/notify._Cfunc_CFRunLoopRun"),
+		goleak.IgnoreTopFunction("github.com/syndtr/goleveldb/leveldb.(*DB).compactionError"),
+		goleak.IgnoreTopFunction("github.com/syndtr/goleveldb/leveldb.(*DB).tCompaction"),
+		goleak.IgnoreTopFunction("github.com/syndtr/goleveldb/leveldb.(*DB).mCompaction"),
+		goleak.IgnoreTopFunction("github.com/syndtr/goleveldb/leveldb.(*session).refLoop"),
+		goleak.IgnoreTopFunction("github.com/syndtr/goleveldb/leveldb.(*DB).mpoolDrain"),
 	)
 }

--- a/pkg/api/pss.go
+++ b/pkg/api/pss.go
@@ -99,7 +99,7 @@ func (s *Service) pssPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	stamper := postage.NewStamper(i, s.signer)
+	stamper := postage.NewStamper(s.stamperStore, i, s.signer)
 
 	err = s.pss.Send(r.Context(), topic, payload, stamper, queries.Recipient, targets)
 	if err != nil {

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -43,6 +43,7 @@ import (
 	swapmock "github.com/ethersphere/bee/pkg/settlement/swap/mock"
 	"github.com/ethersphere/bee/pkg/statestore/leveldb"
 	mockSteward "github.com/ethersphere/bee/pkg/steward/mock"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
 	"github.com/ethersphere/bee/pkg/storageincentives/staking"
 	stakingContractMock "github.com/ethersphere/bee/pkg/storageincentives/staking/mock"
 	storer "github.com/ethersphere/bee/pkg/storer"
@@ -201,7 +202,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 			return nil, fmt.Errorf("debug api listener: %w", err)
 		}
 
-		debugApiService = api.New(mockKey.PublicKey, mockKey.PublicKey, overlayEthAddress, logger, mockTransaction, batchStore, api.DevMode, true, true, chainBackend, o.CORSAllowedOrigins)
+		debugApiService = api.New(mockKey.PublicKey, mockKey.PublicKey, overlayEthAddress, logger, mockTransaction, batchStore, api.DevMode, true, true, chainBackend, o.CORSAllowedOrigins, inmemstore.New())
 		debugAPIServer := &http.Server{
 			IdleTimeout:       30 * time.Second,
 			ReadHeaderTimeout: 3 * time.Second,
@@ -387,7 +388,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		}),
 	)
 
-	apiService := api.New(mockKey.PublicKey, mockKey.PublicKey, overlayEthAddress, logger, mockTransaction, batchStore, api.DevMode, true, true, chainBackend, o.CORSAllowedOrigins)
+	apiService := api.New(mockKey.PublicKey, mockKey.PublicKey, overlayEthAddress, logger, mockTransaction, batchStore, api.DevMode, true, true, chainBackend, o.CORSAllowedOrigins, inmemstore.New())
 
 	apiService.Configure(signer, authenticator, tracer, api.Options{
 		CORSAllowedOrigins: o.CORSAllowedOrigins,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -377,6 +377,11 @@ func NewBee(
 		}
 	}(probe)
 
+	stamperStore, err := InitStamperStore(logger, o.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize stamper store: %w", err)
+	}
+
 	var debugService *api.Service
 
 	if o.DebugAPIAddr != "" {
@@ -405,6 +410,7 @@ func NewBee(
 			o.SwapEnable,
 			chainBackend,
 			o.CORSAllowedOrigins,
+			stamperStore,
 		)
 		debugService.MountTechnicalDebug()
 		debugService.SetProbe(probe)
@@ -443,6 +449,7 @@ func NewBee(
 			o.SwapEnable,
 			chainBackend,
 			o.CORSAllowedOrigins,
+			stamperStore,
 		)
 		apiService.MountTechnicalDebug()
 		apiService.SetProbe(probe)
@@ -1098,7 +1105,7 @@ func NewBee(
 
 	if o.APIAddr != "" {
 		if apiService == nil {
-			apiService = api.New(*publicKey, pssPrivateKey.PublicKey, overlayEthAddress, logger, transactionService, batchStore, beeNodeMode, o.ChequebookEnable, o.SwapEnable, chainBackend, o.CORSAllowedOrigins)
+			apiService = api.New(*publicKey, pssPrivateKey.PublicKey, overlayEthAddress, logger, transactionService, batchStore, beeNodeMode, o.ChequebookEnable, o.SwapEnable, chainBackend, o.CORSAllowedOrigins, stamperStore)
 			apiService.SetProbe(probe)
 			apiService.SetRedistributionAgent(agent)
 		}

--- a/pkg/node/statestore.go
+++ b/pkg/node/statestore.go
@@ -7,8 +7,9 @@ package node
 import (
 	"errors"
 	"fmt"
-	"github.com/ethersphere/bee/pkg/storage/leveldbstore"
 	"path/filepath"
+
+	"github.com/ethersphere/bee/pkg/storage/leveldbstore"
 
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/storage"
@@ -29,6 +30,18 @@ func InitStateStore(logger log.Logger, dataDir string) (storage.StateStorer, err
 		return nil, err
 	}
 	return storage.NewStateStorerAdapter(ldb), nil
+}
+
+// InitStamperStore will create new stamper store with the given path to the
+// data directory. When given an empty directory path, the function will instead
+// initialize an in-memory state store that will not be persisted.
+func InitStamperStore(logger log.Logger, dataDir string) (storage.Store, error) {
+	if dataDir == "" {
+		logger.Warning("using in-mem stamper store, no node state will be persisted")
+	} else {
+		dataDir = filepath.Join(dataDir, "stamperstore")
+	}
+	return leveldbstore.New(dataDir, nil)
 }
 
 const noncedOverlayKey = "nonce-overlay"

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 
 	"github.com/ethersphere/bee/pkg/storage"
-	"github.com/ethersphere/bee/pkg/storage/inmemstore"
 )
 
 const (
@@ -63,7 +62,6 @@ func NewService(store storage.StateStorer, postageStore Storer, chainID int64) (
 		if err := st.UnmarshalBinary(value); err != nil {
 			return false, err
 		}
-		st.store = inmemstore.New()
 		_ = s.add(st)
 		return false, nil
 	}); err != nil {

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/postage/batchstore/mock"
 	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
 	chunktesting "github.com/ethersphere/bee/pkg/storage/testing"
 )
 
@@ -77,7 +78,7 @@ func TestValidStamp(t *testing.T) {
 	bs := mock.New(mock.WithBatch(b))
 	signer := crypto.NewDefaultSigner(privKey)
 	issuer := postage.NewStampIssuer("label", "keyID", b.ID, big.NewInt(3), b.Depth, b.BucketDepth, 1000, true)
-	stamper := postage.NewStamper(issuer, signer)
+	stamper := postage.NewStamper(inmemstore.New(), issuer, signer)
 
 	// this creates a chunk with a mocked stamp. ValidStamp will override this
 	// stamp on execution

--- a/pkg/postage/stamper_test.go
+++ b/pkg/postage/stamper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/postage"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -40,7 +41,7 @@ func TestStamperStamping(t *testing.T) {
 	// tests a valid stamp
 	t.Run("valid stamp", func(t *testing.T) {
 		st := newTestStampIssuer(t, 1000)
-		stamper := postage.NewStamper(st, signer)
+		stamper := postage.NewStamper(inmemstore.New(), st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		if err := stamp.Valid(chunkAddr, owner, 12, 8, true); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -50,7 +51,7 @@ func TestStamperStamping(t *testing.T) {
 	// tests that Stamps returns with postage.ErrBucketMismatch
 	t.Run("bucket mismatch", func(t *testing.T) {
 		st := newTestStampIssuer(t, 1000)
-		stamper := postage.NewStamper(st, signer)
+		stamper := postage.NewStamper(inmemstore.New(), st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		a := chunkAddr.Bytes()
 		a[0] ^= 0xff
@@ -62,7 +63,7 @@ func TestStamperStamping(t *testing.T) {
 	// tests that Stamps returns with postage.ErrInvalidIndex
 	t.Run("invalid index", func(t *testing.T) {
 		st := newTestStampIssuer(t, 1000)
-		stamper := postage.NewStamper(st, signer)
+		stamper := postage.NewStamper(inmemstore.New(), st, signer)
 		// issue 1 stamp
 		chunkAddr, _ := createStamp(t, stamper)
 		// issue another 15
@@ -86,7 +87,7 @@ func TestStamperStamping(t *testing.T) {
 	// issuer has the corresponding collision bucket filled]
 	t.Run("bucket full", func(t *testing.T) {
 		st := postage.NewStampIssuer("", "", newTestStampIssuer(t, 1000).ID(), big.NewInt(3), 12, 8, 1000, true)
-		stamper := postage.NewStamper(st, signer)
+		stamper := postage.NewStamper(inmemstore.New(), st, signer)
 		// issue 1 stamp
 		chunkAddr, _ := createStamp(t, stamper)
 		// issue another 15
@@ -107,7 +108,7 @@ func TestStamperStamping(t *testing.T) {
 	t.Run("owner mismatch", func(t *testing.T) {
 		owner[0] ^= 0xff // bitflip the owner first byte, this case must come last!
 		st := newTestStampIssuer(t, 1000)
-		stamper := postage.NewStamper(st, signer)
+		stamper := postage.NewStamper(inmemstore.New(), st, signer)
 		chunkAddr, stamp := createStamp(t, stamper)
 		if err := stamp.Valid(chunkAddr, owner, 12, 8, true); !errors.Is(err, postage.ErrOwnerMismatch) {
 			t.Fatalf("expected ErrOwnerMismatch, got %v", err)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Use leveldb instead of in-memory db in the stamper.
