### PR TITLE
fix: move eviction to the end of batch expiration handling

### DIFF
--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -300,17 +300,17 @@ func (s *store) cleanup() error {
 	}
 
 	for _, b := range evictions {
-		err := s.evictFn(b.ID)
-		if err != nil {
-			return fmt.Errorf("evict batch %x: %w", b.ID, err)
-		}
-		err = s.store.Delete(valueKey(b.Value, b.ID))
+		err := s.store.Delete(valueKey(b.Value, b.ID))
 		if err != nil {
 			return fmt.Errorf("delete value key for batch %x: %w", b.ID, err)
 		}
 		err = s.store.Delete(batchKey(b.ID))
 		if err != nil {
 			return fmt.Errorf("delete batch %x: %w", b.ID, err)
+		}
+		err = s.evictFn(b.ID)
+		if err != nil {
+			return fmt.Errorf("evict batch %x: %w", b.ID, err)
 		}
 		if s.batchExpiry != nil {
 			err = s.batchExpiry.HandleStampExpiry(b.ID)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
We should delete the batchstore contents before doing the eviction on localstore. This is to ensure the validStamp function will return error for this batch while eviction can happen at its pace.