### PR TITLE
refactor: enrich transaction service logs with sender address

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -90,7 +90,7 @@ func InitChain(
 
 	transactionMonitor := transaction.NewMonitor(logger, backend, overlayEthAddress, pollingInterval, cancellationDepth)
 
-	transactionService, err := transaction.NewService(logger, backend, signer, stateStore, chainID, transactionMonitor)
+	transactionService, err := transaction.NewService(logger, overlayEthAddress, backend, signer, stateStore, chainID, transactionMonitor)
 	if err != nil {
 		return nil, common.Address{}, 0, nil, nil, fmt.Errorf("new transaction service: %w", err)
 	}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -112,7 +112,7 @@ type transactionService struct {
 }
 
 // NewService creates a new transaction service.
-func NewService(logger log.Logger, backend Backend, signer crypto.Signer, store storage.StateStorer, chainID *big.Int, monitor Monitor) (Service, error) {
+func NewService(logger log.Logger, overlayEthAddress common.Address, backend Backend, signer crypto.Signer, store storage.StateStorer, chainID *big.Int, monitor Monitor) (Service, error) {
 	senderAddress, err := signer.EthereumAddress()
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func NewService(logger log.Logger, backend Backend, signer crypto.Signer, store 
 	t := &transactionService{
 		ctx:     ctx,
 		cancel:  cancel,
-		logger:  logger.WithName(loggerName).Register(),
+		logger:  logger.WithName(loggerName).WithValues("sender_address", overlayEthAddress).Register(),
 		backend: backend,
 		signer:  signer,
 		sender:  senderAddress,

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -112,7 +112,7 @@ func TestTransactionSend(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != signedTx {
@@ -243,7 +243,7 @@ func TestTransactionSend(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != signedTx {
@@ -364,7 +364,7 @@ func TestTransactionSend(t *testing.T) {
 		}
 		store := storemock.NewStateStore()
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != signedTx {
@@ -445,7 +445,7 @@ func TestTransactionSend(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != signedTx {
@@ -505,6 +505,7 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 	t.Parallel()
 
 	logger := log.Noop
+	sender := common.HexToAddress("0xddff")
 	txHash := common.HexToHash("0xabcdee")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)
@@ -519,7 +520,7 @@ func TestTransactionWaitForReceipt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	transactionService, err := transaction.NewService(logger,
+	transactionService, err := transaction.NewService(logger, sender,
 		backendmock.New(
 			backendmock.WithTransactionReceiptFunc(func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 				return &types.Receipt{
@@ -565,6 +566,7 @@ func TestTransactionResend(t *testing.T) {
 	t.Parallel()
 
 	logger := log.Noop
+	sender := common.HexToAddress("0xddff")
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)
@@ -601,7 +603,7 @@ func TestTransactionResend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	transactionService, err := transaction.NewService(logger,
+	transactionService, err := transaction.NewService(logger, sender,
 		backendmock.New(
 			backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 				if tx != signedTx {
@@ -636,6 +638,7 @@ func TestTransactionCancel(t *testing.T) {
 	t.Parallel()
 
 	logger := log.Noop
+	sender := common.HexToAddress("0xddff")
 	recipient := common.HexToAddress("0xbbbddd")
 	chainID := big.NewInt(5)
 	nonce := uint64(10)
@@ -690,7 +693,7 @@ func TestTransactionCancel(t *testing.T) {
 			Data:      []byte{},
 		})
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != cancelTx {
@@ -741,7 +744,7 @@ func TestTransactionCancel(t *testing.T) {
 			Data:      []byte{},
 		})
 
-		transactionService, err := transaction.NewService(logger,
+		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
 				backendmock.WithSendTransactionFunc(func(ctx context.Context, tx *types.Transaction) error {
 					if tx != cancelTx {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Enriches transaction service logs to always have the sender address included.

Closes #4357