### PR TITLE
fix: remove stamp data on expiration, not on node start up and API changes

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 5.0.0
+  version: 5.1.0
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 
@@ -1651,12 +1651,6 @@ paths:
           description: Default response
 
   "/stamps":
-    parameters:
-      - in: query
-        name: all
-        schema:
-          $ref: "SwarmCommon.yaml#/components/schemas/isAll"
-        description: Gets all stamps. Default is null.
     get:
       summary: Get stamps for this node
       description: This endpoint is available on the main API only if the node is spawned with the `--restricted` flag along with a bearer authentication token.
@@ -1671,6 +1665,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/DebugPostageBatchesResponse"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
 
         default:
           description: Default response
@@ -1697,6 +1693,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/DebugPostageBatch"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         default:
@@ -1724,6 +1722,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/PostageStampBuckets"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         default:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 3.2.5
+  version: 3.2.6
   title: Common Data Types
   description: |
     \*****bzzz*****
@@ -470,8 +470,6 @@ components:
           type: boolean
         batchTTL:
           type: integer
-        expired:
-          type: boolean
 
     PostageBatchNoIssuer:
       type: object

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 4.0.2
+  version: 4.1.0
   title: Bee Debug API
   description: "A list of the currently provided debug interfaces to interact with the bee node"
 
@@ -783,13 +783,6 @@ paths:
           description: Default response
 
   "/stamps":
-    parameters:
-      - in: query
-        name: all
-        schema:
-          type: string
-          required: false
-        description: Gets all stamps. Default is null.
     get:
       summary: Get stamps for this node
       tags:
@@ -801,6 +794,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/DebugPostageBatchesResponse"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
 
         default:
           description: Default response
@@ -824,6 +819,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/DebugPostageBatch"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         default:
@@ -848,6 +845,8 @@ paths:
             application/json:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/PostageStampBuckets"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         default:

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -180,14 +180,6 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 	stampIssuers := s.post.StampIssuers()
 	resp.Stamps = make([]postageStampResponse, 0, len(stampIssuers))
 	for _, v := range stampIssuers {
-		exists, err := s.batchStore.Exists(v.ID())
-		if err != nil {
-			logger.Debug("get stamp issuer: check batch failed", "batch_id", hex.EncodeToString(v.ID()), "error", err)
-			logger.Error(nil, "get stamp issuer: check batch failed")
-			jsonhttp.InternalServerError(w, "unable to check batch")
-			return
-		}
-
 		batchTTL, err := s.estimateBatchTTLFromID(v.ID())
 		if err != nil {
 			logger.Debug("get stamp issuer: estimate batch expiration failed", "batch_id", hex.EncodeToString(v.ID()), "error", err)
@@ -195,21 +187,19 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 			jsonhttp.InternalServerError(w, "unable to estimate batch expiration")
 			return
 		}
-		if exists {
-			resp.Stamps = append(resp.Stamps, postageStampResponse{
-				BatchID:       v.ID(),
-				Utilization:   v.Utilization(),
-				Usable:        s.post.IssuerUsable(v),
-				Label:         v.Label(),
-				Depth:         v.Depth(),
-				Amount:        bigint.Wrap(v.Amount()),
-				BucketDepth:   v.BucketDepth(),
-				BlockNumber:   v.BlockNumber(),
-				ImmutableFlag: v.ImmutableFlag(),
-				Exists:        true,
-				BatchTTL:      batchTTL,
-			})
-		}
+		resp.Stamps = append(resp.Stamps, postageStampResponse{
+			BatchID:       v.ID(),
+			Utilization:   v.Utilization(),
+			Usable:        s.post.IssuerUsable(v),
+			Label:         v.Label(),
+			Depth:         v.Depth(),
+			Amount:        bigint.Wrap(v.Amount()),
+			BucketDepth:   v.BucketDepth(),
+			BlockNumber:   v.BlockNumber(),
+			ImmutableFlag: v.ImmutableFlag(),
+			Exists:        true,
+			BatchTTL:      batchTTL,
+		})
 	}
 
 	jsonhttp.OK(w, resp)

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -145,7 +144,6 @@ type postageStampResponse struct {
 	ImmutableFlag bool           `json:"immutableFlag"`
 	Exists        bool           `json:"exists"`
 	BatchTTL      int64          `json:"batchTTL"`
-	Expired       bool           `json:"expired"`
 }
 
 type postageStampsResponse struct {
@@ -178,14 +176,6 @@ type bucketData struct {
 func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithName("get_stamps").Build()
 
-	queries := struct {
-		All bool `map:"all"`
-	}{}
-	if response := s.mapStructure(r.URL.Query(), &queries); response != nil {
-		response("invalid query params", logger, w)
-		return
-	}
-
 	resp := postageStampsResponse{}
 	stampIssuers := s.post.StampIssuers()
 	resp.Stamps = make([]postageStampResponse, 0, len(stampIssuers))
@@ -205,20 +195,19 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 			jsonhttp.InternalServerError(w, "unable to estimate batch expiration")
 			return
 		}
-		if queries.All || exists {
+		if exists {
 			resp.Stamps = append(resp.Stamps, postageStampResponse{
 				BatchID:       v.ID(),
 				Utilization:   v.Utilization(),
-				Usable:        exists && s.post.IssuerUsable(v),
+				Usable:        s.post.IssuerUsable(v),
 				Label:         v.Label(),
 				Depth:         v.Depth(),
 				Amount:        bigint.Wrap(v.Amount()),
 				BucketDepth:   v.BucketDepth(),
 				BlockNumber:   v.BlockNumber(),
 				ImmutableFlag: v.ImmutableFlag(),
-				Exists:        exists,
+				Exists:        true,
 				BatchTTL:      batchTTL,
-				Expired:       v.Expired(),
 			})
 		}
 	}
@@ -318,28 +307,21 @@ func (s *Service) postageGetStampHandler(w http.ResponseWriter, r *http.Request)
 	}
 	hexBatchID := hex.EncodeToString(paths.BatchID)
 
-	var issuer *postage.StampIssuer
-	stampIssuers := s.post.StampIssuers()
-	for _, stampIssuer := range stampIssuers {
-		if bytes.Equal(paths.BatchID, stampIssuer.ID()) {
-			issuer = stampIssuer
-			break
+	issuer, _, err := s.post.GetStampIssuer(paths.BatchID)
+	if err != nil {
+		logger.Debug("get stamp issuer: get issuer failed", "batch_id", hexBatchID, "error", err)
+		logger.Error(nil, "get stamp issuer: get issuer failed")
+		switch {
+		case errors.Is(err, postage.ErrNotUsable):
+			jsonhttp.BadRequest(w, "batch not usable")
+		case errors.Is(err, postage.ErrNotFound):
+			jsonhttp.NotFound(w, "unable to get stamp issuer")
+		default:
+			jsonhttp.InternalServerError(w, "get issuer failed")
 		}
-	}
-	if issuer == nil {
-		logger.Debug("get issuer failed", "batch_id", hexBatchID)
-		logger.Error(nil, "get issuer failed")
-		jsonhttp.BadRequest(w, "cannot find batch")
 		return
 	}
 
-	exists, err := s.batchStore.Exists(paths.BatchID)
-	if err != nil {
-		logger.Debug("exist check failed", "batch_id", hexBatchID, "error", err)
-		logger.Error(nil, "exist check failed")
-		jsonhttp.InternalServerError(w, "unable to check batch")
-		return
-	}
 	batchTTL, err := s.estimateBatchTTLFromID(paths.BatchID)
 	if err != nil {
 		logger.Debug("estimate batch expiration failed", "batch_id", hexBatchID, "error", err)
@@ -353,14 +335,13 @@ func (s *Service) postageGetStampHandler(w http.ResponseWriter, r *http.Request)
 		Depth:         issuer.Depth(),
 		BucketDepth:   issuer.BucketDepth(),
 		ImmutableFlag: issuer.ImmutableFlag(),
-		Exists:        exists,
+		Exists:        true,
 		BatchTTL:      batchTTL,
 		Utilization:   issuer.Utilization(),
-		Usable:        exists && s.post.IssuerUsable(issuer),
+		Usable:        s.post.IssuerUsable(issuer),
 		Label:         issuer.Label(),
 		Amount:        bigint.Wrap(issuer.Amount()),
 		BlockNumber:   issuer.BlockNumber(),
-		Expired:       issuer.Expired(),
 	})
 }
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -246,17 +246,6 @@ func TestPostageGetStamps(t *testing.T) {
 		)
 	})
 
-	t.Run("expired batch", func(t *testing.T) {
-		t.Parallel()
-
-		bsForNonExistingBatch := mock.New(mock.WithChainState(cs))
-		tsForNonExistingBatch, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true, Post: mp, BatchStore: bsForNonExistingBatch, BlockTime: 2 * time.Second})
-
-		jsonhttptest.Request(t, tsForNonExistingBatch, http.MethodGet, "/stamps", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{Stamps: []api.PostageStampResponse{}}),
-		)
-	})
-
 	t.Run("single expired Stamp", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -240,7 +240,6 @@ func TestPostageGetStamps(t *testing.T) {
 						ImmutableFlag: si.ImmutableFlag(),
 						Exists:        true,
 						BatchTTL:      15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
-						Expired:       false,
 					},
 				},
 			}),
@@ -256,60 +255,6 @@ func TestPostageGetStamps(t *testing.T) {
 		jsonhttptest.Request(t, tsForNonExistingBatch, http.MethodGet, "/stamps", http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{Stamps: []api.PostageStampResponse{}}),
 		)
-
-		jsonhttptest.Request(t, tsForNonExistingBatch, http.MethodGet, "/stamps?all=true", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{
-				Stamps: []api.PostageStampResponse{
-					{
-						BatchID:       b.ID,
-						Utilization:   si.Utilization(),
-						Usable:        false,
-						Label:         si.Label(),
-						Depth:         si.Depth(),
-						Amount:        bigint.Wrap(si.Amount()),
-						BucketDepth:   si.BucketDepth(),
-						BlockNumber:   si.BlockNumber(),
-						ImmutableFlag: si.ImmutableFlag(),
-						Exists:        false,
-						BatchTTL:      -1,
-					},
-				},
-			}),
-		)
-	})
-
-	t.Run("expired Stamp", func(t *testing.T) {
-		t.Parallel()
-
-		eb := postagetesting.MustNewBatch(postagetesting.WithValue(20))
-
-		esi := postage.NewStampIssuer("", "", eb.ID, big.NewInt(3), 11, 10, 1000, true)
-		emp := mockpost.New(mockpost.WithIssuer(esi))
-		emp.HandleStampExpiry(eb.ID)
-		ecs := &postage.ChainState{Block: 10, TotalAmount: big.NewInt(15), CurrentPrice: big.NewInt(12)}
-		ebs := mock.New(mock.WithChainState(ecs))
-		ts, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true, Post: emp, BatchStore: ebs, BlockTime: 2 * time.Second})
-
-		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps?all=true", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{
-				Stamps: []api.PostageStampResponse{
-					{
-						BatchID:       eb.ID,
-						Utilization:   esi.Utilization(),
-						Usable:        false,
-						Label:         esi.Label(),
-						Depth:         esi.Depth(),
-						Amount:        bigint.Wrap(si.Amount()),
-						BucketDepth:   esi.BucketDepth(),
-						BlockNumber:   esi.BlockNumber(),
-						ImmutableFlag: esi.ImmutableFlag(),
-						Exists:        false,
-						BatchTTL:      -1, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
-						Expired:       true,
-					},
-				},
-			}),
-		)
 	})
 
 	t.Run("single expired Stamp", func(t *testing.T) {
@@ -319,25 +264,18 @@ func TestPostageGetStamps(t *testing.T) {
 
 		esi := postage.NewStampIssuer("", "", eb.ID, big.NewInt(3), 11, 10, 1000, true)
 		emp := mockpost.New(mockpost.WithIssuer(esi))
-		emp.HandleStampExpiry(eb.ID)
+		err := emp.HandleStampExpiry(context.Background(), eb.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
 		ecs := &postage.ChainState{Block: 10, TotalAmount: big.NewInt(15), CurrentPrice: big.NewInt(12)}
 		ebs := mock.New(mock.WithChainState(ecs))
 		ts, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true, Post: emp, BatchStore: ebs, BlockTime: 2 * time.Second})
 
-		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps/"+hex.EncodeToString(eb.ID), http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampResponse{
-				BatchID:       eb.ID,
-				Utilization:   esi.Utilization(),
-				Usable:        false,
-				Label:         esi.Label(),
-				Depth:         esi.Depth(),
-				Amount:        bigint.Wrap(esi.Amount()),
-				BucketDepth:   esi.BucketDepth(),
-				BlockNumber:   esi.BlockNumber(),
-				ImmutableFlag: esi.ImmutableFlag(),
-				Exists:        false,
-				BatchTTL:      -1, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
-				Expired:       true,
+		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps/"+hex.EncodeToString(eb.ID), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Message: "unable to get stamp issuer",
+				Code:    404,
 			}),
 		)
 	})
@@ -951,42 +889,6 @@ func Test_postageCreateHandler_invalidInputs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			jsonhttptest.Request(t, client, http.MethodPost, "/stamps/"+tc.amount+"/"+tc.depth, tc.want.Code,
-				jsonhttptest.WithExpectedJSONResponse(tc.want),
-			)
-		})
-	}
-}
-
-func Test_postageGetStampsHandler_invalidInputs(t *testing.T) {
-	t.Parallel()
-
-	client, _, _, _ := newTestServer(t, testServerOptions{DebugAPI: true})
-
-	tests := []struct {
-		name string
-		all  string
-		want jsonhttp.StatusResponse
-	}{{
-		name: "all - invalid value",
-		all:  "123",
-		want: jsonhttp.StatusResponse{
-			Code:    http.StatusBadRequest,
-			Message: "invalid query params",
-			Reasons: []jsonhttp.Reason{
-				{
-					Field: "all",
-					Error: strconv.ErrSyntax.Error(),
-				},
-			},
-		},
-	}}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			jsonhttptest.Request(t, client, http.MethodGet, "/stamps?all="+tc.all, tc.want.Code,
 				jsonhttptest.WithExpectedJSONResponse(tc.want),
 			)
 		})

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -795,11 +795,6 @@ func NewBee(
 			if err != nil {
 				syncErr.Store(err)
 				return nil, fmt.Errorf("unable to start batch service: %w", err)
-			} else {
-				err = post.SetExpired(ctx)
-				if err != nil {
-					return nil, fmt.Errorf("unable to set expirations: %w", err)
-				}
 			}
 		} else {
 			go func() {
@@ -810,11 +805,6 @@ func NewBee(
 					syncErr.Store(err)
 					logger.Error(err, "unable to sync batches")
 					b.syncingStopped.Signal() // trigger shutdown in start.go
-				} else {
-					err = post.SetExpired(ctx)
-					if err != nil {
-						logger.Error(err, "unable to set expirations")
-					}
 				}
 			}()
 		}

--- a/pkg/postage/batchstore/store.go
+++ b/pkg/postage/batchstore/store.go
@@ -5,6 +5,7 @@
 package batchstore
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -294,6 +295,12 @@ func (s *store) cleanup() error {
 
 	for _, b := range evictions {
 		s.logger.Debug("batch expired", "batch_id", hex.EncodeToString(b.ID))
+		if s.batchExpiry != nil {
+			err = s.batchExpiry.HandleStampExpiry(context.Background(), b.ID)
+			if err != nil {
+				return fmt.Errorf("handle stamp expiry, batch %x: %w", b.ID, err)
+			}
+		}
 		err = s.evictFn(b.ID)
 		if err != nil {
 			return fmt.Errorf("evict batch %x: %w", b.ID, err)
@@ -305,9 +312,6 @@ func (s *store) cleanup() error {
 		err = s.store.Delete(batchKey(b.ID))
 		if err != nil {
 			return fmt.Errorf("delete batch %x: %w", b.ID, err)
-		}
-		if s.batchExpiry != nil {
-			s.batchExpiry.HandleStampExpiry(b.ID)
 		}
 	}
 

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -506,8 +506,8 @@ func TestBatchExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !esi.Expired() {
-		t.Fatalf("Want %v, got %v", true, esi.Expired())
+	if exists, err := store.Exists(esi.ID()); err != nil || exists {
+		t.Fatalf("Want %v, got %v, error %v", false, exists, err)
 	}
 }
 
@@ -537,8 +537,8 @@ func TestUnexpiredBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if esi.Expired() {
-		t.Fatalf("Want %v, got %v", false, esi.Expired())
+	if exists, err := store.Exists(esi.ID()); err != nil || !exists {
+		t.Fatalf("Want %v, got %v, error %v", false, exists, err)
 	}
 }
 

--- a/pkg/postage/interface.go
+++ b/pkg/postage/interface.go
@@ -97,6 +97,5 @@ type BatchEventListener interface {
 }
 
 type BatchExpiryHandler interface {
-	HandleStampExpiry([]byte)
-	SetExpired(context.Context) error
+	HandleStampExpiry(context.Context, []byte) error
 }

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -52,19 +52,16 @@ type mockPostage struct {
 	acceptAll  bool
 }
 
-func (m *mockPostage) SetExpired(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockPostage) HandleStampExpiry(id []byte) {
+func (m *mockPostage) HandleStampExpiry(ctx context.Context, id []byte) error {
 	m.issuerLock.Lock()
 	defer m.issuerLock.Unlock()
 
-	for _, v := range m.issuersMap {
+	for k, v := range m.issuersMap {
 		if bytes.Equal(id, v.ID()) {
-			v.SetExpired(true)
+			delete(m.issuersMap, k)
 		}
 	}
+	return nil
 }
 
 func (m *mockPostage) Add(s *postage.StampIssuer) error {

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -244,7 +244,7 @@ func TestSetExpired(t *testing.T) {
 		t.Fatalf("expected %v, got %v", postage.ErrNotUsable, err)
 	}
 
-	err = ps.SetExpired(context.Background())
+	err = ps.HandleStampExpiry(context.Background(), issuer.ID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -130,7 +130,6 @@ type stampIssuerData struct {
 	MaxBucketCount uint32   `msgpack:"maxBucketCount"` // the count of the fullest bucket
 	BlockNumber    uint64   `msgpack:"blockNumber"`    // BlockNumber when this batch was created
 	ImmutableFlag  bool     `msgpack:"immutableFlag"`  // Specifies immutability of the created batch.
-	Expired        bool     `msgpack:"expired"`        // Specifies the expiry of the batch
 }
 
 // Clone returns a deep copy of the stampIssuerData.
@@ -145,7 +144,6 @@ func (s stampIssuerData) Clone() stampIssuerData {
 		Buckets:       append([]uint32(nil), s.Buckets...),
 		BlockNumber:   s.BlockNumber,
 		ImmutableFlag: s.ImmutableFlag,
-		Expired:       s.Expired,
 	}
 }
 
@@ -278,16 +276,6 @@ func (si *StampIssuer) Buckets() []uint32 {
 	b := make([]uint32, len(si.data.Buckets))
 	copy(b, si.data.Buckets)
 	return b
-}
-
-// Expired returns the expired property of stamp
-func (si *StampIssuer) Expired() bool {
-	return si.data.Expired
-}
-
-// SetExpired is setter for Expired property
-func (si *StampIssuer) SetExpired(e bool) {
-	si.data.Expired = e
 }
 
 // StampIssuerItem is a storage.Item implementation for StampIssuer.


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
closes #4438

When a batch is expired, the stamp issuer and stamp data are removed immediately.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
