### PR TITLE
fix: return 404 when no peers found during retrieval

### DIFF
--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -136,6 +136,10 @@ func TestBytes(t *testing.T) {
 			}),
 		)
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		jsonhttptest.Request(t, client, http.MethodGet, resource+"/"+swarm.EmptyAddress.String(), http.StatusNotFound)
+	})
 }
 
 // nolint:paralleltest,tparallel

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/ethersphere/bee/pkg/topology"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -441,9 +442,9 @@ func (s *Service) serveManifestEntry(
 func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *http.Request, reference swarm.Address, additionalHeaders http.Header, etag bool) {
 	reader, l, err := joiner.New(r.Context(), s.storer.Download(true), reference)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
+		if errors.Is(err, storage.ErrNotFound) || errors.Is(err, topology.ErrNotFound) {
 			logger.Debug("api download: not found ", "address", reference, "error", err)
-			logger.Error(nil, "not found")
+			logger.Error(nil, err.Error())
 			jsonhttp.NotFound(w, nil)
 			return
 		}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

The node should return 404 when no peers are found during retrieval

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
Closes #4374, closes #4340

### Screenshots (if appropriate):
