### PR TITLE
fix: read chunk data during migration

### DIFF
--- a/pkg/storer/epoch_migration.go
+++ b/pkg/storer/epoch_migration.go
@@ -335,7 +335,13 @@ func (e *epochMigrator) migrateReserve(ctx context.Context) error {
 				return false, err
 			}
 
-			ch := swarm.NewChunk(addr, nil).
+			chData := make([]byte, l.Length)
+			err = e.recovery.Read(ctx, l, chData)
+			if err != nil {
+				return false, nil // continue
+			}
+
+			ch := swarm.NewChunk(addr, chData).
 				WithStamp(postage.NewStamp(item.BatchID, item.Index, item.Timestamp, item.Sig))
 
 			select {

--- a/pkg/storer/epoch_migration.go
+++ b/pkg/storer/epoch_migration.go
@@ -338,6 +338,7 @@ func (e *epochMigrator) migrateReserve(ctx context.Context) error {
 			chData := make([]byte, l.Length)
 			err = e.recovery.Read(ctx, l, chData)
 			if err != nil {
+				e.logger.Debug("reading location failed", "chunk_address", addr, "error", err)
 				return false, nil // continue
 			}
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Read chunk data in order to populate the chunk type information during migration. If for some reason we get error while reading from sharky there is no recovery path. So ignore the error and continue. The location will be freed and chunk will be gone in this case. This should never happen though.
