### PR TITLE
fix: clean up runs when reserve is constructed and reserve size recount is removed

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -777,6 +777,7 @@ func NewBee(
 		lo.ReserveCapacity = ReserveCapacity
 		lo.ReserveWakeUpDuration = reserveWakeUpDuration
 		lo.RadiusSetter = kad
+		lo.ReserveInitialCleanup = true
 	}
 
 	localStore, err := storer.New(ctx, path, lo)

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -63,10 +63,11 @@ func New(
 	}
 	rs.radius.Store(uint32(rItem.Radius))
 
-	err = rs.RecountSize(store)
+	size, err := store.Count(&batchRadiusItem{})
 	if err != nil {
 		return nil, err
 	}
+	rs.size.Store(int64(size))
 
 	return rs, nil
 }
@@ -366,18 +367,6 @@ func (r *Reserve) Radius() uint8 {
 
 func (r *Reserve) Size() int {
 	return int(r.size.Load())
-}
-
-// RecountSize recounts the entire reserve from the Store.
-// Not thread-safe so it must NOT be called along all other calls to update the size.
-func (r *Reserve) RecountSize(store storage.Store) error {
-	size, err := store.Count(&batchRadiusItem{})
-	if err != nil {
-		return err
-	}
-	r.size.Store(int64(size))
-
-	return nil
 }
 
 func (r *Reserve) Capacity() int {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -279,10 +279,11 @@ func (db *DB) reserveCleanup(ctx context.Context) error {
 	dur := captureDuration(time.Now())
 	removed := 0
 	defer func() {
+		db.reserve.AddSize(-removed)
+		db.logger.Info("cleanup finished", "removed", removed, "duration", dur())
 		db.metrics.MethodCallsDuration.WithLabelValues("reserve", "cleanup").Observe(dur())
 		db.metrics.ReserveCleanup.Add(float64(removed))
-		db.logger.Info("cleanup finished", "removed", removed, "duration", dur())
-		db.reserve.AddSize(-removed)
+		db.metrics.ReserveSize.Set(float64(db.reserve.Size()))
 	}()
 
 	ids := map[string]struct{}{}

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -46,10 +46,6 @@ func (db *DB) reserveWorker(ctx context.Context, warmupDur, wakeUpDur time.Durat
 		cancel()
 	}()
 
-	if err := db.reserveCleanup(ctx); err != nil {
-		db.logger.Error(err, "cleanup")
-	}
-
 	overCapTrigger, overCapUnsub := db.events.Subscribe(reserveOverCapacity)
 	defer overCapUnsub()
 
@@ -286,20 +282,7 @@ func (db *DB) reserveCleanup(ctx context.Context) error {
 		db.metrics.MethodCallsDuration.WithLabelValues("reserve", "cleanup").Observe(dur())
 		db.metrics.ReserveCleanup.Add(float64(removed))
 		db.logger.Info("cleanup finished", "removed", removed, "duration", dur())
-
-		if removed == 0 {
-			return
-		}
-
-		db.lock.Lock(reserveUpdateLockKey)
-		defer db.lock.Unlock(reserveUpdateLockKey)
-
-		if err := db.reserve.RecountSize(db.repo.IndexStore()); err != nil {
-			db.logger.Error(err, "recount reserve size")
-		}
-
-		db.metrics.ReserveSize.Set(float64(db.ReserveSize()))
-
+		db.reserve.AddSize(-removed)
 	}()
 
 	ids := map[string]struct{}{}

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -382,6 +382,7 @@ type Options struct {
 	RadiusSetter   topology.SetStorageRadiuser
 	StateStore     storage.StateStorer
 
+	ReserveInitialCleanup bool
 	ReserveCapacity       int
 	ReserveWakeUpDuration time.Duration
 }
@@ -506,6 +507,14 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 			return nil, err
 		}
 		db.reserve = rs
+
+		if opts.ReserveInitialCleanup {
+			err = db.reserveCleanup(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		db.metrics.StorageRadius.Set(float64(rs.Radius()))
 		db.metrics.ReserveSize.Set(float64(rs.Size()))
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
