### PR TITLE
fix: ask for a new libp2p password only once

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -524,13 +524,13 @@ func getConfigByNetworkID(networkID uint64, defaultBlockTimeInSeconds uint64) *n
 		config.bootNodes = []string{"/dnsaddr/mainnet.ethswarm.org"}
 		config.blockTime = 5 * time.Second
 		config.chainID = chaincfg.Mainnet.ChainID
-	case 5: // staging
+	case 5: // Staging.
 		config.chainID = chaincfg.Testnet.ChainID
 	case chaincfg.Testnet.NetworkID:
 		config.bootNodes = []string{"/dnsaddr/testnet.ethswarm.org"}
 		config.blockTime = 15 * time.Second
 		config.chainID = chaincfg.Testnet.ChainID
-	default: // will use the value provided by the chain
+	default: // Will use the value provided by the chain.
 		config.chainID = -1
 	}
 

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -23,9 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/kardianos/service"
-	"github.com/spf13/cobra"
-
 	"github.com/ethersphere/bee"
 	chaincfg "github.com/ethersphere/bee/pkg/config"
 	"github.com/ethersphere/bee/pkg/crypto"
@@ -38,6 +35,8 @@ import (
 	"github.com/ethersphere/bee/pkg/resolver/multiresolver"
 	"github.com/ethersphere/bee/pkg/spinlock"
 	"github.com/ethersphere/bee/pkg/swarm"
+	"github.com/kardianos/service"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -244,7 +243,7 @@ func buildBeeNode(ctx context.Context, c *command, cmd *cobra.Command, logger lo
 	// if mainnet is true then we only accept networkID value 1, error otherwise
 	// if the user has not provided a network ID but mainnet is true - just overwrite with mainnet network ID (1)
 	// in all the other cases we default to test network ID (10)
-	var networkID = defaultTestNetworkID
+	networkID := defaultTestNetworkID
 
 	if userHasSetNetworkID {
 		networkID = c.config.GetUint64(optionNameNetworkID)
@@ -523,7 +522,7 @@ type networkConfig struct {
 }
 
 func getConfigByNetworkID(networkID uint64, defaultBlockTimeInSeconds uint64) *networkConfig {
-	var config = networkConfig{
+	config := networkConfig{
 		blockTime: time.Duration(defaultBlockTimeInSeconds) * time.Second,
 	}
 	switch networkID {
@@ -531,13 +530,13 @@ func getConfigByNetworkID(networkID uint64, defaultBlockTimeInSeconds uint64) *n
 		config.bootNodes = []string{"/dnsaddr/mainnet.ethswarm.org"}
 		config.blockTime = 5 * time.Second
 		config.chainID = chaincfg.Mainnet.ChainID
-	case 5: //staging
+	case 5: // staging
 		config.chainID = chaincfg.Testnet.ChainID
-	case 10: //testnet
+	case 10: // testnet
 		config.bootNodes = []string{"/dnsaddr/testnet.ethswarm.org"}
 		config.blockTime = 15 * time.Second
 		config.chainID = chaincfg.Testnet.ChainID
-	default: //will use the value provided by the chain
+	default: // will use the value provided by the chain
 		config.chainID = -1
 	}
 

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -23,6 +23,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/kardianos/service"
+	"github.com/spf13/cobra"
+
 	"github.com/ethersphere/bee"
 	chaincfg "github.com/ethersphere/bee/pkg/config"
 	"github.com/ethersphere/bee/pkg/crypto"
@@ -35,12 +38,11 @@ import (
 	"github.com/ethersphere/bee/pkg/resolver/multiresolver"
 	"github.com/ethersphere/bee/pkg/spinlock"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"github.com/kardianos/service"
-	"github.com/spf13/cobra"
 )
 
 const (
-	serviceName = "SwarmBeeSvc"
+	serviceName      = "SwarmBeeSvc"
+	libp2pPKFilename = "libp2p_v2"
 )
 
 // default values for network IDs
@@ -413,7 +415,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 		// if libp2p key exists we can assume all required keys exist
 		// so prompt for a password to unlock them
 		// otherwise prompt for new password with confirmation to create them
-		exists, err := keystore.Exists("libp2p")
+		exists, err := keystore.Exists(libp2pPKFilename)
 		if err != nil {
 			return nil, err
 		}
@@ -477,7 +479,7 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 
 	logger.Info("swarm public key", "public_key", hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(publicKey)))
 
-	libp2pPrivateKey, created, err := keystore.Key("libp2p_v2", password, crypto.EDGSecp256_R1)
+	libp2pPrivateKey, created, err := keystore.Key(libp2pPKFilename, password, crypto.EDGSecp256_R1)
 	if err != nil {
 		return nil, fmt.Errorf("libp2p v2 key: %w", err)
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Fixes https://github.com/ethersphere/bee/issues/4262.

Currently, when starting a node with a default config, it asks for a new lib2p2 password each time, even when theres already one set.

Changes:
- take the libp2p PK filename from 1 source for both writes and reads
- `make format`


