### PR TITLE
feat: add feed after index

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -753,6 +753,12 @@ paths:
           required: false
           description: "Timestamp of the update (default: now)"
         - in: query
+          name: after
+          schema:
+            type: integer
+          required: false
+          description: "Start index (default: 0)"
+        - in: query
           name: type
           schema:
             $ref: "SwarmCommon.yaml#/components/schemas/FeedType"

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -52,7 +52,8 @@ func (s *Service) feedGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queries := struct {
-		At int64 `map:"at"`
+		At    int64  `map:"at"`
+		After uint64 `map:"after"`
 	}{}
 	if response := s.mapStructure(r.URL.Query(), &queries); response != nil {
 		response("invalid query params", logger, w)
@@ -76,7 +77,7 @@ func (s *Service) feedGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch, cur, next, err := lookup.At(r.Context(), queries.At, 0)
+	ch, cur, next, err := lookup.At(r.Context(), queries.At, queries.After)
 	if err != nil {
 		logger.Debug("lookup at failed", "at", queries.At, "error", err)
 		logger.Error(nil, "lookup at failed")

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -211,17 +211,18 @@ func (f *factoryMock) NewLookup(t feeds.Type, feed *feeds.Feed) (feeds.Lookup, e
 }
 
 type mockLookup struct {
-	at, after int64
+	at        int64
+	after     uint64
 	chunk     swarm.Chunk
 	err       error
 	cur, next feeds.Index
 }
 
-func newMockLookup(at, after int64, ch swarm.Chunk, err error, cur, next feeds.Index) *mockLookup {
+func newMockLookup(at int64, after uint64, ch swarm.Chunk, err error, cur, next feeds.Index) *mockLookup {
 	return &mockLookup{at: at, after: after, chunk: ch, err: err, cur: cur, next: next}
 }
 
-func (l *mockLookup) At(_ context.Context, at, after int64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
+func (l *mockLookup) At(_ context.Context, at int64, after uint64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
 	if l.at == -1 {
 		// shortcut to ignore the value in the call since time.Now() is a moving target
 		return l.chunk, l.cur, l.next, nil

--- a/pkg/feeds/epochs/epoch.go
+++ b/pkg/feeds/epochs/epoch.go
@@ -61,7 +61,7 @@ func lca(at, after uint64) *epoch {
 	diff := at - after
 	length := uint64(1)
 	var level uint8
-	for level < maxLevel && (length < diff || uint64(at)/length != after/length) {
+	for level < maxLevel && (length < diff || at/length != after/length) {
 		length <<= 1
 		level++
 	}

--- a/pkg/feeds/epochs/epoch.go
+++ b/pkg/feeds/epochs/epoch.go
@@ -50,22 +50,22 @@ func (e *epoch) Next(last int64, at uint64) feeds.Index {
 	if e.start+e.length() > at {
 		return e.childAt(at)
 	}
-	return lca(int64(at), last).childAt(at)
+	return lca(at, uint64(last)).childAt(at)
 }
 
 // lca calculates the lowest common ancestor epoch given two unix times
-func lca(at, after int64) *epoch {
+func lca(at, after uint64) *epoch {
 	if after == 0 {
 		return &epoch{0, maxLevel}
 	}
-	diff := uint64(at - after)
+	diff := at - after
 	length := uint64(1)
 	var level uint8
-	for level < maxLevel && (length < diff || uint64(at)/length != uint64(after)/length) {
+	for level < maxLevel && (length < diff || uint64(at)/length != after/length) {
 		length <<= 1
 		level++
 	}
-	start := (uint64(after) / length) * length
+	start := (after / length) * length
 	return &epoch{start, level}
 }
 

--- a/pkg/feeds/epochs/finder.go
+++ b/pkg/feeds/epochs/finder.go
@@ -29,7 +29,7 @@ func NewFinder(getter storage.Getter, feed *feeds.Feed) feeds.Lookup {
 
 // At looks up the version valid at time `at`
 // after is a unix time hint of the latest known update
-func (f *finder) At(ctx context.Context, at, after int64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
+func (f *finder) At(ctx context.Context, at int64, after uint64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
 	e, ch, err := f.common(ctx, at, after)
 	if err != nil {
 		return nil, nil, nil, err
@@ -39,8 +39,8 @@ func (f *finder) At(ctx context.Context, at, after int64) (swarm.Chunk, feeds.In
 }
 
 // common returns the lowest common ancestor for which a feed update chunk is found in the chunk store
-func (f *finder) common(ctx context.Context, at, after int64) (*epoch, swarm.Chunk, error) {
-	for e := lca(at, after); ; e = e.parent() {
+func (f *finder) common(ctx context.Context, at int64, after uint64) (*epoch, swarm.Chunk, error) {
+	for e := lca(uint64(at), after); ; e = e.parent() {
 		ch, err := f.getter.Get(ctx, e)
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -165,7 +165,7 @@ func (f *asyncFinder) at(ctx context.Context, at int64, p *path, e *epoch, c cha
 		}
 	}
 }
-func (f *asyncFinder) At(ctx context.Context, at, after int64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
+func (f *asyncFinder) At(ctx context.Context, at int64, after uint64) (swarm.Chunk, feeds.Index, feeds.Index, error) {
 	// TODO: current and next index return values need to be implemented
 	ch, err := f.asyncAt(ctx, at, after)
 	return ch, nil, nil, err
@@ -173,7 +173,7 @@ func (f *asyncFinder) At(ctx context.Context, at, after int64) (swarm.Chunk, fee
 
 // At looks up the version valid at time `at`
 // after is a unix time hint of the latest known update
-func (f *asyncFinder) asyncAt(ctx context.Context, at, after int64) (swarm.Chunk, error) {
+func (f *asyncFinder) asyncAt(ctx context.Context, at int64, _ uint64) (swarm.Chunk, error) {
 	c := make(chan *result)
 	go f.at(ctx, at, newPath(at), &epoch{0, maxLevel}, c)
 LOOP:

--- a/pkg/feeds/epochs/lookup_benchmark_test.go
+++ b/pkg/feeds/epochs/lookup_benchmark_test.go
@@ -19,7 +19,7 @@ import (
 func BenchmarkFinder(b *testing.B) {
 	for _, i := range []int{0, 8, 30} {
 		for _, prefill := range []int64{1, 50} {
-			after := int64(50)
+			after := uint64(50)
 			storer := &feedstesting.Timeout{ChunkStore: inmemchunkstore.New()}
 			topicStr := "testtopic"
 			topic, err := crypto.LegacyKeccak256([]byte(topicStr))
@@ -45,7 +45,7 @@ func BenchmarkFinder(b *testing.B) {
 				}
 			}
 			latest := after + (1 << i)
-			err = updater.Update(ctx, latest, payload)
+			err = updater.Update(ctx, int64(latest), payload)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -59,7 +59,7 @@ func BenchmarkFinder(b *testing.B) {
 					names := []string{"sync", "async"}
 					b.Run(fmt.Sprintf("%s:prefill=%d, latest=%d, now=%d", names[k], prefill, latest, now), func(b *testing.B) {
 						for n := 0; n < b.N; n++ {
-							_, _, _, err := finder.At(ctx, now, after)
+							_, _, _, err := finder.At(ctx, int64(now), after)
 							if err != nil {
 								b.Fatal(err)
 							}

--- a/pkg/feeds/getter.go
+++ b/pkg/feeds/getter.go
@@ -18,7 +18,7 @@ import (
 
 // Lookup is the interface for time based feed lookup
 type Lookup interface {
-	At(ctx context.Context, at, after int64) (chunk swarm.Chunk, currentIndex, nextIndex Index, err error)
+	At(ctx context.Context, at int64, after uint64) (chunk swarm.Chunk, currentIndex, nextIndex Index, err error)
 }
 
 // Getter encapsulates a chunk Getter getter and a feed and provides non-concurrent lookup methods
@@ -34,7 +34,7 @@ func NewGetter(getter storage.Getter, feed *Feed) *Getter {
 
 // Latest looks up the latest update of the feed
 // after is a unix time hint of the latest known update
-func Latest(ctx context.Context, l Lookup, after int64) (swarm.Chunk, error) {
+func Latest(ctx context.Context, l Lookup, after uint64) (swarm.Chunk, error) {
 	c, _, _, err := l.At(ctx, time.Now().Unix(), after)
 	return c, err
 }

--- a/pkg/feeds/sequence/sequence.go
+++ b/pkg/feeds/sequence/sequence.go
@@ -67,7 +67,7 @@ func NewFinder(getter storage.Getter, feed *feeds.Feed) feeds.Lookup {
 }
 
 // At looks for incremental feed updates from 0 upwards, if it does not find one, it assumes that the last found update is the most recent
-func (f *finder) At(ctx context.Context, at, after int64) (ch swarm.Chunk, current, next feeds.Index, err error) {
+func (f *finder) At(ctx context.Context, at int64, _ uint64) (ch swarm.Chunk, current, next feeds.Index, err error) {
 	for i := uint64(0); ; i++ {
 		u, err := f.getter.Get(ctx, &index{i})
 		if err != nil {
@@ -147,10 +147,10 @@ type result struct {
 
 // At looks up the version valid at time `at`
 // after is a unix time hint of the latest known update
-func (f *asyncFinder) At(ctx context.Context, at, after int64) (ch swarm.Chunk, cur, next feeds.Index, err error) {
+func (f *asyncFinder) At(ctx context.Context, at int64, after uint64) (ch swarm.Chunk, cur, next feeds.Index, err error) {
 	// first lookup update at the 0 index
 	// TODO: consider receive after as uint
-	ch, err = f.get(ctx, at, uint64(after))
+	ch, err = f.get(ctx, at, after)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/feeds/sequence/sequence.go
+++ b/pkg/feeds/sequence/sequence.go
@@ -155,7 +155,7 @@ func (f *asyncFinder) At(ctx context.Context, at int64, after uint64) (ch swarm.
 		return nil, nil, nil, err
 	}
 	if ch == nil {
-		return nil, nil, &index{uint64(after)}, nil
+		return nil, nil, &index{after}, nil
 	}
 	// if chunk exists construct an initial interval with base=0
 	c := make(chan *result)

--- a/pkg/feeds/testing/lookup.go
+++ b/pkg/feeds/testing/lookup.go
@@ -149,7 +149,7 @@ func TestFinderIntervals(t *testing.T, nextf func() (bool, int64), finderf func(
 		at := ats[j]
 		diff := ats[j+1] - at
 		for now := at; now < ats[j+1]; now += int64(rand.Intn(int(diff)) + 1) {
-			after := int64(0)
+			after := uint64(0)
 			ch, current, next, err := finder.At(ctx, now, after)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
### Checklist

Adds an `after` query param for `GET feed` that helps speed up the lookup.

Closes #4173 

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
