### PR TITLE
feat(kademlia): prune out of depth oversaturated bins based on peer health

### DIFF
--- a/pkg/api/status.go
+++ b/pkg/api/status.go
@@ -136,7 +136,7 @@ func (s *Service) statusGetPeersHandler(w http.ResponseWriter, r *http.Request) 
 
 	err := s.topologyDriver.EachConnectedPeer(
 		peerFunc,
-		topology.Filter{},
+		topology.Select{},
 	)
 	if err != nil {
 		logger.Debug("status snapshot", "error", err)

--- a/pkg/api/status_test.go
+++ b/pkg/api/status_test.go
@@ -93,11 +93,11 @@ func TestGetStatus(t *testing.T) {
 // topologyPeersIterNoopMock is noop topology.PeerIterator.
 type topologyPeersIterNoopMock struct{}
 
-func (m *topologyPeersIterNoopMock) EachConnectedPeer(_ topology.EachPeerFunc, _ topology.Filter) error {
+func (m *topologyPeersIterNoopMock) EachConnectedPeer(_ topology.EachPeerFunc, _ topology.Select) error {
 	return nil
 }
 
-func (m *topologyPeersIterNoopMock) EachConnectedPeerRev(_ topology.EachPeerFunc, _ topology.Filter) error {
+func (m *topologyPeersIterNoopMock) EachConnectedPeerRev(_ topology.EachPeerFunc, _ topology.Select) error {
 	return nil
 }
 func (m *topologyPeersIterNoopMock) IsReachable() bool {

--- a/pkg/chainsyncer/chainsyncer.go
+++ b/pkg/chainsyncer/chainsyncer.go
@@ -163,7 +163,7 @@ func (c *ChainSyncer) manage() {
 				atomic.AddInt32(&positives, 1)
 			}(p)
 			return false, false, nil
-		}, topology.Filter{Reachable: true})
+		}, topology.Select{Reachable: true})
 
 		// wait for all operations to finish
 		wg.Wait()

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -283,7 +283,7 @@ func waitPeers(kad *kademlia.Kad) error {
 		_ = kad.EachConnectedPeer(func(_ swarm.Address, _ uint8) (bool, bool, error) {
 			count++
 			return false, false, nil
-		}, topology.Filter{})
+		}, topology.Select{})
 		return count >= minPeersCount
 	})
 }

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -189,7 +189,7 @@ func (p *Puller) recalcPeers(ctx context.Context, storageRadius uint8) {
 		peer.Lock()
 		err := p.syncPeer(ctx, peer, storageRadius)
 		if err != nil {
-			p.logger.Error(err, "recalc peers sync failed", "bin", storageRadius, "peer", peer.address)
+			p.logger.Debug("recalc peers sync failed", "bin", storageRadius, "peer", peer.address, "error", err)
 		}
 		peer.Unlock()
 	}

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -142,7 +142,7 @@ func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 			}
 			delete(peersDisconnected, addr.ByteString())
 			return false, false, nil
-		}, topology.Filter{})
+		}, topology.Select{})
 
 		for _, peer := range peersDisconnected {
 			p.disconnectPeer(peer.address)

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -316,7 +316,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			// If no peer can be found from an origin peer, the origin peer may store the chunk.
 			// Non-origin peers store the chunk if the chunk is within depth.
 			// For non-origin peers, if the chunk is not within depth, they may store the chunk if they are the closest peer to the chunk.
-			peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), ps.fullNode && !origin, topology.Filter{Reachable: true, Healthy: true}, ps.skipList.ChunkPeers(ch.Address())...)
+			peer, err := ps.topologyDriver.ClosestPeer(ch.Address(), ps.fullNode && !origin, topology.Select{Reachable: true, Healthy: true}, ps.skipList.ChunkPeers(ch.Address())...)
 
 			if errors.Is(err, topology.ErrNotFound) {
 				if ps.skipList.PruneExpiresAfter(ch.Address(), overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -358,7 +358,7 @@ func (s *Service) prepareCredit(ctx context.Context, peer, chunk swarm.Address, 
 // retrieve request.
 func (s *Service) closestPeer(addr swarm.Address, skipPeers []swarm.Address, allowUpstream bool) (swarm.Address, error) {
 
-	closest, err := s.peerSuggester.ClosestPeer(addr, false, topology.Filter{Reachable: true}, skipPeers...)
+	closest, err := s.peerSuggester.ClosestPeer(addr, false, topology.Select{Reachable: true}, skipPeers...)
 	if err != nil {
 		return swarm.Address{}, err
 	}

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -150,7 +150,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 			mtx.Unlock()
 		}()
 		return false, false, nil
-	}, topology.Filter{})
+	}, topology.Select{})
 
 	wg.Wait()
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,7 +63,7 @@ func (s *Service) LocalSnapshot() (*Snapshot, error) {
 			}
 			return false, false, nil
 		},
-		topology.Filter{},
+		topology.Select{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("iterate connected peers: %w", err)
@@ -152,7 +152,7 @@ func (s *Service) handler(ctx context.Context, _ p2p.Peer, stream p2p.Stream) er
 			}
 			return false, false, nil
 		},
-		topology.Filter{},
+		topology.Select{},
 	)
 	if err != nil {
 		s.logger.Error(err, "iteration of connected peers failed")

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -93,11 +93,11 @@ func TestStatus(t *testing.T) {
 // topologyPeersIterNoopMock is noop topology.PeerIterator.
 type topologyPeersIterNoopMock struct{}
 
-func (m *topologyPeersIterNoopMock) EachConnectedPeer(_ topology.EachPeerFunc, _ topology.Filter) error {
+func (m *topologyPeersIterNoopMock) EachConnectedPeer(_ topology.EachPeerFunc, _ topology.Select) error {
 	return nil
 }
 
-func (m *topologyPeersIterNoopMock) EachConnectedPeerRev(_ topology.EachPeerFunc, _ topology.Filter) error {
+func (m *topologyPeersIterNoopMock) EachConnectedPeerRev(_ topology.EachPeerFunc, _ topology.Select) error {
 	return nil
 }
 

--- a/pkg/topology/depthmonitor/depthmonitor.go
+++ b/pkg/topology/depthmonitor/depthmonitor.go
@@ -152,7 +152,7 @@ func (s *Service) manage(warmupTime, wakeupInterval time.Duration, freshNode boo
 		}
 
 		// if historical syncing rate is at zero, we proactively decrease the storage radius to allow nodes to widen their neighbourhoods
-		if rate == 0 && s.topology.PeersCount(topologyDriver.Filter{}) != 0 {
+		if rate == 0 && s.topology.PeersCount(topologyDriver.Select{}) != 0 {
 			err = s.bs.SetStorageRadius(func(radius uint8) uint8 {
 				if radius > s.minimumRadius {
 					radius--

--- a/pkg/topology/depthmonitor/depthmonitor_test.go
+++ b/pkg/topology/depthmonitor/depthmonitor_test.go
@@ -193,7 +193,7 @@ func (m *mockTopology) SetStorageRadius(newDepth uint8) {
 	m.storageDepth = newDepth
 }
 
-func (m *mockTopology) PeersCount(topology.Filter) int {
+func (m *mockTopology) PeersCount(topology.Select) int {
 	return m.peers
 }
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -703,6 +703,9 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 		}
 
 		binPeersCount := k.connectedPeers.BinSize(uint8(i))
+		if binPeersCount <= k.opt.OverSaturationPeers {
+			continue
+		}
 
 		for j := 0; j < len(k.commonBinPrefixes[i]) && k.connectedPeers.BinSize(uint8(i)) > k.opt.OverSaturationPeers; j++ {
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -702,13 +702,9 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 			return
 		}
 
-		for j := 0; j < len(k.commonBinPrefixes[i]); j++ {
+		binPeersCount := k.connectedPeers.BinSize(uint8(i))
 
-			binPeersCount := k.connectedPeers.BinSize(uint8(i))
-
-			if binPeersCount <= k.opt.OverSaturationPeers {
-				break
-			}
+		for j := 0; j < len(k.commonBinPrefixes[i]) && k.connectedPeers.BinSize(uint8(i)) > k.opt.OverSaturationPeers; j++ {
 
 			binPeers := k.connectedPeers.BinPeers(uint8(i))
 			peers := k.balancedSlotPeers(k.commonBinPrefixes[i][j], binPeers, i)
@@ -738,13 +734,13 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 				}
 			}
 
-			k.logger.Debug("pruning", "bin", i, "binSize", binPeersCount, "peer_address", disconnectPeer)
-
 			err := k.p2p.Disconnect(disconnectPeer, "pruned from oversaturated bin")
 			if err != nil {
 				k.logger.Debug("prune disconnect failed", "error", err)
 			}
 		}
+
+		k.logger.Debug("pruning", "bin", i, "oldBinSize", binPeersCount, "newBinSize", k.connectedPeers.BinSize(uint8(i)))
 	}
 }
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -729,7 +729,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 				}
 			}
 
-			if disconnectPeer.IsEmpty() {
+			if disconnectPeer.IsZero() {
 				if unreachablePeer.IsZero() {
 					disconnectPeer = peers[0] // pick any peer
 				} else {

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -53,7 +53,7 @@ const (
 
 // Default option values
 const (
-	defaultBitSuffixLength             = 4 // the number of bits used to create pseudo addresses for balancing
+	defaultBitSuffixLength             = 4 // the number of bits used to create pseudo addresses for balancing, 2^4, 16 addresses
 	defaultLowWaterMark                = 3 // the number of peers in consecutive deepest bins that constitute as nearest neighbours
 	defaultSaturationPeers             = 8
 	defaultOverSaturationPeers         = 20

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"net"
 	"sync"
 	"syscall"
@@ -731,7 +732,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 
 			if disconnectPeer.IsZero() {
 				if unreachablePeer.IsZero() {
-					disconnectPeer = peers[0] // pick any peer
+					disconnectPeer = peers[rand.Intn(len(peers))]
 				} else {
 					disconnectPeer = unreachablePeer // pick unrechable peer
 				}

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -693,7 +693,7 @@ func (k *Kad) recordPeerLatencies(ctx context.Context) {
 }
 
 // pruneOversaturatedBins disconnects out of depth peers from oversaturated bins
-// while maintaining the balance of the bin and favoring peers with longers connections
+// while maintaining the balance of the bin and favoring healthy and reachable peers.
 func (k *Kad) pruneOversaturatedBins(depth uint8) {
 
 	for i := range k.commonBinPrefixes {
@@ -702,42 +702,45 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 			return
 		}
 
-		binPeersCount := k.connectedPeers.BinSize(uint8(i))
-		if binPeersCount <= k.opt.OverSaturationPeers {
-			continue
-		}
-
-		binPeers := k.connectedPeers.BinPeers(uint8(i))
-
-		k.logger.Debug("starting pruning", "bin", i, "binSize", binPeersCount)
-
 		for j := 0; j < len(k.commonBinPrefixes[i]); j++ {
 
-			if k.connectedPeers.BinSize(uint8(i)) <= k.opt.OverSaturationPeers {
+			binPeersCount := k.connectedPeers.BinSize(uint8(i))
+
+			if binPeersCount <= k.opt.OverSaturationPeers {
 				break
 			}
 
-			pseudoAddr := k.commonBinPrefixes[i][j]
-			peers := k.balancedSlotPeers(pseudoAddr, binPeers, i)
-
+			binPeers := k.connectedPeers.BinPeers(uint8(i))
+			peers := k.balancedSlotPeers(k.commonBinPrefixes[i][j], binPeers, i)
 			if len(peers) <= 1 {
 				continue
 			}
 
-			var smallestDuration time.Duration
-			var newestPeer swarm.Address
+			var disconnectPeer = swarm.ZeroAddress
+			var unreachablePeer = swarm.ZeroAddress
 			for _, peer := range peers {
-				ss := k.collector.Inspect(peer)
-				if ss == nil {
-					continue
-				}
-				duration := ss.SessionConnectionDuration
-				if smallestDuration == 0 || duration < smallestDuration {
-					smallestDuration = duration
-					newestPeer = peer
+				if ss := k.collector.Inspect(peer); ss != nil {
+					if !ss.Healthy {
+						disconnectPeer = peer
+						break
+					}
+					if ss.Reachability != p2p.ReachabilityStatusPublic {
+						unreachablePeer = peer
+					}
 				}
 			}
-			err := k.p2p.Disconnect(newestPeer, "pruned from oversaturated bin")
+
+			if disconnectPeer.IsEmpty() {
+				if unreachablePeer.IsZero() {
+					disconnectPeer = peers[0] // pick any peer
+				} else {
+					disconnectPeer = unreachablePeer // pick unrechable peer
+				}
+			}
+
+			k.logger.Debug("pruning", "bin", i, "binSize", binPeersCount, "peer_address", disconnectPeer)
+
+			err := k.p2p.Disconnect(disconnectPeer, "pruned from oversaturated bin")
 			if err != nil {
 				k.logger.Debug("prune disconnect failed", "error", err)
 			}
@@ -1153,7 +1156,7 @@ func (k *Kad) binReachablePeers(bin uint8) (peers []swarm.Address) {
 
 		return false, true, nil
 
-	}, topology.Filter{Reachable: true})
+	}, topology.Select{Reachable: true})
 
 	return
 }
@@ -1267,7 +1270,7 @@ func (k *Kad) IsReachable() bool {
 }
 
 // ClosestPeer returns the closest peer to a given address.
-func (k *Kad) ClosestPeer(addr swarm.Address, includeSelf bool, filter topology.Filter, skipPeers ...swarm.Address) (swarm.Address, error) {
+func (k *Kad) ClosestPeer(addr swarm.Address, includeSelf bool, filter topology.Select, skipPeers ...swarm.Address) (swarm.Address, error) {
 	if k.connectedPeers.Length() == 0 {
 		return swarm.Address{}, topology.ErrNotFound
 	}
@@ -1315,7 +1318,7 @@ func (k *Kad) ClosestPeer(addr swarm.Address, includeSelf bool, filter topology.
 }
 
 // EachConnectedPeer implements topology.PeerIterator interface.
-func (k *Kad) EachConnectedPeer(f topology.EachPeerFunc, filter topology.Filter) error {
+func (k *Kad) EachConnectedPeer(f topology.EachPeerFunc, filter topology.Select) error {
 	filters := filterOps(filter)
 
 	return k.connectedPeers.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
@@ -1327,7 +1330,7 @@ func (k *Kad) EachConnectedPeer(f topology.EachPeerFunc, filter topology.Filter)
 }
 
 // EachConnectedPeerRev implements topology.PeerIterator interface.
-func (k *Kad) EachConnectedPeerRev(f topology.EachPeerFunc, filter topology.Filter) error {
+func (k *Kad) EachConnectedPeerRev(f topology.EachPeerFunc, filter topology.Select) error {
 	filters := filterOps(filter)
 	return k.connectedPeers.EachBinRev(func(addr swarm.Address, po uint8) (bool, bool, error) {
 		if len(filters) > 0 && k.opt.FilterFunc(filters...)(addr) {
@@ -1336,7 +1339,7 @@ func (k *Kad) EachConnectedPeerRev(f topology.EachPeerFunc, filter topology.Filt
 		return f(addr, po)
 	})
 }
-func (k *Kad) PeersCount(filter topology.Filter) int {
+func (k *Kad) PeersCount(filter topology.Select) int {
 	return k.connectedPeers.Length()
 }
 
@@ -1399,7 +1402,7 @@ func (k *Kad) SubscribeTopologyChange() (c <-chan struct{}, unsubscribe func()) 
 	return channel, unsubscribe
 }
 
-func filterOps(filter topology.Filter) []im.FilterOp {
+func filterOps(filter topology.Select) []im.FilterOp {
 
 	ops := make([]im.FilterOp, 0, 2)
 

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -701,7 +701,7 @@ func TestNotifierHooks(t *testing.T) {
 
 	connectOne(t, signer, kad, ab, peer, nil)
 
-	p, err := kad.ClosestPeer(addr, true, topology.Filter{})
+	p, err := kad.ClosestPeer(addr, true, topology.Select{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -712,7 +712,7 @@ func TestNotifierHooks(t *testing.T) {
 
 	// disconnect the peer, expect error
 	kad.Disconnected(p2p.Peer{Address: peer})
-	_, err = kad.ClosestPeer(addr, true, topology.Filter{})
+	_, err = kad.ClosestPeer(addr, true, topology.Select{})
 	if !errors.Is(err, topology.ErrNotFound) {
 		t.Fatalf("expected topology.ErrNotFound but got %v", err)
 	}
@@ -1032,7 +1032,7 @@ func TestClosestPeer(t *testing.T) {
 			includeSelf:  false,
 		},
 	} {
-		peer, err := kad.ClosestPeer(tc.chunkAddress, tc.includeSelf, topology.Filter{})
+		peer, err := kad.ClosestPeer(tc.chunkAddress, tc.includeSelf, topology.Select{})
 		if err != nil {
 			if tc.expectedPeer == -1 && !errors.Is(err, topology.ErrWantSelf) {
 				t.Fatalf("wanted %v but got %v", topology.ErrWantSelf, err)
@@ -1505,7 +1505,7 @@ func TestBootnodeProtectedNodes(t *testing.T) {
 				return true, false, nil
 			}
 			return false, false, nil
-		}, topology.Filter{})
+		}, topology.Select{})
 		if !found {
 			t.Fatalf("protected node %s not found in connected list", pn)
 		}
@@ -1689,7 +1689,7 @@ func TestIteratorOpts(t *testing.T) {
 			kad.UpdatePeerHealth(addr, true)
 		}
 		return false, false, nil
-	}, topology.Filter{})
+	}, topology.Select{})
 
 	t.Run("EachConnectedPeer reachable", func(t *testing.T) {
 		t.Parallel()
@@ -1701,7 +1701,7 @@ func TestIteratorOpts(t *testing.T) {
 			}
 			count++
 			return false, false, nil
-		}, topology.Filter{Reachable: true})
+		}, topology.Select{Reachable: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1720,7 +1720,7 @@ func TestIteratorOpts(t *testing.T) {
 			}
 			count++
 			return false, false, nil
-		}, topology.Filter{Healthy: true})
+		}, topology.Select{Healthy: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1739,7 +1739,7 @@ func TestIteratorOpts(t *testing.T) {
 				t.Fatal("iterator returned incorrect peer")
 			}
 			return false, false, nil
-		}, topology.Filter{Reachable: true, Healthy: true})
+		}, topology.Select{Reachable: true, Healthy: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1755,7 +1755,7 @@ func TestIteratorOpts(t *testing.T) {
 			}
 			count++
 			return false, false, nil
-		}, topology.Filter{Reachable: true})
+		}, topology.Select{Reachable: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1774,7 +1774,7 @@ func TestIteratorOpts(t *testing.T) {
 			}
 			count++
 			return false, false, nil
-		}, topology.Filter{Healthy: true})
+		}, topology.Select{Healthy: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1793,7 +1793,7 @@ func TestIteratorOpts(t *testing.T) {
 				t.Fatal("iterator returned incorrect peer")
 			}
 			return false, false, nil
-		}, topology.Filter{Reachable: true, Healthy: true})
+		}, topology.Select{Reachable: true, Healthy: true})
 		if err != nil {
 			t.Fatal("iterator returned error")
 		}
@@ -1877,7 +1877,7 @@ func binSizes(kad *kademlia.Kad) []int {
 	_ = kad.EachConnectedPeer(func(a swarm.Address, u uint8) (stop bool, jumpToNext bool, err error) {
 		bins[u]++
 		return false, false, nil
-	}, topology.Filter{})
+	}, topology.Select{})
 
 	return bins
 }
@@ -2085,7 +2085,7 @@ func waitPeers(t *testing.T, k *kademlia.Kad, peers int) {
 		_ = k.EachConnectedPeer(func(_ swarm.Address, _ uint8) (bool, bool, error) {
 			i++
 			return false, false, nil
-		}, topology.Filter{})
+		}, topology.Select{})
 		return i == peers
 	})
 	if err != nil {

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -65,7 +65,7 @@ func (m *Mock) AddPeers(addr ...swarm.Address) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) ClosestPeer(addr swarm.Address, _ bool, _ topology.Filter, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (m *Mock) ClosestPeer(addr swarm.Address, _ bool, _ topology.Select, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -82,7 +82,7 @@ func (m *Mock) UpdatePeerHealth(swarm.Address, bool) {
 }
 
 // PeerIterator iterates from closest bin to farthest
-func (m *Mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) error {
+func (m *Mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Select) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -99,7 +99,7 @@ func (m *Mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) err
 }
 
 // EachPeerRev iterates from farthest bin to closest
-func (m *Mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Filter) error {
+func (m *Mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Select) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	for _, v := range m.eachPeerRev {

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -125,7 +125,7 @@ func (d *mock) Peers() []swarm.Address {
 	return d.peers
 }
 
-func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, _ topology.Filter, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
+func (d *mock) ClosestPeer(addr swarm.Address, wantSelf bool, _ topology.Select, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error) {
 	if len(skipPeers) == 0 {
 		if d.closestPeerErr != nil {
 			return d.closestPeer, d.closestPeerErr
@@ -188,7 +188,7 @@ func (m *mock) NeighborhoodDepth() uint8 {
 }
 
 // EachConnectedPeer implements topology.PeerIterator interface.
-func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) (err error) {
+func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Select) (err error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -207,7 +207,7 @@ func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Filter) (er
 }
 
 // EachConnectedPeerRev implements topology.PeerIterator interface.
-func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Filter) (err error) {
+func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Select) (err error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -58,7 +58,8 @@ type PeerIterator interface {
 	EachConnectedPeerRev(EachPeerFunc, Select) error
 }
 
-// Select defines the different filters that can be used with the Peer iterators
+// Select defines the different filters that can be used with the Peer iterators.
+// The fields only take effect if set to true. The logical AND operator is applied to multiple selected fields.
 type Select struct {
 	Reachable bool
 	Healthy   bool

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -45,21 +45,21 @@ type ClosestPeerer interface {
 	// given chunk address.
 	// This function will ignore peers with addresses provided in skipPeers.
 	// Returns topology.ErrWantSelf in case base is the closest to the address.
-	ClosestPeer(addr swarm.Address, includeSelf bool, f Filter, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
+	ClosestPeer(addr swarm.Address, includeSelf bool, f Select, skipPeers ...swarm.Address) (peerAddr swarm.Address, err error)
 }
 
 // PeerIterator is an interface that allows iteration over peers.
 type PeerIterator interface {
 	// EachConnectedPeer iterates through connected
 	// peers from the closest bin to the farthest.
-	EachConnectedPeer(EachPeerFunc, Filter) error
+	EachConnectedPeer(EachPeerFunc, Select) error
 	// EachConnectedPeerRev iterates through connected
 	// peers from the farthest bin to the closest.
-	EachConnectedPeerRev(EachPeerFunc, Filter) error
+	EachConnectedPeerRev(EachPeerFunc, Select) error
 }
 
-// Filter defines the different filters that can be used with the Peer iterators
-type Filter struct {
+// Select defines the different filters that can be used with the Peer iterators
+type Select struct {
 	Reachable bool
 	Healthy   bool
 }
@@ -155,5 +155,5 @@ type SetStorageRadiuser interface {
 }
 
 type PeersCounter interface {
-	PeersCount(Filter) int
+	PeersCount(Select) int
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
pruning out of depth and oversaturated bins is for unhealthy or reachable peers.

renamed topology.Filter -> topology.Select

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
