### PR TITLE
fix: raname ethereum and eth log and error strings to blockchain

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -268,7 +268,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameBootnodeMode, false, "cause the node to always accept incoming connections")
 	cmd.Flags().Bool(optionNameClefSignerEnable, false, "enable clef signer")
 	cmd.Flags().String(optionNameClefSignerEndpoint, "", "clef signer endpoint")
-	cmd.Flags().String(optionNameClefSignerEthereumAddress, "", "ethereum address to use from clef signer")
+	cmd.Flags().String(optionNameClefSignerEthereumAddress, "", "blockchain address to use from clef signer")
 	cmd.Flags().String(optionNameSwapEndpoint, "", "swap blockchain endpoint") // deprecated: use rpc endpoint instead
 	cmd.Flags().String(optionNameBlockchainRpcEndpoint, "", "rpc blockchain endpoint")
 	cmd.Flags().String(optionNameSwapFactoryAddress, "", "swap factory addresses")

--- a/pkg/bzz/address.go
+++ b/pkg/bzz/address.go
@@ -84,7 +84,7 @@ func ParseAddress(underlay, overlay, signature, nonce []byte, validateOverlay bo
 
 	ethAddress, err := crypto.NewEthereumAddress(*recoveredPK)
 	if err != nil {
-		return nil, fmt.Errorf("extract ethereum address: %w: %w", err, ErrInvalidAddress)
+		return nil, fmt.Errorf("extract blockchain address: %w: %w", err, ErrInvalidAddress)
 	}
 
 	return &Address{

--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -63,17 +63,17 @@ func InitChain(
 		// connect to the real one
 		rpcClient, err := rpc.DialContext(ctx, endpoint)
 		if err != nil {
-			return nil, common.Address{}, 0, nil, nil, fmt.Errorf("dial eth client: %w", err)
+			return nil, common.Address{}, 0, nil, nil, fmt.Errorf("dial blockchain client: %w", err)
 		}
 
 		var versionString string
 		err = rpcClient.CallContext(ctx, &versionString, "web3_clientVersion")
 		if err != nil {
 			logger.Info("could not connect to backend; in a swap-enabled network a working blockchain node (for xdai network in production, goerli in testnet) is required; check your node or specify another node using --swap-endpoint.", "backend_endpoint", endpoint)
-			return nil, common.Address{}, 0, nil, nil, fmt.Errorf("eth client get version: %w", err)
+			return nil, common.Address{}, 0, nil, nil, fmt.Errorf("blockchain client get version: %w", err)
 		}
 
-		logger.Info("connected to ethereum backend", "version", versionString)
+		logger.Info("connected to blockchain backend", "version", versionString)
 
 		backend = wrapped.NewBackend(ethclient.NewClient(rpcClient))
 	}
@@ -85,7 +85,7 @@ func InitChain(
 
 	overlayEthAddress, err := signer.EthereumAddress()
 	if err != nil {
-		return nil, common.Address{}, 0, nil, nil, fmt.Errorf("eth address: %w", err)
+		return nil, common.Address{}, 0, nil, nil, fmt.Errorf("blockchain address: %w", err)
 	}
 
 	transactionMonitor := transaction.NewMonitor(logger, backend, overlayEthAddress, pollingInterval, cancellationDepth)

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -138,7 +138,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 
 	overlayEthAddress, err := signer.EthereumAddress()
 	if err != nil {
-		return nil, fmt.Errorf("eth address: %w", err)
+		return nil, fmt.Errorf("blockchain address: %w", err)
 	}
 
 	var authenticator auth.Authenticator

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -346,7 +346,7 @@ func NewBee(
 	logger.Info("using chain with network network", "chain_id", chainID, "network_id", networkID)
 
 	if o.ChainID != -1 && o.ChainID != chainID {
-		return nil, fmt.Errorf("connected to wrong ethereum network; network chainID %d; configured chainID %d", chainID, o.ChainID)
+		return nil, fmt.Errorf("connected to wrong blockchain network; network chainID %d; configured chainID %d", chainID, o.ChainID)
 	}
 
 	b.transactionCloser = tracerCloser
@@ -488,7 +488,7 @@ func NewBee(
 		return nil, fmt.Errorf("is synced: %w", err)
 	}
 	if !isSynced {
-		logger.Info("waiting to sync with the Ethereum backend")
+		logger.Info("waiting to sync with the blockchain backend")
 
 		err := transaction.WaitSynced(ctx, logger, chainBackend, maxDelay)
 		if err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Ranames "ethereum"/"eth" log and error strings to blockchain on order to minimize confusion reported here #3980 

Closes #3980