### PR TITLE
fix: close iterator on empty iteration

### DIFF
--- a/pkg/storage/leveldbstore/store.go
+++ b/pkg/storage/leveldbstore/store.go
@@ -141,6 +141,12 @@ func (s *Store) Iterate(q storage.Query, fn storage.IterateFn) error {
 	var iter iterator.Iterator
 	var prefix string
 
+	defer func() {
+		if iter != nil {
+			iter.Release()
+		}
+	}()
+
 	if q.PrefixAtStart {
 		prefix = q.Factory().Namespace()
 		iter = s.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
@@ -221,8 +227,6 @@ func (s *Store) Iterate(q storage.Query, fn storage.IterateFn) error {
 			break
 		}
 	}
-
-	iter.Release()
 
 	if err := iter.Error(); err != nil {
 		retErr = errors.Join(retErr, err)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Closes iterator if prefix is not found.
