### PR TITLE
fix: retry on shallow receipt for direct upload

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -359,7 +359,7 @@ func (s *Service) checkReceipt(receipt *pushsync.Receipt, loggerV1 log.Logger) e
 	if po < d && s.attempts.try(addr) {
 		s.metrics.ShallowReceiptDepth.WithLabelValues(strconv.Itoa(int(po))).Inc()
 		s.metrics.ShallowReceipt.Inc()
-		return fmt.Errorf("pusher: shallow receipt depth %d, want at least %d", po, d)
+		return fmt.Errorf("pusher: shallow receipt depth %d, want at least %d: %w", po, d, ErrShallowReceipt)
 	}
 	loggerV1.Debug("chunk pushed", "chunk_address", addr, "peer_address", peer, "proximity_order", po)
 	s.metrics.ReceiptDepth.WithLabelValues(strconv.Itoa(int(po))).Inc()

--- a/pkg/storer/netstore.go
+++ b/pkg/storer/netstore.go
@@ -46,7 +46,7 @@ func (db *DB) DirectUpload() PutterSession {
 							return ErrDBQuit
 						case err := <-op.Err:
 							// if we get a shallow receipt error, we retry the upload, the pusher will
-							// have an allowed no. of retries before after which a shallow receipt will
+							// have an allowed no. of retries after which a shallow receipt will
 							// no longer be returned as error.
 							if errors.Is(err, pusher.ErrShallowReceipt) {
 								db.logger.Debug("direct upload: shallow receipt received, retrying", "chunk", ch.Address())


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
In the pusher we return shallow receipt error on pushing if we receive a receipt with invalid depth. This is to allow the pusher to retry again to get a better receipt. This was missing in the direct upload. In the old version, direct upload keeps retrying on error, so this change will revert to old behavior. After the allowed retry limit, this error will be swallowed by the pusher and the operation will be termed success.