### PR TITLE
fix: check stampissuer saved index

### DIFF
--- a/pkg/postage/export_test.go
+++ b/pkg/postage/export_test.go
@@ -11,6 +11,7 @@ import (
 var (
 	IndexToBytes   = indexToBytes
 	BlockThreshold = blockThreshold
+	ToBucket       = toBucket
 )
 
 var (

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -44,6 +44,14 @@ func (st *stamper) Stamp(addr swarm.Address) (*Stamp, error) {
 		chunkAddress: addr,
 	}
 	switch err := st.store.Get(item); {
+	case err == nil:
+		// check if this index is in the past, it could happen that we encountered
+		// some error after assigning this index and did not save the issuer data. In
+		// this case we should assign a new index and update it.
+		if st.issuer.assigned(item.BatchIndex) {
+			break
+		}
+		fallthrough
 	case errors.Is(err, storage.ErrNotFound):
 		item.BatchIndex, item.BatchTimestamp, err = st.issuer.increment(addr)
 		if err != nil {

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -60,7 +60,7 @@ func (st *stamper) Stamp(addr swarm.Address) (*Stamp, error) {
 		if err := st.store.Put(item); err != nil {
 			return nil, err
 		}
-	case err != nil:
+	default:
 		return nil, fmt.Errorf("get stamp for %s: %w", item, err)
 	}
 

--- a/pkg/postage/stamper_test.go
+++ b/pkg/postage/stamper_test.go
@@ -114,8 +114,7 @@ func TestStamperStamping(t *testing.T) {
 		testItem := postage.NewStampItem().
 			WithBatchID(st.ID()).
 			WithChunkAddress(chunkAddr).
-			WithBatchIndex(index).
-			WithBatchTimestamp([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+			WithBatchIndex(index)
 		testSt := &testStore{Store: inmemstore.New(), stampItem: testItem}
 		stamper := postage.NewStamper(testSt, st, signer)
 		stamp, err := stamper.Stamp(chunkAddr)

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -198,6 +198,12 @@ func (si *StampIssuer) increment(addr swarm.Address) (batchIndex []byte, batchTi
 	return indexToBytes(bIdx, bCnt), unixTime(), nil
 }
 
+// check if this stamp index has already been assigned
+func (si *StampIssuer) assigned(stampIdx []byte) bool {
+	b, idx := BucketIndexFromBytes(stampIdx)
+	return idx < si.data.Buckets[b]
+}
+
 // Label returns the label of the issuer.
 func (si *StampIssuer) Label() string {
 	return si.data.Label

--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -433,7 +433,7 @@ func (u *uploadPutter) Put(ctx context.Context, s internal.Storage, chunk swarm.
 	case loaded && !item.ChunkIsImmutable:
 		prev := binary.BigEndian.Uint64(item.StampTimestamp)
 		curr := binary.BigEndian.Uint64(chunk.Stamp().Timestamp())
-		if prev > curr {
+		if prev >= curr {
 			return errOverwriteOfNewerBatch
 		}
 		err = stampindex.Store(s.IndexStore(), stampIndexUploadNamespace, chunk)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
If we assign a stamp index to a chunk but the upload fails, we should not assign the same index to the chunk again untill the stampissuer has reached that index. If we dont handle this, we could assign an index to a chunk which will be overwritten in future.
