### PR TITLE
fix: err format

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -967,7 +967,7 @@ func (s *Service) newStreamForPeerID(ctx context.Context, peerID libp2ppeer.ID, 
 		if errors.Is(err, multistream.ErrIncorrectVersion) {
 			return nil, p2p.NewIncompatibleStreamError(err)
 		}
-		return nil, fmt.Errorf("create stream %q to %q: %w", swarmStreamName, peerID, err)
+		return nil, fmt.Errorf("create stream %s to %s: %w", swarmStreamName, peerID, err)
 	}
 	s.metrics.CreatedStreamCount.Inc()
 	return st, nil


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
fixes the unnecessary quotes in logs like these
```
"err"="new stream: new stream for peerid: create stream \"/swarm/pullsync/1.3.0/pullsync\" to \"Qmbioqnig2LCEUZasLEkt5noahWcST4Ur9zSKWwHDCYiSY\": context canceled"
```