### PR TITLE
feat(reserve, salud): utilize network radius from salud for inital storage radius and pusher receipt checks

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -30,8 +30,7 @@ import (
 	"github.com/ethersphere/bee/pkg/settlement/swap/erc20"
 	"github.com/ethersphere/bee/pkg/settlement/swap/priceoracle"
 	"github.com/ethersphere/bee/pkg/settlement/swap/swapprotocol"
-	storage "github.com/ethersphere/bee/pkg/storage"
-	storagev1 "github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/transaction"
 	"github.com/ethersphere/bee/pkg/transaction/wrapped"
 	"github.com/ethersphere/go-sw3-abi/sw3abi"
@@ -49,7 +48,7 @@ const (
 func InitChain(
 	ctx context.Context,
 	logger log.Logger,
-	stateStore storagev1.StateStorer,
+	stateStore storage.StateStorer,
 	endpoint string,
 	oChainID int64,
 	signer crypto.Signer,
@@ -154,7 +153,7 @@ func InitChequebookFactory(
 func InitChequebookService(
 	ctx context.Context,
 	logger log.Logger,
-	stateStore storagev1.StateStorer,
+	stateStore storage.StateStorer,
 	signer crypto.Signer,
 	chainID int64,
 	backend transaction.Backend,
@@ -201,7 +200,7 @@ func InitChequebookService(
 }
 
 func initChequeStoreCashout(
-	stateStore storagev1.StateStorer,
+	stateStore storage.StateStorer,
 	swapBackend transaction.Backend,
 	chequebookFactory chequebook.Factory,
 	chainID int64,
@@ -231,7 +230,7 @@ func initChequeStoreCashout(
 func InitSwap(
 	p2ps *libp2p.Service,
 	logger log.Logger,
-	stateStore storagev1.StateStorer,
+	stateStore storage.StateStorer,
 	networkID uint64,
 	overlayEthAddress common.Address,
 	chequebookService chequebook.Service,
@@ -287,7 +286,7 @@ func InitSwap(
 	return swapService, priceOracle, nil
 }
 
-func GetTxHash(stateStore storagev1.StateStorer, logger log.Logger, trxString string) ([]byte, error) {
+func GetTxHash(stateStore storage.StateStorer, logger log.Logger, trxString string) ([]byte, error) {
 
 	if trxString != "" {
 		txHashTrimmed := strings.TrimPrefix(trxString, "0x")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1013,7 +1013,7 @@ func NewBee(
 		pullerService = puller.New(stateStore, kad, localStore, pullSyncProtocol, p2ps, logger, pullerOpts, warmupTime)
 		b.pullerCloser = pullerService
 
-		localStore.StartReserveWorker(pullerService)
+		localStore.StartReserveWorker(pullerService, saludService)
 
 		nodeStatus.SetStorage(localStore)
 		nodeStatus.SetSync(pullerService)

--- a/pkg/puller/mock/puller.go
+++ b/pkg/puller/mock/puller.go
@@ -4,7 +4,8 @@
 
 package mock
 
-type mockRateReporter struct{ rate float64 }
+type mockSyncer struct{ rate float64 }
 
-func NewMockRateReporter(r float64) *mockRateReporter { return &mockRateReporter{r} }
-func (m *mockRateReporter) SyncRate() float64         { return m.rate }
+func NewMockRateReporter(r float64) *mockSyncer { return &mockSyncer{r} }
+func (m *mockSyncer) SyncRate() float64         { return m.rate }
+func (m *mockSyncer) Start()                    {}

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -537,6 +537,7 @@ func newPuller(t *testing.T, ops opts) (*puller.Puller, storage.StateStorer, *ka
 		SyncSleepDur: ops.syncSleepDur,
 	}
 	p := puller.New(s, kad, ops.rs, ps, nil, logger, o, 0)
+	p.Start()
 
 	testutil.CleanupCloser(t, p)
 

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -158,6 +158,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	wg.Wait()
 
 	if len(peers) == 0 {
+		s.publishRadius(0)
 		return
 	}
 

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -49,7 +49,6 @@ func New(
 	baseAddr swarm.Address,
 	store storage.Store,
 	capacity int,
-	reserveRadius uint8,
 	radiusSetter topology.SetStorageRadiuser,
 	logger log.Logger) (*Reserve, error) {
 
@@ -62,23 +61,15 @@ func New(
 
 	rItem := &radiusItem{}
 	err := store.Get(rItem)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) { // fresh node
-			rItem.Radius = reserveRadius
-		} else {
-			return nil, err
-		}
-	}
-	err = rs.SetRadius(store, rItem.Radius)
-	if err != nil {
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return nil, err
 	}
+	rs.radius = rItem.Radius
 
 	size, err := store.Count(&batchRadiusItem{})
 	if err != nil {
 		return nil, err
 	}
-
 	rs.size = size
 
 	return rs, nil

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -36,7 +36,7 @@ func TestReserve(t *testing.T) {
 		}
 	})
 
-	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, 0, kademlia.NewTopologyDriver(), log.Noop)
+	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, kademlia.NewTopologyDriver(), log.Noop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestReserveChunkType(t *testing.T) {
 		}
 	})
 
-	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, 0, kademlia.NewTopologyDriver(), log.Noop)
+	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, kademlia.NewTopologyDriver(), log.Noop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestReplaceOldIndex(t *testing.T) {
 		}
 	})
 
-	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, 0, kademlia.NewTopologyDriver(), log.Noop)
+	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, kademlia.NewTopologyDriver(), log.Noop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestEvict(t *testing.T) {
 	batches := []*postage.Batch{postagetesting.MustNewBatch(), postagetesting.MustNewBatch(), postagetesting.MustNewBatch()}
 	evictBatch := batches[1]
 
-	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, 0, kademlia.NewTopologyDriver(), log.Noop)
+	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, kademlia.NewTopologyDriver(), log.Noop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,33 +250,6 @@ func TestEvict(t *testing.T) {
 			checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: b, BinID: uint64(binID)}, false)
 			checkChunk(t, ts, ch, false)
 		}
-	}
-}
-
-func TestOldRadius(t *testing.T) {
-	t.Parallel()
-
-	baseAddr := swarm.RandAddress(t)
-
-	ts, closer := internal.NewInmemStorage()
-	t.Cleanup(func() {
-		if err := closer(); err != nil {
-			t.Errorf("failed closing the storage: %v", err)
-		}
-	})
-
-	err := ts.IndexStore().Put(&reserve.RadiusItem{Radius: 3})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, 0, kademlia.NewTopologyDriver(), log.Noop)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if r.Radius() != 3 {
-		t.Errorf("got %d, want %d", r.Radius(), 3)
 	}
 }
 

--- a/pkg/storer/mock/mockreserve.go
+++ b/pkg/storer/mock/mockreserve.go
@@ -114,9 +114,17 @@ func NewReserve(opts ...Option) *ReserveStore {
 
 func (s *ReserveStore) EvictBatch(ctx context.Context, batchID []byte) error { return nil }
 func (s *ReserveStore) IsWithinStorageRadius(addr swarm.Address) bool        { return true }
-func (s *ReserveStore) StorageRadius() uint8                                 { return s.radius }
-func (s *ReserveStore) SetStorageRadius(r uint8)                             { s.radius = r }
 func (s *ReserveStore) IsFullySynced() bool                                  { return true }
+func (s *ReserveStore) StorageRadius() uint8 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.radius
+}
+func (s *ReserveStore) SetStorageRadius(r uint8) {
+	s.mtx.Lock()
+	s.radius = r
+	s.mtx.Unlock()
+}
 
 // IntervalChunks returns a set of chunk in a requested interval.
 func (s *ReserveStore) SubscribeBin(ctx context.Context, bin uint8, start uint64) (<-chan *storer.BinC, func(), <-chan error) {

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -75,7 +75,7 @@ func TestIndexCollision(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestIndexCollision(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 }
@@ -163,7 +163,7 @@ func TestReplaceOldIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestReplaceOldIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 }
@@ -188,7 +188,7 @@ func TestEvictBatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+	st.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 
 	ctx := context.Background()
 
@@ -337,7 +337,7 @@ func TestUnreserveCap(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, bs, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestUnreserveCap(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{0})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, bs, storer)
 	})
 }
@@ -363,7 +363,7 @@ func TestNetworkRadius(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{1})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
 		time.Sleep(time.Second)
 		if want, got := uint8(1), storer.StorageRadius(); want != got {
 			t.Fatalf("want radius %d, got radius %d", want, got)
@@ -376,7 +376,7 @@ func TestNetworkRadius(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{1})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
 		time.Sleep(time.Second)
 		if want, got := uint8(1), storer.StorageRadius(); want != got {
 			t.Fatalf("want radius %d, got radius %d", want, got)
@@ -417,7 +417,7 @@ func TestRadiusManager(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), &mockNetworkRadiusSub{3})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(3))
 
 		batch := postagetesting.MustNewBatch()
 		err = bs.Save(batch)
@@ -460,7 +460,7 @@ func TestRadiusManager(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(1), &mockNetworkRadiusSub{3})
+		storer.StartReserveWorker(pullerMock.NewMockRateReporter(1), networkRadiusFunc(3))
 		waitForRadius(t, storer.Reserve(), 3)
 	})
 }
@@ -877,10 +877,6 @@ func BenchmarkReservePutter(b *testing.B) {
 	storagetest.BenchmarkChunkStoreWriteSequential(b, putter)
 }
 
-type mockNetworkRadiusSub struct {
-	r uint8
-}
-
-func (m *mockNetworkRadiusSub) SubscribeNetworkStorageRadius(cb func(uint8)) {
-	cb(m.r)
+func networkRadiusFunc(r uint8) func() (uint8, error) {
+	return func() (uint8, error) { return r, nil }
 }

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -317,7 +317,7 @@ func performEpochMigration(ctx context.Context, basePath string, opts *Options) 
 
 	var rs *reserve.Reserve
 	if opts.ReserveCapacity > 0 {
-		rs, err = reserve.New(opts.Address, store, opts.ReserveCapacity, opts.Batchstore.Radius(), noopRadiusSetter{}, logger)
+		rs, err = reserve.New(opts.Address, store, opts.ReserveCapacity, noopRadiusSetter{}, logger)
 		if err != nil {
 			return err
 		}
@@ -465,7 +465,7 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 	}
 
 	if opts.ReserveCapacity > 0 {
-		rs, err := reserve.New(opts.Address, repo.IndexStore(), opts.ReserveCapacity, opts.Batchstore.Radius(), opts.RadiusSetter, logger)
+		rs, err := reserve.New(opts.Address, repo.IndexStore(), opts.ReserveCapacity, opts.RadiusSetter, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -530,11 +530,11 @@ func (db *DB) SetRetrievalService(r retrieval.Interface) {
 	db.retrieval = r
 }
 
-func (db *DB) StartReserveWorker(s SyncReporter) {
+func (db *DB) StartReserveWorker(s SyncReporter, f NetworkRadius) {
 	db.setSyncerOnce.Do(func() {
 		db.syncer = s
 		db.reserveWg.Add(1)
-		go db.reserveWorker(db.reserve.Capacity(), db.opts.warmupDuration, db.opts.wakeupDuration)
+		go db.reserveWorker(db.reserve.Capacity(), db.opts.warmupDuration, db.opts.wakeupDuration, f)
 	})
 }
 

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -530,11 +530,11 @@ func (db *DB) SetRetrievalService(r retrieval.Interface) {
 	db.retrieval = r
 }
 
-func (db *DB) StartReserveWorker(s SyncReporter, f NetworkRadius) {
+func (db *DB) StartReserveWorker(s SyncReporter, radius func() (uint8, error)) {
 	db.setSyncerOnce.Do(func() {
 		db.syncer = s
 		db.reserveWg.Add(1)
-		go db.reserveWorker(db.reserve.Capacity(), db.opts.warmupDuration, db.opts.wakeupDuration, f)
+		go db.reserveWorker(db.reserve.Capacity(), db.opts.warmupDuration, db.opts.wakeupDuration, radius)
 	})
 }
 

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -394,7 +394,7 @@ type DB struct {
 	baseAddr         swarm.Address
 	batchstore       postage.Storer
 	setSyncerOnce    sync.Once
-	syncer           SyncReporter
+	syncer           Syncer
 	opts             workerOpts
 }
 
@@ -530,7 +530,7 @@ func (db *DB) SetRetrievalService(r retrieval.Interface) {
 	db.retrieval = r
 }
 
-func (db *DB) StartReserveWorker(s SyncReporter, radius func() (uint8, error)) {
+func (db *DB) StartReserveWorker(s Syncer, radius func() (uint8, error)) {
 	db.setSyncerOnce.Do(func() {
 		db.syncer = s
 		db.reserveWg.Add(1)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Instead of getting the initial radius from the batchstore for the storer reserve, utilize salud's network radius.
this causes the node to quickly start syncing from the correct radius.

With this, light nodes will use the network storage radius for receipt checks, instead of neighborhood depth. 

To be released with #3936 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
