### PR TITLE
fix: transaction rollback logic

### DIFF
--- a/pkg/storage/inmemchunkstore/transaction.go
+++ b/pkg/storage/inmemchunkstore/transaction.go
@@ -76,7 +76,7 @@ func (s *TxChunkStore) Commit() error {
 func (s *TxChunkStore) Rollback() error {
 	defer s.release()
 
-	if err := s.TxState.Done(); err != nil {
+	if err := s.TxChunkStoreBase.Rollback(); err != nil {
 		return err
 	}
 

--- a/pkg/storage/inmemstore/transaction.go
+++ b/pkg/storage/inmemstore/transaction.go
@@ -91,7 +91,7 @@ func (s *TxStore) Commit() error {
 func (s *TxStore) Rollback() error {
 	defer s.release()
 
-	if err := s.TxState.Done(); err != nil {
+	if err := s.TxStoreBase.Rollback(); err != nil {
 		return err
 	}
 

--- a/pkg/storage/leveldbstore/transaction.go
+++ b/pkg/storage/leveldbstore/transaction.go
@@ -107,7 +107,7 @@ func (s *TxStore) Commit() error {
 func (s *TxStore) Rollback() error {
 	defer s.release()
 
-	if err := s.TxState.Done(); err != nil {
+	if err := s.TxStoreBase.Rollback(); err != nil {
 		return err
 	}
 

--- a/pkg/storer/internal/chunkstore/transaction.go
+++ b/pkg/storer/internal/chunkstore/transaction.go
@@ -144,7 +144,7 @@ func (cs *txChunkStoreWrapper) Commit() error {
 }
 
 func (cs *txChunkStoreWrapper) Rollback() error {
-	if err := cs.TxChunkStoreBase.Done(); err != nil {
+	if err := cs.TxChunkStoreBase.Rollback(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

The `Rollback` transaction function returns a value of `nil` on its first call after the parent context has been canceled.