### PR TITLE
fix: remove warning to run clef on startup

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -466,7 +466,6 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 			return nil, err
 		}
 	} else {
-		logger.Warning("clef is not enabled; portability and security of your keys is sub optimal")
 		swarmPrivateKey, _, err := keystore.Key("swarm", password, crypto.EDGSecp256_K1)
 		if err != nil {
 			return nil, fmt.Errorf("swarm key: %w", err)


### PR DESCRIPTION
### Checklist

- [ x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
Removed warning message which says to run Bee Clef so there are no longer logs like this suggesting to run Clef (which has been deprecated):

```
"time"="2023-08-17 07:48:53.313506" "level"="warning" "logger"="node" "msg"="clef is not enabled; portability and security of your keys is sub optimal"
```