### PR TITLE
fix: lightnode migration

### DIFF
--- a/pkg/storer/epoch_migration_test.go
+++ b/pkg/storer/epoch_migration_test.go
@@ -235,11 +235,11 @@ func TestEpochMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !strings.ContainsAny(logBytes.String(), "migrating pinning collections done") {
+	if !strings.Contains(logBytes.String(), "migrating pinning collections done") {
 		t.Fatalf("expected log to contain 'migrating pinning collections done', got %s", logBytes.String())
 	}
 
-	if !strings.ContainsAny(logBytes.String(), "migrating reserve contents done") {
+	if !strings.Contains(logBytes.String(), "migrating reserve contents done") {
 		t.Fatalf("expected log to contain 'migrating pinning collections done', got %s", logBytes.String())
 	}
 
@@ -253,6 +253,67 @@ func TestEpochMigration(t *testing.T) {
 
 	if reserve.size != 10 {
 		t.Fatalf("expected 10 reserve size, got %d", reserve.size)
+	}
+
+	pins, err := pinstore.Pins(indexStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pins) != 1 {
+		t.Fatalf("expected 1 pin, got %d", len(pins))
+	}
+
+	if !strings.Contains(logBytes.String(), pins[0].String()) {
+		t.Fatalf("expected log to contain root pin reference, got %s", logBytes.String())
+	}
+}
+
+func TestEpochMigrationLightNode(t *testing.T) {
+	t.Parallel()
+
+	var (
+		dataPath    = t.TempDir()
+		baseAddress = swarm.RandAddress(t)
+		stateStore  = mockstatestore.NewStateStore()
+		reserve     storer.ReservePutter
+		logBytes    = bytes.NewBuffer(nil)
+		logger      = log.NewLogger("test", log.WithSink(logBytes))
+		indexStore  = inmemstore.New()
+	)
+
+	createOldDataDir(t, dataPath, baseAddress, stateStore)
+
+	r, err := sharky.NewRecovery(path.Join(dataPath, "sharky"), 2, swarm.SocMaxChunkSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sharkyRecovery := &testSharkyRecovery{Recovery: r}
+
+	err = storer.EpochMigration(
+		context.Background(),
+		dataPath,
+		stateStore,
+		indexStore,
+		reserve,
+		sharkyRecovery,
+		logger,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(logBytes.String(), "migrating pinning collections done") {
+		t.Fatalf("expected log to contain 'migrating pinning collections done', got %s", logBytes.String())
+	}
+
+	if strings.Contains(logBytes.String(), "migrating reserve contents done") {
+		t.Fatalf("expected log to not contain 'migrating reserve contents done', got %s", logBytes.String())
+	}
+
+	if sharkyRecovery.addCalls != 21 {
+		t.Fatalf("expected 31 add calls, got %d", sharkyRecovery.addCalls)
 	}
 
 	pins, err := pinstore.Pins(indexStore)

--- a/pkg/storer/export_test.go
+++ b/pkg/storer/export_test.go
@@ -17,6 +17,10 @@ var (
 	EpochMigration  = epochMigration
 )
 
+type (
+	ReservePutter = reservePutter
+)
+
 func (db *DB) Reserve() *reserve.Reserve {
 	return db.reserve
 }

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -466,7 +466,7 @@ func (r *Reserve) EvictionTarget() int {
 	if r.IsWithinCapacity() {
 		return 0
 	}
-	return int(r.size.Load()) - r.capacity
+	return int(r.size.Load()) - int(0.9*float64(r.capacity))
 }
 
 func (r *Reserve) SetRadius(store storage.Store, rad uint8) error {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -586,6 +586,7 @@ func (db *DB) unreserve(ctx context.Context) (err error) {
 	if target == 0 {
 		return nil
 	}
+	db.logger.Info("unreserve", "target", target, "radius", radius)
 
 	totalEvicted := 0
 	for radius < swarm.MaxBins {

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -395,7 +395,8 @@ func performEpochMigration(ctx context.Context, basePath string, opts *Options) 
 
 	logger := opts.Logger.WithName("epochmigration").Register()
 
-	var rs *reserve.Reserve
+	var rs reservePutter
+
 	if opts.ReserveCapacity > 0 {
 		rs, err = reserve.New(
 			opts.Address,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Issues found in upgrage testing. While upgrading light nodes, the way the reserve was passed in to the function resulted in panic. This is because the interface was pointing to a valid type and hence the `!= nil` check failed. As a result the node was trying to migrate reserve for light nodes which caused the panic.