### PR TITLE
fix(api): allow 0 value for rchash depth

### DIFF
--- a/pkg/api/rchash.go
+++ b/pkg/api/rchash.go
@@ -19,7 +19,7 @@ func (s *Service) rchash(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithName("get_rchash").Build()
 
 	paths := struct {
-		Depth   uint8  `map:"depth" validate:"required"`
+		Depth   *uint8 `map:"depth" validate:"required"`
 		Anchor1 string `map:"anchor1" validate:"required"`
 	}{}
 	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
@@ -34,7 +34,7 @@ func (s *Service) rchash(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := s.redistributionAgent.SampleWithProofs(r.Context(), anchor1, paths.Depth)
+	resp, err := s.redistributionAgent.SampleWithProofs(r.Context(), anchor1, *paths.Depth)
 	if err != nil {
 		logger.Error(err, "failed making sample with proofs")
 		jsonhttp.InternalServerError(w, "failed making sample with proofs")


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Fixes the case where the rchash API is called with depth equal to `0`.

Closes  #4249
