### PR TITLE
fix: sharky release in txn

### DIFF
--- a/pkg/storer/internal/chunkstore/recovery_test.go
+++ b/pkg/storer/internal/chunkstore/recovery_test.go
@@ -6,9 +6,10 @@ package chunkstore_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/exp/slices"
-	"testing"
 
 	"github.com/ethersphere/bee/pkg/sharky"
 	"github.com/ethersphere/bee/pkg/storage"

--- a/pkg/storer/internal/chunkstore/transaction.go
+++ b/pkg/storer/internal/chunkstore/transaction.go
@@ -58,8 +58,6 @@ func (t *txSharky) Write(ctx context.Context, buf []byte) (sharky.Location, erro
 	loc, err = t.Sharky.Write(ctx, buf)
 	if err == nil {
 		t.writtenLocs = append(t.writtenLocs, loc)
-		t.toReleaseLocs[sum] = loc
-		t.toReleaseSums[loc] = sum
 
 		buf, err = msgpack.Marshal(t.writtenLocs)
 		if err == nil {

--- a/pkg/storer/internal/chunkstore/transaction.go
+++ b/pkg/storer/internal/chunkstore/transaction.go
@@ -116,6 +116,10 @@ func (cs *TxChunkStoreWrapper) Commit() error {
 		errs = errors.Join(errs, fmt.Errorf("txchunkstore: unable to commit index store transaction: %w", err))
 	}
 
+	for _, loc := range cs.txSharky.toReleaseLocs {
+		errs = errors.Join(errs, cs.txSharky.Sharky.Release(context.Background(), loc))
+	}
+
 	if err := cs.txSharky.store.DB().Delete(cs.txSharky.id, nil); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("txchunkstore: unable to delete transaction: %x: %w", cs.txSharky.id, err))
 	}

--- a/pkg/storer/migration/all_steps.go
+++ b/pkg/storer/migration/all_steps.go
@@ -11,10 +11,11 @@ import (
 )
 
 // AllSteps lists all migration steps for localstore IndexStore.
-func AllSteps(chunkStore storage.ChunkStore) migration.Steps {
+func AllSteps(sharkyPath string, chunkStore storage.ChunkStore) migration.Steps {
 	return map[uint64]migration.StepFn{
 		1: step_01,
 		2: step_02,
 		3: step_03(chunkStore, reserve.ChunkType),
+		4: step_04(sharkyPath),
 	}
 }

--- a/pkg/storer/migration/all_steps.go
+++ b/pkg/storer/migration/all_steps.go
@@ -11,11 +11,15 @@ import (
 )
 
 // AllSteps lists all migration steps for localstore IndexStore.
-func AllSteps(sharkyPath string, chunkStore storage.ChunkStore) migration.Steps {
+func AllSteps(
+	sharkyPath string,
+	sharkyNoOfShards int,
+	chunkStore storage.ChunkStore,
+) migration.Steps {
 	return map[uint64]migration.StepFn{
 		1: step_01,
 		2: step_02,
 		3: step_03(chunkStore, reserve.ChunkType),
-		4: step_04(sharkyPath),
+		4: step_04(sharkyPath, sharkyNoOfShards),
 	}
 }

--- a/pkg/storer/migration/all_steps_test.go
+++ b/pkg/storer/migration/all_steps_test.go
@@ -20,12 +20,12 @@ func TestAllSteps(t *testing.T) {
 
 	chStore := inmemchunkstore.New()
 
-	assert.NotEmpty(t, localmigration.AllSteps(chStore))
+	assert.NotEmpty(t, localmigration.AllSteps("", 0, chStore))
 
 	t.Run("version numbers", func(t *testing.T) {
 		t.Parallel()
 
-		err := migration.ValidateVersions(localmigration.AllSteps(chStore))
+		err := migration.ValidateVersions(localmigration.AllSteps("", 0, chStore))
 		assert.NoError(t, err)
 	})
 
@@ -34,7 +34,7 @@ func TestAllSteps(t *testing.T) {
 
 		store := inmemstore.New()
 
-		err := migration.Migrate(store, localmigration.AllSteps(chStore))
+		err := migration.Migrate(store, localmigration.AllSteps("", 4, chStore))
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/storer/migration/export_test.go
+++ b/pkg/storer/migration/export_test.go
@@ -8,4 +8,5 @@ var (
 	Step_01 = step_01
 	Step_02 = step_02
 	Step_03 = step_03
+	Step_04 = step_04
 )

--- a/pkg/storer/migration/step_04.go
+++ b/pkg/storer/migration/step_04.go
@@ -1,0 +1,46 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/ethersphere/bee/pkg/sharky"
+	storage "github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+// this is the constant used in the previous version of the store
+var sharkyNoOfShards = 32
+
+// step_04 is the fourth step of the migration. It forces a sharky recovery to
+// be run on the localstore.
+func step_04(
+	sharkyBasePath string,
+) func(st storage.BatchedStore) error {
+	return func(st storage.BatchedStore) error {
+
+		sharkyRecover, err := sharky.NewRecovery(sharkyBasePath, sharkyNoOfShards, swarm.SocMaxChunkSize)
+		if err != nil {
+			return err
+		}
+
+		locationResultC := make(chan chunkstore.LocationResult)
+		chunkstore.IterateLocations(context.Background(), st, locationResultC)
+
+		for res := range locationResultC {
+			if res.Err != nil {
+				return res.Err
+			}
+
+			if err := sharkyRecover.Add(res.Location); err != nil {
+				return err
+			}
+		}
+
+		if err := sharkyRecover.Save(); err != nil {
+			return err
+		}
+
+		return sharkyRecover.Close()
+	}
+}

--- a/pkg/storer/migration/step_04.go
+++ b/pkg/storer/migration/step_04.go
@@ -1,3 +1,7 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package migration
 
 import (
@@ -9,15 +13,17 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-// this is the constant used in the previous version of the store
-var sharkyNoOfShards = 32
-
 // step_04 is the fourth step of the migration. It forces a sharky recovery to
 // be run on the localstore.
 func step_04(
 	sharkyBasePath string,
+	sharkyNoOfShards int,
 ) func(st storage.BatchedStore) error {
 	return func(st storage.BatchedStore) error {
+
+		if sharkyBasePath == "" {
+			return nil
+		}
 
 		sharkyRecover, err := sharky.NewRecovery(sharkyBasePath, sharkyNoOfShards, swarm.SocMaxChunkSize)
 		if err != nil {

--- a/pkg/storer/migration/step_04.go
+++ b/pkg/storer/migration/step_04.go
@@ -6,7 +6,9 @@ package migration
 
 import (
 	"context"
+	"os"
 
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/sharky"
 	storage "github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
@@ -21,10 +23,12 @@ func step_04(
 ) func(st storage.BatchedStore) error {
 	return func(st storage.BatchedStore) error {
 
+		logger := log.NewLogger("migration-step-04", log.WithSink(os.Stdout))
 		if sharkyBasePath == "" {
 			return nil
 		}
 
+		logger.Info("starting sharky recovery")
 		sharkyRecover, err := sharky.NewRecovery(sharkyBasePath, sharkyNoOfShards, swarm.SocMaxChunkSize)
 		if err != nil {
 			return err
@@ -46,6 +50,7 @@ func step_04(
 		if err := sharkyRecover.Save(); err != nil {
 			return err
 		}
+		logger.Info("finished sharky recovery")
 
 		return sharkyRecover.Close()
 	}

--- a/pkg/storer/migration/step_04.go
+++ b/pkg/storer/migration/step_04.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/sharky"
-	storage "github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -22,11 +22,11 @@ func step_04(
 	sharkyNoOfShards int,
 ) func(st storage.BatchedStore) error {
 	return func(st storage.BatchedStore) error {
-
-		logger := log.NewLogger("migration-step-04", log.WithSink(os.Stdout))
+		// for in-mem store, skip this step
 		if sharkyBasePath == "" {
 			return nil
 		}
+		logger := log.NewLogger("migration-step-04", log.WithSink(os.Stdout))
 
 		logger.Info("starting sharky recovery")
 		sharkyRecover, err := sharky.NewRecovery(sharkyBasePath, sharkyNoOfShards, swarm.SocMaxChunkSize)

--- a/pkg/storer/migration/step_04_test.go
+++ b/pkg/storer/migration/step_04_test.go
@@ -85,4 +85,6 @@ func Test_Step_04(t *testing.T) {
 			assert.Equal(t, byte(0), buf[i/8]&(1<<(i%8)))
 		}
 	}
+
+	assert.NoError(t, f.Close())
 }

--- a/pkg/storer/migration/step_04_test.go
+++ b/pkg/storer/migration/step_04_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package migration_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/sharky"
+	"github.com/ethersphere/bee/pkg/storage/inmemstore"
+	chunktest "github.com/ethersphere/bee/pkg/storage/testing"
+	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
+	localmigration "github.com/ethersphere/bee/pkg/storer/migration"
+	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/stretchr/testify/assert"
+)
+
+type dirFS struct {
+	basedir string
+}
+
+func (d *dirFS) Open(path string) (fs.File, error) {
+	return os.OpenFile(filepath.Join(d.basedir, path), os.O_RDWR|os.O_CREATE, 0644)
+}
+
+func Test_Step_04(t *testing.T) {
+	t.Parallel()
+
+	sharkyDir := t.TempDir()
+	sharkyStore, err := sharky.New(&dirFS{basedir: sharkyDir}, 1, swarm.SocMaxChunkSize)
+	assert.NoError(t, err)
+
+	store := inmemstore.New()
+	chStore := chunkstore.New(store, sharkyStore)
+	stepFn := localmigration.Step_04(sharkyDir, 1)
+
+	chunks := chunktest.GenerateTestRandomChunks(10)
+
+	for _, ch := range chunks {
+		err := chStore.Put(context.Background(), ch)
+		assert.NoError(t, err)
+	}
+
+	for _, ch := range chunks[:2] {
+		err := store.Delete(&chunkstore.RetrievalIndexItem{Address: ch.Address()})
+		assert.NoError(t, err)
+	}
+
+	err = sharkyStore.Close()
+	assert.NoError(t, err)
+
+	assert.NoError(t, stepFn(store))
+
+	sharkyStore, err = sharky.New(&dirFS{basedir: sharkyDir}, 1, swarm.SocMaxChunkSize)
+	assert.NoError(t, err)
+
+	chStore = chunkstore.New(store, sharkyStore)
+
+	// check that the chunks are still there
+	for _, ch := range chunks[2:] {
+		_, err := chStore.Get(context.Background(), ch.Address())
+		assert.NoError(t, err)
+	}
+
+	err = sharkyStore.Close()
+	assert.NoError(t, err)
+
+	// check that the sharky files are there
+	f, err := os.Open(filepath.Join(sharkyDir, "free_000"))
+	assert.NoError(t, err)
+
+	buf := make([]byte, 2)
+	_, err = f.Read(buf)
+	assert.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		if i < 2 {
+			assert.Greater(t, buf[i/8]&(1<<(i%8)), byte(0))
+		} else {
+			assert.Equal(t, byte(0), buf[i/8]&(1<<(i%8)))
+		}
+	}
+}

--- a/pkg/storer/migration/step_04_test.go
+++ b/pkg/storer/migration/step_04_test.go
@@ -80,8 +80,10 @@ func Test_Step_04(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		if i < 2 {
+			// if the chunk is deleted, the bit is set to 1
 			assert.Greater(t, buf[i/8]&(1<<(i%8)), byte(0))
 		} else {
+			// if the chunk is not deleted, the bit is 0
 			assert.Equal(t, byte(0), buf[i/8]&(1<<(i%8)))
 		}
 	}

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -554,7 +554,6 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 		localmigration.AllSteps(sharkyBasePath, sharkyNoOfShards, repo.ChunkStore()),
 	)
 	if err != nil {
-		fmt.Println("migration error", err)
 		return nil, err
 	}
 

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -545,7 +545,8 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 		}
 	}
 
-	err = migration.Migrate(repo.IndexStore(), localmigration.AllSteps(repo.ChunkStore()))
+	sharkyBasePath := path.Join(dirPath, sharkyPath)
+	err = migration.Migrate(repo.IndexStore(), localmigration.AllSteps(sharkyBasePath, repo.ChunkStore()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -545,9 +545,16 @@ func New(ctx context.Context, dirPath string, opts *Options) (*DB, error) {
 		}
 	}
 
-	sharkyBasePath := path.Join(dirPath, sharkyPath)
-	err = migration.Migrate(repo.IndexStore(), localmigration.AllSteps(sharkyBasePath, repo.ChunkStore()))
+	sharkyBasePath := ""
+	if dirPath != "" {
+		sharkyBasePath = path.Join(dirPath, sharkyPath)
+	}
+	err = migration.Migrate(
+		repo.IndexStore(),
+		localmigration.AllSteps(sharkyBasePath, sharkyNoOfShards, repo.ChunkStore()),
+	)
 	if err != nil {
+		fmt.Println("migration error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
In the latest version we actually dont release the sharky locations properly. This was introduced with the txn recovery mechanism. In order to ensure the correct locations are referenced we will have to perform a new migration.
