### PR TITLE
fix(kademlia, reacher): various connection fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,8 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/go-cid v0.3.2
+	github.com/hashicorp/golang-lru/v2 v2.0.5
+	github.com/ipfs/go-cid v0.4.1
 	github.com/kardianos/service v1.2.0
 	github.com/libp2p/go-libp2p v0.30.0
 	github.com/multiformats/go-multiaddr v0.11.0

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
-	github.com/hashicorp/golang-lru/v2 v2.0.5
-	github.com/ipfs/go-cid v0.4.1
+	github.com/ipfs/go-cid v0.3.2
 	github.com/kardianos/service v1.2.0
 	github.com/libp2p/go-libp2p v0.30.0
 	github.com/multiformats/go-multiaddr v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -438,7 +438,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -41,11 +41,8 @@ const (
 	peersStreamName        = "peers"
 	messageTimeout         = 1 * time.Minute // maximum allowed time for a message to be read or written.
 	maxBatchSize           = 30
-	pingTimeout            = time.Second * 5 // time to wait for ping to succeed
-	batchValidationTimeout = 5 * time.Minute // prevent lock contention on peer validation
-	cacheSize              = 100000
-	bitsPerByte            = 8
-	cachePrefix            = swarm.MaxBins / bitsPerByte // enough bytes (32 bits) to uniquely identify a peer
+	pingTimeout            = time.Second * 15 // time to wait for ping to succeed
+	batchValidationTimeout = 5 * time.Minute  // prevent lock contention on peer validation
 )
 
 var (

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -349,7 +349,7 @@ func (s *Service) checkAndAddPeers(ctx context.Context, peers pb.Peers) {
 		multiUnderlay, err := ma.NewMultiaddrBytes(p.Underlay)
 		if err != nil {
 			s.metrics.PeerUnderlayErr.Inc()
-			s.logger.Error(err, "multi address underlay")
+			s.logger.Debug("multi address underlay", "error", err)
 			continue
 		}
 

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -50,7 +50,7 @@ func TestHandlerRateLimit(t *testing.T) {
 	// new recorder for handling Ping
 	streamer := streamtest.New()
 	// create a hive server that handles the incoming stream
-	server, _ := hive.New(streamer, addressbookclean, networkID, false, true, logger)
+	server := hive.New(streamer, addressbookclean, networkID, false, true, logger)
 	testutil.CleanupCloser(t, server)
 
 	serverAddress := swarm.RandAddress(t)
@@ -90,7 +90,7 @@ func TestHandlerRateLimit(t *testing.T) {
 	}
 
 	// create a hive client that will do broadcast
-	client, _ := hive.New(serverRecorder, addressbook, networkID, false, true, logger)
+	client := hive.New(serverRecorder, addressbook, networkID, false, true, logger)
 	err := client.BroadcastPeers(context.Background(), serverAddress, peers...)
 	if err != nil {
 		t.Fatal(err)
@@ -255,7 +255,7 @@ func TestBroadcastPeers_FLAKY(t *testing.T) {
 				streamer = streamtest.New()
 			}
 			// create a hive server that handles the incoming stream
-			server, _ := hive.New(streamer, addressbookclean, networkID, false, true, logger)
+			server := hive.New(streamer, addressbookclean, networkID, false, true, logger)
 			testutil.CleanupCloser(t, server)
 
 			// setup the stream recorder to record stream data
@@ -264,7 +264,7 @@ func TestBroadcastPeers_FLAKY(t *testing.T) {
 			)
 
 			// create a hive client that will do broadcast
-			client, _ := hive.New(recorder, addressbook, networkID, false, tc.allowPrivateCIDRs, logger)
+			client := hive.New(recorder, addressbook, networkID, false, tc.allowPrivateCIDRs, logger)
 			if err := client.BroadcastPeers(context.Background(), tc.addresee, tc.peers...); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -116,10 +116,7 @@ func bootstrapNode(
 	b.p2pService = p2ps
 	b.p2pHalter = p2ps
 
-	hive, err := hive.New(p2ps, addressbook, networkID, o.BootnodeMode, o.AllowPrivateCIDRs, logger)
-	if err != nil {
-		return nil, fmt.Errorf("hive: %w", err)
-	}
+	hive := hive.New(p2ps, addressbook, networkID, o.BootnodeMode, o.AllowPrivateCIDRs, logger)
 
 	if err = p2ps.AddProtocol(hive.Protocol()); err != nil {
 		return nil, fmt.Errorf("hive service: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -717,10 +717,7 @@ func NewBee(
 		return nil, fmt.Errorf("pingpong service: %w", err)
 	}
 
-	hive, err := hive.New(p2ps, addressbook, networkID, o.BootnodeMode, o.AllowPrivateCIDRs, logger)
-	if err != nil {
-		return nil, fmt.Errorf("hive: %w", err)
-	}
+	hive := hive.New(p2ps, addressbook, networkID, o.BootnodeMode, o.AllowPrivateCIDRs, logger)
 
 	if err = p2ps.AddProtocol(hive.Protocol()); err != nil {
 		return nil, fmt.Errorf("hive service: %w", err)

--- a/pkg/p2p/libp2p/internal/reacher/reacher.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher.go
@@ -22,13 +22,6 @@ const (
 	retryAfterDuration = time.Minute * 5
 )
 
-type peerState int
-
-const (
-	waiting peerState = iota
-	inProgress
-)
-
 type peer struct {
 	overlay    swarm.Address
 	addr       ma.Multiaddr

--- a/pkg/p2p/libp2p/internal/reacher/reacher.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher.go
@@ -164,8 +164,10 @@ func (r *reacher) tryAcquirePeer() (*peer, time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
-	nextClosest := time.Time{}
+	var (
+		now         = time.Now()
+		nextClosest time.Time
+	)
 
 	for _, p := range r.peers {
 

--- a/pkg/p2p/libp2p/internal/reacher/reacher_test.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher_test.go
@@ -80,8 +80,6 @@ func TestPingSuccess(t *testing.T) {
 				t.Fatalf("test timed out")
 			case <-done:
 			}
-
-			testutil.CleanupCloser(t, r)
 		})
 	}
 }
@@ -122,10 +120,6 @@ func TestDisconnected(t *testing.T) {
 	r.Connected(swarm.RandAddress(t), nil)
 	r.Connected(disconnectedOverlay, disconnectedMa)
 	r.Disconnected(disconnectedOverlay)
-
-	time.Sleep(time.Millisecond * 50) // wait for reachable func to be called
-
-	testutil.CleanupCloser(t, r)
 }
 
 type mock struct {

--- a/pkg/p2p/libp2p/internal/reacher/reacher_test.go
+++ b/pkg/p2p/libp2p/internal/reacher/reacher_test.go
@@ -20,7 +20,6 @@ import (
 
 var defaultOptions = reacher.Options{
 	PingTimeout:        time.Second * 5,
-	PingMaxAttempts:    3,
 	Workers:            8,
 	RetryAfterDuration: time.Millisecond,
 }
@@ -81,6 +80,8 @@ func TestPingSuccess(t *testing.T) {
 				t.Fatalf("test timed out")
 			case <-done:
 			}
+
+			testutil.CleanupCloser(t, r)
 		})
 	}
 }
@@ -123,6 +124,8 @@ func TestDisconnected(t *testing.T) {
 	r.Disconnected(disconnectedOverlay)
 
 	time.Sleep(time.Millisecond * 50) // wait for reachable func to be called
+
+	testutil.CleanupCloser(t, r)
 }
 
 type mock struct {

--- a/pkg/spinlock/wait.go
+++ b/pkg/spinlock/wait.go
@@ -13,7 +13,7 @@ var ErrTimedOut = errors.New("timed out waiting for condition")
 
 // Wait blocks execution until condition is satisfied or until it times out.
 func Wait(timeoutDur time.Duration, cond func() bool) error {
-	return WaitWithInterval(timeoutDur, time.Millisecond*20, cond)
+	return WaitWithInterval(timeoutDur, time.Millisecond*50, cond)
 }
 
 // WaitWithInterval blocks execution until condition is satisfied or until it times out.

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -93,3 +93,7 @@ func closestPeer(peers *pslice.PSlice, addr swarm.Address) (swarm.Address, error
 
 	return closest, nil
 }
+
+func (k *Kad) Trigger() {
+	k.manageC <- struct{}{}
+}

--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -140,13 +140,6 @@ type Snapshot struct {
 	Healthy                    bool
 }
 
-// HasAtMaxOneConnectionAttempt returns true if the snapshot represents a new
-// peer which has at maximum one session connection attempt, but it still isn't
-// logged in.
-func (ss *Snapshot) HasAtMaxOneConnectionAttempt() bool {
-	return ss.LastSeenTimestamp == 0 && ss.SessionConnectionRetry <= 1
-}
-
 // persistentCounters is a helper struct used for persisting selected counters.
 type persistentCounters struct {
 	PeerAddress       swarm.Address `json:"peerAddress"`

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -542,6 +542,7 @@ func (k *Kad) manage() {
 		}
 	}()
 
+	// tell each neighbor about other neighbors periodically
 	k.wg.Add(1)
 	go func() {
 		defer k.wg.Done()

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -553,7 +553,7 @@ func (k *Kad) manage() {
 				return
 			case <-time.After(5 * time.Minute):
 				var neighbors []swarm.Address
-				k.connectedPeers.EachBin(func(addr swarm.Address, bin uint8) (stop bool, jumpToNext bool, err error) {
+				_ = k.connectedPeers.EachBin(func(addr swarm.Address, bin uint8) (stop bool, jumpToNext bool, err error) {
 					if bin < k.neighborhoodDepth() {
 						return true, false, nil
 					}

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -815,7 +815,7 @@ func TestAddressBookPrune(t *testing.T) {
 		})
 	)
 
-	kad.SetStorageRadius(0)
+	kad.SetStorageRadius(2)
 
 	if err := kad.Start(context.Background()); err != nil {
 		t.Fatal(err)
@@ -887,7 +887,7 @@ func TestAddressBookQuickPrune(t *testing.T) {
 			TimeToRetry: ptrDuration(50 * time.Millisecond),
 		})
 	)
-	kad.SetStorageRadius(0)
+	kad.SetStorageRadius(2)
 
 	if err := kad.Start(context.Background()); err != nil {
 		t.Fatal(err)

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -888,7 +888,7 @@ func TestAddressBookQuickPrune(t *testing.T) {
 	var (
 		conns, failedConns       int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, &failedConns, kademlia.Options{
-			TimeToRetry: ptrDuration(50 * time.Millisecond),
+			TimeToRetry: ptrDuration(time.Millisecond),
 		})
 	)
 	kad.SetStorageRadius(2)

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -811,11 +811,11 @@ func TestAddressBookPrune(t *testing.T) {
 	var (
 		conns, failedConns       int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, &failedConns, kademlia.Options{
-			TimeToRetry: ptrDuration(20 * time.Millisecond),
+			TimeToRetry: ptrDuration(0),
 		})
 	)
 
-	kad.SetStorageRadius(2)
+	kad.SetStorageRadius(0)
 
 	if err := kad.Start(context.Background()); err != nil {
 		t.Fatal(err)
@@ -833,6 +833,10 @@ func TestAddressBookPrune(t *testing.T) {
 	// add non connectable peer, check connection and failed connection counters
 	kad.AddPeers(nonConnPeer.Overlay)
 	waitCounter(t, &conns, 0)
+	waitCounter(t, &failedConns, 1)
+	kad.Trigger()
+	waitCounter(t, &failedConns, 1)
+	kad.Trigger()
 	waitCounter(t, &failedConns, 1)
 
 	_, err = ab.Get(nonConnPeer.Overlay)

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethersphere/bee/pkg/util/testutil"
 )
 
-const spinLockWaitTime = time.Second * 3
+const spinLockWaitTime = time.Second * 5
 
 var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA")
 var defaultFilterFunc kademlia.FilterFunc = func(...im.FilterOp) kademlia.PeerFilterFunc {
@@ -789,6 +789,8 @@ func TestBackoff(t *testing.T) {
 	// remove that peer
 	removeOne(kad, addr)
 
+	waitCounter(t, &conns, 0)
+
 	// wait for 100ms, add another peer, expect just one more connection
 	time.Sleep(100 * time.Millisecond)
 	addr = swarm.RandAddressAt(t, base, 1)
@@ -832,12 +834,12 @@ func TestAddressBookPrune(t *testing.T) {
 
 	// add non connectable peer, check connection and failed connection counters
 	kad.AddPeers(nonConnPeer.Overlay)
+
+	kad.Trigger()
+	kad.Trigger()
+
 	waitCounter(t, &conns, 0)
-	waitCounter(t, &failedConns, 1)
-	kad.Trigger()
-	waitCounter(t, &failedConns, 1)
-	kad.Trigger()
-	waitCounter(t, &failedConns, 1)
+	waitCounter(t, &failedConns, 3)
 
 	_, err = ab.Get(nonConnPeer.Overlay)
 	if !errors.Is(err, addressbook.ErrNotFound) {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -66,7 +66,7 @@ type Select struct {
 }
 
 // EachPeerFunc is a callback that is called with a peer and its PO
-type EachPeerFunc func(swarm.Address, uint8) (stop, jumpToNext bool, err error)
+type EachPeerFunc func(addr swarm.Address, bin uint8) (stop, jumpToNext bool, err error)
 
 // PeerInfo is a view of peer information exposed to a user.
 type PeerInfo struct {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
* Reacher now periodically tests a peer's reachability, instead of doing it only once after the initial connection
* All of the neighbor peers are broadcasted to the neighbor after a connection
* Kademlia will prediocally (hive) broadcast to each neighbor about other neighbors
* Neighbor max connect attempt increased. 
* Hive will re-add a peer if the underlay has changed.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
