### PR TITLE
refactor: ignore error not found in getter metrics

### DIFF
--- a/pkg/storer/metrics.go
+++ b/pkg/storer/metrics.go
@@ -6,6 +6,7 @@ package storer
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	m "github.com/ethersphere/bee/pkg/metrics"
@@ -136,7 +137,7 @@ func (m getterWithMetrics) Get(ctx context.Context, address swarm.Address) (swar
 	dur := captureDuration(time.Now())
 	chunk, err := m.Getter.Get(ctx, address)
 	m.metrics.MethodCallsDuration.WithLabelValues(m.component, "Get").Observe(dur())
-	if err == nil {
+	if err == nil || errors.Is(err, storage.ErrNotFound) {
 		m.metrics.MethodCalls.WithLabelValues(m.component, "Get", "success").Inc()
 	} else {
 		m.metrics.MethodCalls.WithLabelValues(m.component, "Get", "failure").Inc()


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Ignore `storage.ErrNotFound` error in getterWithMetrics `Get` calls.