### PR TITLE
fix(pushsync): store the chunk locally when no peers are available fo…

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -367,7 +367,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 			if errors.Is(err, topology.ErrNotFound) {
 				if ps.skipList.PruneExpiresAfter(ch.Address(), overDraftRefresh) == 0 { //no overdraft peers, we have depleted ALL peers
 					if inflight == 0 {
-						if ps.fullNode && ps.topologyDriver.IsReachable() {
+						if ps.fullNode {
 							if cac.Valid(ch) {
 								go ps.unwrap(ch)
 							}


### PR DESCRIPTION
…r nonreachable nodes

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In tiny clusters where no peers are available AND the upload is unreachable, the node gets forever stuck trying to sync the chunk. With this change, the uploader will store the chunk after no peer can be found regardless of reachability. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
