### PR TITLE
fix: patch fix for batchstore reset and storage radius

### DIFF
--- a/pkg/statestore/storeadapter/migration.go
+++ b/pkg/statestore/storeadapter/migration.go
@@ -17,6 +17,7 @@ func allSteps() migration.Steps {
 		2: deletePrefix("sync_interval"),
 		3: deletePrefix("sync_interval"),
 		4: deletePrefix("blocklist"),
+		5: deletePrefix("batchstore"),
 	}
 }
 

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -25,8 +25,10 @@ import (
 
 // loggerName is the tree path name of the logger for this package.
 const loggerName = "reserve"
-
 const reserveNamespace = "reserve"
+
+// hack: make sures the network's storage radius does not fall below a certain value
+const minRadius = 9
 
 /*
 	pull by 	bin - binID
@@ -69,7 +71,7 @@ func New(
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return nil, err
 	}
-	rs.radius.Store(uint32(rItem.Radius))
+	rs.radius.Store(uint32(max(rItem.Radius, minRadius)))
 
 	epochItem := &EpochItem{}
 	err = store.Get(epochItem)
@@ -463,6 +465,7 @@ func (r *Reserve) EvictionTarget() int {
 }
 
 func (r *Reserve) SetRadius(store storage.Store, rad uint8) error {
+	rad = max(rad, minRadius)
 	r.radius.Store(uint32(rad))
 	r.radiusSetter.SetStorageRadius(rad)
 	return store.Put(&radiusItem{Radius: rad})


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
1. Properly resets the batchstore.
2. Sets a new minimum storage radius threshold. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
