### PR TITLE
fix: swallowed batchExpiry trigger

### DIFF
--- a/pkg/storer/internal/cache/cache_test.go
+++ b/pkg/storer/internal/cache/cache_test.go
@@ -482,6 +482,30 @@ func TestMoveFromReserve(t *testing.T) {
 
 		verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
 		verifyCacheOrder(t, c, st.IndexStore(), chunks...)
+
+		chunks2 := chunktest.GenerateTestRandomChunks(5)
+		chunksToMove2 := make([]swarm.Address, 0, 5)
+
+		// add the chunks to chunkstore. This simulates the reserve already populating
+		// the chunkstore with chunks.
+		for _, ch := range chunks2 {
+			err := st.ChunkStore().Put(context.Background(), ch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			chunksToMove2 = append(chunksToMove2, ch.Address())
+		}
+
+		// move new chunks
+		err = c.MoveFromReserve(context.Background(), st, chunksToMove2...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cacheChunks := append(chunks[5:], chunks2...)
+
+		verifyCacheState(t, st.IndexStore(), c, cacheChunks[0].Address(), cacheChunks[9].Address(), 10)
+		verifyCacheOrder(t, c, st.IndexStore(), cacheChunks...)
 	})
 
 	t.Run("move from reserve over capacity", func(t *testing.T) {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -154,11 +154,10 @@ func (db *DB) evictionWorker(ctx context.Context) {
 	defer overCapUnsub()
 
 	var (
-		unreserveSem    = semaphore.NewWeighted(1)
-		unreserveCtx    context.Context
-		cancelUnreserve context.CancelFunc
-		expirySem       = semaphore.NewWeighted(1)
-		expiryWorkers   = semaphore.NewWeighted(4)
+		unreserveSem                  = semaphore.NewWeighted(1)
+		unreserveCtx, cancelUnreserve = context.WithCancel(ctx)
+		expirySem                     = semaphore.NewWeighted(1)
+		expiryWorkers                 = semaphore.NewWeighted(4)
 	)
 
 	stopped := make(chan struct{})

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -294,7 +294,7 @@ func TestUnreserveCap(t *testing.T) {
 				if storer.ReserveSize() == capacity {
 					break done
 				}
-			case <-time.After(time.Second * 45):
+			case <-time.After(time.Second * 60):
 				if storer.ReserveSize() != capacity {
 					t.Fatal("timeout waiting for reserve to reach capacity")
 				}

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -294,7 +294,7 @@ func TestUnreserveCap(t *testing.T) {
 				if storer.ReserveSize() == capacity {
 					break done
 				}
-			case <-time.After(time.Second * 60):
+			case <-time.After(time.Second * 30):
 				if storer.ReserveSize() != capacity {
 					t.Fatal("timeout waiting for reserve to reach capacity")
 				}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Missed expiry triggers. If expiry triggers are swallowed after we already selected batches to expire and no new signals for expiry are received, we will keep a hold of the expired chunks till cleanup comes and helps us. This change ensures we trigger a run if we have selected entries to ensure we havent swallowed any triggers. If there are no more batches, then it wont re-trigger it.
