### PR TITLE
fix(reserve): must call set radius to notify kademlia

### DIFF
--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -47,16 +47,20 @@ func (db *DB) reserveWorker(warmupDur, wakeUpDur time.Duration, radius func() (u
 		return
 	}
 
+	initialRadius := db.reserve.Radius()
+
 	// possibly a fresh node, acquire initial radius externally
-	if db.StorageRadius() == 0 {
+	if initialRadius == 0 {
 		r, err := radius()
 		if err != nil {
 			db.logger.Error(err, "reserve worker initial radius")
 		} else {
-			if err := db.reserve.SetRadius(db.repo.IndexStore(), r); err != nil {
-				db.logger.Error(err, "reserve set radius")
-			}
+			initialRadius = r
 		}
+	}
+
+	if err := db.reserve.SetRadius(db.repo.IndexStore(), initialRadius); err != nil {
+		db.logger.Error(err, "reserve set radius")
 	}
 
 	// syncing can now begin now that the reserver worker is running


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Because SetRadius is not called in the initialization of the reserve worker, kademlia never picks up the storage radius from the reserve initially.

The side effect is metrics can show the wrong radius.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
