### PR TITLE
fix: add missing request body to /soc endpoint openapi spec [3761]

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -678,6 +678,12 @@ paths:
             $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
           name: swarm-postage-batch-id
           required: true
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
       responses:
         "201":
           description: Created

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 5.1.0
+  version: 5.1.1
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -679,6 +679,8 @@ paths:
           name: swarm-postage-batch-id
           required: true
       requestBody:
+        required: true
+        description: The SOC binary data is composed of the span (8 bytes) and the at most 4KB payload.
         content:
           application/octet-stream:
             schema:


### PR DESCRIPTION
### Description
The "/soc/{owner}/{id}" endpoint requires a request body. It's not indicated in the Swagger doc.

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/3761
