### PR TITLE
fix: trigger subscribe push to ensure new iteration

### DIFF
--- a/pkg/storer/subscribe_push.go
+++ b/pkg/storer/subscribe_push.go
@@ -59,6 +59,12 @@ func (db *DB) SubscribePush(ctx context.Context) (<-chan swarm.Chunk, func()) {
 					db.logger.Error(err, "subscribe push: iterate error")
 					return
 				}
+				// if we get storage.ErrNotFound, it could happen that the previous
+				// iteration happened on a snapshot that was not fully updated yet.
+				// in this case, we wait for the next event to trigger the iteration
+				// again. This trigger ensures that we perform the iteration on the
+				// latest snapshot.
+				db.events.Trigger(subscribePushEventKey)
 			}
 
 			select {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Just in case we dont get a trigger from anywhere else, we should trigger again.