### PR TITLE
fix(puller): added new mtx locking to interval state storing

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -153,6 +153,9 @@ func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 		p.recalcPeers(ctx, newRadius)
 	}
 
+	tick := time.NewTicker(recalcPeersDur)
+	defer tick.Stop()
+
 	for {
 
 		onChange()
@@ -160,7 +163,7 @@ func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(recalcPeersDur):
+		case <-tick.C:
 		case <-c:
 		}
 	}

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -57,6 +57,7 @@ type Puller struct {
 
 	syncPeers    map[string]*syncPeer // index is bin, map key is peer address
 	syncPeersMtx sync.Mutex
+	intervalMtx  sync.Mutex
 
 	cancel func()
 
@@ -116,6 +117,7 @@ func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 
 	onChange := func() {
 		p.syncPeersMtx.Lock()
+		defer p.syncPeersMtx.Unlock()
 
 		// peersDisconnected is used to mark and prune peers that are no longer connected.
 		peersDisconnected := make(map[string]*syncPeer)
@@ -149,22 +151,17 @@ func (p *Puller) manage(ctx context.Context, warmupDur time.Duration) {
 		}
 
 		p.recalcPeers(ctx, newRadius)
-
-		p.syncPeersMtx.Unlock()
 	}
 
-	tick := time.NewTicker(recalcPeersDur)
-	defer tick.Stop()
-
 	for {
+
+		onChange()
+
 		select {
 		case <-ctx.Done():
 			return
-		case <-tick.C:
-			onChange()
+		case <-time.After(recalcPeersDur):
 		case <-c:
-			tick.Reset(recalcPeersDur)
-			onChange()
 		}
 	}
 }
@@ -397,6 +394,8 @@ func (p *Puller) Close() error {
 }
 
 func (p *Puller) addPeerInterval(peer swarm.Address, bin uint8, start, end uint64) (err error) {
+	p.intervalMtx.Lock()
+	defer p.intervalMtx.Unlock()
 
 	peerStreamKey := peerIntervalKey(peer, bin)
 	i, err := p.getOrCreateInterval(peer, bin)
@@ -410,6 +409,9 @@ func (p *Puller) addPeerInterval(peer swarm.Address, bin uint8, start, end uint6
 }
 
 func (p *Puller) resetIntervals(upto uint8) error {
+	p.intervalMtx.Lock()
+	defer p.intervalMtx.Unlock()
+
 	for bin := uint8(0); bin < upto; bin++ {
 		err := p.statestore.Iterate(binIntervalKey(bin), func(key, _ []byte) (stop bool, err error) {
 			return false, p.statestore.Delete(string(key))
@@ -423,6 +425,8 @@ func (p *Puller) resetIntervals(upto uint8) error {
 }
 
 func (p *Puller) nextPeerInterval(peer swarm.Address, bin uint8) (start, end uint64, empty bool, err error) {
+	p.intervalMtx.Lock()
+	defer p.intervalMtx.Unlock()
 
 	i, err := p.getOrCreateInterval(peer, bin)
 	if err != nil {
@@ -433,6 +437,7 @@ func (p *Puller) nextPeerInterval(peer swarm.Address, bin uint8) (start, end uin
 	return start, end, empty, nil
 }
 
+// Must be called underlock.
 func (p *Puller) getOrCreateInterval(peer swarm.Address, bin uint8) (*intervalstore.Intervals, error) {
 	// check that an interval entry exists
 	key := peerIntervalKey(peer, bin)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
There is a potential for a data race in the way the synced intervals are stored between historical and live syncing so we added a mtx lock.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
