### PR TITLE
docs: update min batch depth

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1752,7 +1752,7 @@ paths:
           schema:
             type: integer
           required: true
-          description: Batch depth which specifies how many chunks can be signed with the batch. It is a logarithm. Must be higher than default bucket depth (16)
+          description: Batch depth which specifies how many chunks can be signed with the batch. It is a logarithm. Minimum batch depth is 24.
         - in: query
           name: label
           schema:

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -871,7 +871,7 @@ paths:
           schema:
             type: integer
           required: true
-          description: Batch depth which specifies how many chunks can be signed with the batch. It is a logarithm. Must be higher than default bucket depth (16)
+          description: Batch depth which specifies how many chunks can be signed with the batch. It is a logarithm. Minimum batch depth is 24.
         - in: query
           name: label
           schema:


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Updated reference to minimum batch depth to 24, removed definition of minimum batch depth being defined by default bucket depth of 16.

### Open API Spec Version Changes (if applicable)

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
