### PR TITLE
perf: reduce locking context during evictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BEEKEEPER_USE_SUDO ?= false
 BEEKEEPER_CLUSTER ?= local
 BEELOCAL_BRANCH ?= main
 BEEKEEPER_BRANCH ?= master
-REACHABILITY_OVERRIDE_PUBLIC ?= true
+REACHABILITY_OVERRIDE_PUBLIC ?= false
 BATCHFACTOR_OVERRIDE_PUBLIC ?= 5
 
 BEE_API_VERSION ?= "$(shell grep '^  version:' openapi/Swarm.yaml | awk '{print $$2}')"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BEEKEEPER_USE_SUDO ?= false
 BEEKEEPER_CLUSTER ?= local
 BEELOCAL_BRANCH ?= main
 BEEKEEPER_BRANCH ?= master
-REACHABILITY_OVERRIDE_PUBLIC ?= false
+REACHABILITY_OVERRIDE_PUBLIC ?= true
 BATCHFACTOR_OVERRIDE_PUBLIC ?= 5
 
 BEE_API_VERSION ?= "$(shell grep '^  version:' openapi/Swarm.yaml | awk '{print $$2}')"

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -281,9 +281,7 @@ func (r *Reserve) IterateChunksItems(store internal.Storage, startBin uint8, cb 
 }
 
 // IterateBatchBin iterates over all chunks pertaining to the batch in the particular bin.
-// The callback function should return true to stop the iteration. The stamp on the
-// chunk is not populated as it is not required. This function is used for eviction
-// purposes.
+// The callback function should return true to stop the iteration.
 func (r *Reserve) IterateBatchBin(
 	ctx context.Context,
 	store internal.Storage,

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -280,57 +280,52 @@ func (r *Reserve) IterateChunksItems(store internal.Storage, startBin uint8, cb 
 	return err
 }
 
-func (r *Reserve) EvictBatchBin(ctx context.Context, batch internal.BatchOperation, bin uint8, batchID []byte, cb func(swarm.Chunk)) (int, error) {
+// IterateBatchBin iterates over all chunks pertaining to the batch in the particular bin.
+// The callback function should return true to stop the iteration. The stamp on the
+// chunk is not populated as it is not required. This function is used for eviction
+// purposes.
+func (r *Reserve) IterateBatchBin(
+	ctx context.Context,
+	store internal.Storage,
+	bin uint8,
+	batchID []byte,
+	cb func(swarm.Chunk) (bool, error),
+) error {
+	return store.IndexStore().Iterate(storage.Query{
+		Factory: func() storage.Item { return &batchRadiusItem{} },
+		Prefix:  batchBinToString(bin, batchID),
+	}, func(res storage.Result) (bool, error) {
+		batchRadius := res.Entry.(*batchRadiusItem)
 
-	var evicted []*batchRadiusItem
-
-	err := batch.Do(ctx, func(store internal.Storage) error {
-		return store.IndexStore().Iterate(storage.Query{
-			Factory: func() storage.Item { return &batchRadiusItem{} },
-			Prefix:  batchBinToString(bin, batchID),
-		}, func(res storage.Result) (bool, error) {
-			batchRadius := res.Entry.(*batchRadiusItem)
-			evicted = append(evicted, batchRadius)
-			return false, nil
-		})
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	batchCnt := 1000
-
-	for i := 0; i < len(evicted); i += batchCnt {
-		end := i + batchCnt
-		if end > len(evicted) {
-			end = len(evicted)
-		}
-
-		err := batch.Do(ctx, func(store internal.Storage) error {
-			for _, item := range evicted[i:end] {
-				c, err := store.ChunkStore().Get(ctx, item.Address)
-				if err != nil {
-					if errors.Is(err, storage.ErrNotFound) {
-						continue
-					}
-					return err
-				}
-
-				cb(c)
-
-				err = removeChunk(ctx, store, item)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
+		ch, err := store.ChunkStore().Get(ctx, batchRadius.Address)
 		if err != nil {
-			return 0, err
+			if errors.Is(err, storage.ErrNotFound) {
+				return false, nil
+			}
+			return true, err
 		}
-	}
+		stamp, err := chunkstamp.LoadWithBatchID(store.IndexStore(), reserveNamespace, batchRadius.Address, batchRadius.BatchID)
+		if err != nil {
+			return true, err
+		}
+		return cb(ch.WithStamp(stamp))
+	})
+}
 
-	return len(evicted), nil
+func (r *Reserve) DeleteChunk(ctx context.Context, store internal.Storage, ch swarm.Chunk) error {
+	item := &batchRadiusItem{
+		Bin:     swarm.Proximity(r.baseAddr.Bytes(), ch.Address().Bytes()),
+		Address: ch.Address(),
+		BatchID: ch.Stamp().BatchID(),
+	}
+	err := store.IndexStore().Get(item)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	return removeChunk(ctx, store, item)
 }
 
 func removeChunk(ctx context.Context, store internal.Storage, item *batchRadiusItem) error {

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -182,7 +182,7 @@ func TestReplaceOldIndex(t *testing.T) {
 	}
 }
 
-func TestEvict(t *testing.T) {
+func TestIterateDeleteBatchBin(t *testing.T) {
 	t.Parallel()
 
 	baseAddr := swarm.RandAddress(t)
@@ -218,17 +218,26 @@ func TestEvict(t *testing.T) {
 		}
 	}
 
-	totalEvicted := 0
+	chsToDelete := make([]swarm.Chunk, 0)
 	for i := 0; i < 3; i++ {
-		evicted, err := r.EvictBatchBin(context.Background(), ts, uint8(i), evictBatch.ID, func(swarm.Chunk) {})
+		err := r.IterateBatchBin(context.Background(), ts, uint8(i), evictBatch.ID, func(ch swarm.Chunk) (bool, error) {
+			chsToDelete = append(chsToDelete, ch)
+			return false, nil
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		totalEvicted += evicted
 	}
 
-	if totalEvicted != chunksPerBatch {
-		t.Fatalf("got %d, want %d", totalEvicted, chunksPerBatch)
+	if len(chsToDelete) != chunksPerBatch {
+		t.Fatalf("got %d, want %d", len(chsToDelete), chunksPerBatch)
+	}
+
+	for _, ch := range chsToDelete {
+		err := r.DeleteChunk(context.Background(), ts, ch)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	for i, ch := range chunks {

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -218,10 +218,14 @@ func TestIterateDeleteBatchBin(t *testing.T) {
 		}
 	}
 
-	chsToDelete := make([]swarm.Chunk, 0)
+	type chInfo struct {
+		Address swarm.Address
+		BatchID []byte
+	}
+	chsToDelete := make([]chInfo, 0)
 	for i := 0; i < 3; i++ {
-		err := r.IterateBatchBin(context.Background(), ts, uint8(i), evictBatch.ID, func(ch swarm.Chunk) (bool, error) {
-			chsToDelete = append(chsToDelete, ch)
+		err := r.IterateBatchBin(context.Background(), ts, uint8(i), evictBatch.ID, func(addr swarm.Address) (bool, error) {
+			chsToDelete = append(chsToDelete, chInfo{Address: addr, BatchID: evictBatch.ID})
 			return false, nil
 		})
 		if err != nil {
@@ -234,7 +238,7 @@ func TestIterateDeleteBatchBin(t *testing.T) {
 	}
 
 	for _, ch := range chsToDelete {
-		err := r.DeleteChunk(context.Background(), ts, ch)
+		err := r.DeleteChunk(context.Background(), ts, ch.Address, ch.BatchID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -209,33 +209,42 @@ func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (er
 		default:
 		}
 
-		err := func() error {
-			db.lock.Lock(reserveUpdateLockKey)
-			defer db.lock.Unlock(reserveUpdateLockKey)
+		var evicted int
 
-			// cache evicted chunks
-			cache := func(c swarm.Chunk) {
-				if err := db.Cache().Put(ctx, c); err != nil {
-					db.logger.Error(err, "reserve cache")
+		err = db.reserve.IterateBatchBin(ctx, db.repo, b, batchID, func(chunk swarm.Chunk) (bool, error) {
+			err := db.Do(ctx, func(txnRepo internal.Storage) error {
+				err := db.Cache().Put(ctx, chunk)
+				if err != nil {
+					db.logger.Warning("reserve eviction cache put", "err", err)
 				}
-			}
 
-			evicted, err := db.reserve.EvictBatchBin(ctx, db, b, batchID, cache)
+				db.lock.Lock(reserveUpdateLockKey)
+				defer db.lock.Unlock(reserveUpdateLockKey)
+
+				err = db.reserve.DeleteChunk(ctx, txnRepo, chunk)
+				if err != nil {
+					return fmt.Errorf("reserve: delete chunk: %w", err)
+				}
+				return nil
+			})
 			if err != nil {
-				return fmt.Errorf("reserve.EvictBatchBin: %w", err)
+				return false, err
 			}
+			evicted++
+			return false, nil
+		})
 
-			db.logger.Info("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())
+		// if there was an error, we still need to update the chunks that have already
+		// been evicted from the reserve
+		db.logger.Debug("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())
 
-			db.reserve.AddSize(-evicted)
-			db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
-			if upToBin == swarm.MaxBins {
-				db.metrics.ExpiredChunkCount.Add(float64(evicted))
-			} else {
-				db.metrics.EvictedChunkCount.Add(float64(evicted))
-			}
-			return nil
-		}()
+		db.reserve.AddSize(-evicted)
+		db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
+		if upToBin == swarm.MaxBins {
+			db.metrics.ExpiredChunkCount.Add(float64(evicted))
+		} else {
+			db.metrics.EvictedChunkCount.Add(float64(evicted))
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -236,15 +236,9 @@ func (db *DB) evictBatch(ctx context.Context, batchID []byte, upToBin uint8) (er
 
 		// if there was an error, we still need to update the chunks that have already
 		// been evicted from the reserve
-		db.lock.Lock(reserveUpdateLockKey)
-
+		db.logger.Debug("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", db.reserve.Size())
 		db.reserve.AddSize(-evicted)
-		newSize := db.reserve.Size()
-
-		db.lock.Unlock(reserveUpdateLockKey)
-
-		db.logger.Debug("reserve eviction", "bin", b, "evicted", evicted, "batchID", hex.EncodeToString(batchID), "size", newSize)
-		db.metrics.ReserveSize.Set(float64(newSize))
+		db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
 
 		if upToBin == swarm.MaxBins {
 			db.metrics.ExpiredChunkCount.Add(float64(evicted))


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Currently, the eviction function holds the lock for the entire duration of the call. This includes holding the lock during iteration of the bin items and also Put to cache. These are not required. We only need the lock while we remove the chunk related indexes.