### PR TITLE
fix(storer): cleanup reserve and cache synchronization

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -372,7 +372,7 @@ func dbImportReserveCmd(cmd *cobra.Command) {
 					return fmt.Errorf("unmarshaling chunk: %w", err)
 				}
 				logger.Debug("importing chunk", "address", chunk.Address().String())
-				if err := db.ReservePut(cmd.Context(), chunk); err != nil {
+				if err := db.ReservePutter().Put(cmd.Context(), chunk); err != nil {
 					return fmt.Errorf("error importing chunk: %w", err)
 				}
 				counter++

--- a/cmd/bee/cmd/db_test.go
+++ b/cmd/bee/cmd/db_test.go
@@ -39,7 +39,7 @@ func TestDBExportImport(t *testing.T) {
 	nChunks := 10
 	for i := 0; i < nChunks; i++ {
 		ch := storagetest.GenerateTestRandomChunk()
-		err := db1.ReservePut(ctx, ch)
+		err := db1.ReservePutter().Put(ctx, ch)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -259,7 +259,7 @@ func (s *Syncer) Sync(ctx context.Context, peer swarm.Address, bin uint8, start 
 		s.metrics.LastReceived.WithLabelValues(fmt.Sprintf("%d", bin)).Add(float64(len(chunksToPut)))
 
 		for _, c := range chunksToPut {
-			if err := s.store.ReservePut(ctx, c); err != nil {
+			if err := s.store.ReservePutter().Put(ctx, c); err != nil {
 				// in case of these errors, no new items are added to the storage, so it
 				// is safe to continue with the next chunk
 				if errors.Is(err, storage.ErrOverwriteNewerChunk) || errors.Is(err, storage.ErrOverwriteOfImmutableBatch) {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -41,7 +41,7 @@ type OpChan <-chan *Op
 type Storer interface {
 	storage.PushReporter
 	storage.PushSubscriber
-	ReservePut(context.Context, swarm.Chunk) error
+	ReservePutter() storage.Putter
 }
 
 type Service struct {
@@ -261,7 +261,7 @@ func (s *Service) pushDeferred(ctx context.Context, logger log.Logger, op *Op) (
 	case errors.Is(err, topology.ErrWantSelf):
 		// store the chunk
 		loggerV1.Debug("chunk stays here, i'm the closest node", "chunk_address", op.Chunk.Address())
-		err = s.storer.ReservePut(ctx, op.Chunk)
+		err = s.storer.ReservePutter().Put(ctx, op.Chunk)
 		if err != nil {
 			loggerV1.Error(err, "pusher: failed to store chunk")
 			return true, err
@@ -321,7 +321,7 @@ func (s *Service) pushDirect(ctx context.Context, logger log.Logger, op *Op) err
 	case errors.Is(err, topology.ErrWantSelf):
 		// store the chunk
 		loggerV1.Debug("chunk stays here, i'm the closest node", "chunk_address", op.Chunk.Address())
-		err = s.storer.ReservePut(ctx, op.Chunk)
+		err = s.storer.ReservePutter().Put(ctx, op.Chunk)
 		if err != nil {
 			loggerV1.Error(err, "pusher: failed to store chunk")
 		}

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -95,12 +95,16 @@ func (m *mockStorer) isReported(chunk swarm.Chunk, state storage.ChunkState) boo
 	return false
 }
 
-func (m *mockStorer) ReservePut(ctx context.Context, chunk swarm.Chunk) error {
-	if m.storedChunks == nil {
-		m.storedChunks = make(map[string]swarm.Chunk)
-	}
-	m.storedChunks[chunk.Address().ByteString()] = chunk
-	return nil
+func (m *mockStorer) ReservePutter() storage.Putter {
+	return storage.PutterFunc(
+		func(ctx context.Context, chunk swarm.Chunk) error {
+			if m.storedChunks == nil {
+				m.storedChunks = make(map[string]swarm.Chunk)
+			}
+			m.storedChunks[chunk.Address().ByteString()] = chunk
+			return nil
+		},
+	)
 }
 
 // TestSendChunkToPushSync sends a chunk to pushsync to be sent ot its closest peer and get a receipt.

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -69,7 +69,7 @@ type Receipt struct {
 
 type Storer interface {
 	storage.PushReporter
-	ReservePut(context.Context, swarm.Chunk) error
+	ReservePutter() storage.Putter
 	IsWithinStorageRadius(swarm.Address) bool
 	StorageRadius() uint8
 }
@@ -208,7 +208,7 @@ func (ps *PushSync) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) 
 			return fmt.Errorf("invalid stamp: %w", err)
 		}
 
-		err = ps.store.ReservePut(ctx, chunkToPut)
+		err = ps.store.ReservePutter().Put(ctx, chunkToPut)
 		if err != nil {
 			return fmt.Errorf("chunk store: %w", err)
 		}

--- a/pkg/pushsync/pushsync_test.go
+++ b/pkg/pushsync/pushsync_test.go
@@ -702,12 +702,15 @@ type testStorer struct {
 	chunksReported map[string]int
 }
 
-func (ts *testStorer) ReservePut(ctx context.Context, chunk swarm.Chunk) error {
-	ts.chunksMu.Lock()
-	defer ts.chunksMu.Unlock()
-
-	ts.chunksPut[chunk.Address().ByteString()] = chunk
-	return nil
+func (ts *testStorer) ReservePutter() storage.Putter {
+	return storage.PutterFunc(
+		func(ctx context.Context, chunk swarm.Chunk) error {
+			ts.chunksMu.Lock()
+			defer ts.chunksMu.Unlock()
+			ts.chunksPut[chunk.Address().ByteString()] = chunk
+			return nil
+		},
+	)
 }
 
 func (ts *testStorer) Report(ctx context.Context, chunk swarm.Chunk, state storage.ChunkState) error {

--- a/pkg/storer/debug_test.go
+++ b/pkg/storer/debug_test.go
@@ -127,7 +127,7 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 			t.Fatal(err)
 		}
 
-		putter := lstore.ReservePutter(context.Background())
+		putter := lstore.ReservePutter()
 
 		chunks := chunktest.GenerateTestRandomChunks(10)
 		for _, ch := range chunks {
@@ -135,11 +135,6 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 			if err != nil {
 				t.Fatalf("session.Put(...): unexpected error: %v", err)
 			}
-		}
-
-		err = putter.Done(swarm.ZeroAddress)
-		if err != nil {
-			t.Fatalf("session.Done(...): unexpected error: %v", err)
 		}
 
 		info, err := lstore.DebugInfo(context.Background())

--- a/pkg/storer/internal/cache/cache.go
+++ b/pkg/storer/internal/cache/cache.go
@@ -177,7 +177,7 @@ func New(ctx context.Context, store internal.Storage, capacity uint64) (*Cache, 
 		return nil, fmt.Errorf("failed updating state: %w", err)
 	}
 
-	return &Cache{capacity: capacity}, nil
+	return &Cache{size: state.Count, capacity: capacity}, nil
 }
 
 // popFront will pop the first item in the queue. It will update the cache state so

--- a/pkg/storer/internal/cache/export_test.go
+++ b/pkg/storer/internal/cache/export_test.go
@@ -20,14 +20,13 @@ var (
 	ErrUnmarshalCacheEntryInvalidSize  = errUnmarshalCacheEntryInvalidSize
 )
 
-func (c *Cache) State() CacheState {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
-	start := c.state.Head.Clone()
-	end := c.state.Tail.Clone()
-
-	return cacheState{Head: start, Tail: end, Count: c.state.Count}
+func (c *Cache) State(store storage.Store) CacheState {
+	state := &CacheState{}
+	err := store.Get(state)
+	if err != nil {
+		return CacheState{}
+	}
+	return *state
 }
 
 func (c *Cache) IterateOldToNew(

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -27,8 +27,7 @@ const loggerName = "reserve"
 const reserveNamespace = "reserve"
 
 type Reserve struct {
-	mtx      sync.Mutex
-	putterMu sync.Mutex
+	mtx sync.Mutex
 
 	baseAddr     swarm.Address
 	radiusSetter topology.SetStorageRadiuser
@@ -77,9 +76,6 @@ func New(
 
 // Put stores a new chunk in the reserve and returns if the reserve size should increase.
 func (r *Reserve) Put(ctx context.Context, store internal.Storage, chunk swarm.Chunk) (bool, error) {
-	r.putterMu.Lock()
-	defer r.putterMu.Unlock()
-
 	indexStore := store.IndexStore()
 	chunkStore := store.ChunkStore()
 
@@ -330,9 +326,7 @@ func (r *Reserve) EvictBatchBin(ctx context.Context, store internal.Storage, bin
 
 		cb(c)
 
-		r.putterMu.Lock()
 		err = removeChunk(ctx, store, item)
-		r.putterMu.Unlock()
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/storer/mock/mockreserve.go
+++ b/pkg/storer/mock/mockreserve.go
@@ -196,16 +196,6 @@ func (s *ReserveStore) ReserveGet(ctx context.Context, addr swarm.Address, batch
 	return nil, storage.ErrNotFound
 }
 
-type reservePutterSession struct {
-	storage.Putter
-	done    func(swarm.Address) error
-	cleanup func() error
-}
-
-func (p *reservePutterSession) Done(addr swarm.Address) error { return p.done(addr) }
-
-func (p *reservePutterSession) Cleanup() error { return p.cleanup() }
-
 // Put chunks.
 func (s *ReserveStore) ReservePutter() storage.Putter {
 	return storage.PutterFunc(

--- a/pkg/storer/mock/mockreserve.go
+++ b/pkg/storer/mock/mockreserve.go
@@ -207,24 +207,15 @@ func (p *reservePutterSession) Done(addr swarm.Address) error { return p.done(ad
 func (p *reservePutterSession) Cleanup() error { return p.cleanup() }
 
 // Put chunks.
-func (s *ReserveStore) ReservePutter(ctx context.Context) storer.PutterSession {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	return &reservePutterSession{
-		Putter: storage.PutterFunc(func(ctx context.Context, c swarm.Chunk) error {
+func (s *ReserveStore) ReservePutter() storage.Putter {
+	return storage.PutterFunc(
+		func(ctx context.Context, c swarm.Chunk) error {
+			s.mtx.Lock()
+			s.putCalls++
+			s.mtx.Unlock()
 			return s.put(ctx, c)
-		}),
-		done:    func(a swarm.Address) error { return nil },
-		cleanup: func() error { return nil },
-	}
-}
-
-func (s *ReserveStore) ReservePut(ctx context.Context, c swarm.Chunk) error {
-	s.mtx.Lock()
-	s.putCalls++
-	s.mtx.Unlock()
-	return s.put(ctx, c)
+		},
+	)
 }
 
 // Put chunks.

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	reserveOverCapacity = "reserveOverCapacity"
-	reserveUnreserved   = "reserveUnreserved"
-	sampleSize          = 16
+	reserveOverCapacity  = "reserveOverCapacity"
+	reserveUnreserved    = "reserveUnreserved"
+	sampleSize           = 16
+	reserveUpdateLockKey = "reserveUpdateLockKey"
 )
 
 var errMaxRadius = errors.New("max radius reached")
@@ -153,70 +154,45 @@ func (db *DB) ReserveHas(addr swarm.Address, batchID []byte) (has bool, err erro
 	return db.reserve.Has(db.repo.IndexStore(), addr, batchID)
 }
 
-func (db *DB) ReservePut(ctx context.Context, chunk swarm.Chunk) (err error) {
-	dur := captureDuration(time.Now())
-	defer func() {
-		db.metrics.MethodCallsDuration.WithLabelValues("reserve", "ReservePut").Observe(dur())
-		if err == nil {
-			db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "success").Inc()
-		} else {
-			db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "failure").Inc()
-		}
-	}()
+// ReservePutter returns a Putter for inserting chunks into the reserve.
+func (db *DB) ReservePutter() storage.Putter {
+	return putterWithMetrics{
+		storage.PutterFunc(
+			func(ctx context.Context, chunk swarm.Chunk) (err error) {
+				dur := captureDuration(time.Now())
+				defer func() {
+					db.metrics.MethodCallsDuration.WithLabelValues("reserve", "ReservePut").Observe(dur())
+					if err == nil {
+						db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "success").Inc()
+					} else {
+						db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "failure").Inc()
+					}
+				}()
 
-	putter := db.ReservePutter(ctx)
-	if err := putter.Put(ctx, chunk); err != nil {
-		return errors.Join(err, putter.Cleanup())
-	}
-	return putter.Done(swarm.ZeroAddress)
-}
+				db.lock.Lock(reserveUpdateLockKey)
+				defer db.lock.Unlock(reserveUpdateLockKey)
 
-// ReservePutter returns a PutterSession for inserting chunks into the reserve.
-func (db *DB) ReservePutter(ctx context.Context) PutterSession {
-
-	trx, commit, rollback := db.repo.NewTx(ctx)
-
-	triggerBins := make(map[uint8]bool)
-	count := 0
-
-	db.reserveMtx.RLock()
-
-	return &putterSession{
-		Putter: putterWithMetrics{
-			storage.PutterFunc(func(ctx context.Context, chunk swarm.Chunk) error {
+				trx, commit, rollback := db.repo.NewTx(ctx)
 				newIndex, err := db.reserve.Put(ctx, trx, chunk)
 				if err != nil {
+					return errors.Join(err, rollback())
+				}
+				if err := commit(); err != nil {
 					return err
 				}
-				triggerBins[db.po(chunk.Address())] = true
 				if newIndex {
-					count++
+					db.reserve.AddSize(1)
 				}
+				db.reserveBinEvents.Trigger(string(db.po(chunk.Address())))
+				if !db.reserve.IsWithinCapacity() {
+					db.events.Trigger(reserveOverCapacity)
+				}
+				db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
 				return nil
-			}),
-			db.metrics,
-			"reserve",
-		},
-		done: func(swarm.Address) error {
-			defer db.reserveMtx.RUnlock()
-			err := commit()
-			if err != nil {
-				return err
-			}
-			db.reserve.AddSize(count)
-			for bin := range triggerBins {
-				db.reserveBinEvents.Trigger(string(bin))
-			}
-			if !db.reserve.IsWithinCapacity() {
-				db.events.Trigger(reserveOverCapacity)
-			}
-			db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
-			return nil
-		},
-		cleanup: func() error {
-			defer db.reserveMtx.RUnlock()
-			return rollback()
-		},
+			},
+		),
+		db.metrics,
+		"reserve",
 	}
 }
 
@@ -240,9 +216,6 @@ func (db *DB) EvictBatch(ctx context.Context, batchID []byte) (err error) {
 
 func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (err error) {
 
-	db.reserveMtx.Lock()
-	defer db.reserveMtx.Unlock()
-
 	for b := uint8(0); b < upToBin; b++ {
 
 		select {
@@ -251,34 +224,42 @@ func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (er
 		default:
 		}
 
-		txnRepo, commit, rollback := db.repo.NewTx(ctx)
+		err := func() error {
+			db.lock.Lock(reserveUpdateLockKey)
+			defer db.lock.Unlock(reserveUpdateLockKey)
 
-		// cache evicted chunks
-		cache := func(c swarm.Chunk) {
-			if err := db.Cache().Put(ctx, c); err != nil {
-				db.logger.Error(err, "reserve cache")
+			txnRepo, commit, rollback := db.repo.NewTx(ctx)
+
+			// cache evicted chunks
+			cache := func(c swarm.Chunk) {
+				if err := db.Cache().Put(ctx, c); err != nil {
+					db.logger.Error(err, "reserve cache")
+				}
 			}
-		}
 
-		evicted, err := db.reserve.EvictBatchBin(ctx, txnRepo, b, batchID, cache)
+			evicted, err := db.reserve.EvictBatchBin(ctx, txnRepo, b, batchID, cache)
+			if err != nil {
+				return errors.Join(err, rollback())
+			}
+
+			err = commit()
+			if err != nil {
+				return err
+			}
+
+			db.logger.Info("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())
+
+			db.reserve.AddSize(-evicted)
+			db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
+			if upToBin == swarm.MaxBins {
+				db.metrics.ExpiredChunkCount.Add(float64(evicted))
+			} else {
+				db.metrics.EvictedChunkCount.Add(float64(evicted))
+			}
+			return nil
+		}()
 		if err != nil {
-			_ = rollback()
 			return err
-		}
-
-		err = commit()
-		if err != nil {
-			return err
-		}
-
-		db.logger.Info("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())
-
-		db.reserve.AddSize(-evicted)
-		db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
-		if upToBin == swarm.MaxBins {
-			db.metrics.ExpiredChunkCount.Add(float64(evicted))
-		} else {
-			db.metrics.EvictedChunkCount.Add(float64(evicted))
 		}
 	}
 

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -159,16 +159,6 @@ func (db *DB) ReservePutter() storage.Putter {
 	return putterWithMetrics{
 		storage.PutterFunc(
 			func(ctx context.Context, chunk swarm.Chunk) (err error) {
-				dur := captureDuration(time.Now())
-				defer func() {
-					db.metrics.MethodCallsDuration.WithLabelValues("reserve", "ReservePut").Observe(dur())
-					if err == nil {
-						db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "success").Inc()
-					} else {
-						db.metrics.MethodCalls.WithLabelValues("reserve", "ReservePut", "failure").Inc()
-					}
-				}()
-
 				db.lock.Lock(reserveUpdateLockKey)
 				defer db.lock.Unlock(reserveUpdateLockKey)
 

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -404,7 +404,7 @@ func TestRadiusManager(t *testing.T) {
 		t.Parallel()
 		bs := batchstore.New()
 
-		storer, err := memStorer(t, dbTestOps(baseAddr, 10, bs, nil, time.Millisecond*50))()
+		storer, err := memStorer(t, dbTestOps(baseAddr, 10, bs, nil, time.Millisecond*500))()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -428,9 +428,9 @@ func TestRadiusManager(t *testing.T) {
 			}
 		}
 
-		waitForRadius(t, storer.Reserve(), 3)
-
 		waitForSize(t, storer.Reserve(), 10)
+
+		waitForRadius(t, storer.Reserve(), 3)
 
 		err = storer.EvictBatch(context.Background(), batch.ID)
 		if err != nil {

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -396,7 +396,6 @@ type DB struct {
 
 	reserve          *reserve.Reserve
 	reserveWg        sync.WaitGroup
-	reserveMtx       sync.RWMutex
 	reserveBinEvents *events.Subscriber
 	baseAddr         swarm.Address
 	batchstore       postage.Storer

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -139,8 +139,7 @@ type ReserveIterator interface {
 type ReserveStore interface {
 	ReserveGet(ctx context.Context, addr swarm.Address, batchID []byte) (swarm.Chunk, error)
 	ReserveHas(addr swarm.Address, batchID []byte) (bool, error)
-	ReservePut(context.Context, swarm.Chunk) error
-	ReservePutter(ctx context.Context) PutterSession
+	ReservePutter() storage.Putter
 	SubscribeBin(ctx context.Context, bin uint8, start uint64) (<-chan *BinC, func(), <-chan error)
 	ReserveLastBinIDs() ([]uint64, error)
 	RadiusChecker


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The current Reserve and Cache synchronization is a little problematic. The mutexes in the internal packages dont protect against Txn rollbacks that can occur due to failures. As a result it is better to have the locking in the storer package.

Also, the cache optimization for saving state in memory could also be problematic. Right now it seems like an unnecessary optimization. So instead it will read the state for every op.

The mem profiles after the changes show significant improvements all round.

![Screenshot 2023-06-02 at 6 46 36 PM](https://github.com/ethersphere/bee/assets/5412421/aa583929-4cd6-46ed-befd-2a12cd8a9510)

![Screenshot 2023-06-02 at 6 46 56 PM](https://github.com/ethersphere/bee/assets/5412421/cb46fd2c-aff9-43b9-88b1-d0014d359dba)

![Screenshot 2023-06-02 at 6 47 13 PM](https://github.com/ethersphere/bee/assets/5412421/da68f2bb-eec6-482a-a53f-8699d2ed9fdc)
