### PR TITLE
perf: improve eviction worker cpu use

### DIFF
--- a/pkg/storer/internal/reserve/items.go
+++ b/pkg/storer/internal/reserve/items.go
@@ -33,13 +33,9 @@ func (b *batchRadiusItem) Namespace() string {
 	return "batchRadius"
 }
 
-// bin/batchID/ChunkAddr
+// batchID/bin/ChunkAddr
 func (b *batchRadiusItem) ID() string {
-	return batchBinToString(b.Bin, b.BatchID) + b.Address.ByteString()
-}
-
-func batchBinToString(bin uint8, batchID []byte) string {
-	return string(bin) + string(batchID)
+	return string(b.BatchID) + string(b.Bin) + b.Address.ByteString()
 }
 
 func (b *batchRadiusItem) String() string {

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -337,13 +337,10 @@ func (r *Reserve) EvictBatchBin(
 				}
 				moveToCache = append(moveToCache, item.Address)
 			}
+			if err := r.cacheCb(ctx, store, moveToCache...); err != nil {
+				return err
+			}
 			return batch.Commit()
-		})
-		if err != nil {
-			return 0, err
-		}
-		err = txExecutor.Execute(ctx, func(store internal.Storage) error {
-			return r.cacheCb(ctx, store, moveToCache...)
 		})
 		if err != nil {
 			return 0, err

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -290,7 +290,7 @@ func (r *Reserve) IterateChunksItems(store internal.Storage, startBin uint8, cb 
 	return err
 }
 
-// EvictBatchBin evicts all chunks from the bin provided.
+// EvictBatchBin evicts all chunks from bins upto the bin provided.
 func (r *Reserve) EvictBatchBin(
 	ctx context.Context,
 	txExecutor internal.TxExecutor,
@@ -303,9 +303,12 @@ func (r *Reserve) EvictBatchBin(
 	err := txExecutor.Execute(ctx, func(store internal.Storage) error {
 		return store.IndexStore().Iterate(storage.Query{
 			Factory: func() storage.Item { return &batchRadiusItem{} },
-			Prefix:  batchBinToString(bin, batchID),
+			Prefix:  string(batchID),
 		}, func(res storage.Result) (bool, error) {
 			batchRadius := res.Entry.(*batchRadiusItem)
+			if batchRadius.Bin >= bin {
+				return true, nil
+			}
 			evicted = append(evicted, batchRadius)
 			return false, nil
 		})
@@ -315,6 +318,7 @@ func (r *Reserve) EvictBatchBin(
 	}
 
 	batchCnt := 1000
+	evictionCompleted := 0
 
 	for i := 0; i < len(evicted); i += batchCnt {
 		end := i + batchCnt
@@ -343,11 +347,12 @@ func (r *Reserve) EvictBatchBin(
 			return batch.Commit()
 		})
 		if err != nil {
-			return 0, err
+			return evictionCompleted, err
 		}
+		evictionCompleted += end - i
 	}
 
-	return len(evicted), nil
+	return evictionCompleted, nil
 }
 
 func (r *Reserve) DeleteChunk(

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -32,8 +32,8 @@ const (
 	cleanupDur = time.Hour * 6
 )
 
-func reserveUpdateBatchLockKey(batchID []byte, bin uint8) string {
-	return fmt.Sprintf("%s%s%d", reserveUpdateLockKey, string(batchID), bin)
+func reserveUpdateBatchLockKey(batchID []byte) string {
+	return fmt.Sprintf("%s%s", reserveUpdateLockKey, string(batchID))
 }
 
 var errMaxRadius = errors.New("max radius reached")
@@ -352,10 +352,7 @@ func (db *DB) ReservePutter() storage.Putter {
 				var (
 					newIndex bool
 				)
-				lockKey := reserveUpdateBatchLockKey(
-					chunk.Stamp().BatchID(),
-					db.po(chunk.Address()),
-				)
+				lockKey := reserveUpdateBatchLockKey(chunk.Stamp().BatchID())
 				db.lock.Lock(lockKey)
 				err = db.Execute(ctx, func(tx internal.Storage) error {
 					newIndex, err = db.reserve.Put(ctx, tx, chunk)
@@ -464,41 +461,20 @@ func (db *DB) evictBatch(
 		} else {
 			db.metrics.EvictedChunkCount.Add(float64(evicted))
 		}
-	}()
-
-	for b := uint8(0); b < upToBin; b++ {
-
-		select {
-		case <-ctx.Done():
-			return evicted, ctx.Err()
-		default:
-		}
-
-		binEvicted, err := func() (int, error) {
-			lockKey := reserveUpdateBatchLockKey(batchID, b)
-			db.lock.Lock(lockKey)
-			defer db.lock.Unlock(lockKey)
-
-			return db.reserve.EvictBatchBin(ctx, db, b, batchID)
-		}()
-		evicted += binEvicted
-
-		// if there was an error, we still need to update the chunks that have already
-		// been evicted from the reserve
 		db.logger.Debug(
 			"reserve eviction",
-			"bin", b,
-			"evicted", binEvicted,
+			"uptoBin", upToBin,
+			"evicted", evicted,
 			"batchID", hex.EncodeToString(batchID),
 			"new_size", db.reserve.Size(),
 		)
+	}()
 
-		if err != nil {
-			return evicted, err
-		}
-	}
+	lockKey := reserveUpdateBatchLockKey(batchID)
+	db.lock.Lock(lockKey)
+	defer db.lock.Unlock(lockKey)
 
-	return evicted, nil
+	return db.reserve.EvictBatchBin(ctx, db, upToBin, batchID)
 }
 
 func (db *DB) reserveCleanup(ctx context.Context) error {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -255,8 +255,6 @@ func (db *DB) evictionWorker(ctx context.Context) {
 			// check if there are expired batches first
 			db.metrics.OverCapTriggerCount.Inc()
 
-			cleanupExpired()
-
 			if !unreserveSem.TryAcquire(1) {
 				// if there is already a goroutine taking care of unreserving
 				// dont wait for it to finish

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -520,6 +520,7 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 				return nil, err
 			}
 		}
+
 		repo, dbCloser, err = initDiskRepository(ctx, dirPath, opts)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Debugging on resource-constrained machines, we found some unnecessary goroutine creations and also excessive expiry checks. Thanks to @ldeffenb for helping out with this! These changes should improve the CPU consumption of the nodes.

Also, a bug was found with the move to cache where the reserve size was not being changed correctly. This is fixed by moving the cache op into the same transaction, so it can be reverted together.
