### PR TITLE
fix: protect pStorage.location in migratePinning

### DIFF
--- a/pkg/storer/epoch_migration.go
+++ b/pkg/storer/epoch_migration.go
@@ -367,7 +367,7 @@ func (e *epochMigrator) migratePinning(ctx context.Context) error {
 		store:    e.store,
 		recovery: e.recovery,
 	}
-	var mu sync.Mutex	// used to protect pStorage.location
+	var mu sync.Mutex // used to protect pStorage.location
 
 	traverser := traversal.New(
 		storage.GetterFunc(func(ctx context.Context, addr swarm.Address) (ch swarm.Chunk, err error) {

--- a/pkg/storer/epoch_migration.go
+++ b/pkg/storer/epoch_migration.go
@@ -367,6 +367,8 @@ func (e *epochMigrator) migratePinning(ctx context.Context) error {
 		store:    e.store,
 		recovery: e.recovery,
 	}
+	var mu sync.Mutex	// used to protect pStorage.location
+
 	traverser := traversal.New(
 		storage.GetterFunc(func(ctx context.Context, addr swarm.Address) (ch swarm.Chunk, err error) {
 			i := shed.Item{
@@ -412,7 +414,6 @@ func (e *epochMigrator) migratePinning(ctx context.Context) error {
 					if err != nil {
 						return err
 					}
-					var mu sync.Mutex
 
 					traverserFn := func(chAddr swarm.Address) error {
 						item, err := e.retrievalDataIndex.Get(shed.Item{Address: chAddr.Bytes()})


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
The migratePinning routine uses a single putOpStorage structure to specify the chunk location through pinningPutter.Put and back to putOpStorage's Write in order to properly invoke p.recovery.Add for that location.  Unfortunately, the mutex wasn't actually protecting the single structure, but allowed each of the 4 goroutines to clobber the location before it could get to sharky.

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
Migrating a node with pins from 1.16 to 1.17 ends up with incorrect chunk reference counts in Sharky resulting in invalid chunk content being read at some point in the future.

Note that this only fixes future pinning nodes that migrate.   Something else needs to be done to correct the sharky refCnt for nodes that have already migrated with active pins.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
