### PR TITLE
chore(linter): using binary staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
     - prealloc
     - predeclared
     - promlinter
-    - staticcheck
     - thelper
     - typecheck
     - unconvert

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ format:
 
 .PHONY: lint
 lint: linter
+	$(GOBIN)/staticcheck ./...
 	$(GOLANGCI_LINT) run ./...
 
 .PHONY: linter

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -108,8 +108,7 @@ type UpgradedResponseWriter interface {
 	http.Pusher
 	http.Hijacker
 	http.Flusher
-	// lint:ignore SA1019 CloseNotifier interface is required by gorilla compress handler
-	// nolint:staticcheck
+	//lint:ignore SA1019 CloseNotifier interface is required by gorilla compress handler
 	http.CloseNotifier
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -108,7 +108,8 @@ type UpgradedResponseWriter interface {
 	http.Pusher
 	http.Hijacker
 	http.Flusher
-	//lint:ignore SA1019 CloseNotifier interface is required by gorilla compress handler
+	// lint:ignore SA1019 CloseNotifier interface is required by gorilla compress handler
+	// nolint:staticcheck
 	http.CloseNotifier
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -108,8 +108,7 @@ type UpgradedResponseWriter interface {
 	http.Pusher
 	http.Hijacker
 	http.Flusher
-	// staticcheck SA1019 CloseNotifier interface is required by gorilla compress handler
-	// nolint:staticcheck
+	//lint:ignore SA1019 CloseNotifier interface is required by gorilla compress handler
 	http.CloseNotifier
 }
 

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -116,6 +116,7 @@ func NewEthereumAddress(p ecdsa.PublicKey) ([]byte, error) {
 	if p.X == nil || p.Y == nil {
 		return nil, errors.New("invalid public key")
 	}
+	//lint:ignore SA1019 to be addressed soon
 	pubBytes := elliptic.Marshal(btcec.S256(), p.X, p.Y)
 	pubHash, err := LegacyKeccak256(pubBytes[1:])
 	if err != nil {

--- a/pkg/keystore/file/key.go
+++ b/pkg/keystore/file/key.go
@@ -83,6 +83,7 @@ func encryptKey(k *ecdsa.PrivateKey, password string, edg keystore.EDG) ([]byte,
 		}
 		addr = a
 	case elliptic.P256():
+		//lint:ignore SA1019 to be addressed soon
 		addr = elliptic.Marshal(elliptic.P256(), k.PublicKey.X, k.PublicKey.Y)
 	default:
 		return nil, fmt.Errorf("unsupported curve: %v", k.PublicKey.Curve)

--- a/pkg/log/httpaccess/http_access.go
+++ b/pkg/log/httpaccess/http_access.go
@@ -113,7 +113,8 @@ func (rr *responseRecorder) WriteHeader(s int) {
 
 // CloseNotify implements http.CloseNotifier.
 func (rr *responseRecorder) CloseNotify() <-chan bool {
-	//lint:ignore SA1019  CloseNotifier interface is required by gorilla compress handler.
+	// nolint:staticcheck
+	// lint:ignore SA1019  CloseNotifier interface is required by gorilla compress handler
 	return rr.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 

--- a/pkg/log/httpaccess/http_access.go
+++ b/pkg/log/httpaccess/http_access.go
@@ -113,8 +113,7 @@ func (rr *responseRecorder) WriteHeader(s int) {
 
 // CloseNotify implements http.CloseNotifier.
 func (rr *responseRecorder) CloseNotify() <-chan bool {
-	// nolint:staticcheck
-	// lint:ignore SA1019  CloseNotifier interface is required by gorilla compress handler
+	//lint:ignore SA1019  CloseNotifier interface is required by gorilla compress handler
 	return rr.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 

--- a/pkg/log/httpaccess/http_access.go
+++ b/pkg/log/httpaccess/http_access.go
@@ -113,8 +113,7 @@ func (rr *responseRecorder) WriteHeader(s int) {
 
 // CloseNotify implements http.CloseNotifier.
 func (rr *responseRecorder) CloseNotify() <-chan bool {
-	// staticcheck SA1019 CloseNotifier interface is required by gorilla compress handler.
-	// nolint:staticcheck
+	//lint:ignore SA1019  CloseNotifier interface is required by gorilla compress handler.
 	return rr.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 

--- a/pkg/manifest/mantaray/marshal.go
+++ b/pkg/manifest/mantaray/marshal.go
@@ -192,7 +192,7 @@ func (bb *bitsForBytes) set(b byte) {
 	bb.bits[b/8] |= 1 << (b % 8)
 }
 
-//nolint:unused
+//lint:ignore U1000 we keep this around for now
 func (bb *bitsForBytes) get(b byte) bool {
 	return bb.getUint8(b)
 }

--- a/pkg/manifest/mantaray/node.go
+++ b/pkg/manifest/mantaray/node.go
@@ -110,12 +110,12 @@ func (n *Node) makeWithMetadata() {
 	n.nodeType = n.nodeType | nodeTypeWithMetadata
 }
 
-//nolint:unused
+//lint:ignore U1000 we keep this around for now
 func (n *Node) makeNotValue() {
 	n.nodeType = (nodeTypeMask ^ nodeTypeValue) & n.nodeType
 }
 
-//nolint:unused
+//lint:ignore U1000 we keep this around for now
 func (n *Node) makeNotEdge() {
 	n.nodeType = (nodeTypeMask ^ nodeTypeEdge) & n.nodeType
 }
@@ -124,7 +124,7 @@ func (n *Node) makeNotWithPathSeparator() {
 	n.nodeType = (nodeTypeMask ^ nodeTypeWithPathSeparator) & n.nodeType
 }
 
-//nolint:unused
+//lint:ignore U1000 we keep this around for now
 func (n *Node) makeNotWithMetadata() {
 	n.nodeType = (nodeTypeMask ^ nodeTypeWithMetadata) & n.nodeType
 }

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -55,7 +55,6 @@ import (
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
 	m2 "github.com/ethersphere/bee/pkg/metrics"
-	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -175,7 +174,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	}
 
 	if o.Registry != nil {
-		rcmgrObs.MustRegisterWith(o.Registry)
+		rcmgr.MustRegisterWith(o.Registry)
 	}
 
 	_, err = ocprom.NewExporter(ocprom.Options{
@@ -201,7 +200,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 	// The resource manager expects a limiter, se we create one from our limits.
 	limiter := rcmgr.NewFixedLimiter(limits)
 
-	str, err := rcmgrObs.NewStatsTraceReporter()
+	str, err := rcmgr.NewStatsTraceReporter()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/leveldbstore/recovery_test.go
+++ b/pkg/storage/leveldbstore/recovery_test.go
@@ -23,7 +23,7 @@ type obj struct {
 }
 
 func (o *obj) ID() string                 { return o.Key }
-func (_ *obj) Namespace() string          { return "obj" }
+func (*obj) Namespace() string            { return "obj" }
 func (o *obj) Marshal() ([]byte, error)   { return json.Marshal(o) }
 func (o *obj) Unmarshal(buf []byte) error { return json.Unmarshal(buf, o) }
 func (o *obj) Clone() storage.Item        { return &obj{Key: o.Key, Val: slices.Clone(o.Val)} }


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
recently I noticed that staticcheck messages in my IDE do not get picked by the `golangci-lint` here's why:

```
swarm:bee/ (fix-add-static-check) $ golangci-lint -v linters | grep staticcheck                                                                                                                                                                                                  [18:45:58]
INFO [config_reader] Config search paths: [./ /home/swarm/swarm/bee /home/swarm/swarm /home/swarm /home /]
INFO [config_reader] Used config file .golangci.yml
staticcheck (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
```
The author of staticcheck insists the linter to be used as a separate binary.

This PR adds the check before the `golangci-lint` step and updates the `//nolint:` directives using the original syntax.
