### PR TITLE
fix(postage): added postage stamps json marshaling

### DIFF
--- a/pkg/postage/stamp.go
+++ b/pkg/postage/stamp.go
@@ -6,6 +6,7 @@ package postage
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -115,6 +116,35 @@ func (s *Stamp) UnmarshalBinary(buf []byte) error {
 	s.index = buf[32:40]
 	s.timestamp = buf[40:48]
 	s.sig = buf[48:]
+	return nil
+}
+
+type stampJson struct {
+	BatchID   []byte
+	Index     []byte
+	Timestamp []byte
+	Sig       []byte
+}
+
+func (s *Stamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&stampJson{
+		s.batchID,
+		s.index,
+		s.timestamp,
+		s.sig,
+	})
+}
+
+func (a *Stamp) UnmarshalJSON(b []byte) error {
+	v := &stampJson{}
+	err := json.Unmarshal(b, v)
+	if err != nil {
+		return err
+	}
+	a.batchID = v.BatchID
+	a.index = v.Index
+	a.timestamp = v.Timestamp
+	a.sig = v.Sig
 	return nil
 }
 

--- a/pkg/postage/stamp.go
+++ b/pkg/postage/stamp.go
@@ -120,10 +120,10 @@ func (s *Stamp) UnmarshalBinary(buf []byte) error {
 }
 
 type stampJson struct {
-	BatchID   []byte
-	Index     []byte
-	Timestamp []byte
-	Sig       []byte
+	BatchID   []byte `json:"batchID"`
+	Index     []byte `json:"index"`
+	Timestamp []byte `json:"timestamp"`
+	Sig       []byte `json:"sig"`
 }
 
 func (s *Stamp) MarshalJSON() ([]byte, error) {

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -6,6 +6,7 @@ package postage_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -28,6 +29,24 @@ func TestStampMarshalling(t *testing.T) {
 	if err := s.UnmarshalBinary(buf); err != nil {
 		t.Fatalf("unexpected error unmarshalling stamp: %v", err)
 	}
+	compareStamps(t, sExp, s)
+}
+
+// TestStampMarshalling tests the idempotence  of binary marshal/unmarshals for Stamps.
+func TestStampJsonMarshalling(t *testing.T) {
+	sExp := postagetesting.MustNewStamp()
+
+	b, err := json.Marshal(sExp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := postage.NewStamp(nil, nil, nil, nil)
+	err = json.Unmarshal(b, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	compareStamps(t, sExp, s)
 }
 

--- a/pkg/storer/sample.go
+++ b/pkg/storer/sample.go
@@ -32,7 +32,7 @@ type SampleItem struct {
 	TransformedAddress swarm.Address
 	ChunkAddress       swarm.Address
 	ChunkData          []byte
-	Stamp              swarm.Stamp
+	Stamp              *postage.Stamp
 }
 
 type Sample struct {
@@ -288,7 +288,7 @@ func (db *DB) ReserveSample(
 
 			stats.ValidStampDuration += time.Since(start)
 
-			item.Stamp = stamp
+			item.Stamp = postage.NewStamp(stamp.BatchID(), stamp.Index(), stamp.Timestamp(), stamp.Sig())
 
 			// ensuring to pass the check order function of redistribution contract
 			if index := contains(item.TransformedAddress); index != -1 {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
```
"time"="2023-09-29 17:19:18.849686" "level"="error" "logger"="node" "msg"="failed to build bee node" "error"="storage incentives agent: failed decoding value json: cannot unmarshal object into Go struct field SampleItem.RoundData.Sa
mpleData.ReserveSampleItems.Stamp of type swarm.Stamp"
```
### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
