### PR TITLE
fix(salud): remove reserve size self health check

### DIFF
--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -133,46 +133,6 @@ func TestSelfUnhealthyRadius(t *testing.T) {
 	}
 }
 
-func TestSelfUnhealthyReserveSize(t *testing.T) {
-	t.Parallel()
-	peers := []peer{
-		// fully healhy
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", ReserveSize: 100}, 0, true},
-		{swarm.RandAddress(t), &status.Snapshot{ConnectedPeers: 100, StorageRadius: 8, BeeMode: "full", ReserveSize: 100}, 0, true},
-	}
-
-	statusM := &statusMock{make(map[string]peer)}
-	addrs := make([]swarm.Address, 0, len(peers))
-	for _, p := range peers {
-		addrs = append(addrs, p.addr)
-		statusM.peers[p.addr.ByteString()] = p
-	}
-
-	topM := topMock.NewTopologyDriver(topMock.WithPeers(addrs...))
-
-	reserve := mockstorer.NewReserve(
-		mockstorer.WithRadius(8),
-		mockstorer.WithReserveSize(97),
-	)
-
-	service := salud.New(statusM, topM, reserve, log.Noop, -1, "full", 0)
-
-	err := spinlock.Wait(time.Minute, func() bool {
-		return len(topM.PeersHealth()) == len(peers)
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if service.IsHealthy() {
-		t.Fatalf("self should NOT be healthy")
-	}
-
-	if err := service.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestSubToRadius(t *testing.T) {
 	t.Parallel()
 	peers := []peer{


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
After v1.17.0, the reserve size is no longer a count of chunks of PO >= storage radius.
It includes chunks of all POs, as such, reserve sizes between [0, storage radius) can be under constant fluctuation, mainly due to unpredictable batch evictions.
So we remove the self reserve size check.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
