### PR TITLE
feat(api): serve underlay and connections in /peers response

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/bee/pkg/accounting"
+	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/auth"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/feeds"
@@ -177,6 +178,7 @@ type Service struct {
 	chequebook     chequebook.Service
 	pseudosettle   settlement.Interface
 	pingpong       pingpong.Interface
+	addressBook    addressbook.Getter
 
 	batchStore   postage.Storer
 	stamperStore storage.Store
@@ -248,6 +250,7 @@ type ExtraOptions struct {
 	Steward         steward.Interface
 	SyncStatus      func() (bool, error)
 	NodeStatus      *status.Service
+	AddressBook     addressbook.Getter
 }
 
 func New(
@@ -323,6 +326,7 @@ func (s *Service) Configure(signer crypto.Signer, auth auth.Authenticator, trace
 	s.postageContract = e.PostageContract
 	s.steward = e.Steward
 	s.stakingContract = e.Staking
+	s.addressBook = e.AddressBook
 
 	s.pingpong = e.Pingpong
 	s.topologyDriver = e.TopologyDriver

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	accountingmock "github.com/ethersphere/bee/pkg/accounting/mock"
+	"github.com/ethersphere/bee/pkg/addressbook"
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/auth"
 	mockauth "github.com/ethersphere/bee/pkg/auth/mock"
@@ -170,6 +171,8 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 	chequebook := chequebookmock.NewChequebook(o.ChequebookOpts...)
 	ln := lightnode.NewContainer(o.Overlay)
 
+	addressBook := addressbook.New(statestore.NewStateStore())
+
 	transaction := transactionmock.New(o.TransactionOpts...)
 
 	storeRecipient := statestore.NewStateStore()
@@ -200,6 +203,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		SyncStatus:      o.SyncStatus,
 		Staking:         o.StakingContract,
 		NodeStatus:      o.NodeStatus,
+		AddressBook:     addressBook,
 	}
 
 	// By default bee mode is set to full mode.

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1094,6 +1094,7 @@ func NewBee(
 		Steward:         steward,
 		SyncStatus:      syncStatusFn,
 		NodeStatus:      nodeStatus,
+		AddressBook:     addressbook,
 	}
 
 	if o.APIAddr != "" {

--- a/pkg/p2p/libp2p/peer.go
+++ b/pkg/p2p/libp2p/peer.go
@@ -124,7 +124,7 @@ func (r *peerRegistry) peers() []p2p.Peer {
 			FullNode: r.full[p],
 		}
 		for conn := range r.connections[p] {
-			peer.Underlay = append(peer.Underlay, conn.RemoteMultiaddr())
+			peer.Connections = append(peer.Connections, conn.RemoteMultiaddr())
 		}
 		peers = append(peers, peer)
 	}

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -191,7 +191,7 @@ type Peer struct {
 	Address         swarm.Address
 	FullNode        bool
 	EthereumAddress []byte
-	Underlay        []ma.Multiaddr
+	Connections     []ma.Multiaddr
 }
 
 // BlockListedPeer holds information about a Peer that is blocked.


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR is adding the underlay address from the addressbook and and sets connections field as it is useful to get the information about the established connections.

### Open API Spec Version Changes (if applicable)
TODO

#### Motivation and Context (Optional)
More precise debugging information.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
