### PR TITLE
fix(joiner): run subtests in parallel

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1065,6 +1065,7 @@ func TestJoinerRedundancy(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("redundancy=%d encryption=%t", tc.rLevel, tc.encryptChunk), func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			shardCnt := tc.rLevel.GetMaxShards()


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
small fix to decrease the run time of the `TestJoinerRedundancy` from 28s -> 7s