### PR TITLE
fix(batchstore,reserve): cleanup mtx locks

### DIFF
--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -117,7 +117,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		return nil, err
 	}
 
-	batchStore, err := batchstore.New(stateStore, func(b []byte) error { return nil }, swarmAddress, 1000000, logger)
+	batchStore, err := batchstore.New(stateStore, func(b []byte) error { return nil }, 1000000, logger)
 	if err != nil {
 		return nil, fmt.Errorf("batchstore: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -320,7 +320,6 @@ func NewBee(
 			func(id []byte) error {
 				return evictFn(id)
 			},
-			swarmAddress,
 			ReserveCapacity,
 			logger,
 		)

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -140,7 +140,7 @@ func (s *store) Save(batch *postage.Batch) error {
 			return err
 		}
 
-		s.logger.Debug("batch saved", "batch_id", hex.EncodeToString(batch.ID), "batch_depth", batch.Depth, "batch_value", batch.Value.Int64())
+		s.logger.Debug("batch saved", "batch_id", hex.EncodeToString(batch.ID), "batch_depth", batch.Depth, "batch_value", batch.Value.Int64(), "radius", s.radius.Load())
 
 		return nil
 	case err != nil:

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -11,11 +11,11 @@ import (
 	"math"
 	"math/big"
 	"sync"
+	"sync/atomic"
 
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/postage"
 	"github.com/ethersphere/bee/pkg/storage"
-	"go.uber.org/atomic"
 )
 
 // loggerName is the tree path name of the logger for this package.
@@ -42,7 +42,7 @@ type store struct {
 	store    storage.StateStorer // State store backend to persist batches.
 	cs       *postage.ChainState // the chain state
 
-	radius  *atomic.Uint32
+	radius  atomic.Uint32
 	evictFn evictFn // evict function
 	metrics metrics // metrics
 	logger  log.Logger
@@ -77,7 +77,6 @@ func New(st storage.StateStorer, ev evictFn, capacity int, logger log.Logger) (p
 		capacity: capacity,
 		store:    st,
 		cs:       cs,
-		radius:   atomic.NewUint32(uint32(radius)),
 		evictFn:  ev,
 		metrics:  newMetrics(),
 		logger:   logger.WithName(loggerName).Register(),
@@ -244,7 +243,7 @@ func (s *store) Reset() error {
 		CurrentPrice: big.NewInt(0),
 	}
 
-	s.radius = atomic.NewUint32(0)
+	s.radius = atomic.Uint32{}
 
 	return nil
 }

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -81,6 +81,9 @@ func New(st storage.StateStorer, ev evictFn, capacity int, logger log.Logger) (p
 		metrics:  newMetrics(),
 		logger:   logger.WithName(loggerName).Register(),
 	}
+
+	s.radius.Store(uint32(radius))
+
 	return s, nil
 }
 

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -27,11 +27,10 @@ var noopEvictFn = func([]byte) error { return nil }
 const defaultCapacity = 2 ^ 22
 
 func TestBatchStore_Get(t *testing.T) {
-	baseAddr := swarm.RandAddress(t)
 	testBatch := postagetest.MustNewBatch()
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	err := batchStore.Save(testBatch)
 	if err != nil {
@@ -43,12 +42,11 @@ func TestBatchStore_Get(t *testing.T) {
 }
 
 func TestBatchStore_Iterate(t *testing.T) {
-	baseAddr := swarm.RandAddress(t)
 	testBatch := postagetest.MustNewBatch()
 	key := batchstore.BatchKey(testBatch.ID)
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	stateStorePut(t, stateStore, key, testBatch)
 
@@ -65,7 +63,6 @@ func TestBatchStore_Iterate(t *testing.T) {
 }
 
 func TestBatchStore_IterateStopsEarly(t *testing.T) {
-	baseAddr := swarm.RandAddress(t)
 	testBatch1 := postagetest.MustNewBatch()
 	key1 := batchstore.BatchKey(testBatch1.ID)
 
@@ -73,7 +70,7 @@ func TestBatchStore_IterateStopsEarly(t *testing.T) {
 	key2 := batchstore.BatchKey(testBatch2.ID)
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	stateStorePut(t, stateStore, key1, testBatch1)
 	stateStorePut(t, stateStore, key2, testBatch2)
@@ -116,12 +113,11 @@ func TestBatchStore_IterateStopsEarly(t *testing.T) {
 }
 
 func TestBatchStore_SaveAndUpdate(t *testing.T) {
-	baseAddr := swarm.RandAddress(t)
 	testBatch := postagetest.MustNewBatch()
 	key := batchstore.BatchKey(testBatch.ID)
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	if err := batchStore.Save(testBatch); err != nil {
 		t.Fatalf("storer.Save(...): unexpected error: %v", err)
@@ -161,11 +157,10 @@ func TestBatchStore_SaveAndUpdate(t *testing.T) {
 }
 
 func TestBatchStore_GetChainState(t *testing.T) {
-	baseAddr := swarm.RandAddress(t)
 	testChainState := postagetest.NewChainState()
 
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	err := batchStore.PutChainState(testChainState)
 	if err != nil {
@@ -178,9 +173,8 @@ func TestBatchStore_GetChainState(t *testing.T) {
 func TestBatchStore_PutChainState(t *testing.T) {
 	testChainState := postagetest.NewChainState()
 
-	baseAddr := swarm.RandAddress(t)
 	stateStore := mock.NewStateStore()
-	batchStore, _ := batchstore.New(stateStore, nil, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, nil, defaultCapacity, log.Noop)
 
 	batchStorePutChainState(t, batchStore, testChainState)
 	var got postage.ChainState
@@ -194,7 +188,6 @@ func TestBatchStore_Reset(t *testing.T) {
 		postagetest.WithValue(15),
 		postagetest.WithDepth(8),
 	)
-	baseAddr := swarm.RandAddress(t)
 
 	path := t.TempDir()
 	logger := log.Noop
@@ -208,7 +201,7 @@ func TestBatchStore_Reset(t *testing.T) {
 	}
 	defer stateStore.Close()
 
-	batchStore, _ := batchstore.New(stateStore, noopEvictFn, baseAddr, defaultCapacity, log.Noop)
+	batchStore, _ := batchstore.New(stateStore, noopEvictFn, defaultCapacity, log.Noop)
 	err = batchStore.Save(testBatch)
 	if err != nil {
 		t.Fatal(err)
@@ -564,7 +557,7 @@ func setupBatchStore(t *testing.T, capacity int) postage.Storer {
 		return nil
 	}
 
-	bStore, _ := batchstore.New(stateStore, evictFn, swarm.RandAddress(t), capacity, log.Noop)
+	bStore, _ := batchstore.New(stateStore, evictFn, capacity, log.Noop)
 
 	err = bStore.PutChainState(&postage.ChainState{
 		Block:        0,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
The mutex locks were originally placed to protect internal variables like radius. The PR cleans up these mutexes.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
