### PR TITLE
feat(salud): self health check based on reserve size

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -972,7 +972,7 @@ func NewBee(ctx context.Context, addr string, publicKey *ecdsa.PublicKey, signer
 		return nil, fmt.Errorf("status service: %w", err)
 	}
 
-	saludService := salud.New(nodeStatus, kad, batchStore, logger, warmupTime, api.FullMode.String(), salud.DefaultMinPeersPerBin)
+	saludService := salud.New(nodeStatus, kad, batchStore, storer, logger, warmupTime, api.FullMode.String(), salud.DefaultMinPeersPerBin)
 	b.saludCloser = saludService
 
 	var (

--- a/pkg/salud/main_test.go
+++ b/pkg/salud/main_test.go
@@ -1,0 +1,15 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package salud_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -16,6 +16,7 @@ type metrics struct {
 	NetworkRadius      prometheus.Gauge
 	NeighborhoodRadius prometheus.Gauge
 	Commitment         prometheus.Gauge
+	ReserveSize        prometheus.Gauge
 	Healthy            prometheus.Counter
 	Unhealthy          prometheus.Counter
 }
@@ -71,6 +72,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "batch_commitment",
 			Help:      "Most common batch commitment.",
+		}),
+		ReserveSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "reserve_size",
+			Help:      "Avg reserve size of the peers.",
 		}),
 	}
 }

--- a/pkg/salud/metrics.go
+++ b/pkg/salud/metrics.go
@@ -10,15 +10,15 @@ import (
 )
 
 type metrics struct {
-	AvgDur             prometheus.Gauge
-	PDur               prometheus.Gauge
-	PConns             prometheus.Gauge
-	NetworkRadius      prometheus.Gauge
-	NeighborhoodRadius prometheus.Gauge
-	Commitment         prometheus.Gauge
-	ReserveSize        prometheus.Gauge
-	Healthy            prometheus.Counter
-	Unhealthy          prometheus.Counter
+	AvgDur                prometheus.Gauge
+	PDur                  prometheus.Gauge
+	PConns                prometheus.Gauge
+	NetworkRadius         prometheus.Gauge
+	NeighborhoodRadius    prometheus.Gauge
+	Commitment            prometheus.Gauge
+	ReserveSizePercentErr prometheus.Gauge
+	Healthy               prometheus.Counter
+	Unhealthy             prometheus.Counter
 }
 
 func newMetrics() metrics {
@@ -73,11 +73,11 @@ func newMetrics() metrics {
 			Name:      "batch_commitment",
 			Help:      "Most common batch commitment.",
 		}),
-		ReserveSize: prometheus.NewGauge(prometheus.GaugeOpts{
+		ReserveSizePercentErr: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
-			Name:      "reserve_size",
-			Help:      "Avg reserve size of the peers.",
+			Name:      "reserve_size_percentage_err",
+			Help:      "Pecentage error of the reservesize relative to the network average.",
 		}),
 	}
 }

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -217,9 +217,9 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	selfHealth := true
 	if s.rad.StorageRadius() != networkRadius {
 		selfHealth = false
-		s.logger.Warning("node is unhealthy to due storage radius discrepency", "self_radius", s.rad.StorageRadius(), "network_radius", networkRadius)
+		s.logger.Warning("node is unhealthy due to storage radius discrepency", "self_radius", s.rad.StorageRadius(), "network_radius", networkRadius)
 	} else if percentageErr(float64(s.reserve.ReserveSize()), float64(reserveSize)) > maxReserveSizePercentageErr {
-		s.logger.Warning("node is unhealthy to due reserve size discrepency", "self_size", s.reserve.ReserveSize(), "network_size", reserveSize)
+		s.logger.Warning("node is unhealthy due to reserve size discrepency", "self_size", s.reserve.ReserveSize(), "network_size", reserveSize)
 		selfHealth = false
 	}
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -172,7 +172,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	pDur := percentileDur(peers, percentile)
 	pConns := percentileConns(peers, percentile)
 	commitment := commitment(peers)
-	reserveSize := reserveSize(peers, networkRadius, 0.9)
+	reserveSize := reserveSize(peers, networkRadius, (1-percentile)/2)
 
 	s.metrics.AvgDur.Set(avgDur)
 	s.metrics.PDur.Set(pDur)
@@ -180,6 +180,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	s.metrics.NetworkRadius.Set(float64(networkRadius))
 	s.metrics.NeighborhoodRadius.Set(float64(nHoodRadius))
 	s.metrics.Commitment.Set(float64(commitment))
+	s.metrics.ReserveSize.Set(float64(reserveSize))
 
 	s.logger.Debug("computed", "average", avgDur, "percentile", percentile, "pDur", pDur, "pConns", pConns, "network_radius", networkRadius, "neighborhood_radius", nHoodRadius, "batch_commitment", commitment, "reserve_size", reserveSize)
 
@@ -218,7 +219,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	if s.rad.StorageRadius() != networkRadius {
 		selfHealth = false
 		s.logger.Warning("node is unhealthy due to storage radius discrepency", "self_radius", s.rad.StorageRadius(), "network_radius", networkRadius)
-	} else if percentageErr(float64(s.reserve.ReserveSize()), float64(reserveSize)) > maxReserveSizePercentageErr {
+	} else if reserveSize > 0 && percentageErr(float64(s.reserve.ReserveSize()), float64(reserveSize)) > maxReserveSizePercentageErr {
 		s.logger.Warning("node is unhealthy due to reserve size discrepency", "self_size", s.reserve.ReserveSize(), "network_size", reserveSize)
 		selfHealth = false
 	}
@@ -304,8 +305,8 @@ func commitment(peers []peer) uint64 {
 // reserveSize returns the avg reserveSize, trimmed by p percent
 func reserveSize(peers []peer, radius uint8, p float64) uint64 {
 
-	startIndex := int(float64(len(peers)) * (1 - p))
-	endIndex := int(float64(len(peers)) * p)
+	startIndex := int(float64(len(peers)) * p)
+	endIndex := int(float64(len(peers)) * (1 - p))
 
 	sort.Slice(peers, func(i, j int) bool {
 		return peers[i].status.ReserveSize < peers[j].status.ReserveSize // ascendings
@@ -321,7 +322,12 @@ func reserveSize(peers []peer, radius uint8, p float64) uint64 {
 		}
 	}
 
-	return avg / count
+	if count > 0 {
+		return avg / count
+	}
+
+	return 0
+
 }
 
 func percentageErr(x, y float64) float64 {

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -31,28 +31,28 @@ func TestSalud(t *testing.T) {
 	t.Parallel()
 	peers := []peer{
 		// fully healhy
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
 
 		// healthy since radius >= most common radius -  1
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7, BeeMode: "full", BatchCommitment: 500}, 1, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 7, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, true},
 
 		// radius too low
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 6, BeeMode: "full", BatchCommitment: 500}, 1, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 6, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, false},
 
 		// dur too long
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 2, false},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 2, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 2, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 2, false},
 
 		// connections not enough
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 500}, 1, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 90, StorageRadius: 8, BeeMode: "full", BatchCommitment: 50, ReserveSize: 100}, 1, false},
 
 		// commitment wrong
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 350}, 1, false},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", BatchCommitment: 35, ReserveSize: 100}, 1, false},
 	}
 
 	statusM := &statusMock{make(map[string]peer)}
@@ -67,7 +67,7 @@ func TestSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 8}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, -1, "full", 0)
+	service := salud.New(statusM, topM, bs, &reserveMock{100}, log.Noop, -1, "full", 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)
@@ -85,9 +85,13 @@ func TestSalud(t *testing.T) {
 	if !service.IsHealthy() {
 		t.Fatalf("self should be healthy")
 	}
+
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
-func TestSelfUnhealthSalud(t *testing.T) {
+func TestSelfUnhealthyRadius(t *testing.T) {
 	t.Parallel()
 	peers := []peer{
 		// fully healhy
@@ -106,7 +110,7 @@ func TestSelfUnhealthSalud(t *testing.T) {
 
 	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 7}))
 
-	service := salud.New(statusM, topM, bs, log.Noop, -1, "full", 0)
+	service := salud.New(statusM, topM, bs, &reserveMock{100}, log.Noop, -1, "full", 0)
 
 	err := spinlock.Wait(time.Minute, func() bool {
 		return len(topM.PeersHealth()) == len(peers)
@@ -117,6 +121,47 @@ func TestSelfUnhealthSalud(t *testing.T) {
 
 	if service.IsHealthy() {
 		t.Fatalf("self should NOT be healthy")
+	}
+
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSelfUnhealthyReserveSize(t *testing.T) {
+	t.Parallel()
+	peers := []peer{
+		// fully healhy
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", ReserveSize: 100}, 0, true},
+		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", ReserveSize: 100}, 0, true},
+	}
+
+	statusM := &statusMock{make(map[string]peer)}
+	addrs := make([]swarm.Address, 0, len(peers))
+	for _, p := range peers {
+		addrs = append(addrs, p.addr)
+		statusM.peers[p.addr.ByteString()] = p
+	}
+
+	topM := topMock.NewTopologyDriver(topMock.WithPeers(addrs...))
+
+	bs := bsMock.New(bsMock.WithIsWithinStorageRadius(true), bsMock.WithReserveState(&postage.ReserveState{StorageRadius: 8}))
+
+	service := salud.New(statusM, topM, bs, &reserveMock{97}, log.Noop, -1, "full", 0)
+
+	err := spinlock.Wait(time.Minute, func() bool {
+		return len(topM.PeersHealth()) == len(peers)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if service.IsHealthy() {
+		t.Fatalf("self should NOT be healthy")
+	}
+
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -130,4 +175,12 @@ func (p *statusMock) PeerSnapshot(ctx context.Context, peer swarm.Address) (*sta
 		return peer.status, nil
 	}
 	return nil, errors.New("peer not found")
+}
+
+type reserveMock struct {
+	size uint64
+}
+
+func (r *reserveMock) ReserveSize() uint64 {
+	return r.size
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Stops the node from playing the game when the reserve is off by some percentage err.
the reserve size avg is computed by first trimming the lower and top 10% of the responses, this actually ends up creating a rather accurate number.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
