### PR TITLE
fix(pullsync): panic on reading from closed channel

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -410,7 +410,11 @@ func (s *Syncer) collectAddrs(ctx context.Context, bin uint8, start uint64) ([]*
 	LOOP:
 		for limit > 0 {
 			select {
-			case c := <-chC:
+			case c, ok := <-chC:
+				if !ok {
+					break LOOP // The stream has been closed.
+				}
+
 				chs = append(chs, &storer.BinC{Address: c.Address, BatchID: c.BatchID})
 				if c.BinID > topmost {
 					topmost = c.BinID

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethersphere/bee/pkg/pullsync"
 	"github.com/ethersphere/bee/pkg/storage"
 	testingc "github.com/ethersphere/bee/pkg/storage/testing"
-	storer "github.com/ethersphere/bee/pkg/storer"
+	"github.com/ethersphere/bee/pkg/storer"
 	mock "github.com/ethersphere/bee/pkg/storer/mock"
 	"github.com/ethersphere/bee/pkg/swarm"
 )


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixes panic on reading zero value from closed channel:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x118f6c1]
bee
goroutine 136436466 [running]:
github.com/ethersphere/bee/pkg/pullsync.(*Syncer).collectAddrs.func1({0x1afb098, 0xc0690ee460})
    github.com/ethersphere/bee/pkg/pullsync/pullsync.go:414 +0x2a1
resenje.org/singleflight.(*Group).Do.func1()
    resenje.org/singleflight@v0.2.0/singleflight.go:59 +0x35
created by resenje.org/singleflight.(*Group).Do
    resenje.org/singleflight@v0.2.0/singleflight.go:58 +0x2d5
```    