### PR TITLE
fix: cache and stamper store

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -796,7 +796,7 @@ func NewBee(
 				syncErr.Store(err)
 				return nil, fmt.Errorf("unable to start batch service: %w", err)
 			} else {
-				err = post.SetExpired()
+				err = post.SetExpired(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("unable to set expirations: %w", err)
 				}
@@ -811,7 +811,7 @@ func NewBee(
 					logger.Error(err, "unable to sync batches")
 					b.syncingStopped.Signal() // trigger shutdown in start.go
 				} else {
-					err = post.SetExpired()
+					err = post.SetExpired(ctx)
 					if err != nil {
 						logger.Error(err, "unable to set expirations")
 					}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -293,6 +293,11 @@ func (s *store) cleanup() error {
 	}
 
 	for _, b := range evictions {
+		s.logger.Debug("batch expired", "batch_id", hex.EncodeToString(b.ID))
+		err = s.evictFn(b.ID)
+		if err != nil {
+			return fmt.Errorf("evict batch %x: %w", b.ID, err)
+		}
 		err := s.store.Delete(valueKey(b.Value, b.ID))
 		if err != nil {
 			return fmt.Errorf("delete value key for batch %x: %w", b.ID, err)
@@ -300,10 +305,6 @@ func (s *store) cleanup() error {
 		err = s.store.Delete(batchKey(b.ID))
 		if err != nil {
 			return fmt.Errorf("delete batch %x: %w", b.ID, err)
-		}
-		err = s.evictFn(b.ID)
-		if err != nil {
-			return fmt.Errorf("evict batch %x: %w", b.ID, err)
 		}
 		if s.batchExpiry != nil {
 			s.batchExpiry.HandleStampExpiry(b.ID)

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -98,5 +98,5 @@ type BatchEventListener interface {
 
 type BatchExpiryHandler interface {
 	HandleStampExpiry([]byte)
-	SetExpired() error
+	SetExpired(context.Context) error
 }

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	"bytes"
+	"context"
 	"math/big"
 	"sync"
 
@@ -51,7 +52,7 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
-func (m *mockPostage) SetExpired() error {
+func (m *mockPostage) SetExpired(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -198,7 +198,7 @@ func (ps *service) SetExpired() error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
-	ps.logger.Debug("running set expired")
+	ps.logger.Debug("removing expired stamp issuers and stamp data")
 
 	for _, issuer := range ps.issuers {
 		exists, err := ps.postageStore.Exists(issuer.ID())

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -238,6 +238,8 @@ func (ps *service) SetExpired() error {
 		}
 	}
 
+	ps.logger.Debug("removed expired stamps", "count", len(deleteItems))
+
 	return ps.reload()
 }
 

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -6,6 +6,7 @@ package postage_test
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"errors"
 	"io"
@@ -243,7 +244,7 @@ func TestSetExpired(t *testing.T) {
 		t.Fatalf("expected %v, got %v", postage.ErrNotUsable, err)
 	}
 
-	err = ps.SetExpired()
+	err = ps.SetExpired(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storer/cachestore.go
+++ b/pkg/storer/cachestore.go
@@ -32,12 +32,15 @@ func (db *DB) cacheWorker(ctx context.Context) {
 		select {
 		case <-overCapTrigger:
 
-			var size, capc = db.cacheObj.Size(), db.cacheObj.Capacity()
+			var (
+				size = db.cacheObj.Size()
+				capc = db.cacheObj.Capacity()
+			)
 			if size <= capc {
 				continue
 			}
 
-			evict := (size - capc) + uint64(float64(capc)*0.01) // evict (size - cap) + some buffer
+			evict := (size - capc)
 
 			dur := captureDuration(time.Now())
 			err := db.Execute(ctx, func(s internal.Storage) error {
@@ -115,7 +118,10 @@ func (db *DB) CacheShallowCopy(ctx context.Context, store internal.Storage, addr
 
 func (db *DB) triggerCacheEviction() {
 
-	var size, capc = db.cacheObj.Size(), db.cacheObj.Capacity()
+	var (
+		size = db.cacheObj.Size()
+		capc = db.cacheObj.Capacity()
+	)
 	db.metrics.CacheSize.Set(float64(size))
 
 	if size > capc {

--- a/pkg/storer/cachestore.go
+++ b/pkg/storer/cachestore.go
@@ -41,7 +41,7 @@ func (db *DB) cacheWorker(ctx context.Context) {
 
 			dur := captureDuration(time.Now())
 			err := db.Execute(ctx, func(s internal.Storage) error {
-				return db.cacheObj.RemoveOldest(ctx, s, s.ChunkStore(), uint64(evict))
+				return db.cacheObj.RemoveOldest(ctx, s, s.ChunkStore(), evict)
 			})
 			db.metrics.MethodCallsDuration.WithLabelValues("cachestore", "RemoveOldest").Observe(dur())
 			if err != nil {

--- a/pkg/storer/cachestore.go
+++ b/pkg/storer/cachestore.go
@@ -49,7 +49,7 @@ func (db *DB) cacheWorker(ctx context.Context) {
 			if err != nil {
 				db.logger.Warning("cache eviction failure", "error", err)
 			}
-		case <-ctx.Done():
+		case <-db.quit:
 			return
 		}
 	}

--- a/pkg/storer/cachestore.go
+++ b/pkg/storer/cachestore.go
@@ -30,6 +30,8 @@ func (db *DB) cacheWorker(ctx context.Context) {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-overCapTrigger:
 
 			var (
@@ -40,7 +42,7 @@ func (db *DB) cacheWorker(ctx context.Context) {
 				continue
 			}
 
-			evict := (size - capc)
+			evict := min(1_000, (size - capc))
 
 			dur := captureDuration(time.Now())
 			err := db.Execute(ctx, func(s internal.Storage) error {

--- a/pkg/storer/cachestore.go
+++ b/pkg/storer/cachestore.go
@@ -41,10 +41,10 @@ func (db *DB) cacheWorker(ctx context.Context) {
 				continue
 			}
 
-			newSize := size - uint64((float64(capc) * 0.90)) // evict until cache size is 90% of capacity
+			evict := size - uint64((float64(capc) * 0.90)) // evict until cache size is 90% of capacity
 
 			err := db.Execute(ctx, func(s internal.Storage) error {
-				return db.cacheObj.RemoveOldest(ctx, s, s.ChunkStore(), newSize)
+				return db.cacheObj.RemoveOldest(ctx, s, s.ChunkStore(), evict)
 			})
 			if err != nil {
 				db.logger.Warning("cache eviction failure", "error", err)

--- a/pkg/storer/internal/cache/cache.go
+++ b/pkg/storer/internal/cache/cache.go
@@ -311,7 +311,14 @@ func (c *Cache) RemoveOldest(
 		}
 	}
 
-	return batch.Commit()
+	err = batch.Commit()
+	if err != nil {
+		return err
+	}
+
+	c.size.Add(-int64(len(evictItems)))
+
+	return nil
 }
 
 type cacheEntry struct {

--- a/pkg/storer/internal/cache/cache.go
+++ b/pkg/storer/internal/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -27,13 +28,295 @@ const cacheEntrySize = swarm.HashSize + 8
 
 var _ storage.Item = (*cacheEntry)(nil)
 
-var CacheEvictionBatchSize = 1000
+var CacheEvictionBatchSize = 10_000
 
 var (
 	errMarshalCacheEntryInvalidAddress   = errors.New("marshal cacheEntry: invalid address")
 	errMarshalCacheEntryInvalidTimestamp = errors.New("marshal cacheEntry: invalid timestamp")
 	errUnmarshalCacheEntryInvalidSize    = errors.New("unmarshal cacheEntry: invalid size")
 )
+
+// Cache is the part of the localstore which keeps track of the chunks that are not
+// part of the reserve but are potentially useful to store for obtaining bandwidth
+// incentives. In order to avoid GC we will only keep track of a fixed no. of chunks
+// as part of the cache and evict a chunk as soon as we go above capacity.
+type Cache struct {
+	size     atomic.Int64
+	capacity int
+
+	mtx sync.RWMutex
+}
+
+// New creates a new Cache component with the specified capacity. The store is used
+// here only to read the initial state of the cache before shutdown if there was
+// any.
+func New(ctx context.Context, store internal.Storage, capacity uint64) (*Cache, error) {
+	count, err := store.IndexStore().Count(&cacheEntry{})
+	if err != nil {
+		return nil, fmt.Errorf("failed counting cache entries: %w", err)
+	}
+
+	c := &Cache{capacity: int(capacity)}
+	c.size.Store(int64(count))
+
+	return c, nil
+}
+
+// Size returns the current size of the cache.
+func (c *Cache) Size() uint64 {
+	return uint64(c.size.Load())
+}
+
+// Capacity returns the capacity of the cache.
+func (c *Cache) Capacity() uint64 { return uint64(c.capacity) }
+
+// Putter returns a Storage.Putter instance which adds the chunk to the underlying
+// chunkstore and also adds a Cache entry for the chunk.
+func (c *Cache) Putter(store internal.Storage) storage.Putter {
+	return storage.PutterFunc(func(ctx context.Context, chunk swarm.Chunk) error {
+
+		c.mtx.Lock()
+		defer c.mtx.Unlock()
+
+		newEntry := &cacheEntry{Address: chunk.Address()}
+		found, err := store.IndexStore().Has(newEntry)
+		if err != nil {
+			return fmt.Errorf("failed checking has cache entry: %w", err)
+		}
+
+		// if chunk is already part of cache, return found.
+		if found {
+			return nil
+		}
+
+		batch, err := store.IndexStore().Batch(ctx)
+		if err != nil {
+			return fmt.Errorf("failed creating batch: %w", err)
+		}
+
+		newEntry.AccessTimestamp = now().UnixNano()
+		err = batch.Put(newEntry)
+		if err != nil {
+			return fmt.Errorf("failed adding cache entry: %w", err)
+		}
+
+		err = batch.Put(&cacheOrderIndex{
+			Address:         newEntry.Address,
+			AccessTimestamp: newEntry.AccessTimestamp,
+		})
+		if err != nil {
+			return fmt.Errorf("failed adding cache order index: %w", err)
+		}
+
+		if err := batch.Commit(); err != nil {
+			return fmt.Errorf("batch commit: %w", err)
+		}
+
+		err = store.ChunkStore().Put(ctx, chunk)
+		if err != nil {
+			return fmt.Errorf("failed adding chunk to chunkstore: %w", err)
+		}
+
+		c.size.Add(1)
+
+		return nil
+	})
+}
+
+// Getter returns a Storage.Getter instance which checks if the chunks accessed are
+// part of cache it will update the cache indexes. If the operation to update the
+// cache indexes fail, we need to fail the operation as this should signal the user
+// of this getter to rollback the operation.
+func (c *Cache) Getter(store internal.Storage) storage.Getter {
+	return storage.GetterFunc(func(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
+
+		c.mtx.RLock()
+		defer c.mtx.RUnlock()
+
+		ch, err := store.ChunkStore().Get(ctx, address)
+		if err != nil {
+			return nil, err
+		}
+
+		// check if there is an entry in Cache. As this is the download path, we do
+		// a best-effort operation. So in case of any error we return the chunk.
+		entry := &cacheEntry{Address: address}
+		err = store.IndexStore().Get(entry)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return ch, nil
+			}
+			return nil, fmt.Errorf("unexpected error getting indexstore entry: %w", err)
+		}
+
+		batch, err := store.IndexStore().Batch(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating batch: %w", err)
+		}
+
+		err = batch.Delete(&cacheOrderIndex{
+			Address:         entry.Address,
+			AccessTimestamp: entry.AccessTimestamp,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed deleting cache order index: %w", err)
+		}
+
+		entry.AccessTimestamp = now().UnixNano()
+		err = batch.Put(&cacheOrderIndex{
+			Address:         entry.Address,
+			AccessTimestamp: entry.AccessTimestamp,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed adding cache order index: %w", err)
+		}
+
+		err = batch.Put(entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed adding cache entry: %w", err)
+		}
+
+		err = batch.Commit()
+		if err != nil {
+			return nil, fmt.Errorf("batch commit: %w", err)
+		}
+
+		return ch, nil
+	})
+}
+
+// ShallowCopy creates cache entries with the expectation that the chunk already exists in the chunkstore.
+func (c *Cache) ShallowCopy(
+	ctx context.Context,
+	store internal.Storage,
+	addrs ...swarm.Address,
+) (err error) {
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	defer func() {
+		if err != nil {
+			for _, addr := range addrs {
+				err = errors.Join(store.ChunkStore().Delete(context.Background(), addr))
+			}
+		}
+	}()
+
+	//consider only the amount that can fit, the rest should be deleted from the chunkstore.
+	if len(addrs) > c.capacity {
+		for _, addr := range addrs[:len(addrs)-c.capacity] {
+			_ = store.ChunkStore().Delete(ctx, addr)
+		}
+		addrs = addrs[len(addrs)-c.capacity:]
+	}
+
+	entriesToAdd := make([]*cacheEntry, 0, len(addrs))
+	for _, addr := range addrs {
+		entry := &cacheEntry{Address: addr}
+		if has, err := store.IndexStore().Has(entry); err == nil && has {
+			continue
+		}
+		entry.AccessTimestamp = now().UnixNano()
+		entriesToAdd = append(entriesToAdd, entry)
+	}
+
+	if len(entriesToAdd) == 0 {
+		return nil
+	}
+
+	batch, err := store.IndexStore().Batch(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating batch: %w", err)
+	}
+
+	for _, entry := range entriesToAdd {
+		err = batch.Put(entry)
+		if err != nil {
+			return fmt.Errorf("failed adding entry %s: %w", entry, err)
+		}
+		err = batch.Put(&cacheOrderIndex{
+			Address:         entry.Address,
+			AccessTimestamp: entry.AccessTimestamp,
+		})
+		if err != nil {
+			return fmt.Errorf("failed adding cache order index: %w", err)
+		}
+	}
+
+	if err := batch.Commit(); err != nil {
+		return fmt.Errorf("batch commit: %w", err)
+	}
+
+	c.size.Add(int64(len(entriesToAdd)))
+
+	return nil
+}
+
+// RemoveOldest removes the oldest cache entries from the store. The count
+// specifies the number of entries to remove.
+func (c *Cache) RemoveOldest(
+	ctx context.Context,
+	store internal.Storage,
+	chStore storage.ChunkStore,
+	count uint64,
+) error {
+	if count <= 0 {
+		return nil
+	}
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	evictItems := make([]*cacheEntry, 0, count)
+	err := store.IndexStore().Iterate(
+		storage.Query{
+			Factory:      func() storage.Item { return &cacheOrderIndex{} },
+			ItemProperty: storage.QueryItemID,
+		},
+		func(res storage.Result) (bool, error) {
+			accessTime, addr, err := idFromKey(res.ID)
+			if err != nil {
+				return false, fmt.Errorf("failed to parse cache order index %s: %w", res.ID, err)
+			}
+			entry := &cacheEntry{
+				Address:         addr,
+				AccessTimestamp: accessTime,
+			}
+			evictItems = append(evictItems, entry)
+			count--
+			return count == 0, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed iterating over cache order index: %w", err)
+	}
+
+	batch, err := store.IndexStore().Batch(ctx)
+	if err != nil {
+		return fmt.Errorf("failed creating batch: %w", err)
+	}
+
+	for _, entry := range evictItems {
+		err = batch.Delete(entry)
+		if err != nil {
+			return fmt.Errorf("failed deleting cache entry %s: %w", entry, err)
+		}
+		err = batch.Delete(&cacheOrderIndex{
+			Address:         entry.Address,
+			AccessTimestamp: entry.AccessTimestamp,
+		})
+		if err != nil {
+			return fmt.Errorf("failed deleting cache order index %s: %w", entry.Address, err)
+		}
+		err = chStore.Delete(ctx, entry.Address)
+		if err != nil {
+			return fmt.Errorf("failed deleting chunk %s from chunkstore: %w", entry.Address, err)
+		}
+	}
+
+	return batch.Commit()
+}
 
 type cacheEntry struct {
 	Address         swarm.Address
@@ -138,318 +421,4 @@ func (c cacheOrderIndex) String() string {
 		c.AccessTimestamp,
 		c.Address.ByteString(),
 	)
-}
-
-// Cache is the part of the localstore which keeps track of the chunks that are not
-// part of the reserve but are potentially useful to store for obtaining bandwidth
-// incentives. In order to avoid GC we will only keep track of a fixed no. of chunks
-// as part of the cache and evict a chunk as soon as we go above capacity.
-type Cache struct {
-	size     atomic.Int64
-	capacity int
-}
-
-// New creates a new Cache component with the specified capacity. The store is used
-// here only to read the initial state of the cache before shutdown if there was
-// any.
-func New(ctx context.Context, store internal.Storage, capacity uint64) (*Cache, error) {
-	count, err := store.IndexStore().Count(&cacheEntry{})
-	if err != nil {
-		return nil, fmt.Errorf("failed counting cache entries: %w", err)
-	}
-
-	if count > int(capacity) {
-		err := removeOldest(
-			ctx,
-			store.IndexStore(),
-			store.IndexStore(),
-			store.ChunkStore(),
-			count-int(capacity),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed removing oldest cache entries: %w", err)
-		}
-		count = int(capacity)
-	}
-
-	c := &Cache{capacity: int(capacity)}
-	c.size.Store(int64(count))
-
-	return c, nil
-}
-
-// removeOldest removes the oldest cache entries from the store. The count
-// specifies the number of entries to remove.
-func removeOldest(
-	ctx context.Context,
-	store storage.Reader,
-	writer storage.Writer,
-	chStore storage.ChunkStore,
-	count int,
-) error {
-	if count <= 0 {
-		return nil
-	}
-
-	evictItems := make([]*cacheEntry, 0, count)
-	err := store.Iterate(
-		storage.Query{
-			Factory:      func() storage.Item { return &cacheOrderIndex{} },
-			ItemProperty: storage.QueryItemID,
-		},
-		func(res storage.Result) (bool, error) {
-			accessTime, addr, err := idFromKey(res.ID)
-			if err != nil {
-				return false, fmt.Errorf("failed to parse cache order index %s: %w", res.ID, err)
-			}
-			entry := &cacheEntry{
-				Address:         addr,
-				AccessTimestamp: accessTime,
-			}
-			evictItems = append(evictItems, entry)
-			count--
-			return count == 0, nil
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed iterating over cache order index: %w", err)
-	}
-
-	for _, entry := range evictItems {
-		err = writer.Delete(entry)
-		if err != nil {
-			return fmt.Errorf("failed deleting cache entry %s: %w", entry, err)
-		}
-		err = writer.Delete(&cacheOrderIndex{
-			Address:         entry.Address,
-			AccessTimestamp: entry.AccessTimestamp,
-		})
-		if err != nil {
-			return fmt.Errorf("failed deleting cache order index %s: %w", entry.Address, err)
-		}
-		err = chStore.Delete(ctx, entry.Address)
-		if err != nil {
-			return fmt.Errorf("failed deleting chunk %s from chunkstore: %w", entry.Address, err)
-		}
-	}
-
-	return nil
-}
-
-// Size returns the current size of the cache.
-func (c *Cache) Size() uint64 {
-	return uint64(c.size.Load())
-}
-
-// Capacity returns the capacity of the cache.
-func (c *Cache) Capacity() uint64 { return uint64(c.capacity) }
-
-// Putter returns a Storage.Putter instance which adds the chunk to the underlying
-// chunkstore and also adds a Cache entry for the chunk.
-func (c *Cache) Putter(store internal.Storage) storage.Putter {
-	return storage.PutterFunc(func(ctx context.Context, chunk swarm.Chunk) error {
-		newEntry := &cacheEntry{Address: chunk.Address()}
-		found, err := store.IndexStore().Has(newEntry)
-		if err != nil {
-			return fmt.Errorf("failed checking has cache entry: %w", err)
-		}
-
-		// if chunk is already part of cache, return found.
-		if found {
-			return nil
-		}
-
-		batch, err := store.IndexStore().Batch(ctx)
-		if err != nil {
-			return fmt.Errorf("failed creating batch: %w", err)
-		}
-
-		newEntry.AccessTimestamp = now().UnixNano()
-		err = batch.Put(newEntry)
-		if err != nil {
-			return fmt.Errorf("failed adding cache entry: %w", err)
-		}
-
-		err = batch.Put(&cacheOrderIndex{
-			Address:         newEntry.Address,
-			AccessTimestamp: newEntry.AccessTimestamp,
-		})
-		if err != nil {
-			return fmt.Errorf("failed adding cache order index: %w", err)
-		}
-
-		evicted := false
-		if c.size.Load() >= int64(c.capacity) {
-			evicted = true
-			err := removeOldest(
-				ctx,
-				store.IndexStore(),
-				batch,
-				store.ChunkStore(),
-				CacheEvictionBatchSize,
-			)
-			if err != nil {
-				return fmt.Errorf("failed removing oldest cache entries: %w", err)
-			}
-		}
-
-		if err := batch.Commit(); err != nil {
-			return fmt.Errorf("batch commit: %w", err)
-		}
-
-		err = store.ChunkStore().Put(ctx, chunk)
-		if err != nil {
-			return fmt.Errorf("failed adding chunk to chunkstore: %w", err)
-		}
-
-		if evicted {
-			c.size.Add(-int64(CacheEvictionBatchSize))
-		}
-		c.size.Add(1)
-
-		return nil
-	})
-}
-
-// Getter returns a Storage.Getter instance which checks if the chunks accessed are
-// part of cache it will update the cache indexes. If the operation to update the
-// cache indexes fail, we need to fail the operation as this should signal the user
-// of this getter to rollback the operation.
-func (c *Cache) Getter(store internal.Storage) storage.Getter {
-	return storage.GetterFunc(func(ctx context.Context, address swarm.Address) (swarm.Chunk, error) {
-		ch, err := store.ChunkStore().Get(ctx, address)
-		if err != nil {
-			return nil, err
-		}
-
-		// check if there is an entry in Cache. As this is the download path, we do
-		// a best-effort operation. So in case of any error we return the chunk.
-		entry := &cacheEntry{Address: address}
-		err = store.IndexStore().Get(entry)
-		if err != nil {
-			if errors.Is(err, storage.ErrNotFound) {
-				return ch, nil
-			}
-			return nil, fmt.Errorf("unexpected error getting indexstore entry: %w", err)
-		}
-
-		batch, err := store.IndexStore().Batch(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed creating batch: %w", err)
-		}
-
-		err = batch.Delete(&cacheOrderIndex{
-			Address:         entry.Address,
-			AccessTimestamp: entry.AccessTimestamp,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed deleting cache order index: %w", err)
-		}
-
-		entry.AccessTimestamp = now().UnixNano()
-		err = batch.Put(&cacheOrderIndex{
-			Address:         entry.Address,
-			AccessTimestamp: entry.AccessTimestamp,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed adding cache order index: %w", err)
-		}
-
-		err = batch.Put(entry)
-		if err != nil {
-			return nil, fmt.Errorf("failed adding cache entry: %w", err)
-		}
-
-		err = batch.Commit()
-		if err != nil {
-			return nil, fmt.Errorf("batch commit: %w", err)
-		}
-
-		return ch, nil
-	})
-}
-
-// MoveFromReserve moves the chunks from the reserve to the cache. This is
-// called when the reserve is full and we need to perform eviction.
-// It avoids the need to delete the chunk and re-add it to the cache.
-func (c *Cache) MoveFromReserve(
-	ctx context.Context,
-	store internal.Storage,
-	addrs ...swarm.Address,
-) (err error) {
-
-	defer func() {
-		if err != nil {
-			for _, addr := range addrs {
-				err = errors.Join(store.ChunkStore().Delete(context.Background(), addr))
-			}
-		}
-	}()
-
-	batch, err := store.IndexStore().Batch(ctx)
-	if err != nil {
-		return fmt.Errorf("failed creating batch: %w", err)
-	}
-
-	entriesToAdd := make([]*cacheEntry, 0, len(addrs))
-	for _, addr := range addrs {
-		entry := &cacheEntry{Address: addr}
-		if has, err := store.IndexStore().Has(entry); err == nil && has {
-			continue
-		}
-		entry.AccessTimestamp = now().UnixNano()
-		entriesToAdd = append(entriesToAdd, entry)
-	}
-
-	if len(entriesToAdd) == 0 {
-		return nil
-	}
-
-	//consider only the amount that can fit, the rest should be deleted from the chunkstore.
-	if len(entriesToAdd) > c.capacity {
-		for _, e := range entriesToAdd[:len(entriesToAdd)-c.capacity] {
-			_ = store.ChunkStore().Delete(ctx, e.Address)
-		}
-		entriesToAdd = entriesToAdd[len(entriesToAdd)-c.capacity:]
-	}
-
-	var entriesToRemove int
-	if c.size.Load()+int64(len(entriesToAdd)) > int64(c.capacity) {
-		entriesToRemove = int(c.size.Load() + int64(len(entriesToAdd)) - int64(c.capacity))
-	}
-
-	if entriesToRemove > 0 {
-		err := removeOldest(
-			ctx,
-			store.IndexStore(),
-			batch,
-			store.ChunkStore(),
-			entriesToRemove,
-		)
-		if err != nil {
-			return fmt.Errorf("failed removing oldest cache entries: %w", err)
-		}
-	}
-
-	for _, entry := range entriesToAdd {
-		err = batch.Put(entry)
-		if err != nil {
-			return fmt.Errorf("failed adding entry %s: %w", entry, err)
-		}
-		err = batch.Put(&cacheOrderIndex{
-			Address:         entry.Address,
-			AccessTimestamp: entry.AccessTimestamp,
-		})
-		if err != nil {
-			return fmt.Errorf("failed adding cache order index: %w", err)
-		}
-	}
-
-	if err := batch.Commit(); err != nil {
-		return fmt.Errorf("batch commit: %w", err)
-	}
-
-	c.size.Add(int64(len(entriesToAdd)) - int64(entriesToRemove))
-
-	return nil
 }

--- a/pkg/storer/internal/cache/cache.go
+++ b/pkg/storer/internal/cache/cache.go
@@ -28,8 +28,6 @@ const cacheEntrySize = swarm.HashSize + 8
 
 var _ storage.Item = (*cacheEntry)(nil)
 
-var CacheEvictionBatchSize = 10_000
-
 var (
 	errMarshalCacheEntryInvalidAddress   = errors.New("marshal cacheEntry: invalid address")
 	errMarshalCacheEntryInvalidTimestamp = errors.New("marshal cacheEntry: invalid timestamp")

--- a/pkg/storer/internal/cache/cache.go
+++ b/pkg/storer/internal/cache/cache.go
@@ -261,9 +261,6 @@ func (c *Cache) RemoveOldest(
 		return nil
 	}
 
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
 	evictItems := make([]*cacheEntry, 0, count)
 	err := store.IndexStore().Iterate(
 		storage.Query{
@@ -292,6 +289,9 @@ func (c *Cache) RemoveOldest(
 	if err != nil {
 		return fmt.Errorf("failed creating batch: %w", err)
 	}
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 
 	for _, entry := range evictItems {
 		err = batch.Delete(entry)

--- a/pkg/storer/internal/cache/cache_test.go
+++ b/pkg/storer/internal/cache/cache_test.go
@@ -158,12 +158,9 @@ func (t *timeProvider) Now() func() time.Time {
 func TestMain(m *testing.M) {
 	p := &timeProvider{t: time.Now().UnixNano()}
 	done := cache.ReplaceTimeNow(p.Now())
-	old := cache.CacheEvictionBatchSize
 	defer func() {
 		done()
-		cache.CacheEvictionBatchSize = old
 	}()
-	cache.CacheEvictionBatchSize = 1
 	code := m.Run()
 	os.Exit(code)
 }

--- a/pkg/storer/internal/cache/cache_test.go
+++ b/pkg/storer/internal/cache/cache_test.go
@@ -212,35 +212,6 @@ func TestCache(t *testing.T) {
 			verifyCacheState(t, st.IndexStore(), c2, chunks[0].Address(), chunks[len(chunks)-1].Address(), uint64(len(chunks)))
 			verifyCacheOrder(t, c2, st.IndexStore(), chunks...)
 		})
-
-		chunks2 := chunktest.GenerateTestRandomChunks(10)
-
-		t.Run("add over capacity", func(t *testing.T) {
-			for idx, ch := range chunks2 {
-				err := c.Putter(st).Put(context.TODO(), ch)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if idx == len(chunks)-1 {
-					verifyCacheState(t, st.IndexStore(), c, chunks2[0].Address(), chunks2[idx].Address(), 10)
-					verifyCacheOrder(t, c, st.IndexStore(), chunks2...)
-				} else {
-					verifyCacheState(t, st.IndexStore(), c, chunks[idx+1].Address(), chunks2[idx].Address(), 10)
-					verifyCacheOrder(t, c, st.IndexStore(), append(chunks[idx+1:], chunks2[:idx+1]...)...)
-				}
-			}
-			verifyChunksDeleted(t, st.ChunkStore(), chunks...)
-		})
-
-		t.Run("new with lower capacity", func(t *testing.T) {
-			c2, err := cache.New(context.TODO(), st, 5)
-			if err != nil {
-				t.Fatal(err)
-			}
-			verifyCacheState(t, st.IndexStore(), c2, chunks2[5].Address(), chunks2[len(chunks)-1].Address(), 5)
-			verifyCacheOrder(t, c2, st.IndexStore(), chunks2[5:]...)
-			verifyChunksDeleted(t, st.ChunkStore(), chunks[:5]...)
-		})
 	})
 
 	t.Run("getter", func(t *testing.T) {
@@ -379,7 +350,7 @@ func TestCache(t *testing.T) {
 	})
 }
 
-func TestMoveFromReserve(t *testing.T) {
+func TestShallowCopy(t *testing.T) {
 	t.Parallel()
 
 	st := newTestStorage(t)
@@ -388,109 +359,103 @@ func TestMoveFromReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("move from reserve", func(t *testing.T) {
-		chunks := chunktest.GenerateTestRandomChunks(10)
-		chunksToMove := make([]swarm.Address, 0, 10)
+	chunks := chunktest.GenerateTestRandomChunks(10)
+	chunksToMove := make([]swarm.Address, 0, 10)
 
-		// add the chunks to chunkstore. This simulates the reserve already populating
-		// the chunkstore with chunks.
-		for _, ch := range chunks {
-			err := st.ChunkStore().Put(context.Background(), ch)
-			if err != nil {
-				t.Fatal(err)
-			}
-			chunksToMove = append(chunksToMove, ch.Address())
-		}
-
-		err = c.MoveFromReserve(context.Background(), st, chunksToMove...)
+	// add the chunks to chunkstore. This simulates the reserve already populating
+	// the chunkstore with chunks.
+	for _, ch := range chunks {
+		err := st.ChunkStore().Put(context.Background(), ch)
 		if err != nil {
 			t.Fatal(err)
 		}
+		chunksToMove = append(chunksToMove, ch.Address())
+	}
 
-		verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
-		verifyCacheOrder(t, c, st.IndexStore(), chunks...)
+	err = c.ShallowCopy(context.Background(), st, chunksToMove...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		// move again, should be no-op
-		err = c.MoveFromReserve(context.Background(), st, chunksToMove...)
+	verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
+	verifyCacheOrder(t, c, st.IndexStore(), chunks...)
+
+	// move again, should be no-op
+	err = c.ShallowCopy(context.Background(), st, chunksToMove...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
+	verifyCacheOrder(t, c, st.IndexStore(), chunks...)
+
+	chunks1 := chunktest.GenerateTestRandomChunks(10)
+	chunksToMove1 := make([]swarm.Address, 0, 10)
+
+	// add the chunks to chunkstore. This simulates the reserve already populating
+	// the chunkstore with chunks.
+	for _, ch := range chunks1 {
+		err := st.ChunkStore().Put(context.Background(), ch)
 		if err != nil {
 			t.Fatal(err)
 		}
+		chunksToMove1 = append(chunksToMove1, ch.Address())
+	}
 
-		verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
-		verifyCacheOrder(t, c, st.IndexStore(), chunks...)
-	})
+	// move new chunks
+	err = c.ShallowCopy(context.Background(), st, chunksToMove1...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	t.Run("move from reserve new chunks", func(t *testing.T) {
-		chunks := chunktest.GenerateTestRandomChunks(10)
-		chunksToMove := make([]swarm.Address, 0, 10)
+	verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks1[9].Address(), 20)
+	verifyCacheOrder(t, c, st.IndexStore(), append(chunks, chunks1...)...)
 
-		// add the chunks to chunkstore. This simulates the reserve already populating
-		// the chunkstore with chunks.
-		for _, ch := range chunks {
-			err := st.ChunkStore().Put(context.Background(), ch)
-			if err != nil {
-				t.Fatal(err)
-			}
-			chunksToMove = append(chunksToMove, ch.Address())
-		}
+	err = c.RemoveOldest(context.Background(), st, st.ChunkStore(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		// move new chunks
-		err = c.MoveFromReserve(context.Background(), st, chunksToMove...)
+	verifyChunksDeleted(t, st.ChunkStore(), chunks...)
+}
+
+func TestShallowCopyOverCap(t *testing.T) {
+	t.Parallel()
+
+	st := newTestStorage(t)
+	c, err := cache.New(context.Background(), st, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chunks := chunktest.GenerateTestRandomChunks(15)
+	chunksToMove := make([]swarm.Address, 0, 15)
+
+	// add the chunks to chunkstore. This simulates the reserve already populating
+	// the chunkstore with chunks.
+	for _, ch := range chunks {
+		err := st.ChunkStore().Put(context.Background(), ch)
 		if err != nil {
 			t.Fatal(err)
 		}
+		chunksToMove = append(chunksToMove, ch.Address())
+	}
 
-		verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[9].Address(), 10)
-		verifyCacheOrder(t, c, st.IndexStore(), chunks...)
+	// move new chunks
+	err = c.ShallowCopy(context.Background(), st, chunksToMove...)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		chunks2 := chunktest.GenerateTestRandomChunks(5)
-		chunksToMove2 := make([]swarm.Address, 0, 5)
+	verifyCacheState(t, st.IndexStore(), c, chunks[5].Address(), chunks[14].Address(), 10)
+	verifyCacheOrder(t, c, st.IndexStore(), chunks[5:15]...)
 
-		// add the chunks to chunkstore. This simulates the reserve already populating
-		// the chunkstore with chunks.
-		for _, ch := range chunks2 {
-			err := st.ChunkStore().Put(context.Background(), ch)
-			if err != nil {
-				t.Fatal(err)
-			}
-			chunksToMove2 = append(chunksToMove2, ch.Address())
-		}
+	err = c.RemoveOldest(context.Background(), st, st.ChunkStore(), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		// move new chunks
-		err = c.MoveFromReserve(context.Background(), st, chunksToMove2...)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cacheChunks := append(chunks[5:], chunks2...)
-
-		verifyCacheState(t, st.IndexStore(), c, cacheChunks[0].Address(), cacheChunks[9].Address(), 10)
-		verifyCacheOrder(t, c, st.IndexStore(), cacheChunks...)
-	})
-
-	t.Run("move from reserve over capacity", func(t *testing.T) {
-		chunks := chunktest.GenerateTestRandomChunks(15)
-		chunksToMove := make([]swarm.Address, 0, 15)
-
-		// add the chunks to chunkstore. This simulates the reserve already populating
-		// the chunkstore with chunks.
-		for _, ch := range chunks {
-			err := st.ChunkStore().Put(context.Background(), ch)
-			if err != nil {
-				t.Fatal(err)
-			}
-			chunksToMove = append(chunksToMove, ch.Address())
-		}
-
-		// move new chunks
-		err = c.MoveFromReserve(context.Background(), st, chunksToMove...)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		verifyCacheState(t, st.IndexStore(), c, chunks[5].Address(), chunks[14].Address(), 10)
-		verifyCacheOrder(t, c, st.IndexStore(), chunks[5:15]...)
-	})
+	verifyChunksDeleted(t, st.ChunkStore(), chunks[5:10]...)
 }
 
 func verifyCacheState(

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -336,7 +336,7 @@ func (r *Reserve) EvictBatchBin(
 		return 0, err
 	}
 
-	batchCnt := 10_000
+	batchCnt := 1_000
 	evictionCompleted := 0
 
 	for i := 0; i < len(evicted); i += batchCnt {

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -336,7 +336,7 @@ func (r *Reserve) EvictBatchBin(
 		return 0, err
 	}
 
-	batchCnt := 1000
+	batchCnt := 10_000
 	evictionCompleted := 0
 
 	for i := 0; i < len(evicted); i += batchCnt {
@@ -364,14 +364,9 @@ func (r *Reserve) EvictBatchBin(
 				return err
 			}
 
-			go func(addrs []swarm.Address) {
-				_ = txExecutor.Execute(ctx, func(store internal.Storage) error {
-					if err := r.cacheCb(ctx, store, addrs...); err != nil {
-						r.logger.Error(err, "evict and move to cache")
-					}
-					return nil
-				})
-			}(moveToCache)
+			if err := r.cacheCb(ctx, store, moveToCache...); err != nil {
+				r.logger.Error(err, "evict and move to cache")
+			}
 
 			return nil
 		})
@@ -409,20 +404,6 @@ func (r *Reserve) DeleteChunk(
 		return err
 	}
 	return nil
-}
-
-// CleanupBinIndex removes the bin index entry for the chunk. This is called mainly
-// to cleanup the bin index if other indexes are missing during reserve cleanup.
-func (r *Reserve) CleanupBinIndex(
-	ctx context.Context,
-	batch storage.Batch,
-	chunkAddress swarm.Address,
-	binID uint64,
-) {
-	_ = batch.Delete(&ChunkBinItem{
-		Bin:   swarm.Proximity(r.baseAddr.Bytes(), chunkAddress.Bytes()),
-		BinID: binID,
-	})
 }
 
 func removeChunk(

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -660,7 +660,7 @@ func (db *DB) Close() error {
 	bgReserveWorkersClosed := make(chan struct{})
 	go func() {
 		defer close(bgReserveWorkersClosed)
-		if !syncutil.WaitWithTimeout(&db.inFlight, 2*time.Second) {
+		if !syncutil.WaitWithTimeout(&db.inFlight, 5*time.Second) {
 			db.logger.Warning("db shutting down with running goroutines")
 		}
 	}()
@@ -668,7 +668,7 @@ func (db *DB) Close() error {
 	bgCacheWorkersClosed := make(chan struct{})
 	go func() {
 		defer close(bgCacheWorkersClosed)
-		if !syncutil.WaitWithTimeout(&db.cacheLimiter.wg, 2*time.Second) {
+		if !syncutil.WaitWithTimeout(&db.cacheLimiter.wg, 5*time.Second) {
 			db.logger.Warning("cache goroutines still running after the wait timeout; force closing")
 			db.cacheLimiter.cancel()
 		}

--- a/pkg/storer/storer_test.go
+++ b/pkg/storer/storer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethersphere/bee/pkg/storage/inmemchunkstore"
 	"github.com/ethersphere/bee/pkg/storage/migration"
 	"github.com/ethersphere/bee/pkg/storer"
-	"github.com/ethersphere/bee/pkg/storer/internal/cache"
 	pinstore "github.com/ethersphere/bee/pkg/storer/internal/pinning"
 	"github.com/ethersphere/bee/pkg/storer/internal/upload"
 	localmigration "github.com/ethersphere/bee/pkg/storer/migration"
@@ -98,12 +97,9 @@ func verifyPinCollection(
 // TestMain exists to adjust the time.Now function to a fixed value.
 func TestMain(m *testing.M) {
 	storer.ReplaceSharkyShardLimit(4)
-	old := cache.CacheEvictionBatchSize
 	defer func() {
-		cache.CacheEvictionBatchSize = old
 		storer.ReplaceSharkyShardLimit(32)
 	}()
-	cache.CacheEvictionBatchSize = 1
 	code := m.Run()
 	os.Exit(code)
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Includes various improvements to how the cache works.
The storer now has a cache worker that keeps track of the cache size and evicts as necessary.
This means that other cache ops do not need to remove any items before inserting entries.

In the postage service, the set expire func now removes all expired stamp issuers and stamp data.

Added new metrics to cachestore.

<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
