### PR TITLE
fix(status): get radius before calculations

### DIFF
--- a/pkg/api/status_test.go
+++ b/pkg/api/status_test.go
@@ -49,9 +49,9 @@ func TestGetStatus(t *testing.T) {
 			new(topologyPeersIterNoopMock),
 			mode.String(),
 			ssMock,
+			ssMock,
 		)
 
-		statusSvc.SetStorage(ssMock)
 		statusSvc.SetSync(ssMock)
 
 		client, _, _, _ := newTestServer(t, testServerOptions{
@@ -76,6 +76,7 @@ func TestGetStatus(t *testing.T) {
 				nil,
 				new(topologyPeersIterNoopMock),
 				"",
+				nil,
 				nil,
 			),
 		})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -943,7 +943,7 @@ func NewBee(
 	// set the pushSyncer in the PSS
 	pssService.SetPushSyncer(pushSyncProtocol)
 
-	nodeStatus := status.NewService(logger, p2ps, kad, beeNodeMode.String(), batchStore)
+	nodeStatus := status.NewService(logger, p2ps, kad, beeNodeMode.String(), batchStore, localStore)
 	if err = p2ps.AddProtocol(nodeStatus.Protocol()); err != nil {
 		return nil, fmt.Errorf("status service: %w", err)
 	}
@@ -1039,8 +1039,6 @@ func NewBee(
 		b.pullerCloser = pullerService
 
 		localStore.StartReserveWorker(pullerService, networkRadiusFunc)
-
-		nodeStatus.SetStorage(localStore)
 		nodeStatus.SetSync(pullerService)
 
 		if o.EnableStorageIncentives {

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -42,14 +42,14 @@ func TestStatus(t *testing.T) {
 		peersIterMock,
 		want.BeeMode,
 		sssMock,
+		sssMock,
 	)
 
-	peer1.SetStorage(sssMock)
 	peer1.SetSync(sssMock)
 
 	recorder := streamtest.New(streamtest.WithProtocols(peer1.Protocol()))
 
-	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil)
+	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil)
 
 	address := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 
@@ -119,11 +119,12 @@ func TestStatusLightNode(t *testing.T) {
 		peersIterMock,
 		want.BeeMode,
 		sssMock,
+		nil,
 	)
 
 	recorder := streamtest.New(streamtest.WithProtocols(peer1.Protocol()))
 
-	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil)
+	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil)
 
 	address := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -46,7 +46,7 @@ type Syncer interface {
 
 func threshold(capacity int) int { return capacity * 5 / 10 }
 
-func (db *DB) reserveWorker(capacity int, warmupDur, wakeUpDur time.Duration, radius func() (uint8, error)) {
+func (db *DB) reserveWorker(warmupDur, wakeUpDur time.Duration, radius func() (uint8, error)) {
 	defer db.reserveWg.Done()
 
 	overCapTrigger, overCapUnsub := db.events.Subscribe(reserveOverCapacity)
@@ -91,7 +91,7 @@ func (db *DB) reserveWorker(capacity int, warmupDur, wakeUpDur time.Duration, ra
 			db.metrics.OverCapTriggerCount.Inc()
 		case <-wakeUpTicker.C:
 			radius := db.reserve.Radius()
-			if db.reserve.Size() < threshold(capacity) && db.syncer.SyncRate() == 0 && radius > 0 {
+			if db.reserve.Size() < threshold(db.reserve.Capacity()) && db.syncer.SyncRate() == 0 && radius > 0 {
 				radius--
 				err := db.reserve.SetRadius(db.repo.IndexStore(), radius)
 				if err != nil {

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -546,7 +546,7 @@ func (db *DB) StartReserveWorker(s Syncer, radius func() (uint8, error)) {
 	db.setSyncerOnce.Do(func() {
 		db.syncer = s
 		db.reserveWg.Add(1)
-		go db.reserveWorker(db.reserve.Capacity(), db.opts.warmupDuration, db.opts.wakeupDuration, radius)
+		go db.reserveWorker(db.opts.warmupDuration, db.opts.wakeupDuration, radius)
 	})
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
status api returns that all connected peers are neighbors because of a bug in the status pkg.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
