### PR TITLE
fix: correct initial storage radius metric

### DIFF
--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -78,7 +78,7 @@ func (db *DB) startReserveWorkers(
 		db.logger.Error(err, "reserve set radius")
 	}
 
-	db.metrics.StorageRadius.Set(float64(db.reserve.Size()))
+	db.metrics.StorageRadius.Set(float64(r))
 
 	// syncing can now begin now that the reserver worker is running
 	db.syncer.Start(ctx)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [N/A] My change requires a documentation update, and I have done it.
- [N/A] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The `bee_localstore_storage_radius` metric always had a value equal to the reserve size at startup until the reserve workers actually started working.   This fixes the initial value to be the initial radius, not the size, of the reserve.

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
Putting the size into this metric seriously messes with Grafana's automatic scaling.

### Related Issue (Optional)
N/A

### Screenshots (if appropriate):
![image](https://github.com/ethersphere/bee/assets/5175026/9dcd5bb1-22ad-4357-a77e-e62fe161c2f2)
