### PR TITLE
fix: overwrite existing stampindex if they have the same timestamp

### DIFF
--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -433,7 +433,7 @@ func (u *uploadPutter) Put(ctx context.Context, s internal.Storage, writer stora
 	case loaded && !item.ChunkIsImmutable:
 		prev := binary.BigEndian.Uint64(item.StampTimestamp)
 		curr := binary.BigEndian.Uint64(chunk.Stamp().Timestamp())
-		if prev >= curr {
+		if prev > curr {
 			return errOverwriteOfNewerBatch
 		}
 		err = stampindex.Store(writer, stampIndexUploadNamespace, chunk)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Return `errOverwriteOfNewerBatch` only when the timestamp of the existing stamp index is actually newer (strictly greater) than that of the chunk to store 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
Closes #4460

### Screenshots (if appropriate):
