### PR TITLE
feat(retrieval): multiplex into the neighborhood

### DIFF
--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -182,7 +182,7 @@ func bootstrapNode(
 	}
 	b.localstoreCloser = localStore
 
-	retrieve := retrieval.New(swarmAddress, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
+	retrieve := retrieval.New(swarmAddress, nil, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -182,7 +182,9 @@ func bootstrapNode(
 	}
 	b.localstoreCloser = localStore
 
-	retrieve := retrieval.New(swarmAddress, nil, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
+	r := func() (uint8, error) { return swarm.MaxBins, nil }
+
+	retrieve := retrieval.New(swarmAddress, r, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -182,9 +182,9 @@ func bootstrapNode(
 	}
 	b.localstoreCloser = localStore
 
-	r := func() (uint8, error) { return swarm.MaxBins, nil }
+	radiusF := func() (uint8, error) { return swarm.MaxBins, nil }
 
-	retrieve := retrieval.New(swarmAddress, r, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
+	retrieve := retrieval.New(swarmAddress, radiusF, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
 	if err = p2ps.AddProtocol(retrieve.Protocol()); err != nil {
 		return nil, fmt.Errorf("retrieval service: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -976,7 +976,7 @@ func NewBee(
 
 	radiusFunc := func() (uint8, error) {
 		currentRadius := localStore.StorageRadius()
-		if currentRadius == 0 && networkR.Load() != 0 {
+		if currentRadius == 0 { // the radius has not been set by localstore yet
 			currentRadius = uint8(networkR.Load())
 		}
 		return currentRadius, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -974,6 +974,14 @@ func NewBee(
 		}
 	}()
 
+	radiusFunc := func() (uint8, error) {
+		currentRadius := localStore.StorageRadius()
+		if currentRadius == 0 && networkR.Load() != 0 {
+			currentRadius = uint8(networkR.Load())
+		}
+		return currentRadius, nil
+	}
+
 	waitNetworkRFunc := func() (uint8, error) {
 		if networkR.Load() == uint32(swarm.MaxBins) {
 			select {
@@ -983,20 +991,7 @@ func NewBee(
 			}
 		}
 
-		// radius has not been set by the localstore, use networkR instead
-		if localStore.StorageRadius() == 0 && networkR.Load() != 0 {
-			return uint8(networkR.Load()), nil
-		}
-
-		return localStore.StorageRadius(), nil
-	}
-
-	radiusFunc := func() (uint8, error) {
-		currentRadius := localStore.StorageRadius()
-		if currentRadius == 0 && networkR.Load() != 0 {
-			currentRadius = uint8(networkR.Load())
-		}
-		return currentRadius, nil
+		return radiusFunc()
 	}
 
 	retrieve := retrieval.New(swarmAddress, radiusFunc, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -994,8 +994,8 @@ func NewBee(
 		return radiusFunc()
 	}
 
-	retrieve := retrieval.New(swarmAddress, radiusFunc, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
-	localStore.SetRetrievalService(retrieve)
+	retrieval := retrieval.New(swarmAddress, radiusFunc, localStore, p2ps, kad, logger, acc, pricer, tracer, o.RetrievalCaching)
+	localStore.SetRetrievalService(retrieval)
 
 	pusherService := pusher.New(networkID, localStore, waitNetworkRFunc, pushSyncProtocol, validStamp, logger, tracer, warmupTime, pusher.DefaultRetryCount)
 	b.pusherCloser = pusherService
@@ -1005,7 +1005,7 @@ func NewBee(
 	pullSyncProtocol := pullsync.New(p2ps, localStore, pssService.TryUnwrap, validStamp, logger, pullsync.DefaultMaxPage)
 	b.pullSyncCloser = pullSyncProtocol
 
-	retrieveProtocolSpec := retrieve.Protocol()
+	retrieveProtocolSpec := retrieval.Protocol()
 	pushSyncProtocolSpec := pushSyncProtocol.Protocol()
 	pullSyncProtocolSpec := pullSyncProtocol.Protocol()
 
@@ -1111,7 +1111,7 @@ func NewBee(
 	b.resolverCloser = multiResolver
 
 	feedFactory := factory.New(localStore.Download(true))
-	steward := steward.New(localStore, retrieve)
+	steward := steward.New(localStore, retrieval)
 
 	extraOpts := api.ExtraOptions{
 		Pingpong:        pingPong,
@@ -1199,7 +1199,7 @@ func NewBee(
 		debugService.MustRegisterMetrics(pushSyncProtocol.Metrics()...)
 		debugService.MustRegisterMetrics(pusherService.Metrics()...)
 		debugService.MustRegisterMetrics(pullSyncProtocol.Metrics()...)
-		debugService.MustRegisterMetrics(retrieve.Metrics()...)
+		debugService.MustRegisterMetrics(retrieval.Metrics()...)
 		debugService.MustRegisterMetrics(lightNodes.Metrics()...)
 		debugService.MustRegisterMetrics(hive.Metrics()...)
 

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -47,8 +47,8 @@ const (
 )
 
 const (
-	nPeersToReplicate = 2 // number of peers to replicate to as receipt is sent upstream
-	maxPushErrors     = 32
+	maxMultiplexForwards = 2 // number of extra peers to forward the request from the multiplex node
+	maxPushErrors        = 32
 )
 
 var (
@@ -304,7 +304,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 		sentErrorsLeft   = 1
 		preemptiveTicker <-chan time.Time
 		inflight         int
-		parallelForwards = nPeersToReplicate
+		parallelForwards = maxMultiplexForwards
 	)
 
 	if origin {

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -64,6 +64,7 @@ type Storer interface {
 
 type Service struct {
 	addr          swarm.Address
+	radiusFunc    func() (uint8, error)
 	streamer      p2p.Streamer
 	peerSuggester topology.ClosestPeerer
 	storer        Storer
@@ -79,6 +80,7 @@ type Service struct {
 
 func New(
 	addr swarm.Address,
+	radiusFunc func() (uint8, error),
 	storer Storer,
 	streamer p2p.Streamer,
 	chunkPeerer topology.ClosestPeerer,
@@ -90,6 +92,7 @@ func New(
 ) *Service {
 	return &Service{
 		addr:          addr,
+		radiusFunc:    radiusFunc,
 		streamer:      streamer,
 		peerSuggester: chunkPeerer,
 		storer:        storer,
@@ -121,8 +124,9 @@ const (
 	preemptiveInterval   = time.Second
 	overDraftRefresh     = time.Millisecond * 600
 	skiplistDur          = time.Minute
-	maxRetrievedErrors   = 32
 	originSuffix         = "_origin"
+	maxOriginErrors      = 16
+	maxMultiplexForwards = 2
 )
 
 func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr swarm.Address) (swarm.Chunk, error) {
@@ -162,16 +166,19 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 		quit := make(chan struct{})
 		defer close(quit)
 
+		var forwards = maxMultiplexForwards
+
+		// if we are the origin node, allow many preemptive retries to speed up the retrieval of the chunk.
 		errorsLeft := 1
 		if origin {
 			ticker := time.NewTicker(preemptiveInterval)
 			defer ticker.Stop()
 			preemptiveTicker = ticker.C
-			errorsLeft = maxRetrievedErrors
+			errorsLeft = maxOriginErrors
 		}
 
 		resultC := make(chan retrievalResult, 1)
-		retryC := make(chan struct{}, 1)
+		retryC := make(chan struct{}, forwards)
 
 		retry := func() {
 			select {
@@ -226,6 +233,15 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 						return nil, err
 					}
 					continue
+				}
+
+				// since we can reach into the neighborhood of the chunk
+				// act as the multiplexer and push the chunk in parallel to multiple peers
+				if radius, err := s.radiusFunc(); err == nil && swarm.Proximity(peer.Bytes(), chunkAddr.Bytes()) >= radius {
+					for ; forwards > 0; forwards-- {
+						retry()
+						errorsLeft++
+					}
 				}
 
 				action, err := s.prepareCredit(ctx, peer, chunkAddr, origin)

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -236,7 +236,9 @@ func (s *Service) RetrieveChunk(ctx context.Context, chunkAddr, sourcePeerAddr s
 				}
 
 				// since we can reach into the neighborhood of the chunk
-				// act as the multiplexer and push the chunk in parallel to multiple peers
+				// act as the multiplexer and push the chunk in parallel to multiple peers.
+				// neighbor peers will also have multiple retries, which means almost the entire neighborhood
+				// will be scanned for the chunk, starting from the closest to the furthest peer in the neighborhood.
 				if radius, err := s.radiusFunc(); err == nil && swarm.Proximity(peer.Bytes(), chunkAddr.Bytes()) >= radius {
 					for ; forwards > 0; forwards-- {
 						retry()

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -713,9 +713,7 @@ func createRetrieval(
 ) *retrieval.Service {
 	t.Helper()
 
-	r := func() (uint8, error) {
-		return swarm.MaxBins, nil
-	}
+	r := func() (uint8, error) { return swarm.MaxBins, nil }
 
 	ret := retrieval.New(addr, r, storer, streamer, chunkPeerer, logger, accounting, pricer, tracer, forwarderCaching)
 	t.Cleanup(func() { ret.Close() })

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -713,9 +713,9 @@ func createRetrieval(
 ) *retrieval.Service {
 	t.Helper()
 
-	r := func() (uint8, error) { return swarm.MaxBins, nil }
+	radiusF := func() (uint8, error) { return swarm.MaxBins, nil }
 
-	ret := retrieval.New(addr, r, storer, streamer, chunkPeerer, logger, accounting, pricer, tracer, forwarderCaching)
+	ret := retrieval.New(addr, radiusF, storer, streamer, chunkPeerer, logger, accounting, pricer, tracer, forwarderCaching)
 	t.Cleanup(func() { ret.Close() })
 	return ret
 }

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -712,7 +712,12 @@ func createRetrieval(
 	forwarderCaching bool,
 ) *retrieval.Service {
 	t.Helper()
-	ret := retrieval.New(addr, storer, streamer, chunkPeerer, logger, accounting, pricer, tracer, forwarderCaching)
+
+	r := func() (uint8, error) {
+		return swarm.MaxBins, nil
+	}
+
+	ret := retrieval.New(addr, r, storer, streamer, chunkPeerer, logger, accounting, pricer, tracer, forwarderCaching)
 	t.Cleanup(func() { ret.Close() })
 	return ret
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
introduces a similar multiplexing mechanism as the pushsync one.
Peers that are one hop away from the neighborhood (and the neighbor peers) have extra retries to find the chunk.

closes https://github.com/ethersphere/bee-backlog/issues/67

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
