### PR TITLE
fix: do epoch migration only once

### DIFF
--- a/pkg/storer/internal/reserve/items.go
+++ b/pkg/storer/internal/reserve/items.go
@@ -33,13 +33,13 @@ func (b *batchRadiusItem) Namespace() string {
 	return "batchRadius"
 }
 
-// batchID/bin/ChunkAddr
+// bin/batchID/ChunkAddr
 func (b *batchRadiusItem) ID() string {
-	return batchBinToString(b.BatchID, b.Bin) + b.Address.ByteString()
+	return batchBinToString(b.Bin, b.BatchID) + b.Address.ByteString()
 }
 
-func batchBinToString(batchID []byte, bin uint8) string {
-	return string(batchID) + string(bin)
+func batchBinToString(bin uint8, batchID []byte) string {
+	return string(bin) + string(batchID)
 }
 
 func (b *batchRadiusItem) String() string {

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -286,7 +286,7 @@ func (r *Reserve) IterateChunksItems(store internal.Storage, startBin uint8, cb 
 	return err
 }
 
-// EvictBatchBin evicts all chunks from bins upto the bin provided.
+// EvictBatchBin evicts all chunks from the bin provided.
 func (r *Reserve) EvictBatchBin(
 	ctx context.Context,
 	txExecutor internal.TxExecutor,
@@ -300,12 +300,9 @@ func (r *Reserve) EvictBatchBin(
 	err := txExecutor.Execute(ctx, func(store internal.Storage) error {
 		return store.IndexStore().Iterate(storage.Query{
 			Factory: func() storage.Item { return &batchRadiusItem{} },
-			Prefix:  string(batchID),
+			Prefix:  batchBinToString(bin, batchID),
 		}, func(res storage.Result) (bool, error) {
 			batchRadius := res.Entry.(*batchRadiusItem)
-			if batchRadius.Bin >= bin {
-				return true, nil
-			}
 			evicted = append(evicted, batchRadius)
 			return false, nil
 		})

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -32,8 +32,8 @@ const (
 	cleanupDur = time.Hour * 6
 )
 
-func reserveUpdateBatchLockKey(batchID []byte) string {
-	return fmt.Sprintf("%s%s", reserveUpdateLockKey, string(batchID))
+func reserveUpdateBatchLockKey(batchID []byte, bin uint8) string {
+	return fmt.Sprintf("%s%s%d", reserveUpdateLockKey, string(batchID), bin)
 }
 
 var errMaxRadius = errors.New("max radius reached")
@@ -351,7 +351,10 @@ func (db *DB) ReservePutter() storage.Putter {
 				var (
 					newIndex bool
 				)
-				lockKey := reserveUpdateBatchLockKey(chunk.Stamp().BatchID())
+				lockKey := reserveUpdateBatchLockKey(
+					chunk.Stamp().BatchID(),
+					db.po(chunk.Address()),
+				)
 				db.lock.Lock(lockKey)
 				err = db.Execute(ctx, func(tx internal.Storage) error {
 					newIndex, err = db.reserve.Put(ctx, tx, chunk)
@@ -460,27 +463,48 @@ func (db *DB) evictBatch(
 		} else {
 			db.metrics.EvictedChunkCount.Add(float64(evicted))
 		}
+	}()
+
+	for b := uint8(0); b < upToBin; b++ {
+
+		select {
+		case <-ctx.Done():
+			return evicted, ctx.Err()
+		default:
+		}
+
+		binEvicted, err := func() (int, error) {
+			lockKey := reserveUpdateBatchLockKey(batchID, b)
+			db.lock.Lock(lockKey)
+			defer db.lock.Unlock(lockKey)
+
+			// cache evicted chunks
+			cache := func(c swarm.Chunk) {
+				if err := db.Cache().Put(ctx, c); err != nil {
+					db.logger.Error(err, "reserve cache")
+				}
+			}
+
+			return db.reserve.EvictBatchBin(ctx, db, b, batchID, cache)
+		}()
+		evicted += binEvicted
+
+		// if there was an error, we still need to update the chunks that have already
+		// been evicted from the reserve
 		db.logger.Debug(
 			"reserve eviction",
-			"uptoBin", upToBin,
+			"bin", b,
 			"evicted", evicted,
 			"batchID", hex.EncodeToString(batchID),
 			"new_size", db.reserve.Size(),
 		)
-	}()
 
-	lockKey := reserveUpdateBatchLockKey(batchID)
-	db.lock.Lock(lockKey)
-	defer db.lock.Unlock(lockKey)
-
-	// cache evicted chunks
-	cache := func(c swarm.Chunk) {
-		if err := db.Cache().Put(ctx, c); err != nil {
-			db.logger.Error(err, "reserve cache")
+		if err != nil {
+			return evicted, err
 		}
 	}
 
-	return db.reserve.EvictBatchBin(ctx, db, upToBin, batchID, cache)
+	return evicted, nil
 }
 
 func (db *DB) reserveCleanup(ctx context.Context) error {

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -503,9 +503,12 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 			return nil, err
 		}
 	} else {
-		err = performEpochMigration(ctx, dirPath, opts)
-		if err != nil {
-			return nil, err
+		// only perform migration if not done already
+		if _, err := os.Stat(path.Join(dirPath, indexPath)); err != nil {
+			err = performEpochMigration(ctx, dirPath, opts)
+			if err != nil {
+				return nil, err
+			}
 		}
 		repo, dbCloser, err = initDiskRepository(ctx, dirPath, opts)
 		if err != nil {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Caused us to release all sharky slots on restart. Was discovered with the help of @ldeffenb. For more details please go to discord.
