### PR TITLE
fix: first binID to start from 1 and print the last bin ids in /debugstore

### DIFF
--- a/pkg/storer/cachestore_test.go
+++ b/pkg/storer/cachestore_test.go
@@ -127,7 +127,7 @@ func TestCacheStore(t *testing.T) {
 
 		testCacheStore(t, func() (*storer.DB, error) {
 
-			opts := dbTestOps(swarm.RandAddress(t), 0, nil, nil, time.Second)
+			opts := dbTestOps(swarm.RandAddress(t), 100, nil, nil, time.Second)
 			opts.CacheCapacity = 10
 
 			return storer.New(context.Background(), "", opts)
@@ -136,7 +136,7 @@ func TestCacheStore(t *testing.T) {
 	t.Run("disk", func(t *testing.T) {
 		t.Parallel()
 
-		opts := dbTestOps(swarm.RandAddress(t), 0, nil, nil, time.Second)
+		opts := dbTestOps(swarm.RandAddress(t), 100, nil, nil, time.Second)
 		opts.CacheCapacity = 10
 
 		testCacheStore(t, diskStorer(t, opts))

--- a/pkg/storer/debug.go
+++ b/pkg/storer/debug.go
@@ -30,8 +30,9 @@ type CacheStat struct {
 }
 
 type ReserveStat struct {
-	Size     int
-	Capacity int
+	Size       int
+	Capacity   int
+	LastBinIDs []uint64
 }
 
 type ChunkStoreStat struct {
@@ -125,6 +126,11 @@ func (db *DB) DebugInfo(ctx context.Context) (Info, error) {
 		return Info{}, err
 	}
 
+	lastbinIds, err := db.ReserveLastBinIDs()
+	if err != nil {
+		return Info{}, err
+	}
+
 	return Info{
 		Upload: UploadStat{
 			TotalUploaded: uploaded,
@@ -139,8 +145,9 @@ func (db *DB) DebugInfo(ctx context.Context) (Info, error) {
 			Capacity: int(cacheCapacity),
 		},
 		Reserve: ReserveStat{
-			Size:     reserveSize,
-			Capacity: reserveCapacity,
+			Size:       reserveSize,
+			Capacity:   reserveCapacity,
+			LastBinIDs: lastbinIds,
 		},
 		ChunkStore: ChunkStoreStat{
 			TotalChunks: totalChunks,

--- a/pkg/storer/debug_test.go
+++ b/pkg/storer/debug_test.go
@@ -15,13 +15,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
+func emptyBinIDs() []uint64 {
+	return make([]uint64, swarm.MaxBins)
+}
+
+func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, swarm.Address, error)) {
 	t.Helper()
 
 	t.Run("upload and pin", func(t *testing.T) {
 		t.Parallel()
 
-		lstore, err := newStorer()
+		lstore, _, err := newStorer()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +75,8 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 				Capacity: 1000000,
 			},
 			Reserve: storer.ReserveStat{
-				Capacity: 100,
+				Capacity:   100,
+				LastBinIDs: emptyBinIDs(),
 			},
 		}
 
@@ -83,7 +88,7 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 	t.Run("cache", func(t *testing.T) {
 		t.Parallel()
 
-		lstore, err := newStorer()
+		lstore, _, err := newStorer()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,7 +115,8 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 				Capacity: 1000000,
 			},
 			Reserve: storer.ReserveStat{
-				Capacity: 100,
+				Capacity:   100,
+				LastBinIDs: emptyBinIDs(),
 			},
 		}
 
@@ -122,16 +128,16 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 	t.Run("reserve", func(t *testing.T) {
 		t.Parallel()
 
-		lstore, err := newStorer()
+		lstore, addr, err := newStorer()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		putter := lstore.ReservePutter()
 
-		chunks := chunktest.GenerateTestRandomChunks(10)
-		for _, ch := range chunks {
-			err := putter.Put(context.Background(), ch)
+		for i := 0; i < 10; i++ {
+			chunk := chunktest.GenerateTestRandomChunkAt(t, addr, 0)
+			err := putter.Put(context.Background(), chunk)
 			if err != nil {
 				t.Fatalf("session.Put(...): unexpected error: %v", err)
 			}
@@ -142,6 +148,9 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 			t.Fatalf("DebugInfo(...): unexpected error: %v", err)
 		}
 
+		ids := emptyBinIDs()
+		ids[0] = 10
+
 		wantInfo := storer.Info{
 			ChunkStore: storer.ChunkStoreStat{
 				TotalChunks: 10,
@@ -150,8 +159,9 @@ func testDebugInfo(t *testing.T, newStorer func() (*storer.DB, error)) {
 				Capacity: 1000000,
 			},
 			Reserve: storer.ReserveStat{
-				Size:     10,
-				Capacity: 100,
+				Size:       10,
+				Capacity:   100,
+				LastBinIDs: ids,
 			},
 		}
 
@@ -168,13 +178,19 @@ func TestDebugInfo(t *testing.T) {
 	t.Run("inmem", func(t *testing.T) {
 		t.Parallel()
 
-		testDebugInfo(t, func() (*storer.DB, error) {
-			return storer.New(context.Background(), "", dbTestOps(swarm.RandAddress(t), 100, nil, nil, time.Second))
+		testDebugInfo(t, func() (*storer.DB, swarm.Address, error) {
+			addr := swarm.RandAddress(t)
+			store, err := storer.New(context.Background(), "", dbTestOps(addr, 100, nil, nil, time.Second))
+			return store, addr, err
 		})
 	})
 	t.Run("disk", func(t *testing.T) {
 		t.Parallel()
 
-		testDebugInfo(t, diskStorer(t, dbTestOps(swarm.RandAddress(t), 100, nil, nil, time.Second)))
+		testDebugInfo(t, func() (*storer.DB, swarm.Address, error) {
+			addr := swarm.RandAddress(t)
+			store, err := diskStorer(t, dbTestOps(addr, 100, nil, nil, time.Second))()
+			return store, addr, err
+		})
 	})
 }

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/ethersphere/bee/pkg/log"
@@ -41,6 +42,8 @@ type Reserve struct {
 	size     atomic.Int64
 	radius   atomic.Uint32
 	cacheCb  func(context.Context, internal.Storage, ...swarm.Address) error
+
+	binMtx sync.Mutex
 }
 
 func New(
@@ -149,7 +152,7 @@ func (r *Reserve) Put(ctx context.Context, store internal.Storage, chunk swarm.C
 		return false, err
 	}
 
-	binID, err := r.incBinID(indexStore, storeBatch, po)
+	binID, err := r.incBinID(indexStore, po)
 	if err != nil {
 		return false, err
 	}
@@ -489,13 +492,16 @@ func (r *Reserve) SetRadius(store storage.Store, rad uint8) error {
 }
 
 // should be called under lock
-func (r *Reserve) incBinID(store storage.Store, batch storage.Writer, bin uint8) (uint64, error) {
+func (r *Reserve) incBinID(store storage.Store, bin uint8) (uint64, error) {
+	r.binMtx.Lock()
+	defer r.binMtx.Unlock()
+
 	item := &binItem{Bin: bin}
 	err := store.Get(item)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			item.BinID = 1
-			return 1, batch.Put(item)
+			return 1, store.Put(item)
 		}
 
 		return 0, err
@@ -503,5 +509,5 @@ func (r *Reserve) incBinID(store storage.Store, batch storage.Writer, bin uint8)
 
 	item.BinID += 1
 
-	return item.BinID, batch.Put(item)
+	return item.BinID, store.Put(item)
 }

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -494,7 +494,8 @@ func (r *Reserve) incBinID(store storage.Store, batch storage.Writer, bin uint8)
 	err := store.Get(item)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return 0, store.Put(item)
+			item.BinID = 1
+			return 1, store.Put(item)
 		}
 
 		return 0, err

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -495,7 +495,7 @@ func (r *Reserve) incBinID(store storage.Store, batch storage.Writer, bin uint8)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			item.BinID = 1
-			return 1, store.Put(item)
+			return 1, batch.Put(item)
 		}
 
 		return 0, err

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -52,7 +52,7 @@ func TestReserve(t *testing.T) {
 	}
 
 	for b := 0; b < 2; b++ {
-		for i := 0; i < 50; i++ {
+		for i := 1; i < 51; i++ {
 			ch := chunk.GenerateTestRandomChunkAt(t, baseAddr, b)
 			c, err := r.Put(context.Background(), ts, ch)
 			if err != nil {
@@ -195,12 +195,12 @@ func TestReplaceOldIndex(t *testing.T) {
 
 	// Chunk 1 must be gone
 	checkStore(t, ts.IndexStore(), &reserve.BatchRadiusItem{Bin: 0, BatchID: ch1.Stamp().BatchID(), Address: ch1.Address()}, true)
-	checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: 0, BinID: 0}, true)
+	checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: 0, BinID: 1}, true)
 	checkChunk(t, ts, ch1, true)
 
 	// Chunk 2 must be stored
 	checkStore(t, ts.IndexStore(), &reserve.BatchRadiusItem{Bin: 0, BatchID: ch2.Stamp().BatchID(), Address: ch2.Address()}, false)
-	checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: 0, BinID: 1}, false)
+	checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: 0, BinID: 2}, false)
 	checkChunk(t, ts, ch2, false)
 
 	item, err := stampindex.Load(ts.IndexStore(), "reserve", ch2)
@@ -276,7 +276,7 @@ func TestEvict(t *testing.T) {
 	}
 
 	for i, ch := range chunks {
-		binID := i % chunksPerBatch
+		binID := i%chunksPerBatch + 1
 		b := swarm.Proximity(baseAddr.Bytes(), ch.Address().Bytes())
 		_, err := r.Get(context.Background(), ts, ch.Address(), ch.Stamp().BatchID())
 		if bytes.Equal(ch.Stamp().BatchID(), evictBatch.ID) {
@@ -344,7 +344,7 @@ func TestIterate(t *testing.T) {
 
 		r, ts := createReserve(t)
 
-		var id uint64 = 0
+		var id uint64 = 1
 		err := r.IterateBin(ts.IndexStore(), 1, 0, func(ch swarm.Address, binID uint64, _ []byte) (bool, error) {
 			if binID != id {
 				t.Fatalf("got %d, want %d", binID, id)
@@ -355,8 +355,8 @@ func TestIterate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if id != 10 {
-			t.Fatalf("got %d, want %d", id, 10)
+		if id != 11 {
+			t.Fatalf("got %d, want %d", id, 11)
 		}
 	})
 
@@ -407,8 +407,8 @@ func TestIterate(t *testing.T) {
 		}
 		for i, id := range ids {
 			if i < 3 {
-				if id != 9 {
-					t.Fatalf("got %d, want %d", id, 9)
+				if id != 10 {
+					t.Fatalf("got %d, want %d", id, 10)
 				}
 			} else {
 				if id != 0 {

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -239,8 +239,8 @@ func TestEvictBatch(t *testing.T) {
 	}
 
 	for bin, id := range ids {
-		if bin < 3 && id != 9 {
-			t.Fatalf("bin %d got binID %d, want %d", bin, id, 9)
+		if bin < 3 && id != 10 {
+			t.Fatalf("bin %d got binID %d, want %d", bin, id, 10)
 		}
 		if bin >= 3 && id != 0 {
 			t.Fatalf("bin %d  got binID %d, want %d", bin, id, 0)
@@ -509,7 +509,7 @@ func TestSubscribeBin(t *testing.T) {
 		t.Run("subscribe range higher bin", func(t *testing.T) {
 			t.Parallel()
 
-			binC, _, _ := storer.SubscribeBin(context.Background(), 0, 1)
+			binC, _, _ := storer.SubscribeBin(context.Background(), 0, 2)
 
 			i := uint64(1)
 			for c := range binC {
@@ -526,7 +526,7 @@ func TestSubscribeBin(t *testing.T) {
 		t.Run("subscribe beyond range", func(t *testing.T) {
 			t.Parallel()
 
-			binC, _, _ := storer.SubscribeBin(context.Background(), 0, 1)
+			binC, _, _ := storer.SubscribeBin(context.Background(), 0, 2)
 			i := uint64(1)
 			timer := time.After(time.Millisecond * 500)
 
@@ -591,7 +591,7 @@ func TestSubscribeBinTrigger(t *testing.T) {
 			}
 		}
 
-		binC, _, _ := storer.SubscribeBin(context.Background(), 0, 1)
+		binC, _, _ := storer.SubscribeBin(context.Background(), 0, 2)
 		i := uint64(1)
 		timer := time.After(time.Millisecond * 500)
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Puller sync intervals start from binID 1, as such the first binID in localstore should also start from 1, not 0!

ex log: `"msg"="syncWorker interval failed" "peer_address"="a71da0378051958fab7a299f7036cc1cb1dd9fc4e47135c51bf6e27c2169e43b" "bin"=18 "cursor"=0 "start"=1 "topmost"=0 "err"="read offer: stream reset"`

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
