### PR TITLE
fix(direct-upload): use same concurrency as deferred upload

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -61,7 +61,7 @@ type Service struct {
 
 const (
 	traceDuration     = 30 * time.Second // duration for every root tracing span
-	concurrentPushes  = 100              // how many chunks to push simultaneously
+	ConcurrentPushes  = 100              // how many chunks to push simultaneously
 	DefaultRetryCount = 6
 )
 
@@ -116,7 +116,7 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 		wg                sync.WaitGroup
 		span, logger, ctx = tracer.StartSpanFromContext(cctx, "pusher-sync-batch", s.logger)
 		timer             = time.NewTimer(traceDuration)
-		sem               = make(chan struct{}, concurrentPushes)
+		sem               = make(chan struct{}, ConcurrentPushes)
 		cc                = make(chan *Op)
 	)
 

--- a/pkg/storer/export_test.go
+++ b/pkg/storer/export_test.go
@@ -100,11 +100,11 @@ func (db *DB) SetRepoStorePutHook(fn func(storage.Item) error) {
 
 func (db *DB) WaitForBgCacheWorkers() (unblock func()) {
 	for i := 0; i < defaultBgCacheWorkers; i++ {
-		db.bgCacheWorkers <- struct{}{}
+		db.bgCacheLimiter <- struct{}{}
 	}
 	return func() {
 		for i := 0; i < defaultBgCacheWorkers; i++ {
-			<-db.bgCacheWorkers
+			<-db.bgCacheLimiter
 		}
 	}
 }

--- a/pkg/storer/netstore.go
+++ b/pkg/storer/netstore.go
@@ -74,12 +74,12 @@ func (db *DB) Download(cache bool) storage.Getter {
 						select {
 						case <-ctx.Done():
 						case <-db.quit:
-						case db.bgCacheWorkers <- struct{}{}:
-							db.bgCacheWorkersWg.Add(1)
+						case db.bgCacheLimiter <- struct{}{}:
+							db.bgCacheLimiterWg.Add(1)
 							go func() {
 								defer func() {
-									<-db.bgCacheWorkers
-									db.bgCacheWorkersWg.Done()
+									<-db.bgCacheLimiter
+									db.bgCacheLimiterWg.Done()
 								}()
 
 								err := db.Cache().Put(ctx, ch)

--- a/pkg/storer/netstore.go
+++ b/pkg/storer/netstore.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	directUploadWorkers = 16
+	directUploadWorkers = pusher.ConcurrentPushes
 )
 
 // DirectUpload is the implementation of the NetStore.DirectUpload method.

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -400,17 +400,21 @@ type DB struct {
 	logger  log.Logger
 	metrics metrics
 
-	repo             storage.Repository
-	lock             *multex.Multex
-	cacheObj         *cache.Cache
-	retrieval        retrieval.Interface
-	pusherFeed       chan *pusher.Op
-	quit             chan struct{}
-	bgCacheWorkers   chan struct{}
-	bgCacheWorkersWg sync.WaitGroup
-	dbCloser         io.Closer
-	subscriptionsWG  sync.WaitGroup
-	events           *events.Subscriber
+	repo                storage.Repository
+	lock                *multex.Multex
+	cacheObj            *cache.Cache
+	retrieval           retrieval.Interface
+	pusherFeed          chan *pusher.Op
+	quit                chan struct{}
+	bgCacheWorkers      chan struct{}
+	bgCacheWorkersWg    sync.WaitGroup
+	dbCloser            io.Closer
+	subscriptionsWG     sync.WaitGroup
+	events              *events.Subscriber
+	bgCacheLimiter      chan struct{}
+	bgCacheLimitersWg   sync.WaitGroup
+	directUploadLimiter chan struct{}
+
 	reserve          *reserve.Reserve
 	reserveWg        sync.WaitGroup
 	reserveBinEvents *events.Subscriber
@@ -477,7 +481,7 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 		retrieval:        noopRetrieval{},
 		pusherFeed:       make(chan *pusher.Op),
 		quit:             make(chan struct{}),
-		bgCacheWorkers:   make(chan struct{}, 16),
+		bgCacheLimiter:   make(chan struct{}, 16),
 		dbCloser:         dbCloser,
 		batchstore:       opts.Batchstore,
 		validStamp:       opts.ValidStamp,
@@ -487,6 +491,7 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 			warmupDuration: opts.WarmupDuration,
 			wakeupDuration: opts.ReserveWakeUpDuration,
 		},
+		directUploadLimiter: make(chan struct{}, pusher.ConcurrentPushes),
 	}
 
 	if db.validStamp == nil {
@@ -538,7 +543,7 @@ func (db *DB) Close() error {
 	bgCacheWorkersClosed := make(chan struct{})
 	go func() {
 		defer close(bgCacheWorkersClosed)
-		db.bgCacheWorkersWg.Wait()
+		db.bgCacheLimitersWg.Wait()
 	}()
 
 	var err error

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -406,13 +406,11 @@ type DB struct {
 	retrieval           retrieval.Interface
 	pusherFeed          chan *pusher.Op
 	quit                chan struct{}
-	bgCacheWorkers      chan struct{}
-	bgCacheWorkersWg    sync.WaitGroup
+	bgCacheLimiter      chan struct{}
+	bgCacheLimiterWg    sync.WaitGroup
 	dbCloser            io.Closer
 	subscriptionsWG     sync.WaitGroup
 	events              *events.Subscriber
-	bgCacheLimiter      chan struct{}
-	bgCacheLimitersWg   sync.WaitGroup
 	directUploadLimiter chan struct{}
 
 	reserve          *reserve.Reserve
@@ -543,7 +541,7 @@ func (db *DB) Close() error {
 	bgCacheWorkersClosed := make(chan struct{})
 	go func() {
 		defer close(bgCacheWorkersClosed)
-		db.bgCacheLimitersWg.Wait()
+		db.bgCacheLimiterWg.Wait()
 	}()
 
 	var err error


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
PR makes direct upload concurrency level the same as differed uploads.
multiple parallel uploads are limited by the same worker so the node remains protected against goroutine pileup.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
