### PR TITLE
chore(puller, pullsync): remove 24 wait period for puller, new metrics, cleanup

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -981,7 +981,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 	)
 
 	if o.FullNodeMode && !o.BootnodeMode {
-		pullerService = puller.New(stateStore, kad, batchStore, pullSyncProtocol, p2ps, logger, puller.Options{SyncSleepDur: puller.DefaultSyncErrorSleepDur, ShallowBinsWarmupDur: puller.DefaultShallowBinsWarmupDur}, warmupTime)
+		pullerService = puller.New(stateStore, kad, batchStore, pullSyncProtocol, p2ps, logger, puller.Options{}, warmupTime)
 		b.pullerCloser = pullerService
 
 		depthMonitor := depthmonitor.New(kad, pullSyncProtocol, storer, batchStore, logger, warmupTime, depthmonitor.DefaultWakeupInterval, !batchStoreExists)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -927,7 +927,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 
 	pullStorage := pullstorage.New(storer, logger)
 
-	pullSyncProtocol := pullsync.New(p2ps, pullStorage, pssService.TryUnwrap, validStamp, logger, batchStore, swarmAddress)
+	pullSyncProtocol := pullsync.New(p2ps, pullStorage, pssService.TryUnwrap, validStamp, logger, batchStore)
 	b.pullSyncCloser = pullSyncProtocol
 
 	retrieveProtocolSpec := retrieve.Protocol()

--- a/pkg/puller/metrics.go
+++ b/pkg/puller/metrics.go
@@ -16,6 +16,7 @@ type metrics struct {
 	LiveWorkerIterCounter prometheus.Counter // counts the number of live syncing iterations
 	LiveWorkerErrCounter  prometheus.Counter // count number of errors
 	MaxUintErrCounter     prometheus.Counter // how many times we got maxuint as topmost
+	HistSyncTimeout       prometheus.Counter // counts the number of historical syncing timeouts
 }
 
 func newMetrics() metrics {
@@ -57,6 +58,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "max_uint_errors",
 			Help:      "Total max uint errors.",
+		}),
+		HistSyncTimeout: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "hist_sync_timeout",
+			Help:      "Count of timeouts of historical sync request.",
 		}),
 	}
 }

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -788,8 +788,7 @@ func newPuller(t *testing.T, ops opts) (*puller.Puller, storage.StateStorer, *ka
 	logger := log.Noop
 
 	o := puller.Options{
-		Bins:         ops.bins,
-		SyncSleepDur: ops.syncSleepDur,
+		Bins: ops.bins,
 	}
 	p := puller.New(s, kad, bs, ps, nil, logger, o, 0)
 

--- a/pkg/pullsync/metrics.go
+++ b/pkg/pullsync/metrics.go
@@ -13,7 +13,7 @@ type metrics struct {
 	Offered       prometheus.Counter     // number of chunks offered
 	Wanted        prometheus.Counter     // number of chunks wanted
 	Delivered     prometheus.Counter     // number of chunk deliveries
-	DbOps         prometheus.Counter     // number of db ops
+	Sent          prometheus.Counter     // number of chunks sent
 	DuplicateRuid prometheus.Counter     // number of duplicate RUID requests we got
 	LastReceived  *prometheus.CounterVec // last timestamp of the received chunks per bin
 }
@@ -40,11 +40,11 @@ func newMetrics() metrics {
 			Name:      "chunks_delivered",
 			Help:      "Total chunks delivered.",
 		}),
-		DbOps: prometheus.NewCounter(prometheus.CounterOpts{
+		Sent: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "db_ops",
-			Help:      "Total Db Ops.",
+			Name:      "chunks_sent",
+			Help:      "Total chunks sent.",
 		}),
 		DuplicateRuid: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pullsync/metrics.go
+++ b/pkg/pullsync/metrics.go
@@ -10,12 +10,12 @@ import (
 )
 
 type metrics struct {
-	Offered       prometheus.Counter   // number of chunks offered
-	Wanted        prometheus.Counter   // number of chunks wanted
-	Delivered     prometheus.Counter   // number of chunk deliveries
-	DbOps         prometheus.Counter   // number of db ops
-	DuplicateRuid prometheus.Counter   // number of duplicate RUID requests we got
-	LastReceived  *prometheus.GaugeVec // last timestamp of the received chunks per bin
+	Offered       prometheus.Counter     // number of chunks offered
+	Wanted        prometheus.Counter     // number of chunks wanted
+	Delivered     prometheus.Counter     // number of chunk deliveries
+	DbOps         prometheus.Counter     // number of db ops
+	DuplicateRuid prometheus.Counter     // number of duplicate RUID requests we got
+	LastReceived  *prometheus.CounterVec // last timestamp of the received chunks per bin
 }
 
 func newMetrics() metrics {
@@ -52,8 +52,8 @@ func newMetrics() metrics {
 			Name:      "duplicate_ruids",
 			Help:      "Total duplicate RUIDs.",
 		}),
-		LastReceived: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
+		LastReceived: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
 				Name:      "last_received",

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -256,7 +256,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		if err := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
 			return 0, errors.Join(chunkErr, fmt.Errorf("delivery put: %w", err))
 		}
-		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Set(float64(time.Now().UnixMilli()))
+		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Inc()
 	}
 
 	return topmost, chunkErr

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -248,7 +248,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		}
 
 		s.metrics.Delivered.Add(float64(len(chunksToPut)))
-		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Inc()
+		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Add(float64(len(chunksToPut)))
 
 		if err := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
 			return 0, errors.Join(chunkErr, fmt.Errorf("delivery put: %w", err))

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -256,7 +256,7 @@ func (s *Syncer) SyncInterval(ctx context.Context, peer swarm.Address, bin uint8
 		if err := s.storage.Put(ctx, storage.ModePutSync, chunksToPut...); err != nil {
 			return 0, errors.Join(chunkErr, fmt.Errorf("delivery put: %w", err))
 		}
-		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Set(float64(time.Now().Unix()))
+		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Set(float64(time.Now().UnixMilli()))
 	}
 
 	return topmost, chunkErr

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -258,6 +258,5 @@ func newPullSync(s p2p.Streamer, o ...mock.Option) (*pullsync.Syncer, *mock.Pull
 		validStamp,
 		logger,
 		mockbatchstore.New(),
-		swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c"),
 	), storage
 }


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Added some new metrics.
Removed the 24h wait period for out of depth syncing now that hist syncing is rate limited.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
