### PR TITLE
fix: redundant error unwrap method

### DIFF
--- a/pkg/replicas/getter_test.go
+++ b/pkg/replicas/getter_test.go
@@ -195,18 +195,11 @@ func TestGetter(t *testing.T) {
 				}
 
 				t.Run("returns correct error", func(t *testing.T) {
-					var esg *replicas.ErrSwarmageddon
-					if !errors.As(err, &esg) {
+					if !errors.Is(err, replicas.ErrSwarmageddon) {
 						t.Fatalf("incorrect error. want Swarmageddon. got %v", err)
 					}
-					errs := esg.Unwrap()
-					for _, err := range errs {
-						if !errors.Is(err, tc.failure.err) {
-							t.Fatalf("incorrect error. want it to wrap %v. got %v", tc.failure.err, err)
-						}
-					}
-					if len(errs) != tc.count+1 {
-						t.Fatalf("incorrect error. want %d. got %d", tc.count+1, len(errs))
+					if !errors.Is(err, tc.failure.err) {
+						t.Fatalf("incorrect error. want it to wrap %v. got %v", tc.failure.err, err)
 					}
 				})
 			}
@@ -265,7 +258,6 @@ func TestGetter(t *testing.T) {
 					}
 				}
 			})
-
 		})
 	}
 }


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
We seem to be doing error unwrapping by hand when there is a convenient method provided.