### PR TITLE
fix: pass ctx to stop puller

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1035,7 +1035,7 @@ func NewBee(
 		pullerService = puller.New(stateStore, kad, localStore, pullSyncProtocol, p2ps, logger, puller.Options{}, warmupTime)
 		b.pullerCloser = pullerService
 
-		localStore.StartReserveWorker(pullerService, networkRadiusFunc)
+		localStore.StartReserveWorker(ctx, pullerService, networkRadiusFunc)
 		nodeStatus.SetSync(pullerService)
 
 		if o.EnableStorageIncentives {
@@ -1313,7 +1313,7 @@ func (b *Bee) Shutdown() error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(10)
+	wg.Add(8)
 	go func() {
 		defer wg.Done()
 		tryClose(b.chainSyncerCloser, "chain syncer")

--- a/pkg/puller/mock/puller.go
+++ b/pkg/puller/mock/puller.go
@@ -4,8 +4,10 @@
 
 package mock
 
+import "context"
+
 type mockSyncer struct{ rate float64 }
 
 func NewMockRateReporter(r float64) *mockSyncer { return &mockSyncer{r} }
 func (m *mockSyncer) SyncRate() float64         { return m.rate }
-func (m *mockSyncer) Start()                    {}
+func (m *mockSyncer) Start(context.Context)     {}

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -109,9 +109,9 @@ func New(
 	return p
 }
 
-func (p *Puller) Start() {
+func (p *Puller) Start(ctx context.Context) {
 	p.start.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		p.cancel = cancel
 
 		p.wg.Add(1)

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -111,11 +111,11 @@ func New(
 
 func (p *Puller) Start(ctx context.Context) {
 	p.start.Do(func() {
-		ctx, cancel := context.WithCancel(ctx)
+		cctx, cancel := context.WithCancel(ctx)
 		p.cancel = cancel
 
 		p.wg.Add(1)
-		go p.manage(ctx)
+		go p.manage(cctx)
 	})
 }
 

--- a/pkg/puller/puller_test.go
+++ b/pkg/puller/puller_test.go
@@ -5,6 +5,7 @@
 package puller_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -536,7 +537,7 @@ func newPuller(t *testing.T, ops opts) (*puller.Puller, storage.StateStorer, *ka
 		Bins: ops.bins,
 	}
 	p := puller.New(s, kad, ops.rs, ps, nil, logger, o, 0)
-	p.Start()
+	p.Start(context.Background())
 
 	testutil.CleanupCloser(t, p)
 

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -38,7 +38,7 @@ func threshold(capacity int) int { return capacity * 5 / 10 }
 func (db *DB) reserveWorker(ctx context.Context, warmupDur, wakeUpDur time.Duration, radius func() (uint8, error)) {
 	defer db.reserveWg.Done()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		<-db.quit
 		cancel()

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -30,12 +30,12 @@ var errMaxRadius = errors.New("max radius reached")
 type Syncer interface {
 	// Number of active historical syncing jobs.
 	SyncRate() float64
-	Start()
+	Start(context.Context)
 }
 
 func threshold(capacity int) int { return capacity * 5 / 10 }
 
-func (db *DB) reserveWorker(warmupDur, wakeUpDur time.Duration, radius func() (uint8, error)) {
+func (db *DB) reserveWorker(ctx context.Context, warmupDur, wakeUpDur time.Duration, radius func() (uint8, error)) {
 	defer db.reserveWg.Done()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,7 +74,7 @@ func (db *DB) reserveWorker(warmupDur, wakeUpDur time.Duration, radius func() (u
 	}
 
 	// syncing can now begin now that the reserver worker is running
-	db.syncer.Start()
+	db.syncer.Start(ctx)
 
 	wakeUpTicker := time.NewTicker(wakeUpDur)
 

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -67,7 +67,7 @@ func TestIndexCollision(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestIndexCollision(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 }
@@ -150,7 +150,7 @@ func TestReplaceOldIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -160,7 +160,7 @@ func TestReplaceOldIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, storer)
 	})
 }
@@ -175,7 +175,7 @@ func TestEvictBatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+	st.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 
 	ctx := context.Background()
 
@@ -325,7 +325,7 @@ func TestUnreserveCap(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, bs, storer)
 	})
 	t.Run("mem", func(t *testing.T) {
@@ -336,7 +336,7 @@ func TestUnreserveCap(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(0))
 		testF(t, baseAddr, bs, storer)
 	})
 }
@@ -351,7 +351,7 @@ func TestNetworkRadius(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
 		time.Sleep(time.Second)
 		if want, got := uint8(1), storer.StorageRadius(); want != got {
 			t.Fatalf("want radius %d, got radius %d", want, got)
@@ -364,7 +364,7 @@ func TestNetworkRadius(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(1))
 		time.Sleep(time.Second)
 		if want, got := uint8(1), storer.StorageRadius(); want != got {
 			t.Fatalf("want radius %d, got radius %d", want, got)
@@ -405,7 +405,7 @@ func TestRadiusManager(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(0), networkRadiusFunc(3))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(3))
 
 		batch := postagetesting.MustNewBatch()
 		err = bs.Save(batch)
@@ -443,7 +443,7 @@ func TestRadiusManager(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		storer.StartReserveWorker(pullerMock.NewMockRateReporter(1), networkRadiusFunc(3))
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(1), networkRadiusFunc(3))
 		waitForRadius(t, storer.Reserve(), 3)
 	})
 }

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -576,11 +576,11 @@ func (db *DB) SetRetrievalService(r retrieval.Interface) {
 	db.retrieval = r
 }
 
-func (db *DB) StartReserveWorker(s Syncer, radius func() (uint8, error)) {
+func (db *DB) StartReserveWorker(ctx context.Context, s Syncer, radius func() (uint8, error)) {
 	db.setSyncerOnce.Do(func() {
 		db.syncer = s
 		db.reserveWg.Add(1)
-		go db.reserveWorker(db.opts.warmupDuration, db.opts.wakeupDuration, radius)
+		go db.reserveWorker(ctx, db.opts.warmupDuration, db.opts.wakeupDuration, radius)
 	})
 }
 


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
During shutdown the pullsync protocol is stuck with:
```
"time"="2023-06-27 11:35:15.950681" "level"="debug" "logger"="node/libp2p" "msg"="handle protocol: handle headers failed" "protocol"="pullsync" "version"="1.3.0" "stream"="pullsync" "peer"="e1dc994c4a8ba82c183cd9b773210d7c88061c507fb9a9dfcbccea04b8380134" "error"="read message: context canceled"
"time"="2023-06-27 11:35:15.950759" "level"="debug" "logger"="node/libp2p" "msg"="handle protocol: handle headers failed" "protocol"="pullsync" "version"="1.3.0" "stream"="pullsync" "peer"="e1dc994c4a8ba82c183cd9b773210d7c88061c507fb9a9dfcbccea04b8380134" "error"="read message: context canceled"
"time"="2023-06-27 11:35:15.950764" "level"="debug" "logger"="node/libp2p" "msg"="handle protocol: handle headers failed" "protocol"="pullsync" "version"="1.3.0" "stream"="pullsync" "peer"="df6c1b18cc21d07e0b89b05d16153002037f76982709ff879f2e6d60de7d2127" "error"="read message: context canceled"
"time"="2023-06-27 11:35:15.951274" "level"="debug" "logger"="node/libp2p" "msg"="handle protocol: handle headers failed" "protocol"="pullsync" "version"="1.3.0" "stream"="pullsync" "peer"="df6c1b18cc21d07e0b89b05d16153002037f76982709ff879f2e6d60de7d2127" "error"="read message: context canceled"
"time"="2023-06-27 11:35:15.951544" "level"="debug" "logger"="node/libp2p" "msg"="handle protocol: handle headers failed" "protocol"="pullsync" "version"="1.3.0" "stream"="pullsync" "peer"="df6c1b18cc21d07e0b89b05d16153002037f76982709ff879f2e6d60de7d2127" "error"="read message: context canceled"
```