### PR TITLE
fix: don't panic if no reserve in ReserveLastBinIDs

### DIFF
--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -403,6 +403,9 @@ func (db *DB) unreserve(ctx context.Context) (err error) {
 
 // ReserveLastBinIDs returns all of the highest binIDs from all the bins in the reserve.
 func (db *DB) ReserveLastBinIDs() ([]uint64, error) {
+	if db.reserve == nil {
+		return make([]uint64, 0), nil
+	}
 	return db.reserve.LastBinIDs(db.repo.IndexStore())
 }
 

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -404,7 +404,7 @@ func (db *DB) unreserve(ctx context.Context) (err error) {
 // ReserveLastBinIDs returns all of the highest binIDs from all the bins in the reserve.
 func (db *DB) ReserveLastBinIDs() ([]uint64, error) {
 	if db.reserve == nil {
-		return make([]uint64, 0), nil
+		return nil, nil
 	}
 	return db.reserve.LastBinIDs(db.repo.IndexStore())
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [N/A] My change requires a documentation update, and I have done it.
- [N/A] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Avoid panic if querying ReserveLastBinIDs on ultra-light node with no reserve.

Closes #4270

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
Issue #4270 

### Related Issue (Optional)
#4270 

### Screenshots (if appropriate):
