### PR TITLE
fix(storer): refactor upload and pinning putters

### DIFF
--- a/pkg/api/tag.go
+++ b/pkg/api/tag.go
@@ -42,7 +42,7 @@ func newTagResponse(tag storer.SessionInfo) tagResponse {
 		Synced:    tag.Synced,
 		Uid:       tag.TagID,
 		Address:   tag.Address,
-		StartedAt: time.Unix(tag.StartedAt, 0),
+		StartedAt: time.Unix(0, tag.StartedAt),
 	}
 }
 

--- a/pkg/storage/storageutil/storageutil.go
+++ b/pkg/storage/storageutil/storageutil.go
@@ -12,8 +12,3 @@ import (
 func JoinFields(fields ...string) string {
 	return strings.Join(fields, "/")
 }
-
-// SplitFields splits the given path by slash.
-func SplitFields(path string) []string {
-	return strings.Split(path, "/")
-}

--- a/pkg/storer/epoch_migration_test.go
+++ b/pkg/storer/epoch_migration_test.go
@@ -1,0 +1,266 @@
+package storer_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/file/splitter"
+	"github.com/ethersphere/bee/pkg/log"
+	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
+	"github.com/ethersphere/bee/pkg/sharky"
+	"github.com/ethersphere/bee/pkg/shed"
+	mockstatestore "github.com/ethersphere/bee/pkg/statestore/mock"
+	storage "github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
+	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
+	storer "github.com/ethersphere/bee/pkg/storer"
+	"github.com/ethersphere/bee/pkg/storer/internal"
+	pinstore "github.com/ethersphere/bee/pkg/storer/internal/pinning"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+type dirFS struct {
+	basedir string
+}
+
+func (d *dirFS) Open(path string) (fs.File, error) {
+	return os.OpenFile(filepath.Join(d.basedir, path), os.O_RDWR|os.O_CREATE, 0644)
+}
+
+func createOldDataDir(t *testing.T, dataPath string, baseAddress swarm.Address, stateStore storage.StateStorer) {
+	t.Helper()
+
+	binIDs := map[uint8]int{}
+
+	assignBinID := func(addr swarm.Address) int {
+		po := swarm.Proximity(baseAddress.Bytes(), addr.Bytes())
+		if _, ok := binIDs[po]; !ok {
+			binIDs[po] = 1
+			return 1
+		}
+		binIDs[po]++
+		return binIDs[po]
+	}
+
+	err := os.Mkdir(filepath.Join(dataPath, "sharky"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sharkyStore, err := sharky.New(&dirFS{basedir: filepath.Join(dataPath, "sharky")}, 2, swarm.SocMaxChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sharkyStore.Close()
+
+	shedDB, err := shed.NewDB(dataPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shedDB.Close()
+
+	pIdx, rIdx, err := storer.InitShedIndexes(shedDB, baseAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reserveChunks := chunktest.GenerateTestRandomChunks(10)
+
+	for _, c := range reserveChunks {
+		loc, err := sharkyStore.Write(context.Background(), c.Data())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		locBuf, err := loc.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		binID := assignBinID(c.Address())
+
+		err = pIdx.Put(shed.Item{
+			Address: c.Address().Bytes(),
+			BinID:   uint64(binID),
+			BatchID: c.Stamp().BatchID(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = rIdx.Put(shed.Item{
+			Address:   c.Address().Bytes(),
+			BinID:     uint64(binID),
+			BatchID:   c.Stamp().BatchID(),
+			Index:     c.Stamp().Index(),
+			Timestamp: c.Stamp().Timestamp(),
+			Sig:       c.Stamp().Sig(),
+			Location:  locBuf,
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// create a pinning collection
+	writer := splitter.NewSimpleSplitter(
+		storage.PutterFunc(
+			func(ctx context.Context, chunk swarm.Chunk) error {
+				c := chunk.WithStamp(postagetesting.MustNewStamp())
+
+				loc, err := sharkyStore.Write(context.Background(), c.Data())
+				if err != nil {
+					return err
+				}
+
+				locBuf, err := loc.MarshalBinary()
+				if err != nil {
+					return err
+				}
+
+				return rIdx.Put(shed.Item{
+					Address:   c.Address().Bytes(),
+					BatchID:   c.Stamp().BatchID(),
+					Index:     c.Stamp().Index(),
+					Timestamp: c.Stamp().Timestamp(),
+					Sig:       c.Stamp().Sig(),
+					Location:  locBuf,
+				})
+			},
+		),
+	)
+
+	randData := make([]byte, 4096*20)
+	_, err = rand.Read(randData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := writer.Split(context.Background(), io.NopCloser(bytes.NewBuffer(randData)), 4096*20, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = stateStore.Put(fmt.Sprintf("root-pin-%s", root.String()), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type testSharkyRecovery struct {
+	*sharky.Recovery
+	mtx      sync.Mutex
+	addCalls int
+}
+
+func (t *testSharkyRecovery) Add(loc sharky.Location) error {
+	t.mtx.Lock()
+	t.addCalls++
+	t.mtx.Unlock()
+	return t.Recovery.Add(loc)
+}
+
+type testReservePutter struct {
+	mtx   sync.Mutex
+	size  int
+	calls int
+}
+
+func (t *testReservePutter) Put(ctx context.Context, st internal.Storage, ch swarm.Chunk) (bool, error) {
+	t.mtx.Lock()
+	t.calls++
+	t.mtx.Unlock()
+	return true, st.ChunkStore().Put(ctx, ch)
+}
+
+func (t *testReservePutter) AddSize(size int) {
+	t.mtx.Lock()
+	t.size += size
+	t.mtx.Unlock()
+}
+
+func (t *testReservePutter) Size() int {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.size
+}
+
+func TestEpochMigration(t *testing.T) {
+	t.Parallel()
+
+	var (
+		dataPath    = t.TempDir()
+		baseAddress = swarm.RandAddress(t)
+		stateStore  = mockstatestore.NewStateStore()
+		reserve     = &testReservePutter{}
+		logBytes    = bytes.NewBuffer(nil)
+		logger      = log.NewLogger("test", log.WithSink(logBytes))
+		indexStore  = inmemstore.New()
+	)
+
+	createOldDataDir(t, dataPath, baseAddress, stateStore)
+
+	r, err := sharky.NewRecovery(path.Join(dataPath, "sharky"), 2, swarm.SocMaxChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sharkyRecovery := &testSharkyRecovery{Recovery: r}
+
+	err = storer.EpochMigration(
+		context.Background(),
+		dataPath,
+		stateStore,
+		indexStore,
+		reserve,
+		sharkyRecovery,
+		logger,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.ContainsAny(logBytes.String(), "migrating pinning collections done") {
+		t.Fatalf("expected log to contain 'migrating pinning collections done', got %s", logBytes.String())
+	}
+
+	if !strings.ContainsAny(logBytes.String(), "migrating reserve contents done") {
+		t.Fatalf("expected log to contain 'migrating pinning collections done', got %s", logBytes.String())
+	}
+
+	if sharkyRecovery.addCalls != 31 {
+		t.Fatalf("expected 31 add calls, got %d", sharkyRecovery.addCalls)
+	}
+
+	if reserve.calls != 10 {
+		t.Fatalf("expected 10 reserve calls, got %d", reserve.calls)
+	}
+
+	if reserve.size != 10 {
+		t.Fatalf("expected 10 reserve size, got %d", reserve.size)
+	}
+
+	pins, err := pinstore.Pins(indexStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pins) != 1 {
+		t.Fatalf("expected 1 pin, got %d", len(pins))
+	}
+
+	if !strings.ContainsAny(logBytes.String(), pins[0].String()) {
+		t.Fatalf("expected log to contain root pin reference, got %s", logBytes.String())
+	}
+}

--- a/pkg/storer/epoch_migration_test.go
+++ b/pkg/storer/epoch_migration_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package storer_test
 
 import (

--- a/pkg/storer/epoch_migration_test.go
+++ b/pkg/storer/epoch_migration_test.go
@@ -7,10 +7,10 @@ package storer_test
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"io/fs"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"

--- a/pkg/storer/export_test.go
+++ b/pkg/storer/export_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/ethersphere/bee/pkg/storer/internal/reserve"
 )
 
+var (
+	InitShedIndexes = initShedIndexes
+	EpochMigration  = epochMigration
+)
+
 func (db *DB) Reserve() *reserve.Reserve {
 	return db.reserve
 }

--- a/pkg/storer/internal/internal.go
+++ b/pkg/storer/internal/internal.go
@@ -6,6 +6,7 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"errors"
 
 	storage "github.com/ethersphere/bee/pkg/storage"
@@ -23,8 +24,9 @@ type Storage interface {
 // PutterCloserWithReference provides a Putter which can be closed with a root
 // swarm reference associated with this session.
 type PutterCloserWithReference interface {
-	storage.Putter
-	Close(swarm.Address) error
+	Put(context.Context, Storage, swarm.Chunk) error
+	Close(Storage, swarm.Address) error
+	Cleanup(Storage) error
 }
 
 var emptyAddr = make([]byte, swarm.HashSize)

--- a/pkg/storer/internal/pinning/export_test.go
+++ b/pkg/storer/internal/pinning/export_test.go
@@ -14,6 +14,7 @@ import (
 type (
 	PinCollectionItem = pinCollectionItem
 	PinChunkItem      = pinChunkItem
+	DirtyCollection   = dirtyCollection
 )
 
 var (

--- a/pkg/storer/internal/pinning/pinning.go
+++ b/pkg/storer/internal/pinning/pinning.go
@@ -42,9 +42,6 @@ var (
 	errCollectionRootAddressIsZero = errors.New("pin store: collection root address is zero")
 )
 
-// batchSize used for deletion
-var batchSize = 100
-
 // creates a new UUID and returns it as a byte slice
 func newUUID() []byte {
 	id := uuid.New()

--- a/pkg/storer/internal/pinning/pinning_test.go
+++ b/pkg/storer/internal/pinning/pinning_test.go
@@ -25,7 +25,7 @@ type pinningCollection struct {
 	dupChunks    []swarm.Chunk
 }
 
-func newTestStorage(t *testing.T) internal.Storage {
+func newTestStorage(t *testing.T) internal.BatchedStorage {
 	t.Helper()
 
 	storg, closer := internal.NewInmemStorage()

--- a/pkg/storer/internal/pinning/pinning_test.go
+++ b/pkg/storer/internal/pinning/pinning_test.go
@@ -299,9 +299,10 @@ func TestPinStore(t *testing.T) {
 func TestCleanup(t *testing.T) {
 	t.Parallel()
 
-	st := newTestStorage(t)
-
 	t.Run("cleanup putter", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestStorage(t)
 		chunks := chunktest.GenerateTestRandomChunks(5)
 
 		putter, err := pinstore.NewCollection(st)
@@ -333,6 +334,9 @@ func TestCleanup(t *testing.T) {
 	})
 
 	t.Run("cleanup dirty", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestStorage(t)
 		chunks := chunktest.GenerateTestRandomChunks(5)
 
 		putter, err := pinstore.NewCollection(st)

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -253,6 +253,108 @@ func TestEvict(t *testing.T) {
 	}
 }
 
+func TestIterate(t *testing.T) {
+	t.Parallel()
+
+	baseAddr := swarm.RandAddress(t)
+
+	ts, closer := internal.NewInmemStorage()
+	t.Cleanup(func() {
+		if err := closer(); err != nil {
+			t.Errorf("failed closing the storage: %v", err)
+		}
+	})
+
+	r, err := reserve.New(baseAddr, ts.IndexStore(), 0, kademlia.NewTopologyDriver(), log.Noop)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for b := 0; b < 3; b++ {
+		for i := 0; i < 10; i++ {
+			ch := chunk.GenerateTestRandomChunkAt(t, baseAddr, b)
+			c, err := r.Put(context.Background(), ts, ch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !c {
+				t.Fatal("entered unique chunk")
+			}
+		}
+	}
+
+	t.Run("iterate bin", func(t *testing.T) {
+		t.Parallel()
+
+		var id uint64 = 0
+		err := r.IterateBin(ts.IndexStore(), 1, 0, func(ch swarm.Address, binID uint64, _ []byte) (bool, error) {
+			if binID != id {
+				t.Fatalf("got %d, want %d", binID, id)
+			}
+			id++
+			return false, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != 10 {
+			t.Fatalf("got %d, want %d", id, 10)
+		}
+	})
+
+	t.Run("iterate chunks", func(t *testing.T) {
+		t.Parallel()
+
+		count := 0
+		err := r.IterateChunks(ts, 2, func(_ swarm.Chunk) (bool, error) {
+			count++
+			return false, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 10 {
+			t.Fatalf("got %d, want %d", count, 10)
+		}
+	})
+
+	t.Run("iterate chunk items", func(t *testing.T) {
+		t.Parallel()
+
+		count := 0
+		err := r.IterateChunksItems(ts, 0, func(_ reserve.ChunkItem) (bool, error) {
+			count++
+			return false, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 30 {
+			t.Fatalf("got %d, want %d", count, 30)
+		}
+	})
+
+	t.Run("last bin id", func(t *testing.T) {
+		t.Parallel()
+
+		ids, err := r.LastBinIDs(ts.IndexStore())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, id := range ids {
+			if i < 3 {
+				if id != 9 {
+					t.Fatalf("got %d, want %d", id, 9)
+				}
+			} else {
+				if id != 0 {
+					t.Fatalf("got %d, want %d", id, 0)
+				}
+			}
+		}
+	})
+}
+
 func checkStore(t *testing.T, s storage.Store, k storage.Key, gone bool) {
 	t.Helper()
 	h, err := s.Has(k)

--- a/pkg/storer/internal/upload/export_test.go
+++ b/pkg/storer/internal/upload/export_test.go
@@ -22,12 +22,15 @@ var (
 	ErrOverwriteOfNewerBatch     = errOverwriteOfNewerBatch
 
 	ErrNextTagIDUnmarshalInvalidSize = errNextTagIDUnmarshalInvalidSize
+
+	ErrDirtyTagItemUnmarshalInvalidSize = errDirtyTagItemUnmarshalInvalidSize
 )
 
 type (
-	PushItem   = pushItem
-	UploadItem = uploadItem
-	NextTagID  = nextTagID
+	PushItem     = pushItem
+	UploadItem   = uploadItem
+	NextTagID    = nextTagID
+	DirtyTagItem = dirtyTagItem
 )
 
 func ReplaceTimeNow(fn func() time.Time) { now = fn }

--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -794,7 +794,7 @@ func Iterate(ctx context.Context, s internal.Storage, consumerFn func(chunk swar
 		Factory: func() storage.Item { return &pushItem{} },
 	}, func(r storage.Result) (bool, error) {
 		pi := r.Entry.(*pushItem)
-		has, err := s.IndexStore().Has(&dirtyTagItem{TagID: uint64(pi.TagID)})
+		has, err := s.IndexStore().Has(&dirtyTagItem{TagID: pi.TagID})
 		if err != nil {
 			return true, err
 		}

--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -870,11 +870,10 @@ func BatchIDForChunk(st storage.Store, addr swarm.Address) ([]byte, error) {
 			ItemProperty: storage.QueryItemID,
 		},
 		func(r storage.Result) (bool, error) {
-			fields := storageutil.SplitFields(r.ID)
-			if len(fields) == 2 && len(fields[1]) > 0 {
-				batchID = []byte(fields[1])
-				return true, nil
+			if len(r.ID) < 32 {
+				return false, nil
 			}
+			batchID = []byte(r.ID[len(r.ID)-32:])
 			return false, nil
 		},
 	)

--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -296,6 +296,62 @@ func (i uploadItem) String() string {
 	return storageutil.JoinFields(i.Namespace(), i.ID())
 }
 
+// dirtyTagItemUnmarshalInvalidSize is returned when trying
+// to unmarshal buffer that is not of size dirtyTagItemSize.
+var errDirtyTagItemUnmarshalInvalidSize = errors.New("unmarshal dirtyTagItem: invalid size")
+
+// dirtyTagItemSize is the size of a marshaled dirtyTagItem.
+const dirtyTagItemSize = 8 + 8
+
+type dirtyTagItem struct {
+	TagID   uint64
+	Started int64
+}
+
+// ID implements the storage.Item interface.
+func (i dirtyTagItem) ID() string {
+	return strconv.FormatUint(i.TagID, 10)
+}
+
+// Namespace implements the storage.Item interface.
+func (i dirtyTagItem) Namespace() string {
+	return "DirtyTagItem"
+}
+
+// Marshal implements the storage.Item interface.
+func (i dirtyTagItem) Marshal() ([]byte, error) {
+	buf := make([]byte, dirtyTagItemSize)
+	binary.LittleEndian.PutUint64(buf, i.TagID)
+	binary.LittleEndian.PutUint64(buf[8:], uint64(i.Started))
+	return buf, nil
+}
+
+// Unmarshal implements the storage.Item interface.
+func (i *dirtyTagItem) Unmarshal(bytes []byte) error {
+	if len(bytes) != dirtyTagItemSize {
+		return errDirtyTagItemUnmarshalInvalidSize
+	}
+	i.TagID = binary.LittleEndian.Uint64(bytes[:8])
+	i.Started = int64(binary.LittleEndian.Uint64(bytes[8:]))
+	return nil
+}
+
+// Clone implements the storage.Item interface.
+func (i *dirtyTagItem) Clone() storage.Item {
+	if i == nil {
+		return nil
+	}
+	return &dirtyTagItem{
+		TagID:   i.TagID,
+		Started: i.Started,
+	}
+}
+
+// String implements the fmt.Stringer interface.
+func (i dirtyTagItem) String() string {
+	return storageutil.JoinFields(i.Namespace(), i.ID())
+}
+
 // stampIndexUploadNamespace represents the
 // namespace name of the stamp index for upload.
 const stampIndexUploadNamespace = "upload"
@@ -319,7 +375,6 @@ type uploadPutter struct {
 	mtx    sync.Mutex
 	split  uint64
 	seen   uint64
-	s      internal.Storage
 	closed bool
 }
 
@@ -333,9 +388,12 @@ func NewPutter(s internal.Storage, tagID uint64) (internal.PutterCloserWithRefer
 	if !has {
 		return nil, fmt.Errorf("upload store: tag %d not found: %w", tagID, storage.ErrNotFound)
 	}
+	err = s.IndexStore().Put(&dirtyTagItem{TagID: tagID, Started: now().UnixNano()})
+	if err != nil {
+		return nil, err
+	}
 	return &uploadPutter{
 		tagID: ti.TagID,
-		s:     s,
 	}, nil
 }
 
@@ -345,7 +403,7 @@ func NewPutter(s internal.Storage, tagID uint64) (internal.PutterCloserWithRefer
 // - uploadItem entry to keep track of this chunk.
 // - pushItem entry to make it available for PushSubscriber
 // - add chunk to the chunkstore till it is synced
-func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
+func (u *uploadPutter) Put(ctx context.Context, s internal.Storage, chunk swarm.Chunk) error {
 	u.mtx.Lock()
 	defer u.mtx.Unlock()
 
@@ -358,7 +416,7 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 		Address: chunk.Address(),
 		BatchID: chunk.Stamp().BatchID(),
 	}
-	switch exists, err := u.s.IndexStore().Has(ui); {
+	switch exists, err := s.IndexStore().Has(ui); {
 	case err != nil:
 		return fmt.Errorf("store has item %q call failed: %w", ui, err)
 	case exists:
@@ -367,7 +425,7 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 		return nil
 	}
 
-	switch item, loaded, err := stampindex.LoadOrStore(u.s.IndexStore(), stampIndexUploadNamespace, chunk); {
+	switch item, loaded, err := stampindex.LoadOrStore(s.IndexStore(), stampIndexUploadNamespace, chunk); {
 	case err != nil:
 		return fmt.Errorf("load or store stamp index for chunk %v has fail: %w", chunk, err)
 	case loaded && item.ChunkIsImmutable:
@@ -378,7 +436,7 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 		if prev >= curr {
 			return errOverwriteOfNewerBatch
 		}
-		err = stampindex.Store(u.s.IndexStore(), stampIndexUploadNamespace, chunk)
+		err = stampindex.Store(s.IndexStore(), stampIndexUploadNamespace, chunk)
 		if err != nil {
 			return fmt.Errorf("failed updating stamp index: %w", err)
 		}
@@ -386,18 +444,18 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 
 	u.split++
 
-	if err := u.s.ChunkStore().Put(ctx, chunk); err != nil {
+	if err := s.ChunkStore().Put(ctx, chunk); err != nil {
 		return fmt.Errorf("chunk store put chunk %q call failed: %w", chunk.Address(), err)
 	}
 
-	if err := chunkstamp.Store(u.s.IndexStore(), chunkStampNamespace, chunk); err != nil {
+	if err := chunkstamp.Store(s.IndexStore(), chunkStampNamespace, chunk); err != nil {
 		return fmt.Errorf("associate chunk with stamp %q call failed: %w", chunk.Address(), err)
 	}
 
 	ui.Uploaded = now().UnixNano()
 	ui.TagID = u.tagID
 
-	if err := u.s.IndexStore().Put(ui); err != nil {
+	if err := s.IndexStore().Put(ui); err != nil {
 		return fmt.Errorf("store put item %q call failed: %w", ui, err)
 	}
 
@@ -407,7 +465,7 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 		BatchID:   chunk.Stamp().BatchID(),
 		TagID:     u.tagID,
 	}
-	if err := u.s.IndexStore().Put(pi); err != nil {
+	if err := s.IndexStore().Put(pi); err != nil {
 		return fmt.Errorf("store put item %q call failed: %w", pi, err)
 	}
 
@@ -418,12 +476,16 @@ func (u *uploadPutter) Put(ctx context.Context, chunk swarm.Chunk) error {
 // with a swarm reference. This can be useful while keeping track of uploads through
 // the tags. It will update the tag. This will be filled with the Split and Seen count
 // by the Putter.
-func (u *uploadPutter) Close(addr swarm.Address) error {
+func (u *uploadPutter) Close(s internal.Storage, addr swarm.Address) error {
 	u.mtx.Lock()
 	defer u.mtx.Unlock()
 
+	if u.closed {
+		return nil
+	}
+
 	ti := &TagItem{TagID: u.tagID}
-	err := u.s.IndexStore().Get(ti)
+	err := s.IndexStore().Get(ti)
 	if err != nil {
 		return fmt.Errorf("failed reading tag while closing: %w", err)
 	}
@@ -435,12 +497,114 @@ func (u *uploadPutter) Close(addr swarm.Address) error {
 		ti.Address = addr.Clone()
 	}
 
-	err = u.s.IndexStore().Put(ti)
+	err = s.IndexStore().Put(ti)
 	if err != nil {
 		return fmt.Errorf("failed storing tag: %w", err)
 	}
 
+	err = s.IndexStore().Delete(&dirtyTagItem{TagID: u.tagID})
+	if err != nil {
+		return fmt.Errorf("failed deleting dirty tag: %w", err)
+	}
+
 	u.closed = true
+
+	return nil
+}
+
+func (u *uploadPutter) Cleanup(s internal.Storage) error {
+	u.mtx.Lock()
+	defer u.mtx.Unlock()
+
+	if u.closed {
+		return nil
+	}
+
+	di := &dirtyTagItem{TagID: u.tagID}
+	err := s.IndexStore().Get(di)
+	if err != nil {
+		return fmt.Errorf("failed reading dirty tag while cleaning up: %w", err)
+	}
+
+	itemsToDelete := make([]*pushItem, 0)
+
+	err = s.IndexStore().Iterate(
+		storage.Query{
+			Factory:       func() storage.Item { return &pushItem{} },
+			PrefixAtStart: true,
+			Prefix:        fmt.Sprintf("%d", di.Started),
+		},
+		func(res storage.Result) (bool, error) {
+			pi := res.Entry.(*pushItem)
+			if pi.TagID == u.tagID {
+				itemsToDelete = append(itemsToDelete, pi)
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed iterating push items: %w", err)
+	}
+
+	for _, pi := range itemsToDelete {
+		_ = remove(s, pi.Address, pi.BatchID)
+		_ = s.IndexStore().Delete(pi)
+	}
+
+	return s.IndexStore().Delete(&dirtyTagItem{TagID: u.tagID})
+}
+
+// Remove removes all the state associated with the given address and batchID.
+func remove(st internal.Storage, address swarm.Address, batchID []byte) error {
+	ui := &uploadItem{
+		Address: address,
+		BatchID: batchID,
+	}
+
+	err := st.IndexStore().Get(ui)
+	if err != nil {
+		return fmt.Errorf("failed to read uploadItem %s: %w", ui, err)
+	}
+
+	err = st.IndexStore().Delete(ui)
+	if err != nil {
+		return fmt.Errorf("failed deleting upload item: %w", err)
+	}
+
+	if ui.Synced == 0 {
+		err = st.ChunkStore().Delete(context.Background(), address)
+		if err != nil {
+			return fmt.Errorf("failed deleting chunk: %w", err)
+		}
+		err = chunkstamp.Delete(st.IndexStore(), chunkStampNamespace, address, batchID)
+		if err != nil {
+			return fmt.Errorf("failed deleting chunk stamp %x: %w", batchID, err)
+		}
+	}
+	return nil
+}
+
+// CleanupDirty does a best-effort cleanup of dirty tags. This is called on startup.
+func CleanupDirty(st internal.Storage) error {
+	dirtyTags := make([]*dirtyTagItem, 0)
+
+	err := st.IndexStore().Iterate(
+		storage.Query{
+			Factory: func() storage.Item { return &dirtyTagItem{} },
+		},
+		func(res storage.Result) (bool, error) {
+			di := res.Entry.(*dirtyTagItem)
+			dirtyTags = append(dirtyTags, di)
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed iterating dirty tags: %w", err)
+	}
+
+	for _, di := range dirtyTags {
+		_ = (&uploadPutter{tagID: di.TagID}).Cleanup(st)
+	}
 
 	return nil
 }
@@ -526,7 +690,7 @@ func (p *pushReporter) Report(
 		return fmt.Errorf("failed deleting chunk %s: %w", chunk.Address(), err)
 	}
 
-	ui.Synced = now().Unix()
+	ui.Synced = now().UnixNano()
 	err = p.s.IndexStore().Put(ui)
 	if err != nil {
 		return fmt.Errorf("failed updating uploadItem %s: %w", ui, err)
@@ -593,7 +757,7 @@ func NextTag(st storage.Store) (TagItem, error) {
 	}
 
 	tag.TagID = uint64(tagID)
-	tag.StartedAt = now().Unix()
+	tag.StartedAt = now().UnixNano()
 
 	return tag, st.Put(&tag)
 }
@@ -630,6 +794,13 @@ func Iterate(ctx context.Context, s internal.Storage, consumerFn func(chunk swar
 		Factory: func() storage.Item { return &pushItem{} },
 	}, func(r storage.Result) (bool, error) {
 		pi := r.Entry.(*pushItem)
+		has, err := s.IndexStore().Has(&dirtyTagItem{TagID: uint64(pi.TagID)})
+		if err != nil {
+			return true, err
+		}
+		if has {
+			return false, nil
+		}
 		chunk, err := s.ChunkStore().Get(ctx, pi.Address)
 		if err != nil {
 			return true, err

--- a/pkg/storer/internal/upload/uploadstore_test.go
+++ b/pkg/storer/internal/upload/uploadstore_test.go
@@ -1075,7 +1075,7 @@ func TestCleanup(t *testing.T) {
 		}
 
 		count := 0
-		err = upload.Iterate(context.Background(), ts, func(chunk swarm.Chunk) (bool, error) {
+		_ = upload.Iterate(context.Background(), ts, func(chunk swarm.Chunk) (bool, error) {
 			count++
 			return false, nil
 		})
@@ -1111,7 +1111,7 @@ func TestCleanup(t *testing.T) {
 		}
 
 		count := 0
-		err = upload.Iterate(context.Background(), ts, func(chunk swarm.Chunk) (bool, error) {
+		_ = upload.Iterate(context.Background(), ts, func(chunk swarm.Chunk) (bool, error) {
 			count++
 			return false, nil
 		})

--- a/pkg/storer/internal/upload/uploadstore_test.go
+++ b/pkg/storer/internal/upload/uploadstore_test.go
@@ -430,7 +430,7 @@ func TestItemDirtyTagItem(t *testing.T) {
 	}
 }
 
-func newTestStorage(t *testing.T) internal.Storage {
+func newTestStorage(t *testing.T) internal.BatchedStorage {
 	t.Helper()
 
 	storg, closer := internal.NewInmemStorage()

--- a/pkg/storer/internal/upload/uploadstore_test.go
+++ b/pkg/storer/internal/upload/uploadstore_test.go
@@ -1050,9 +1050,10 @@ func TestBatchIDForChunk(t *testing.T) {
 func TestCleanup(t *testing.T) {
 	t.Parallel()
 
-	ts := newTestStorage(t)
-
 	t.Run("cleanup putter", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestStorage(t)
 		tag, err := upload.NextTag(ts.IndexStore())
 		if err != nil {
 			t.Fatal("failed creating tag", err)
@@ -1089,6 +1090,9 @@ func TestCleanup(t *testing.T) {
 	})
 
 	t.Run("cleanup dirty", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestStorage(t)
 		tag, err := upload.NextTag(ts.IndexStore())
 		if err != nil {
 			t.Fatal("failed creating tag", err)

--- a/pkg/storer/mock/mockstorer.go
+++ b/pkg/storer/mock/mockstorer.go
@@ -94,7 +94,7 @@ func (m *mockStorer) Upload(_ context.Context, pin bool, tagID uint64) (storer.P
 func (m *mockStorer) NewSession() (storer.SessionInfo, error) {
 	session := &storer.SessionInfo{
 		TagID:     m.sessionID.Inc(),
-		StartedAt: now().Unix(),
+		StartedAt: now().UnixNano(),
 	}
 
 	m.mu.Lock()

--- a/pkg/storer/mock/mockstorer_test.go
+++ b/pkg/storer/mock/mockstorer_test.go
@@ -41,7 +41,7 @@ func TestMockStorer(t *testing.T) {
 			t.Fatalf("NewSession(): unexpected error: %v", err)
 		}
 
-		want := storer.SessionInfo{TagID: 1, StartedAt: now().Unix()}
+		want := storer.SessionInfo{TagID: 1, StartedAt: now().UnixNano()}
 
 		if diff := cmp.Diff(want, have); diff != "" {
 			t.Fatalf("unexpected session info: (-want +have):\n%s", diff)
@@ -54,7 +54,7 @@ func TestMockStorer(t *testing.T) {
 			t.Fatalf("Session(): unexpected error: %v", err)
 		}
 
-		want := storer.SessionInfo{TagID: 1, StartedAt: now().Unix()}
+		want := storer.SessionInfo{TagID: 1, StartedAt: now().UnixNano()}
 
 		if diff := cmp.Diff(want, have); diff != "" {
 			t.Fatalf("unexpected session info: (-want +have):\n%s", diff)
@@ -68,7 +68,7 @@ func TestMockStorer(t *testing.T) {
 		}
 
 		want := []storer.SessionInfo{
-			{TagID: 1, StartedAt: now().Unix()},
+			{TagID: 1, StartedAt: now().UnixNano()},
 		}
 
 		if diff := cmp.Diff(want, have); diff != "" {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/postage"
 	storage "github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storer/internal"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
@@ -152,12 +153,17 @@ func (db *DB) ReservePutter() storage.Putter {
 				db.lock.Lock(reserveUpdateLockKey)
 				defer db.lock.Unlock(reserveUpdateLockKey)
 
-				trx, commit, rollback := db.repo.NewTx(ctx)
-				newIndex, err := db.reserve.Put(ctx, trx, chunk)
+				var (
+					newIndex bool
+				)
+				err = db.Do(ctx, func(trx internal.Storage) error {
+					newIndex, err = db.reserve.Put(ctx, trx, chunk)
+					if err != nil {
+						return fmt.Errorf("reserve: putter.Put: %w", err)
+					}
+					return nil
+				})
 				if err != nil {
-					return fmt.Errorf("reserve: putter.Put: %w", errors.Join(err, rollback()))
-				}
-				if err := commit(); err != nil {
 					return err
 				}
 				if newIndex {
@@ -208,8 +214,6 @@ func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (er
 			db.lock.Lock(reserveUpdateLockKey)
 			defer db.lock.Unlock(reserveUpdateLockKey)
 
-			txnRepo, commit, rollback := db.repo.NewTx(ctx)
-
 			// cache evicted chunks
 			cache := func(c swarm.Chunk) {
 				if err := db.Cache().Put(ctx, c); err != nil {
@@ -217,14 +221,9 @@ func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (er
 				}
 			}
 
-			evicted, err := db.reserve.EvictBatchBin(ctx, txnRepo, b, batchID, cache)
+			evicted, err := db.reserve.EvictBatchBin(ctx, db, b, batchID, cache)
 			if err != nil {
-				return fmt.Errorf("reserve.EvictBatchBin: %w", errors.Join(err, rollback()))
-			}
-
-			err = commit()
-			if err != nil {
-				return err
+				return fmt.Errorf("reserve.EvictBatchBin: %w", err)
 			}
 
 			db.logger.Info("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -344,6 +344,8 @@ func performEpochMigration(ctx context.Context, basePath string, opts *Options) 
 		}
 	}
 
+	defer sharkyRecover.Save()
+
 	return epochMigration(ctx, basePath, opts.StateStore, store, rs, sharkyRecover, logger)
 }
 

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -316,7 +316,7 @@ type noopRadiusSetter struct{}
 
 func (noopRadiusSetter) SetStorageRadius(uint8) {}
 
-func performEpochMigration(ctx context.Context, basePath string, opts *Options) error {
+func performEpochMigration(ctx context.Context, basePath string, opts *Options) (retErr error) {
 	store, err := initStore(basePath, opts)
 	if err != nil {
 		return err
@@ -344,7 +344,9 @@ func performEpochMigration(ctx context.Context, basePath string, opts *Options) 
 		}
 	}
 
-	defer sharkyRecover.Save()
+	defer func() {
+		retErr = errors.Join(retErr, sharkyRecover.Save())
+	}()
 
 	return epochMigration(ctx, basePath, opts.StateStore, store, rs, sharkyRecover, logger)
 }

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -401,14 +401,8 @@ type DB struct {
 	bgCacheWorkers   chan struct{}
 	bgCacheWorkersWg sync.WaitGroup
 	dbCloser         io.Closer
-
-	subscriptionsWG sync.WaitGroup
-
-	dirtyTagsMu sync.RWMutex
-	dirtyTags   []uint64 // tagIDs
-
-	events *events.Subscriber
-
+	subscriptionsWG  sync.WaitGroup
+	events           *events.Subscriber
 	reserve          *reserve.Reserve
 	reserveWg        sync.WaitGroup
 	reserveBinEvents *events.Subscriber
@@ -584,22 +578,3 @@ type putterSession struct {
 func (p *putterSession) Done(addr swarm.Address) error { return p.done(addr) }
 
 func (p *putterSession) Cleanup() error { return p.cleanup() }
-
-func (db *DB) markDirty(tag uint64) {
-	db.dirtyTagsMu.Lock()
-	defer db.dirtyTagsMu.Unlock()
-
-	db.dirtyTags = append(db.dirtyTags, tag)
-}
-
-func (db *DB) clearDirty(tag uint64) {
-	db.dirtyTagsMu.Lock()
-	defer db.dirtyTagsMu.Unlock()
-
-	for i, tagID := range db.dirtyTags {
-		if tag == tagID {
-			db.dirtyTags = append(db.dirtyTags[:i], db.dirtyTags[i+1:]...)
-			break
-		}
-	}
-}

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -345,7 +345,9 @@ func performEpochMigration(ctx context.Context, basePath string, opts *Options) 
 	}
 
 	defer func() {
-		retErr = errors.Join(retErr, sharkyRecover.Save())
+		if sharkyRecover != nil {
+			retErr = errors.Join(retErr, sharkyRecover.Save())
+		}
 	}()
 
 	return epochMigration(ctx, basePath, opts.StateStore, store, rs, sharkyRecover, logger)

--- a/pkg/storer/subscribe_push.go
+++ b/pkg/storer/subscribe_push.go
@@ -37,12 +37,6 @@ func (db *DB) SubscribePush(ctx context.Context) (<-chan swarm.Chunk, func()) {
 			var count int
 
 			err := upload.Iterate(ctx, db.repo, func(chunk swarm.Chunk) (bool, error) {
-
-				if db.isDirty(uint64(chunk.TagID())) {
-					// continue to see if later tags have been committed
-					return false, nil
-				}
-
 				select {
 				case chunks <- chunk:
 					count++
@@ -82,16 +76,4 @@ func (db *DB) SubscribePush(ctx context.Context) (<-chan swarm.Chunk, func()) {
 	}
 
 	return chunks, stop
-}
-
-func (db *DB) isDirty(tag uint64) bool {
-	db.dirtyTagsMu.RLock()
-	defer db.dirtyTagsMu.RUnlock()
-
-	for _, dirtyTag := range db.dirtyTags {
-		if dirtyTag == tag {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
- During manual testing we observed that there is high memory usage during upload of large (1.5G+) files. One reason for this is currently 1 upload only does 1 txn. This will be a problem for large uploads as the txn state grows in-mem. Also, if the node blows up during this upload, we cannot uncommit the changes. So this change makes upload and pinning stores use 1 txn per Put op. This is similar to how we do for Cache and Reserve. Also, Cleanup mechanism is now added which can recover from restarts as well. So the file will not be pushed till it is successfully uploaded and incomplete pinning collections will also be removed.
- We also saw that the test coverage of the master branch went down. This was contrary to what we had tested before and seems like there is some drop in coverage in the storer pkg. Added tests to cover the cases.
- While adding test for the epoch migration, found an issue while reading chunk data and missing sync in sharky recovery. It is fixed now.