### PR TITLE
fix: mutable batches resets index buckets

### DIFF
--- a/pkg/postage/export_test.go
+++ b/pkg/postage/export_test.go
@@ -48,3 +48,7 @@ func NewStampItem() *StampItem {
 func ModifyBuckets(st *StampIssuer, buckets []uint32) {
 	st.data.Buckets = buckets
 }
+
+func (si *StampIssuer) Increment(addr swarm.Address) ([]byte, []byte, error) {
+	return si.increment(addr)
+}

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -180,8 +180,14 @@ func NewStampIssuer(label, keyID string, batchID []byte, batchAmount *big.Int, b
 func (si *StampIssuer) increment(addr swarm.Address) (batchIndex []byte, batchTimestamp []byte, err error) {
 	bIdx := toBucket(si.BucketDepth(), addr)
 	bCnt := si.data.Buckets[bIdx]
-	if bCnt == 1<<(si.Depth()-si.BucketDepth()) {
-		return nil, nil, ErrBucketFull
+
+	if bCnt == si.BucketUpperBound() {
+		if si.ImmutableFlag() {
+			return nil, nil, ErrBucketFull
+		}
+
+		bCnt = 0
+		si.data.Buckets[bIdx] = 0
 	}
 
 	si.data.Buckets[bIdx]++

--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -433,7 +433,7 @@ func (u *uploadPutter) Put(ctx context.Context, s internal.Storage, chunk swarm.
 	case loaded && !item.ChunkIsImmutable:
 		prev := binary.BigEndian.Uint64(item.StampTimestamp)
 		curr := binary.BigEndian.Uint64(chunk.Stamp().Timestamp())
-		if prev >= curr {
+		if prev > curr {
 			return errOverwriteOfNewerBatch
 		}
 		err = stampindex.Store(s.IndexStore(), stampIndexUploadNamespace, chunk)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
