### PR TITLE
fix: replace fixed network IDs with those imported from ABI

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	chaincfg "github.com/ethersphere/bee/pkg/config"
 	"github.com/ethersphere/bee/pkg/log"
 	"github.com/ethersphere/bee/pkg/node"
 	"github.com/ethersphere/bee/pkg/swarm"
@@ -256,7 +257,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice(optionNameBootnodes, []string{""}, "initial nodes to connect to")
 	cmd.Flags().Bool(optionNameDebugAPIEnable, false, "enable debug HTTP API")
 	cmd.Flags().String(optionNameDebugAPIAddr, ":1635", "debug HTTP API listen address")
-	cmd.Flags().Uint64(optionNameNetworkID, 1, "ID of the Swarm network")
+	cmd.Flags().Uint64(optionNameNetworkID, chaincfg.Mainnet.NetworkID, "ID of the Swarm network")
 	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")
 	cmd.Flags().Bool(optionNameTracingEnabled, false, "enable tracing")
 	cmd.Flags().String(optionNameTracingEndpoint, "127.0.0.1:6831", "endpoint to send tracing data")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -43,12 +43,6 @@ const (
 	serviceName = "SwarmBeeSvc"
 )
 
-// default values for network IDs
-const (
-	defaultMainNetworkID uint64 = 1
-	defaultTestNetworkID uint64 = 10
-)
-
 //go:embed bee-welcome-message.txt
 var beeWelcomeMessage string
 
@@ -242,15 +236,15 @@ func buildBeeNode(ctx context.Context, c *command, cmd *cobra.Command, logger lo
 	// if mainnet is true then we only accept networkID value 1, error otherwise
 	// if the user has not provided a network ID but mainnet is true - just overwrite with mainnet network ID (1)
 	// in all the other cases we default to test network ID (10)
-	var networkID = defaultTestNetworkID
+	var networkID = chaincfg.Testnet.NetworkID
 
 	if userHasSetNetworkID {
 		networkID = c.config.GetUint64(optionNameNetworkID)
-		if mainnet && networkID != defaultMainNetworkID {
+		if mainnet && networkID != chaincfg.Mainnet.NetworkID {
 			return nil, errors.New("provided network ID does not match mainnet")
 		}
 	} else if mainnet {
-		networkID = defaultMainNetworkID
+		networkID = chaincfg.Mainnet.NetworkID
 	}
 
 	bootnodes := c.config.GetStringSlice(optionNameBootnodes)
@@ -525,17 +519,17 @@ func getConfigByNetworkID(networkID uint64, defaultBlockTimeInSeconds uint64) *n
 		blockTime: time.Duration(defaultBlockTimeInSeconds) * time.Second,
 	}
 	switch networkID {
-	case 1: // mainnet
+	case chaincfg.Mainnet.NetworkID:
 		config.bootNodes = []string{"/dnsaddr/mainnet.ethswarm.org"}
 		config.blockTime = 5 * time.Second
 		config.chainID = chaincfg.Mainnet.ChainID
-	case 5: //staging
+	case 5: // Staging.
 		config.chainID = chaincfg.Testnet.ChainID
-	case 10: //testnet
+	case chaincfg.Testnet.NetworkID:
 		config.bootNodes = []string{"/dnsaddr/testnet.ethswarm.org"}
 		config.blockTime = 15 * time.Second
 		config.chainID = chaincfg.Testnet.ChainID
-	default: //will use the value provided by the chain
+	default: // Will use the value provided by the chain.
 		config.chainID = -1
 	}
 

--- a/pkg/config/chain.go
+++ b/pkg/config/chain.go
@@ -16,6 +16,7 @@ import (
 type ChainConfig struct {
 	// General.
 	ChainID                int64
+	NetworkID              uint64
 	PostageStampStartBlock uint64
 	NativeTokenSymbol      string
 	SwarmTokenSymbol       string
@@ -37,6 +38,7 @@ type ChainConfig struct {
 var (
 	Testnet = ChainConfig{
 		ChainID:                abi.TestnetChainID,
+		NetworkID:              abi.TestnetNetworkID,
 		PostageStampStartBlock: abi.TestnetPostageStampBlockNumber,
 		NativeTokenSymbol:      "ETH",
 		SwarmTokenSymbol:       "gBZZ",
@@ -57,6 +59,7 @@ var (
 
 	Mainnet = ChainConfig{
 		ChainID:                abi.MainnetChainID,
+		NetworkID:              abi.MainnetNetworkID,
 		PostageStampStartBlock: abi.MainnetPostageStampBlockNumber,
 		NativeTokenSymbol:      "xDAI",
 		SwarmTokenSymbol:       "xBZZ",


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Replaces fixed network IDs (for mainnet and testnet) with IDs imported from the ABI as the single source of truth.