### PR TITLE
perf: parallelize eviction and expiration

### DIFF
--- a/pkg/storer/internal/reserve/items.go
+++ b/pkg/storer/internal/reserve/items.go
@@ -33,13 +33,13 @@ func (b *batchRadiusItem) Namespace() string {
 	return "batchRadius"
 }
 
-// bin/batchID/ChunkAddr
+// batchID/bin/ChunkAddr
 func (b *batchRadiusItem) ID() string {
-	return batchBinToString(b.Bin, b.BatchID) + b.Address.ByteString()
+	return batchBinToString(b.BatchID, b.Bin) + b.Address.ByteString()
 }
 
-func batchBinToString(bin uint8, batchID []byte) string {
-	return string(bin) + string(batchID)
+func batchBinToString(batchID []byte, bin uint8) string {
+	return string(batchID) + string(bin)
 }
 
 func (b *batchRadiusItem) String() string {

--- a/pkg/storer/metrics.go
+++ b/pkg/storer/metrics.go
@@ -132,16 +132,16 @@ func newMetrics() metrics {
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
-				Name:      "expired_batch_count",
-				Help:      "Number of batches expired, that were processed.",
+				Name:      "expiry_trigger_count",
+				Help:      "Number of batches expiry triggers.",
 			},
 		),
 		ExpiryRunsCount: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
-				Name:      "expired_batch_count",
-				Help:      "Number of batches expired, that were processed.",
+				Name:      "expiry_run_count",
+				Help:      "Number of times the expiry worker was fired.",
 			},
 		),
 	}

--- a/pkg/storer/metrics.go
+++ b/pkg/storer/metrics.go
@@ -28,6 +28,8 @@ type metrics struct {
 	OverCapTriggerCount prometheus.Counter
 	ExpiredBatchCount   prometheus.Counter
 	LevelDBStats        prometheus.HistogramVec
+	ExpiryTriggersCount prometheus.Counter
+	ExpiryRunsCount     prometheus.Counter
 }
 
 // newMetrics is a convenient constructor for creating new metrics.
@@ -125,6 +127,22 @@ func newMetrics() metrics {
 				Help:      "LevelDB statistics.",
 			},
 			[]string{"counter"},
+		),
+		ExpiryTriggersCount: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "expired_batch_count",
+				Help:      "Number of batches expired, that were processed.",
+			},
+		),
+		ExpiryRunsCount: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "expired_batch_count",
+				Help:      "Number of batches expired, that were processed.",
+			},
 		),
 	}
 }

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -166,9 +166,9 @@ func (db *DB) evictionWorker(ctx context.Context) {
 		defer close(stopped)
 
 		// wait for all workers to finish
-		expirySem.Acquire(context.Background(), 1)
-		unreserveSem.Acquire(context.Background(), 1)
-		expiryWorkers.Acquire(context.Background(), 4)
+		_ = expirySem.Acquire(context.Background(), 1)
+		_ = unreserveSem.Acquire(context.Background(), 1)
+		_ = expiryWorkers.Acquire(context.Background(), 4)
 	}
 
 	cleanupExpired := func() {

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -299,7 +299,7 @@ func TestUnreserveCap(t *testing.T) {
 		// wait for unreserve signal
 		<-gotUnreserveSignal
 
-		err = spinlock.Wait(time.Second*30, func() bool {
+		err = spinlock.Wait(time.Second*45, func() bool {
 			return storer.ReserveSize() == capacity
 		})
 		if err != nil {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Single worker is not fast enough to handle unreserve as well as postage expirations. So we will handle them in separate goroutines so the eviction worker is unblocked to listen to signals.