### PR TITLE
perf: control the next start interval to group future requests

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -986,7 +986,7 @@ func NewBee(
 
 	pusherService.AddFeed(localStore.PusherFeed())
 
-	pullSyncProtocol := pullsync.New(p2ps, localStore, pssService.TryUnwrap, validStamp, logger, pullsync.DefaultMaxPage)
+	pullSyncProtocol := pullsync.New(p2ps, localStore, pssService.TryUnwrap, validStamp, logger, pullsync.DefaultMaxPage, pullsync.DefaultPageTimeout)
 	b.pullSyncCloser = pullSyncProtocol
 
 	retrieveProtocolSpec := retrieve.Protocol()

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -441,7 +441,7 @@ func (s *Syncer) collectAddrs(ctx context.Context, bin uint8, start uint64) ([]*
 				}
 				// by stopping at a specific position, we control the binID the next sync call will start at for all peers.
 				// as such, this increases the probability that multiple requests will fall into same single flight group.
-				if c.BinID == nextWindow {
+				if c.BinID >= nextWindow {
 					break LOOP
 				}
 

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -45,7 +45,6 @@ const (
 const (
 	MaxCursor           = math.MaxUint64
 	DefaultRateDuration = time.Minute * 15
-	batchTimeout        = time.Second * 15 //max amount of time to wait for the next chunk after collecting the first addr.
 )
 
 var (
@@ -53,8 +52,9 @@ var (
 )
 
 const (
-	makeOfferTimeout        = 5 * time.Minute
-	DefaultMaxPage   uint64 = 250
+	makeOfferTimeout           = 5 * time.Minute
+	DefaultMaxPage      uint64 = 250
+	DefaultBatchTimeout        = time.Second * 15 //max amount of time to wait for the next chunk after collecting the first addr.
 )
 
 // singleflight key for intervals
@@ -434,12 +434,11 @@ func (s *Syncer) collectAddrs(ctx context.Context, bin uint8, start uint64) ([]*
 				}
 				limit--
 				if timerC == nil {
-					timerC = time.After(batchTimeout)
+					timerC = time.After(DefaultBatchTimeout)
 				}
 				// by stopping at a specific position, we control the binID the next sync call will start at for all peers.
 				// as such, this increases the probability that multiple requests will fall into same single flight group.
 				if c.BinID == nextWindow {
-					s.logger.Debug("collect addr", "bin", bin, "start", start, "nextBucket", nextWindow)
 					break LOOP
 				}
 

--- a/pkg/pullsync/pullsync_test.go
+++ b/pkg/pullsync/pullsync_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/p2p"
@@ -319,6 +320,7 @@ func newPullSyncWithStamperValidator(
 		validStamp,
 		logger,
 		maxPage,
+		time.Second,
 	)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
By stopping at exactly at the end of the current equally divided maxPage sized window,
we get to control the position the next sync request will start at.

This increases the probability that requests will be included in the same single flight group.

Notice how in the logs below, all bin 0 requests converge at start position `nextBucket + 1` or `108501`

Before this PR, start positions were almost all random so the single flight group made minimal performance gains.

### Screenshots (if appropriate):
```
"time"="2023-06-30 03:19:36.473741" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:36.539346" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108401 "nextBucket"=108500
"time"="2023-06-30 03:19:36.557415" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:36.894260" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:36.956802" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:37.147609" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108401 "nextBucket"=108500
"time"="2023-06-30 03:19:37.167041" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:37.196141" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:37.399422" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108401 "nextBucket"=108500
"time"="2023-06-30 03:19:37.461982" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:38.195141" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:38.465204" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:38.515869" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108401 "nextBucket"=108500
"time"="2023-06-30 03:19:38.764043" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:38.846910" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:38.964569" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108401 "nextBucket"=108500
"time"="2023-06-30 03:19:39.277987" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:19:42.110856" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108251 "nextBucket"=108500
"time"="2023-06-30 03:20:08.051707" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500
"time"="2023-06-30 03:21:13.605498" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108382 "nextBucket"=108500


"time"="2023-06-30 03:21:13.932678" "level"="debug" "logger"="node/pullsync" "msg"="collect addr" "bin"=0 "start"=108501 "nextBucket"=108750
```




