### PR TITLE
feat: support db validate command

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -39,6 +39,7 @@ func (c *command) initDBCmd() {
 	dbNukeCmd(cmd)
 	dbInfoCmd(cmd)
 	dbCompactCmd(cmd)
+	dbValidateCmd(cmd)
 
 	c.root.AddCommand(cmd)
 }
@@ -162,6 +163,54 @@ func dbCompactCmd(cmd *cobra.Command) {
 	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
 	c.Flags().Bool(optionNameValidation, false, "run chunk validation checks before and after the compaction")
 	c.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
+	cmd.AddCommand(c)
+}
+
+func dbValidateCmd(cmd *cobra.Command) {
+	c := &cobra.Command{
+		Use:   "validate",
+		Short: "Validates the localstore sharky store.",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			if err != nil {
+				return fmt.Errorf("get verbosity: %w", err)
+			}
+			v = strings.ToLower(v)
+			logger, err := newLogger(cmd, v)
+			if err != nil {
+				return fmt.Errorf("new logger: %w", err)
+			}
+
+			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			if err != nil {
+				return fmt.Errorf("get data-dir: %w", err)
+			}
+			if dataDir == "" {
+				return errors.New("no data-dir provided")
+			}
+
+			logger.Warning("Validation ensures that sharky returns a chunk that hashes to the expected reference.")
+			logger.Warning("    Invalid chunks logged at Warning level.")
+			logger.Warning("    Progress logged at Info level.")
+			logger.Warning("    SOC chunks logged at Debug level.")
+
+			localstorePath := path.Join(dataDir, "localstore")
+
+			err = storer.Validate(context.Background(), localstorePath, &storer.Options{
+				Logger:          logger,
+				RadiusSetter:    noopRadiusSetter{},
+				Batchstore:      new(postage.NoOpBatchStore),
+				ReserveCapacity: node.ReserveCapacity,
+			})
+			if err != nil {
+				return fmt.Errorf("localstore: %w", err)
+			}
+
+			return nil
+		},
+	}
+	c.Flags().String(optionNameDataDir, "", "data directory")
+	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
 	cmd.AddCommand(c)
 }
 

--- a/pkg/storer/compact.go
+++ b/pkg/storer/compact.go
@@ -10,14 +10,9 @@ import (
 	"fmt"
 	"path"
 	"sort"
-	"sync"
 	"time"
 
-	"github.com/ethersphere/bee/pkg/cac"
-	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/sharky"
-	"github.com/ethersphere/bee/pkg/soc"
-	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
 	"github.com/ethersphere/bee/pkg/swarm"
 )
@@ -50,7 +45,7 @@ func Compact(ctx context.Context, basePath string, opts *Options, validate bool)
 
 	if validate {
 		logger.Info("performing chunk validation before compaction")
-		validationWork(logger, store, sharkyRecover)
+		validateWork(logger, store, sharkyRecover.Read)
 	}
 
 	logger.Info("starting compaction")
@@ -148,81 +143,8 @@ func Compact(ctx context.Context, basePath string, opts *Options, validate bool)
 
 	if validate {
 		logger.Info("performing chunk validation after compaction")
-		validationWork(logger, store, sharkyRecover)
+		validateWork(logger, store, sharkyRecover.Read)
 	}
 
 	return nil
-}
-
-func validationWork(logger log.Logger, store storage.Store, sharky *sharky.Recovery) {
-
-	n := time.Now()
-	defer func() {
-		logger.Info("validation finished", "duration", time.Since(n))
-	}()
-
-	iteratateItemsC := make(chan *chunkstore.RetrievalIndexItem)
-
-	validChunk := func(item *chunkstore.RetrievalIndexItem, buf []byte) {
-		err := sharky.Read(context.Background(), item.Location, buf)
-		if err != nil {
-			logger.Warning("invalid chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0), "location", item.Location, "error", err)
-			return
-		}
-
-		ch := swarm.NewChunk(item.Address, buf)
-		if !cac.Valid(ch) && !soc.Valid(ch) {
-
-			logger.Info("invalid cac/soc chunk ", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0))
-
-			h, err := cac.DoHash(buf[swarm.SpanSize:], buf[:swarm.SpanSize])
-			if err != nil {
-				logger.Error(err, "cac hash")
-				return
-			}
-
-			computedAddr := swarm.NewAddress(h)
-
-			if !cac.Valid(swarm.NewChunk(computedAddr, buf)) {
-				logger.Info("computed chunk is also an invalid cac")
-				return
-			}
-
-			shardedEntry := chunkstore.RetrievalIndexItem{Address: computedAddr}
-			err = store.Get(&shardedEntry)
-			if err != nil {
-				logger.Info("no shared entry found")
-				return
-			}
-
-			logger.Info("retrieved chunk with shared slot", "shared_address", shardedEntry.Address, "shared_timestamp", time.Unix(int64(shardedEntry.Timestamp), 0))
-		}
-	}
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			buf := make([]byte, swarm.SocMaxChunkSize)
-			for item := range iteratateItemsC {
-				validChunk(item, buf[:item.Location.Length])
-			}
-		}()
-	}
-
-	count := 0
-	_ = chunkstore.Iterate(store, func(item *chunkstore.RetrievalIndexItem) error {
-		iteratateItemsC <- item
-		count++
-		if count%100_000 == 0 {
-			logger.Info("..still validating chunks", "count", count)
-		}
-		return nil
-	})
-
-	close(iteratateItemsC)
-
-	wg.Wait()
 }

--- a/pkg/storer/validate.go
+++ b/pkg/storer/validate.go
@@ -20,14 +20,6 @@ import (
 	"github.com/ethersphere/bee/pkg/swarm"
 )
 
-//type dirFS struct {
-//	basedir string
-//}
-
-//func (d *dirFS) Open(path string) (fs.File, error) {
-//	return os.OpenFile(filepath.Join(d.basedir, path), os.O_RDWR|os.O_CREATE, 0644)
-//}
-
 // Validate ensures that all retrievalIndex chunks are correctly stored in sharky.
 func Validate(ctx context.Context, basePath string, opts *Options) error {
 
@@ -102,14 +94,14 @@ func validateWork(logger log.Logger, store storage.Store, readFn func(context.Co
 					return
 				}
 
-				shardedEntry := chunkstore.RetrievalIndexItem{Address: computedAddr}
-				err = store.Get(&shardedEntry)
+				sharedEntry := chunkstore.RetrievalIndexItem{Address: computedAddr}
+				err = store.Get(&sharedEntry)
 				if err != nil {
 					logger.Warning("no shared entry found")
 					return
 				}
 
-				logger.Warning("retrieved chunk with shared slot", "shared_address", shardedEntry.Address, "shared_timestamp", time.Unix(int64(shardedEntry.Timestamp), 0))
+				logger.Warning("retrieved chunk with shared slot", "shared_address", sharedEntry.Address, "shared_timestamp", time.Unix(int64(sharedEntry.Timestamp), 0))
 			}
 		}
 	}

--- a/pkg/storer/validate.go
+++ b/pkg/storer/validate.go
@@ -1,0 +1,151 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storer
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/bee/pkg/cac"
+	"github.com/ethersphere/bee/pkg/log"
+	"github.com/ethersphere/bee/pkg/sharky"
+	"github.com/ethersphere/bee/pkg/soc"
+	"github.com/ethersphere/bee/pkg/storage"
+	"github.com/ethersphere/bee/pkg/storer/internal/chunkstore"
+	"github.com/ethersphere/bee/pkg/swarm"
+)
+
+//type dirFS struct {
+//	basedir string
+//}
+
+//func (d *dirFS) Open(path string) (fs.File, error) {
+//	return os.OpenFile(filepath.Join(d.basedir, path), os.O_RDWR|os.O_CREATE, 0644)
+//}
+
+// Validate ensures that all retrievalIndex chunks are correctly stored in sharky.
+func Validate(ctx context.Context, basePath string, opts *Options) error {
+
+	logger := opts.Logger
+
+	store, err := initStore(basePath, opts)
+	if err != nil {
+		return fmt.Errorf("failed creating levelDB index store: %w", err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			logger.Error(err, "failed closing store")
+		}
+	}()
+
+	sharky, err := sharky.New(&dirFS{basedir: path.Join(basePath, sharkyPath)},
+		sharkyNoOfShards, swarm.SocMaxChunkSize)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := sharky.Close(); err != nil {
+			logger.Error(err, "failed closing sharky")
+		}
+	}()
+
+	logger.Info("performing chunk validation")
+	validateWork(logger, store, sharky.Read)
+
+	return nil
+}
+
+func validateWork(logger log.Logger, store storage.Store, readFn func(context.Context, sharky.Location, []byte) error) {
+
+	total := 0
+	socCount := 0
+	invalidCount := 0
+
+	n := time.Now()
+	defer func() {
+		logger.Info("validation finished", "duration", time.Since(n), "invalid", invalidCount, "soc", socCount, "total", total)
+	}()
+
+	iteratateItemsC := make(chan *chunkstore.RetrievalIndexItem)
+
+	validChunk := func(item *chunkstore.RetrievalIndexItem, buf []byte) {
+		err := readFn(context.Background(), item.Location, buf)
+		if err != nil {
+			logger.Warning("invalid chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0), "location", item.Location, "error", err)
+			return
+		}
+
+		ch := swarm.NewChunk(item.Address, buf)
+		if !cac.Valid(ch) {
+			if soc.Valid(ch) {
+				socCount++
+				logger.Debug("found soc chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0))
+			} else {
+				invalidCount++
+				logger.Warning("invalid cac/soc chunk", "address", item.Address, "timestamp", time.Unix(int64(item.Timestamp), 0))
+
+				h, err := cac.DoHash(buf[swarm.SpanSize:], buf[:swarm.SpanSize])
+				if err != nil {
+					logger.Error(err, "cac hash")
+					return
+				}
+
+				computedAddr := swarm.NewAddress(h)
+
+				if !cac.Valid(swarm.NewChunk(computedAddr, buf)) {
+					logger.Warning("computed chunk is also an invalid cac", "err", err)
+					return
+				}
+
+				shardedEntry := chunkstore.RetrievalIndexItem{Address: computedAddr}
+				err = store.Get(&shardedEntry)
+				if err != nil {
+					logger.Warning("no shared entry found")
+					return
+				}
+
+				logger.Warning("retrieved chunk with shared slot", "shared_address", shardedEntry.Address, "shared_timestamp", time.Unix(int64(shardedEntry.Timestamp), 0))
+			}
+		}
+	}
+
+	s := time.Now()
+
+	_ = chunkstore.Iterate(store, func(item *chunkstore.RetrievalIndexItem) error {
+		total++
+		return nil
+	})
+	logger.Info("validation count finished", "duration", time.Since(s), "total", total)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, swarm.SocMaxChunkSize)
+			for item := range iteratateItemsC {
+				validChunk(item, buf[:item.Location.Length])
+			}
+		}()
+	}
+
+	count := 0
+	_ = chunkstore.Iterate(store, func(item *chunkstore.RetrievalIndexItem) error {
+		iteratateItemsC <- item
+		count++
+		if count%100_000 == 0 {
+			logger.Info("..still validating chunks", "count", count, "invalid", invalidCount, "soc", socCount, "total", total, "percent", fmt.Sprintf("%.2f", (float64(count)*100.0)/float64(total)))
+		}
+		return nil
+	})
+
+	close(iteratateItemsC)
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Support `db validate` as separate from the `--validate` option on `db compact`.  Moves the actual validation logic out of compact.go and into validate.go.

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
There are sharky stores in the wild that have corrupted hash chunks.  This makes it possible to do an in-place `validate` without the risks of the `compact`.

### Related Issue (Optional)
N/A

### Screenshots (if appropriate):
Sample output from this features on a database that has a bad chunk hash.
`./bee-amd64-v1.17.5-rc5-f5acd99c-dirty db validate --data-dir xdai5`
```
"time"="2023-10-28 18:53:01.285201" "level"="warning" "logger"="node" "msg"="Validation ensures that sharky returns a chunk that hashes to the expected reference."
"time"="2023-10-28 18:53:01.285249" "level"="warning" "logger"="node" "msg"="    Invalid chunks logged at Warning level."
"time"="2023-10-28 18:53:01.285252" "level"="warning" "logger"="node" "msg"="    Progress logged at Info level."
"time"="2023-10-28 18:53:01.285257" "level"="warning" "logger"="node" "msg"="    SOC chunks logged at Debug level."
"time"="2023-10-28 18:53:01.308913" "level"="info" "logger"="node" "msg"="performing chunk validation"
"time"="2023-10-28 18:53:03.492652" "level"="info" "logger"="node" "msg"="validation count finished" "duration"="2.183717987s" "total"=4818402
"time"="2023-10-28 18:53:07.780108" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=100000 "invalid"=0 "soc"=3 "total"=4818402 "percent"="2.08"
"time"="2023-10-28 18:53:12.532654" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=200000 "invalid"=0 "soc"=9 "total"=4818402 "percent"="4.15"
<snip>
"time"="2023-10-28 18:54:16.389409" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=1100000 "invalid"=0 "soc"=69 "total"=4818402 "percent"="22.83"
"time"="2023-10-28 18:54:18.420134" "level"="warning" "logger"="node" "msg"="invalid cac/soc chunk" "address"="211bb0d50e932be063ab4b84fffb054bd6135d2dae88deb13439cbeef233e2be" "timestamp"="2023-10-16 22:33:39 -0400 EDT"
"time"="2023-10-28 18:54:18.422119" "level"="warning" "logger"="node" "msg"="retrieved chunk with shared slot" "shared_address"="210a7d4291fd4b3b045a2e1059d53c14bcfd62e552d8688245b664b86230dd69" "shared_timestamp"="2023-10-17 10:28:09 -0400 EDT"
"time"="2023-10-28 18:54:21.889372" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=1200000 "invalid"=1 "soc"=73 "total"=4818402 "percent"="24.90"
"time"="2023-10-28 18:54:27.080270" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=1300000 "invalid"=1 "soc"=81 "total"=4818402 "percent"="26.98"
<snip>
"time"="2023-10-28 18:57:36.239540" "level"="info" "logger"="node" "msg"="..still validating chunks" "count"=4800000 "invalid"=1 "soc"=281 "total"=4818402 "percent"="99.62"
"time"="2023-10-28 18:57:36.843834" "level"="info" "logger"="node" "msg"="validation finished" "duration"="4m35.534898659s" "invalid"=1 "soc"=281 "total"=4818402
```