### PR TITLE
fix: prevent a panic on an empty db compact

### DIFF
--- a/pkg/storer/compact.go
+++ b/pkg/storer/compact.go
@@ -20,7 +20,6 @@ import (
 // Compact minimizes sharky disk usage by, using the current sharky locations from the storer,
 // relocating chunks starting from the end of the used slots to the first available slots.
 func Compact(ctx context.Context, basePath string, opts *Options, validate bool) error {
-
 	logger := opts.Logger
 
 	store, err := initStore(basePath, opts)
@@ -74,6 +73,9 @@ func Compact(ctx context.Context, basePath string, opts *Options, validate bool)
 			return items[i].Location.Slot < items[j].Location.Slot
 		})
 
+		if len(items) < 1 {
+			return errors.New("no data to compact")
+		}
 		lastUsedSlot := items[len(items)-1].Location.Slot
 		slots := make([]*chunkstore.RetrievalIndexItem, lastUsedSlot+1) // marks free and used slots
 		for _, l := range items {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Changes:
- check for DB items before compacting

Steps:
1. `mv ~/.bee ~/.bee.bak`
2. `bee start`
3. `CTRL+C`
4.  `bee db compact --data-dir=~/.bee/`

Result:
```
"time"="2023-12-01 13:04:56.120772" "level"="info" "logger"="node" "msg"="starting compaction"
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/ethersphere/bee/pkg/storer.Compact({0x1abfa40?, 0x2777be0}, {0xc0004e8588, 0x11}, 0x4?, 0x0)
        github.com/ethersphere/bee/pkg/storer/compact.go:77 +0x107a
github.com/ethersphere/bee/cmd/bee/cmd.dbCompactCmd.func1(0xc0001b3d00?, {0x1500ebe?, 0x4?, 0x1500dc2?})
        github.com/ethersphere/bee/cmd/bee/cmd/db.go:149 +0x5d8
github.com/spf13/cobra.(*Command).execute(0xc00016a280, {0xc0004f9b40, 0x1, 0x1})
        github.com/spf13/cobra@v1.5.0/command.go:872 +0x6aa
github.com/spf13/cobra.(*Command).ExecuteC(0xc00027b400)
        github.com/spf13/cobra@v1.5.0/command.go:990 +0x38d
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.5.0/command.go:918
github.com/ethersphere/bee/cmd/bee/cmd.(*command).Execute(...)
        github.com/ethersphere/bee/cmd/bee/cmd/cmd.go:168
github.com/ethersphere/bee/cmd/bee/cmd.Execute()
        github.com/ethersphere/bee/cmd/bee/cmd/cmd.go:177 +0x33
main.main()
        github.com/ethersphere/bee/cmd/bee/main.go:15 +0x13
```

Expected:
```
"time"="2023-12-01 13:07:15.884109" "level"="info" "logger"="node" "msg"="starting compaction"
Error: localstore: no data to compact
```
