### PR TITLE
refactor(storagetest): remove duplicate batched store interface

### DIFF
--- a/pkg/storage/storagetest/batch.go
+++ b/pkg/storage/storagetest/batch.go
@@ -13,13 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// BatchedStore is a store that provides batch operations.
-type BatchedStore interface {
-	storage.Store
-	storage.Batcher
-}
-
-func TestBatchedStore(t *testing.T, bs BatchedStore) {
+func TestBatchedStore(t *testing.T, bs storage.BatchedStore) {
 	item := &obj1{Id: "id", SomeInt: 1, Buf: []byte("data")}
 
 	t.Run("duplicates are rejected", func(t *testing.T) {
@@ -100,7 +94,7 @@ func TestBatchedStore(t *testing.T, bs BatchedStore) {
 		if err := batch.Commit(); err != nil {
 			t.Fatalf("Commit(): unexpected error: %v", err)
 		}
-		if err := batch.Commit(); err == nil { // TODO: replace with sentinel error.
+		if err := batch.Commit(); err == nil {
 			t.Fatal("Commit(): expected error; have none")
 		}
 	})

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -851,7 +851,7 @@ func BenchmarkStore(b *testing.B, s storage.Store) {
 
 // BenchmarkBatchedStore provides a benchmark suite for the
 // storage.BatchedStore. Only the Write and Delete methods are tested.
-func BenchmarkBatchedStore(b *testing.B, bs BatchedStore) {
+func BenchmarkBatchedStore(b *testing.B, bs storage.BatchedStore) {
 	b.Run("WriteInBatches", func(b *testing.B) {
 		BenchmarkWriteInBatches(b, bs)
 	})
@@ -946,7 +946,7 @@ func BenchmarkWriteSequential(b *testing.B, db storage.Store) {
 	doWrite(b, db, g)
 }
 
-func BenchmarkWriteInBatches(b *testing.B, bs BatchedStore) {
+func BenchmarkWriteInBatches(b *testing.B, bs storage.BatchedStore) {
 	g := newSequentialEntryGenerator(b.N)
 	batch, _ := bs.Batch(context.Background())
 	resetBenchmark(b)
@@ -965,7 +965,7 @@ func BenchmarkWriteInBatches(b *testing.B, bs BatchedStore) {
 	}
 }
 
-func BenchmarkWriteInFixedSizeBatches(b *testing.B, bs BatchedStore) {
+func BenchmarkWriteInFixedSizeBatches(b *testing.B, bs storage.BatchedStore) {
 	g := newSequentialEntryGenerator(b.N)
 	writer := newBatchDBWriter(bs)
 	resetBenchmark(b)
@@ -1016,7 +1016,7 @@ func BenchmarkDeleteSequential(b *testing.B, db storage.Store) {
 	doDelete(b, db, g)
 }
 
-func BenchmarkDeleteInBatches(b *testing.B, bs BatchedStore) {
+func BenchmarkDeleteInBatches(b *testing.B, bs storage.BatchedStore) {
 	g := newSequentialEntryGenerator(b.N)
 	doWrite(b, bs, g)
 	resetBenchmark(b)
@@ -1034,7 +1034,7 @@ func BenchmarkDeleteInBatches(b *testing.B, bs BatchedStore) {
 	}
 }
 
-func BenchmarkDeleteInFixedSizeBatches(b *testing.B, bs BatchedStore) {
+func BenchmarkDeleteInFixedSizeBatches(b *testing.B, bs storage.BatchedStore) {
 	g := newSequentialEntryGenerator(b.N)
 	doWrite(b, bs, g)
 	resetBenchmark(b)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Remove duplicate batched store interface in the `storagetest` package.