### PR TITLE
fix: restart always systemd service

### DIFF
--- a/packaging/bee.service
+++ b/packaging/bee.service
@@ -9,7 +9,7 @@ NoNewPrivileges=true
 User=bee
 Group=bee
 ExecStart=/usr/bin/bee start --config /etc/bee/bee.yaml
-Restart=on-failure
+Restart=always
 RestartSec=5s
 
 [Install]


### PR DESCRIPTION
Just in case restart service always, even if it exits with a clean code
