### PR TITLE
chore: remove retrieval ctx scope leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	resenje.org/multex v0.1.0
-	resenje.org/singleflight v0.2.0
+	resenje.org/singleflight v0.4.0
 	resenje.org/web v0.4.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1453,8 +1453,8 @@ resenje.org/marshal v0.1.1/go.mod h1:P7Cla6Ju5CFvW4Y8JbRgWX1Hcy4L1w4qcCsyadO7G94
 resenje.org/multex v0.1.0 h1:am9Ndt8dIAeGVaztD8ClsSX+e0EP3mj6UdsvjukKZig=
 resenje.org/multex v0.1.0/go.mod h1:3rHOoMrzqLNzgGWPcl/1GfzN52g7iaPXhbvTQ8TjGaM=
 resenje.org/recovery v0.1.1/go.mod h1:3S6aCVKMJEWsSAb61oZTteaiqkIfQPTr1RdiWnRbhME=
-resenje.org/singleflight v0.2.0 h1:nJ17VAZunMiFrfrltQ4Qs4r9MIP1pZC8u+0iSUTNnvQ=
-resenje.org/singleflight v0.2.0/go.mod h1:plheHgw2rd77IH3J6aN0Lu2JvMvHXoLknDwb6vN0dsE=
+resenje.org/singleflight v0.4.0 h1:NdOEhCxEikK2S2WxGjZV9EGSsItolQKslOOi6pE1tJc=
+resenje.org/singleflight v0.4.0/go.mod h1:lAgQK7VfjG6/pgredbQfmV0RvG/uVhKo6vSuZ0vCWfk=
 resenje.org/web v0.4.3 h1:G9vceKKGvsVg0WpyafJEEMHfstoxSO8rG/1Bo7fOkhw=
 resenje.org/web v0.4.3/go.mod h1:GZw/Jt7IGIYlytsyGdAV5CytZnaQu7GV2u1LLuViihc=
 resenje.org/x v0.2.4/go.mod h1:1b2Xpo29FRc3IMvg/u46/IyjySl5IjvtuSjXTA/AOnk=

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -70,7 +70,7 @@ type Syncer struct {
 	quit           chan struct{}
 	unwrap         func(swarm.Chunk)
 	validStamp     postage.ValidStampFn
-	intervalsSF    singleflight.Group
+	intervalsSF    singleflight.Group[string, *collectAddrsResult]
 	syncInProgress atomic.Int32
 	binLock        *multex.Multex
 
@@ -384,6 +384,11 @@ func (s *Syncer) makeOffer(ctx context.Context, rn pb.Get) (*pb.Offer, error) {
 	return o, nil
 }
 
+type collectAddrsResult struct {
+	chs     []*storer.BinC
+	topmost uint64
+}
+
 // collectAddrs collects chunk addresses at a bin starting at some start BinID until a limit is reached.
 // The function waits for an unbounded amount of time for the first chunk to arrive.
 // After the arrival of the first chunk, the subsequent chunks have a limited amount of time to arrive,
@@ -391,12 +396,7 @@ func (s *Syncer) makeOffer(ctx context.Context, rn pb.Get) (*pb.Offer, error) {
 func (s *Syncer) collectAddrs(ctx context.Context, bin uint8, start uint64) ([]*storer.BinC, uint64, error) {
 	loggerV2 := s.logger.V(2).Register()
 
-	type result struct {
-		chs     []*storer.BinC
-		topmost uint64
-	}
-
-	v, _, err := s.intervalsSF.Do(ctx, sfKey(bin, start), func(ctx context.Context) (interface{}, error) {
+	v, _, err := s.intervalsSF.Do(ctx, sfKey(bin, start), func(ctx context.Context) (*collectAddrsResult, error) {
 		var (
 			chs     []*storer.BinC
 			topmost uint64
@@ -446,13 +446,12 @@ func (s *Syncer) collectAddrs(ctx context.Context, bin uint8, start uint64) ([]*
 			}
 		}
 
-		return &result{chs: chs, topmost: topmost}, nil
+		return &collectAddrsResult{chs: chs, topmost: topmost}, nil
 	})
 	if err != nil {
 		return nil, 0, err
 	}
-	r := v.(*result)
-	return r.chs, r.topmost, nil
+	return v.chs, v.topmost, nil
 }
 
 // processWant compares a received Want to a sent Offer and returns


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR removes the need for topCtx variable that needs to creep into the goroutine that is created in the retrieval singleflight to preserve the tracing span. This is possible by upgrading the singleflight to the latest v0.4.0 release which preserves values between function calls, while keeping the same cancelation behaviour.

It is optional to wait for bee to support building with bee 1.21 and use context.WithoutCancel in the retrieval goroutine.

The side effect of the singleflight upgrade is the usage of type parameters to avoid runtime type casts.

#### Motivation and Context (Optional)
General code improvement.

