### PR TITLE
fix: allow tx rollback on context deadline exceeded error

### DIFF
--- a/pkg/storage/transaction.go
+++ b/pkg/storage/transaction.go
@@ -250,7 +250,9 @@ func (s *TxStoreBase) Delete(item Item) error {
 // Rollback implements the TxStore interface.
 func (s *TxStoreBase) Rollback() error {
 	if s.rolledBack.CompareAndSwap(false, true) {
-		if err := s.Done(); err == nil || errors.Is(err, context.Canceled) {
+		if err := s.Done(); err == nil ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
 			return nil
 		}
 	}
@@ -319,7 +321,9 @@ func (s *TxChunkStoreBase) Delete(ctx context.Context, address swarm.Address) er
 // Rollback implements the TxChunkStore interface.
 func (s *TxChunkStoreBase) Rollback() error {
 	if s.rolledBack.CompareAndSwap(false, true) {
-		if err := s.Done(); err == nil || errors.Is(err, context.Canceled) {
+		if err := s.Done(); err == nil ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
 			return nil
 		}
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Allow transaction rollback on `context.DeadlineExceeded` error.