### PR TITLE
fix: move the postage logger under the node logger tree

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -653,7 +653,7 @@ func NewBee(
 	b.p2pService = p2ps
 	b.p2pHalter = p2ps
 
-	post, err := postage.NewService(stamperStore, batchStore, chainID)
+	post, err := postage.NewService(logger, stamperStore, batchStore, chainID)
 	if err != nil {
 		return nil, fmt.Errorf("postage service: %w", err)
 	}

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -15,6 +15,9 @@ import (
 	"github.com/ethersphere/bee/pkg/storage"
 )
 
+// loggerName is the tree path name of the logger for this package.
+const loggerName = "postage"
+
 const (
 	// blockThreshold is used to allow threshold no of blocks to be synced before a
 	// batch is usable.
@@ -42,6 +45,7 @@ type Service interface {
 // service handles postage batches
 // stores the active batches.
 type service struct {
+	logger       log.Logger
 	lock         sync.Mutex
 	store        storage.Store
 	postageStore Storer
@@ -50,8 +54,9 @@ type service struct {
 }
 
 // NewService constructs a new Service.
-func NewService(store storage.Store, postageStore Storer, chainID int64) (Service, error) {
+func NewService(logger log.Logger, store storage.Store, postageStore Storer, chainID int64) (Service, error) {
 	s := &service{
+		logger:       logger.WithName(loggerName).Register(),
 		store:        store,
 		postageStore: postageStore,
 		chainID:      chainID,
@@ -201,11 +206,10 @@ func (ps *service) HandleStampExpiry(id []byte) {
 func (ps *service) SetExpired() error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
-	logger := log.NewLogger("node").WithName("postage").Register()
 	for _, issuer := range ps.issuers {
 		exists, err := ps.postageStore.Exists(issuer.ID())
 		if err != nil {
-			logger.Error(err, "set expired: checking if issuer exists", "id", issuer.ID())
+			ps.logger.Error(err, "set expired: checking if issuer exists", "id", issuer.ID())
 			return err
 		}
 		issuer.SetExpired(!exists)

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/postage"
 	pstoremock "github.com/ethersphere/bee/pkg/postage/batchstore/mock"
 	postagetesting "github.com/ethersphere/bee/pkg/postage/testing"
@@ -24,7 +25,7 @@ func TestSaveLoad(t *testing.T) {
 	defer store.Close()
 	pstore := pstoremock.New()
 	saved := func(id int64) postage.Service {
-		ps, err := postage.NewService(store, pstore, id)
+		ps, err := postage.NewService(log.Noop, store, pstore, id)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +41,7 @@ func TestSaveLoad(t *testing.T) {
 		return ps
 	}
 	loaded := func(id int64) postage.Service {
-		ps, err := postage.NewService(store, pstore, id)
+		ps, err := postage.NewService(log.Noop, store, pstore, id)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -77,7 +78,7 @@ func TestGetStampIssuer(t *testing.T) {
 	}
 	validBlockNumber := testChainState.Block - uint64(postage.BlockThreshold+1)
 	pstore := pstoremock.New(pstoremock.WithChainState(testChainState))
-	ps, err := postage.NewService(store, pstore, chainID)
+	ps, err := postage.NewService(log.Noop, store, pstore, chainID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Moves the postage logger under the node logger tree.