### PR TITLE
fix(puller): nil pointer on Close

### DIFF
--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -103,6 +103,7 @@ func New(
 		blockLister:     blockLister,
 		histSyncLimiter: make(chan struct{}, maxHistSyncs),
 		rate:            rate.New(DefaultHistRateWindow),
+		cancel:          func() { /* Noop, since the context is initialized in the Start(). */ },
 	}
 
 	return p


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

```
"time"="2023-06-01 10:45:28.299523" "level"="info" "logger"="node/puller" "msg"="puller shutting down"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x118e613]

goroutine 2131 [running]:
github.com/ethersphere/bee/pkg/puller.(*Puller).Close(0xc0002b9080)
        github.com/ethersphere/bee/pkg/puller/puller.go:408 +0x53
github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown.func1({0x1ad73e0?, 0xc0002b9080?}, {0x157a01f, 0x6})
        github.com/ethersphere/bee/pkg/node/node.go:1287 +0x5b
github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown.func7()
        github.com/ethersphere/bee/pkg/node/node.go:1335 +0x7e
created by github.com/ethersphere/bee/pkg/node.(*Bee).Shutdown
        github.com/ethersphere/bee/pkg/node/node.go:1333 +0x56e
```
