### PR TITLE
chore: move sample duration to SampleData

### DIFF
--- a/pkg/storageincentives/agent.go
+++ b/pkg/storageincentives/agent.go
@@ -420,13 +420,12 @@ func (a *Agent) handleSample(ctx context.Context, round uint64) (bool, error) {
 		return false, nil
 	}
 
-	now := time.Now()
 	sample, err := a.makeSample(ctx, storageRadius)
 	if err != nil {
 		return false, err
 	}
 
-	a.state.SetSampleData(round, sample, time.Since(now))
+	a.state.SetSampleData(round, sample)
 
 	return true, nil
 }
@@ -447,7 +446,8 @@ func (a *Agent) makeSample(ctx context.Context, storageRadius uint8) (SampleData
 	if err != nil {
 		return SampleData{}, err
 	}
-	a.metrics.SampleDuration.Set(time.Since(t).Seconds())
+	dur := time.Since(t)
+	a.metrics.SampleDuration.Set(dur.Seconds())
 
 	sampleHash, err := sampleHash(rSample.Items)
 	if err != nil {
@@ -457,6 +457,7 @@ func (a *Agent) makeSample(ctx context.Context, storageRadius uint8) (SampleData
 	sample := SampleData{
 		ReserveSampleHash: sampleHash,
 		StorageRadius:     storageRadius,
+		SampleDuration:    dur,
 	}
 
 	return sample, nil

--- a/pkg/storageincentives/redistributionstate.go
+++ b/pkg/storageincentives/redistributionstate.go
@@ -52,7 +52,6 @@ type Status struct {
 	Reward            *big.Int
 	Fees              *big.Int
 	RoundData         map[uint64]RoundData
-	SampleDuration    time.Duration
 }
 
 type RoundData struct {
@@ -64,6 +63,7 @@ type RoundData struct {
 type SampleData struct {
 	ReserveSampleHash swarm.Address
 	StorageRadius     uint8
+	SampleDuration    time.Duration
 }
 
 func NewStatus() *Status {
@@ -240,14 +240,13 @@ func (r *RedistributionState) SampleData(round uint64) (SampleData, bool) {
 	return *rd.SampleData, true
 }
 
-func (r *RedistributionState) SetSampleData(round uint64, sd SampleData, dur time.Duration) {
+func (r *RedistributionState) SetSampleData(round uint64, sd SampleData) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
 	rd := r.status.RoundData[round]
 	rd.SampleData = &sd
 	r.status.RoundData[round] = rd
-	r.status.SampleDuration = dur
 
 	r.save()
 }

--- a/pkg/storageincentives/redistributionstate_test.go
+++ b/pkg/storageincentives/redistributionstate_test.go
@@ -107,7 +107,7 @@ func TestStateRoundData(t *testing.T) {
 			ReserveSampleHash: swarm.RandAddress(t),
 			StorageRadius:     3,
 		}
-		state.SetSampleData(1, savedSample, 0)
+		state.SetSampleData(1, savedSample)
 
 		sample, exists := state.SampleData(1)
 		if !exists {
@@ -171,7 +171,7 @@ func TestPurgeRoundData(t *testing.T) {
 		}
 		commitKey := testutil.RandBytes(t, swarm.HashSize)
 
-		state.SetSampleData(round, savedSample, 0)
+		state.SetSampleData(round, savedSample)
 		state.SetCommitKey(round, commitKey)
 		state.SetHasRevealed(round)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
`SampleData` struct looks like more appropriate place to hold sample duration value.
