### PR TITLE
feat(compact): log retrieval item data of invalid chunks

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -131,7 +131,7 @@ func dbCompactCmd(cmd *cobra.Command) {
 			}
 
 			logger.Warning("Compaction is a destructive process. If the process is stopped for any reason, the localstore may become corrupted.")
-			logger.Warning("It is highly advised to perform the compaction on a copy of the localtore.")
+			logger.Warning("It is highly advised to perform the compaction on a copy of the localstore.")
 			logger.Warning("After compaction finishes, the data directory may be replaced with the compacted version.")
 			logger.Warning("you have another 10 seconds to change your mind and kill this process with CTRL-C...")
 			time.Sleep(10 * time.Second)

--- a/pkg/cac/cac.go
+++ b/pkg/cac/cac.go
@@ -57,7 +57,7 @@ func validateDataLength(dataLength int) error {
 
 // newWithSpan creates a new chunk prepending the given span to the data.
 func newWithSpan(data, span []byte) (swarm.Chunk, error) {
-	hash, err := doHash(data, span)
+	hash, err := DoHash(data, span)
 	if err != nil {
 		return nil, err
 	}
@@ -77,12 +77,12 @@ func Valid(c swarm.Chunk) bool {
 		return false
 	}
 
-	hash, _ := doHash(data[swarm.SpanSize:], data[:swarm.SpanSize])
+	hash, _ := DoHash(data[swarm.SpanSize:], data[:swarm.SpanSize])
 
 	return bytes.Equal(hash, c.Address().Bytes())
 }
 
-func doHash(data, span []byte) ([]byte, error) {
+func DoHash(data, span []byte) ([]byte, error) {
 	hasher := bmtpool.Get()
 	defer bmtpool.Put(hasher)
 

--- a/pkg/sharky/recovery.go
+++ b/pkg/sharky/recovery.go
@@ -75,14 +75,7 @@ func (r *Recovery) Add(loc Location) error {
 func (r *Recovery) Read(ctx context.Context, loc Location, buf []byte) error {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-
-	shFile := r.shardFiles[loc.Shard]
-	if stat, err := shFile.Stat(); err != nil {
-		return err
-	} else if stat.Size() < int64(loc.Slot)*int64(r.datasize) {
-		return errors.New("slot not found")
-	}
-	_, err := shFile.ReadAt(buf, int64(loc.Slot)*int64(r.datasize))
+	_, err := r.shardFiles[loc.Shard].ReadAt(buf, int64(loc.Slot)*int64(r.datasize))
 	return err
 }
 

--- a/pkg/sharky/shard.go
+++ b/pkg/sharky/shard.go
@@ -7,6 +7,7 @@ package sharky
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -18,6 +19,10 @@ type Location struct {
 	Shard  uint8
 	Slot   uint32
 	Length uint16
+}
+
+func (l Location) String() string {
+	return fmt.Sprintf("shard: %d, slot: %d, length: %d", l.Shard, l.Slot, l.Length)
 }
 
 // MarshalBinary returns byte representation of location

--- a/pkg/storer/compact.go
+++ b/pkg/storer/compact.go
@@ -155,6 +155,7 @@ func validationWork(logger log.Logger, store storage.Store, sharky *sharky.Recov
 		err := sharky.Read(context.Background(), item.Location, buf)
 		if err != nil {
 			logger.Warning("invalid chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0), "error", err)
+			return
 		}
 
 		ch := swarm.NewChunk(item.Address, buf)

--- a/pkg/storer/compact.go
+++ b/pkg/storer/compact.go
@@ -93,13 +93,13 @@ func Compact(ctx context.Context, basePath string, opts *Options, validate bool)
 
 		for start < end {
 
-			if slots[end] == nil {
-				end-- // walk to the left until a used slot found
+			if slots[start] != nil {
+				start++ // walk to the right until a free slot is found
 				continue
 			}
 
-			if slots[start] != nil {
-				start++ // walk to the right until a free slot is found
+			if slots[end] == nil {
+				end-- // walk to the left until a used slot found
 				continue
 			}
 
@@ -154,7 +154,7 @@ func validationWork(logger log.Logger, store storage.Store, sharky *sharky.Recov
 	validChunk := func(item *chunkstore.RetrievalIndexItem, buf []byte) {
 		err := sharky.Read(context.Background(), item.Location, buf)
 		if err != nil {
-			logger.Warning("invalid chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0), "error", err)
+			logger.Warning("invalid chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0), "location", item.Location, "error", err)
 			return
 		}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Log timestamp of invalid chunks.

It was discovered that multiple chunks were sharing the same sharky slot.
To log the chunk that took over the slot, we compute the chunk address using `cac.DoHash` and log relevant info of the chunk if the retrieval index item can be retrieved. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
