### PR TITLE
feat: salud to record peer latency

### DIFF
--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -126,8 +126,18 @@ func bootstrapNode(
 	}
 	b.hiveCloser = hive
 
+<<<<<<< HEAD
 	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, &noopPinger{}, logger,
 		kademlia.Options{Bootnodes: bootnodes, BootnodeMode: o.BootnodeMode, StaticNodes: o.StaticNodes, DataDir: o.DataDir})
+=======
+	metricsDB, err := shed.NewDBWrap(stateStore.DB())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create metrics storage for kademlia: %w", err)
+	}
+
+	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, metricsDB, logger,
+		kademlia.Options{Bootnodes: bootnodes, BootnodeMode: o.BootnodeMode, StaticNodes: o.StaticNodes})
+>>>>>>> 8ca4edf8... fix: salud to record peer latency, not kademlia
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kademlia: %w", err)
 	}
@@ -281,12 +291,6 @@ func waitPeers(kad *kademlia.Kad) error {
 		}, topology.Select{})
 		return count >= minPeersCount
 	})
-}
-
-type noopPinger struct{}
-
-func (p *noopPinger) Ping(context.Context, swarm.Address, ...string) (time.Duration, error) {
-	return time.Duration(1), nil
 }
 
 func getLatestSnapshot(

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -126,18 +126,8 @@ func bootstrapNode(
 	}
 	b.hiveCloser = hive
 
-<<<<<<< HEAD
-	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, &noopPinger{}, logger,
+	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger,
 		kademlia.Options{Bootnodes: bootnodes, BootnodeMode: o.BootnodeMode, StaticNodes: o.StaticNodes, DataDir: o.DataDir})
-=======
-	metricsDB, err := shed.NewDBWrap(stateStore.DB())
-	if err != nil {
-		return nil, fmt.Errorf("unable to create metrics storage for kademlia: %w", err)
-	}
-
-	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, metricsDB, logger,
-		kademlia.Options{Bootnodes: bootnodes, BootnodeMode: o.BootnodeMode, StaticNodes: o.StaticNodes})
->>>>>>> 8ca4edf8... fix: salud to record peer latency, not kademlia
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kademlia: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -744,7 +744,7 @@ func NewBee(
 
 	var swapService *swap.Service
 
-	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, pingPong, logger,
+	kad, err := kademlia.New(swarmAddress, addressbook, hive, p2ps, logger,
 		kademlia.Options{Bootnodes: bootnodes, BootnodeMode: o.BootnodeMode, StaticNodes: o.StaticNodes, IgnoreRadius: !chainEnabled, DataDir: o.DataDir})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kademlia: %w", err)

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -160,7 +160,7 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 			mtx.Lock()
 			bins[bin]++
 			totaldur += dur.Seconds()
-			peers = append(peers, peer{snapshot, dur, addr, bin, s.rad.IsWithinStorageRadius(addr)})
+			peers = append(peers, peer{snapshot, dur, addr, bin, s.reserve.IsWithinStorageRadius(addr)})
 			mtx.Unlock()
 		}()
 		return false, false, nil

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -205,7 +205,6 @@ func New(
 	addressbook addressbook.Interface,
 	discovery discovery.Driver,
 	p2pSvc p2p.Service,
-	metricsDB *shed.DB,
 	logger log.Logger,
 	o Options,
 ) (*Kad, error) {

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/shed"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethersphere/bee/pkg/addressbook"
@@ -26,7 +25,6 @@ import (
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p"
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
-	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/spinlock"
 	mockstate "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -961,7 +959,7 @@ func TestClosestPeer(t *testing.T) {
 	disc := mock.NewDiscovery()
 	ab := addressbook.New(mockstate.NewStateStore())
 
-	kad, err := kademlia.New(base, ab, disc, p2pMock(t, ab, nil, nil, nil), metricsDB, logger, kademlia.Options{})
+	kad, err := kademlia.New(base, ab, disc, p2pMock(t, ab, nil, nil, nil), logger, kademlia.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1835,12 +1833,6 @@ func newTestKademliaWithAddrDiscovery(
 ) (swarm.Address, *kademlia.Kad, addressbook.Interface, *mock.Discovery, beeCrypto.Signer) {
 	t.Helper()
 
-	metricsDB, err := shed.NewDB("", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testutil.CleanupCloser(t, metricsDB)
-
 	var (
 		pk, _  = beeCrypto.GenerateSecp256k1Key()                       // random private key
 		signer = beeCrypto.NewDefaultSigner(pk)                         // signer
@@ -1849,7 +1841,7 @@ func newTestKademliaWithAddrDiscovery(
 		p2p    = p2pMock(t, ab, signer, connCounter, failedConnCounter) // p2p mock
 		logger = log.Noop                                               // logger
 	)
-	kad, err := kademlia.New(base, ab, disc, p2p, metricsDB, logger, kadOpts)
+	kad, err := kademlia.New(base, ab, disc, p2p, logger, kadOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p"
 	p2pmock "github.com/ethersphere/bee/pkg/p2p/mock"
-	pingpongmock "github.com/ethersphere/bee/pkg/pingpong/mock"
+	"github.com/ethersphere/bee/pkg/shed"
 	"github.com/ethersphere/bee/pkg/spinlock"
 	mockstate "github.com/ethersphere/bee/pkg/statestore/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -959,13 +959,9 @@ func TestClosestPeer(t *testing.T) {
 	}
 
 	disc := mock.NewDiscovery()
-	ssMock := mockstate.NewStateStore()
-	ab := addressbook.New(ssMock)
-	ppm := pingpongmock.New(func(_ context.Context, _ swarm.Address, _ ...string) (time.Duration, error) {
-		return 0, nil
-	})
+	ab := addressbook.New(mockstate.NewStateStore())
 
-	kad, err := kademlia.New(base, ab, disc, p2pMock(t, ab, nil, nil, nil), ppm, logger, kademlia.Options{})
+	kad, err := kademlia.New(base, ab, disc, p2pMock(t, ab, nil, nil, nil), metricsDB, logger, kademlia.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1368,54 +1364,6 @@ func TestOutofDepthPrune(t *testing.T) {
 	waitBalanced(t, kad, 1)
 }
 
-// TestLatency tests that kademlia polls peers for latency.
-func TestLatency(t *testing.T) {
-	t.Parallel()
-
-	var (
-		logger = log.Noop
-		base   = swarm.MustParseHexAddress("0000000000000000000000000000000000000000000000000000000000000000") // base is 0000
-		p1     = swarm.RandAddress(t)
-
-		disc   = mock.NewDiscovery()
-		ssMock = mockstate.NewStateStore()
-		ab     = addressbook.New(ssMock)
-		doneC  = make(chan struct{})
-		once   sync.Once
-		ppm    = pingpongmock.New(func(_ context.Context, _ swarm.Address, _ ...string) (time.Duration, error) {
-			once.Do(func() { close(doneC) })
-			return 0, nil
-		})
-	)
-	metricsDB, err := shed.NewDB("", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testutil.CleanupCloser(t, metricsDB)
-
-	kad, err := kademlia.New(base, ab, disc, p2pMock(t, ab, nil, nil, nil), ppm, logger, kademlia.Options{
-		PeerPingPollTime: ptrDuration(1 * time.Second),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := kad.Start(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	testutil.CleanupCloser(t, kad)
-
-	pk, _ := beeCrypto.GenerateSecp256k1Key()
-	signer := beeCrypto.NewDefaultSigner(pk)
-	addOne(t, signer, kad, ab, p1)
-
-	waitPeers(t, kad, 1)
-	select {
-	case <-doneC:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for ping")
-	}
-}
-
 func TestBootnodeProtectedNodes(t *testing.T) {
 	t.Parallel()
 
@@ -1682,7 +1630,7 @@ func TestIteratorOpts(t *testing.T) {
 		if randBool.Bool() {
 			healthy[addr.ByteString()] = struct{}{}
 			totalHealthy++
-			kad.UpdatePeerHealth(addr, true)
+			kad.UpdatePeerHealth(addr, true, 0)
 		}
 		return false, false, nil
 	}, topology.Select{})
@@ -1900,11 +1848,8 @@ func newTestKademliaWithAddrDiscovery(
 		ab     = addressbook.New(ssMock)                                // address book
 		p2p    = p2pMock(t, ab, signer, connCounter, failedConnCounter) // p2p mock
 		logger = log.Noop                                               // logger
-		ppm    = pingpongmock.New(func(_ context.Context, _ swarm.Address, _ ...string) (time.Duration, error) {
-			return 0, nil
-		})
 	)
-	kad, err := kademlia.New(base, ab, disc, p2p, ppm, logger, kadOpts)
+	kad, err := kademlia.New(base, ab, disc, p2p, metricsDB, logger, kadOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1918,7 +1863,7 @@ func newTestKademlia(t *testing.T, connCounter, failedConnCounter *int32, kadOpt
 	t.Helper()
 
 	base := swarm.RandAddress(t)
-	disc := mock.NewDiscovery() // mock discovery protocol
+	disc := mock.NewDiscovery() // mock discovery protocols
 	return newTestKademliaWithAddrDiscovery(t, base, disc, connCounter, failedConnCounter, kadOpts)
 }
 

--- a/pkg/topology/kademlia/metrics.go
+++ b/pkg/topology/kademlia/metrics.go
@@ -28,8 +28,6 @@ type metrics struct {
 	TotalBootNodesConnectionAttempts      prometheus.Counter
 	StartAddAddressBookOverlaysTime       prometheus.Histogram
 	PeerLatencyEWMA                       prometheus.Histogram
-	Flag                                  prometheus.Counter
-	Unflag                                prometheus.Counter
 	Blocklist                             prometheus.Counter
 	ReachabilityStatus                    *prometheus.GaugeVec
 	PeersReachabilityStatus               *prometheus.GaugeVec
@@ -141,18 +139,6 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "peer_latency_ewma",
 			Help:      "Peer latency EWMA value distribution.",
-		}),
-		Flag: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "flag",
-			Help:      "The nubmer of times peers have been flagged.",
-		}),
-		Unflag: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "unflag",
-			Help:      "The nubmer of times peers have been unflagged.",
 		}),
 		Blocklist: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/topology/kademlia/mock/kademlia.go
+++ b/pkg/topology/kademlia/mock/kademlia.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -77,7 +78,7 @@ func (m *Mock) EachNeighborRev(topology.EachPeerFunc) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *Mock) UpdatePeerHealth(swarm.Address, bool) {
+func (m *Mock) UpdatePeerHealth(swarm.Address, bool, time.Duration) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ethersphere/bee/pkg/p2p"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -109,7 +110,7 @@ func (d *mock) AnnounceTo(_ context.Context, _, _ swarm.Address, _ bool) error {
 	return nil
 }
 
-func (d *mock) UpdatePeerHealth(peer swarm.Address, health bool) {
+func (d *mock) UpdatePeerHealth(peer swarm.Address, health bool, pingDur time.Duration) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	d.health[peer.ByteString()] = health

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -32,8 +32,8 @@ type Driver interface {
 	Halter
 	Snapshot() *KadParams
 	IsReachable() bool
-	UpdatePeerHealth(addr swarm.Address, h bool)
 	SetStorageRadiuser
+	UpdatePeerHealth(addr swarm.Address, h bool, t time.Duration)
 }
 
 type PeerAdder interface {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Since salud acquires the status msg from every peer (reachable or not), we can use this mechanism to record peer latency instead of kademlia's ping.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
