### PR TITLE
fix(postage_api): check if batch exists for stamp issuer

### DIFF
--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -183,8 +183,7 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 
 		exists, err := s.batchStore.Exists(v.ID())
 		if err != nil {
-			logger.Debug("get stamp issuer: check batch failed", "batch_id", hex.EncodeToString(v.ID()), "error", err)
-			logger.Error(nil, "get stamp issuer: check batch failed")
+			logger.Error(err, "get stamp issuer: check batch failed", "batch_id", hex.EncodeToString(v.ID()))
 			jsonhttp.InternalServerError(w, "unable to check batch")
 			return
 		}
@@ -194,8 +193,7 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 
 		batchTTL, err := s.estimateBatchTTLFromID(v.ID())
 		if err != nil {
-			logger.Debug("get stamp issuer: estimate batch expiration failed", "batch_id", hex.EncodeToString(v.ID()), "error", err)
-			logger.Error(nil, "get stamp issuer: estimate batch expiration failed")
+			logger.Error(err, "get stamp issuer: estimate batch expiration failed", "batch_id", hex.EncodeToString(v.ID()))
 			jsonhttp.InternalServerError(w, "unable to estimate batch expiration")
 			return
 		}

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -263,7 +263,7 @@ func TestPostageGetStamps(t *testing.T) {
 
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps/"+hex.EncodeToString(eb.ID), http.StatusNotFound,
 			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
-				Message: "unable to get stamp issuer",
+				Message: "issuer does not exist",
 				Code:    404,
 			}),
 		)

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -549,7 +549,7 @@ func (s *Service) mountBusinessDebug(restricted bool) {
 
 	handle("/batches", web.ChainHandlers(
 		web.FinalHandler(jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.postageGetAllStampsHandler),
+			"GET": http.HandlerFunc(s.postageGetAllBatchesHandler),
 		})),
 	)
 

--- a/pkg/postage/mock/service.go
+++ b/pkg/postage/mock/service.go
@@ -5,7 +5,6 @@
 package mock
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"sync"
@@ -55,12 +54,7 @@ type mockPostage struct {
 func (m *mockPostage) HandleStampExpiry(ctx context.Context, id []byte) error {
 	m.issuerLock.Lock()
 	defer m.issuerLock.Unlock()
-
-	for k, v := range m.issuersMap {
-		if bytes.Equal(id, v.ID()) {
-			delete(m.issuersMap, k)
-		}
-	}
+	delete(m.issuersMap, string(id))
 	return nil
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
For older stamps that have not been removed because postage resyncing has not taken place, the API must check the existence of the issuer as well as the batch. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
