### PR TITLE
fix(stamper): global lock stamper across multiple upload sessions

### DIFF
--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -174,8 +174,8 @@ func (ps *service) GetStampIssuer(batchID []byte) (*StampIssuer, func() error, e
 
 // save persists the specified stamp issuer to the stamperstore.
 func (ps *service) save(st *StampIssuer) error {
-	st.bucketMtx.Lock()
-	defer st.bucketMtx.Unlock()
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 
 	if err := ps.store.Put(&StampIssuerItem{
 		Issuer: st,

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethersphere/bee/pkg/crypto"
 	"github.com/ethersphere/bee/pkg/storage"
 	"github.com/ethersphere/bee/pkg/swarm"
-	"resenje.org/multex"
 )
 
 var (
@@ -30,19 +29,18 @@ type stamper struct {
 	store  storage.Store
 	issuer *StampIssuer
 	signer crypto.Signer
-	mu     *multex.Multex
 }
 
 // NewStamper constructs a Stamper.
 func NewStamper(store storage.Store, issuer *StampIssuer, signer crypto.Signer) Stamper {
-	return &stamper{store, issuer, signer, multex.New()}
+	return &stamper{store, issuer, signer}
 }
 
 // Stamp takes chunk, see if the chunk can be included in the batch and
 // signs it with the owner of the batch of this Stamp issuer.
 func (st *stamper) Stamp(addr swarm.Address) (*Stamp, error) {
-	st.mu.Lock(addr.ByteString())
-	defer st.mu.Unlock(addr.ByteString())
+	st.issuer.mtx.Lock()
+	defer st.issuer.mtx.Unlock()
 
 	item := &StampItem{
 		BatchID:      st.issuer.data.BatchID,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Previous lock would only protect against data races within the same upload session, not against parallel upload sessions, using the same batch.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
