### PR TITLE
fix: wait for network radius

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -110,6 +110,14 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 		return
 	}
 
+	// fetch the network radius before starting pusher worker
+	r, err := s.radius()
+	if err != nil {
+		s.logger.Error(err, "pusher: initial radius error")
+	} else {
+		s.logger.Info("pusher: warmup period complete", "radius", r)
+	}
+
 	var (
 		cctx, cancel      = context.WithCancel(context.Background())
 		mtx               sync.Mutex

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -105,7 +105,6 @@ func (s *Service) chunksWorker(warmupTime time.Duration, tracer *tracing.Tracer)
 	defer close(s.chunksWorkerQuitC)
 	select {
 	case <-time.After(warmupTime):
-		s.logger.Info("pusher: warmup period complete, worker starting.")
 	case <-s.quit:
 		return
 	}

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -189,8 +189,6 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	s.metrics.Commitment.Set(float64(commitment))
 	s.metrics.ReserveSizePercentErr.Set(reserveSizePercentErr)
 
-	s.publishRadius(networkRadius)
-
 	s.logger.Debug("computed", "average", avgDur, "percentile", percentile, "pDur", pDur, "pConns", pConns, "network_radius", networkRadius, "neighborhood_radius", nHoodRadius, "batch_commitment", commitment)
 
 	for _, peer := range peers {
@@ -234,6 +232,8 @@ func (s *service) salud(mode string, minPeersPerbin int) {
 	}
 
 	s.isSelfHealthy.Store(selfHealth)
+
+	s.publishRadius(networkRadius)
 }
 
 func (s *service) IsHealthy() bool {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Pusher starts sending chunks even though health service has no run yet. Checking the radius at this point causes pusher to wait for a radius to arrive.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
