### PR TITLE
fix: include the reason when the postage contract call fails

### DIFF
--- a/pkg/postage/postagecontract/contract.go
+++ b/pkg/postage/postagecontract/contract.go
@@ -199,7 +199,13 @@ func (c *postageContract) sendTransaction(ctx context.Context, callData []byte, 
 	}
 
 	if receipt.Status == 0 {
-		return nil, transaction.ErrTransactionReverted
+		err := transaction.ErrTransactionReverted
+		if res, cErr := c.transactionService.Call(ctx, request); cErr == nil {
+			if reason, uErr := abi.UnpackRevert(res); uErr == nil {
+				err = fmt.Errorf("%w: reason: %s", err, reason)
+			}
+		}
+		return nil, err
 	}
 
 	return receipt, nil


### PR DESCRIPTION
…tract

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Indicate the reason for the unsuccessful call of the postage contract.

Closes #3320