### PR TITLE
fix: debug api version in health endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LDFLAGS ?= -s -w \
 -X github.com/ethersphere/bee.commitHash="$(COMMIT_HASH)" \
 -X github.com/ethersphere/bee.commitTime="$(COMMIT_TIME)" \
 -X github.com/ethersphere/bee/pkg/api.Version="$(BEE_API_VERSION)" \
--X github.com/ethersphere/bee/pkg/debugapi.Version="$(BEE_DEBUG_API_VERSION)" \
+-X github.com/ethersphere/bee/pkg/api.DebugVersion="$(BEE_DEBUG_API_VERSION)" \
 -X github.com/ethersphere/bee/pkg/p2p/libp2p.reachabilityOverridePublic="$(REACHABILITY_OVERRIDE_PUBLIC)" \
 -X github.com/ethersphere/bee/pkg/postage/listener.batchFactorOverridePublic="$(BATCHFACTOR_OVERRIDE_PUBLIC)"
 

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -24,6 +24,6 @@ func (s *Service) healthHandler(w http.ResponseWriter, _ *http.Request) {
 		Status:          status.String(),
 		Version:         bee.Version,
 		APIVersion:      Version,
-		DebugAPIVersion: Version,
+		DebugAPIVersion: DebugVersion,
 	})
 }

--- a/pkg/api/version.go
+++ b/pkg/api/version.go
@@ -6,3 +6,4 @@ package api
 
 // Version is set in the build process.
 var Version = "0.0.0"
+var DebugVersion = "0.0.0"


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
```
λ curl localhost:1635/health
{"status":"ok","version":"1.16.0-af961dc1","apiVersion":"4.1.0","debugApiVersion":"3.1.0"}
```