### PR TITLE
chore: bump btcd to version v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/armon/go-radix v1.0.0
-	github.com/btcsuite/btcd v0.22.3
+	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/casbin/casbin/v2 v2.35.0
 	github.com/coreos/go-semver v0.3.0
 	github.com/ethereum/go-ethereum v1.13.4
@@ -63,7 +63,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-00010101000000-000000000000 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,10 +124,8 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
-github.com/btcsuite/btcd v0.22.3 h1:kYNaWFvOw6xvqP0vR20RP1Zq1DVMBxEO8QN5d1/EfNg=
-github.com/btcsuite/btcd v0.22.3/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=

--- a/pkg/api/pss_test.go
+++ b/pkg/api/pss_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/ethersphere/bee/pkg/api"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/jsonhttp"
@@ -171,7 +170,7 @@ func TestPssSend(t *testing.T) {
 		done            bool
 
 		privk, _       = crypto.GenerateSecp256k1Key()
-		publicKeyBytes = (*btcec.PublicKey)(&privk.PublicKey).SerializeCompressed()
+		publicKeyBytes = crypto.EncodeSecp256k1PublicKey(&privk.PublicKey)
 
 		sendFn = func(ctx context.Context, targets pss.Targets, chunk swarm.Chunk) error {
 			mtx.Lock()

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/ethersphere/bee/pkg/swarm"
 	"golang.org/x/crypto/sha3"
 )
@@ -66,12 +66,16 @@ func GenerateSecp256k1Key() (*ecdsa.PrivateKey, error) {
 
 // EncodeSecp256k1PrivateKey encodes raw ECDSA private key.
 func EncodeSecp256k1PrivateKey(k *ecdsa.PrivateKey) ([]byte, error) {
-	return (*btcec.PrivateKey)(k).Serialize(), nil
+	pvk, _ := btcec.PrivKeyFromBytes(k.D.Bytes())
+	return pvk.Serialize(), nil
 }
 
 // EncodeSecp256k1PublicKey encodes raw ECDSA public key in a 33-byte compressed format.
 func EncodeSecp256k1PublicKey(k *ecdsa.PublicKey) []byte {
-	return (*btcec.PublicKey)(k).SerializeCompressed()
+	var x, y btcec.FieldVal
+	x.SetByteSlice(k.X.Bytes())
+	y.SetByteSlice(k.Y.Bytes())
+	return btcec.NewPublicKey(&x, &y).SerializeCompressed()
 }
 
 // DecodeSecp256k1PrivateKey decodes raw ECDSA private key.
@@ -79,8 +83,8 @@ func DecodeSecp256k1PrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 	if l := len(data); l != btcec.PrivKeyBytesLen {
 		return nil, fmt.Errorf("secp256k1 data size %d expected %d", l, btcec.PrivKeyBytesLen)
 	}
-	privk, _ := btcec.PrivKeyFromBytes(btcec.S256(), data)
-	return (*ecdsa.PrivateKey)(privk), nil
+	pvk, _ := btcec.PrivKeyFromBytes(data)
+	return pvk.ToECDSA(), nil
 }
 
 // GenerateSecp256k1Key generates an ECDSA private key using
@@ -102,8 +106,8 @@ func DecodeSecp256r1PrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 // Secp256k1PrivateKeyFromBytes returns an ECDSA private key based on
 // the byte slice.
 func Secp256k1PrivateKeyFromBytes(data []byte) *ecdsa.PrivateKey {
-	privk, _ := btcec.PrivKeyFromBytes(btcec.S256(), data)
-	return (*ecdsa.PrivateKey)(privk)
+	pvk, _ := btcec.PrivKeyFromBytes(data)
+	return pvk.ToECDSA()
 }
 
 // NewEthereumAddress returns a binary representation of ethereum blockchain address.

--- a/pkg/crypto/dh_test.go
+++ b/pkg/crypto/dh_test.go
@@ -6,13 +6,12 @@ package crypto_test
 
 import (
 	"bytes"
-	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/hex"
 	"io"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/ethersphere/bee/pkg/crypto"
 )
 
@@ -66,7 +65,7 @@ func TestSharedKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubkey, err := btcec.ParsePubKey(data, btcec.S256())
+	pubkey, err := btcec.ParsePubKey(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +75,7 @@ func TestSharedKey(t *testing.T) {
 	}
 
 	dh := crypto.NewDH(privKey)
-	sk, err := dh.SharedKey((*ecdsa.PublicKey)(pubkey), salt)
+	sk, err := dh.SharedKey(pubkey.ToECDSA(), salt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/crypto/signer.go
+++ b/pkg/crypto/signer.go
@@ -10,7 +10,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/btcec/v2"
+	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/pkg/crypto/eip712"
@@ -59,8 +60,11 @@ func Recover(signature, data []byte) (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	p, _, err := btcec.RecoverCompact(btcec.S256(), btcsig, hash)
-	return (*ecdsa.PublicKey)(p), err
+	pbk, _, err := btcecdsa.RecoverCompact(btcsig, hash)
+	if err != nil {
+		return nil, err
+	}
+	return pbk.ToECDSA(), err
 }
 
 type defaultSigner struct {
@@ -135,7 +139,8 @@ func (d *defaultSigner) SignTypedData(typedData *eip712.TypedData) ([]byte, erro
 
 // sign the provided hash and convert it to the ethereum (r,s,v) format.
 func (d *defaultSigner) sign(sighash []byte, isCompressedKey bool) ([]byte, error) {
-	signature, err := btcec.SignCompact(btcec.S256(), (*btcec.PrivateKey)(d.key), sighash, false)
+	pvk, _ := btcec.PrivKeyFromBytes(d.key.D.Bytes())
+	signature, err := btcecdsa.SignCompact(pvk, sighash, false)
 	if err != nil {
 		return nil, err
 	}
@@ -167,6 +172,9 @@ func RecoverEIP712(signature []byte, data *eip712.TypedData) (*ecdsa.PublicKey, 
 		return nil, err
 	}
 
-	p, _, err := btcec.RecoverCompact(btcec.S256(), btcsig, sighash)
-	return (*ecdsa.PublicKey)(p), err
+	pbk, _, err := btcecdsa.RecoverCompact(btcsig, sighash)
+	if err != nil {
+		return nil, err
+	}
+	return pbk.ToECDSA(), err
 }

--- a/pkg/keystore/file/key.go
+++ b/pkg/keystore/file/key.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/keystore"
 	"github.com/google/uuid"

--- a/pkg/pss/trojan.go
+++ b/pkg/pss/trojan.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/ethersphere/bee/pkg/bmtpool"
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/encryption"
@@ -96,7 +96,7 @@ func Wrap(ctx context.Context, topic Topic, msg []byte, recipient *ecdsa.PublicK
 	// NOTE: only the random bytes of the compressed public key are used
 	// in order not to leak anything, the one bit parity info of the magic byte
 	// is encoded in the parity of the 28th byte of the mined nonce
-	ephpubBytes := (*btcec.PublicKey)(ephpub).SerializeCompressed()
+	ephpubBytes := crypto.EncodeSecp256k1PublicKey(ephpub)
 	payload := append(ephpubBytes[1:], ciphertext...)
 	odd := ephpubBytes[0]&0x1 != 0
 
@@ -259,8 +259,11 @@ func extractPublicKey(chunkData []byte) (*ecdsa.PublicKey, error) {
 	if chunkData[36]|0x1 != 0 {
 		pubkeyBytes[0] |= 0x1
 	}
-	pubkey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
-	return (*ecdsa.PublicKey)(pubkey), err
+	pubkey, err := btcec.ParsePubKey(pubkeyBytes)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey.ToECDSA(), err
 }
 
 // topic is needed to decrypt the trojan payload, but no need to perform decryption with each
@@ -312,9 +315,9 @@ func ParseRecipient(recipientHexString string) (*ecdsa.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	pubkey, err := btcec.ParsePubKey(publicKeyBytes, btcec.S256())
+	pubkey, err := btcec.ParsePubKey(publicKeyBytes)
 	if err != nil {
 		return nil, err
 	}
-	return (*ecdsa.PublicKey)(pubkey), err
+	return pubkey.ToECDSA(), err
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR bumps the btcd version that fixes the "btcd mishandles witness size checking" vulnerability: https://github.com/ethersphere/bee/security/dependabot/21