### PR TITLE
feat: add isHealthy to redistributionstate

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -710,6 +710,8 @@ components:
           type: boolean
         isFullySynced:
           type: boolean
+        isHealthy:
+          type: boolean
         phase:
           type: string
         round:

--- a/pkg/api/redistribution.go
+++ b/pkg/api/redistribution.go
@@ -28,6 +28,7 @@ type redistributionStatusResponse struct {
 	Block              uint64         `json:"block"`
 	Reward             *bigint.BigInt `json:"reward"`
 	Fees               *bigint.BigInt `json:"fees"`
+	IsHealthy          bool           `json:"isHealthy"`
 }
 
 func (s *Service) redistributionStatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -69,5 +70,6 @@ func (s *Service) redistributionStatusHandler(w http.ResponseWriter, r *http.Req
 		Block:              status.Block,
 		Reward:             bigint.Wrap(status.Reward),
 		Fees:               bigint.Wrap(status.Fees),
+		IsHealthy:          status.IsHealthy,
 	})
 }

--- a/pkg/storageincentives/agent.go
+++ b/pkg/storageincentives/agent.go
@@ -219,6 +219,7 @@ func (a *Agent) start(blockTime time.Duration, blocksPerRound, blocksPerPhase ui
 
 		a.state.SetCurrentEvent(currentPhase, round)
 		a.state.SetFullySynced(a.fullSyncedFunc())
+		a.state.SetHealthy(a.health.IsHealthy())
 		go a.state.purgeStaleRoundData()
 
 		isFrozen, err := a.redistributionStatuser.IsOverlayFrozen(ctx, block)
@@ -398,7 +399,7 @@ func (a *Agent) handleSample(ctx context.Context, round uint64) (bool, error) {
 		return false, nil
 	}
 
-	if !a.health.IsHealthy() {
+	if !a.state.IsHealthy() {
 		a.logger.Info("skipping round because node is unhealhy", "round", round)
 		return false, nil
 	}

--- a/pkg/storageincentives/redistributionstate.go
+++ b/pkg/storageincentives/redistributionstate.go
@@ -53,6 +53,7 @@ type Status struct {
 	Fees              *big.Int
 	RoundData         map[uint64]RoundData
 	SampleDuration    time.Duration
+	IsHealthy         bool
 }
 
 type RoundData struct {
@@ -281,6 +282,19 @@ func (r *RedistributionState) HasRevealed(round uint64) bool {
 
 	rd := r.status.RoundData[round]
 	return rd.HasRevealed
+}
+
+func (r *RedistributionState) SetHealthy(isHealthy bool) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.status.IsHealthy = isHealthy
+	r.save()
+}
+
+func (r *RedistributionState) IsHealthy() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.status.IsHealthy
 }
 
 func (r *RedistributionState) SetHasRevealed(round uint64) {


### PR DESCRIPTION
### Checklist

Adds `isHealthy` to `redistributionstate` response.
Fixes #4212 

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
