### PR TITLE
feat: split input file to chunks with specified redundancy

### DIFF
--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -197,7 +197,8 @@ func splitChunks(cmd *cobra.Command) {
 			var chunksCount int64
 			go func() {
 				for chunk := range store.c {
-					err := writeChunkToFile(outputDir, chunk)
+					filePath := filepath.Join(outputDir, chunk.Address().String())
+					err := os.WriteFile(filePath, chunk.Data(), 0644)
 					if err != nil {
 						logger.Error(err, "write chunk")
 						cancel()
@@ -223,18 +224,4 @@ func splitChunks(cmd *cobra.Command) {
 	c.MarkFlagsRequiredTogether(optionNameInputFile, optionNameOutputDir)
 
 	cmd.AddCommand(c)
-}
-
-func writeChunkToFile(outputDir string, chunk swarm.Chunk) error {
-	path := filepath.Join(outputDir, chunk.Address().String())
-	writer, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("open output file: %w", err)
-	}
-	defer writer.Close()
-	_, err = writer.Write(chunk.Data())
-	if err != nil {
-		return fmt.Errorf("write chunk: %w", err)
-	}
-	return nil
 }

--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ethersphere/bee/pkg/file/pipeline/builder"
@@ -19,12 +20,17 @@ import (
 
 // putter is a putter that stores all the split chunk addresses of a file
 type putter struct {
-	chunkAddresses []string
+	c chan swarm.Chunk
 }
 
 func (s *putter) Put(ctx context.Context, chunk swarm.Chunk) error {
-	s.chunkAddresses = append(s.chunkAddresses, chunk.Address().String())
+	s.c <- chunk
 	return nil
+}
+func newPutter() *putter {
+	return &putter{
+		c: make(chan swarm.Chunk),
+	}
 }
 
 var _ storage.Putter = (*putter)(nil)
@@ -39,11 +45,24 @@ func requestPipelineFn(s storage.Putter, encrypt bool) pipelineFunc {
 }
 
 func (c *command) initSplitCmd() error {
-	optionNameInputFile := "input-file"
-	optionNameOutputFile := "output-file"
 	cmd := &cobra.Command{
 		Use:   "split",
-		Short: "Split a file into a list chunks. The 1st line is the root hash",
+		Short: "Split a file into chunks",
+	}
+
+	splitRefs(cmd)
+	splitChunks(cmd)
+	c.root.AddCommand(cmd)
+	return nil
+}
+
+func splitRefs(cmd *cobra.Command) {
+	optionNameInputFile := "input-file"
+	optionNameOutputFile := "output-file"
+
+	c := &cobra.Command{
+		Use:   "refs",
+		Short: "Write only the chunk referencs to the output file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFileName, err := cmd.Flags().GetString(optionNameInputFile)
 			if err != nil {
@@ -71,43 +90,138 @@ func (c *command) initSplitCmd() error {
 			defer reader.Close()
 
 			logger.Info("splitting", "file", inputFileName)
-			store := new(putter)
-
-			p := requestPipelineFn(store, false)
-			address, err := p(context.Background(), reader)
-			if err != nil {
-				return fmt.Errorf("bmt pipeline: %w", err)
-			}
-
 			logger.Info("writing output", "file", outputFileName)
+
+			store := newPutter()
 			writer, err := os.OpenFile(outputFileName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 			if err != nil {
 				return fmt.Errorf("open output file: %w", err)
 			}
 			defer writer.Close()
 
-			logger.Debug("write root", "hash", address)
-			_, err = writer.WriteString(fmt.Sprintf("%s\n", address))
+			var refs []string
+			go func() {
+				for chunk := range store.c {
+					refs = append(refs, chunk.Address().String())
+				}
+			}()
+
+			p := requestPipelineFn(store, false)
+			rootRef, err := p(context.Background(), reader)
+			close(store.c)
+			if err != nil {
+				return fmt.Errorf("pipeline: %w", err)
+			}
+
+			logger.Debug("write root", "hash", rootRef)
+			_, err = writer.WriteString(fmt.Sprintf("%s\n", rootRef))
 			if err != nil {
 				return fmt.Errorf("write root hash: %w", err)
 			}
-			for _, chunkAddress := range store.chunkAddresses {
-				logger.Debug("write chunk", "hash", chunkAddress)
-				_, err = writer.WriteString(fmt.Sprintf("%s\n", chunkAddress))
+			for _, ref := range refs {
+				logger.Debug("write chunk", "hash", ref)
+				_, err = writer.WriteString(fmt.Sprintf("%s\n", ref))
 				if err != nil {
 					return fmt.Errorf("write chunk address: %w", err)
 				}
 			}
-			logger.Info("done", "hashes", len(store.chunkAddresses))
+			logger.Info("done", "root", rootRef.String(), "chunks", len(refs))
 			return nil
 		},
 	}
 
-	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	cmd.Flags().String(optionNameInputFile, "", "input file")
-	cmd.Flags().String(optionNameOutputFile, "", "output file")
-	cmd.MarkFlagsRequiredTogether(optionNameInputFile, optionNameOutputFile)
+	c.Flags().String(optionNameInputFile, "", "input file")
+	c.Flags().String(optionNameOutputFile, "", "output file")
+	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
 
-	c.root.AddCommand(cmd)
+	c.MarkFlagsRequiredTogether(optionNameInputFile, optionNameOutputFile)
+
+	cmd.AddCommand(c)
+}
+
+func splitChunks(cmd *cobra.Command) {
+	optionNameInputFile := "input-file"
+	optionNameOutputDir := "output-dir"
+
+	c := &cobra.Command{
+		Use:   "chunks",
+		Short: "Write the chunks to the output directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inputFileName, err := cmd.Flags().GetString(optionNameInputFile)
+			if err != nil {
+				return fmt.Errorf("get input file name: %w", err)
+			}
+			outputDir, err := cmd.Flags().GetString(optionNameOutputDir)
+			if err != nil {
+				return fmt.Errorf("get output file name: %w", err)
+			}
+			info, err := os.Stat(outputDir)
+			if err != nil {
+				return fmt.Errorf("stat output dir: %w", err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("output dir %s is not a directory", outputDir)
+			}
+			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			if err != nil {
+				return fmt.Errorf("get verbosity: %w", err)
+			}
+			v = strings.ToLower(v)
+			logger, err := newLogger(cmd, v)
+			if err != nil {
+				return fmt.Errorf("new logger: %w", err)
+			}
+			reader, err := os.Open(inputFileName)
+			if err != nil {
+				return fmt.Errorf("open input file: %w", err)
+			}
+			defer reader.Close()
+
+			logger.Info("splitting", "file", inputFileName)
+			logger.Info("writing output", "dir", outputDir)
+
+			store := newPutter()
+			ctx, cancel := context.WithCancel(context.Background())
+			var chunksCount int64
+			go func() {
+				for chunk := range store.c {
+					err := writeChunkToFile(outputDir, chunk)
+					if err != nil {
+						logger.Error(err, "write chunk")
+						cancel()
+					}
+					chunksCount++
+				}
+			}()
+
+			p := requestPipelineFn(store, false)
+			rootRef, err := p(ctx, reader)
+			close(store.c)
+			if err != nil {
+				return fmt.Errorf("pipeline: %w", err)
+			}
+			logger.Info("done", "root", rootRef.String(), "chunks", chunksCount)
+			return nil
+		},
+	}
+	c.Flags().String(optionNameInputFile, "", "input file")
+	c.Flags().String(optionNameOutputDir, "", "output dir")
+	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	c.MarkFlagsRequiredTogether(optionNameInputFile, optionNameOutputDir)
+
+	cmd.AddCommand(c)
+}
+
+func writeChunkToFile(outputDir string, chunk swarm.Chunk) error {
+	path := filepath.Join(outputDir, chunk.Address().String())
+	writer, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	defer writer.Close()
+	if err != nil {
+		return fmt.Errorf("open output file: %w", err)
+	}
+	_, err = writer.Write(chunk.Data())
+	if err != nil {
+		return fmt.Errorf("write chunk: %w", err)
+	}
 	return nil
 }

--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -64,7 +64,7 @@ func splitRefs(cmd *cobra.Command) {
 
 	c := &cobra.Command{
 		Use:   "refs",
-		Short: "Write only the chunk referencs to the output file",
+		Short: "Write only the chunk reference to the output file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFileName, err := cmd.Flags().GetString(optionNameInputFile)
 			if err != nil {
@@ -228,10 +228,10 @@ func splitChunks(cmd *cobra.Command) {
 func writeChunkToFile(outputDir string, chunk swarm.Chunk) error {
 	path := filepath.Join(outputDir, chunk.Address().String())
 	writer, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	defer writer.Close()
 	if err != nil {
 		return fmt.Errorf("open output file: %w", err)
 	}
+	defer writer.Close()
 	_, err = writer.Write(chunk.Data())
 	if err != nil {
 		return fmt.Errorf("write chunk: %w", err)

--- a/cmd/bee/cmd/split_test.go
+++ b/cmd/bee/cmd/split_test.go
@@ -83,7 +83,7 @@ func TestDBSplitChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = newCommand(t, cmd.WithArgs("split", "chunks", "--input-file", inputFileName, "--output-dir", dir)).Execute()
+	err = newCommand(t, cmd.WithArgs("split", "chunks", "--input-file", inputFileName, "--output-dir", dir, "--r-level", "3")).Execute()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,14 +92,15 @@ func TestDBSplitChunks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantHashes := api.CalculateNumberOfChunks(stat.Size(), false)
+	want := api.CalculateNumberOfChunks(stat.Size(), false)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if int64(len(entries)) != wantHashes {
-		t.Fatalf("got %d hashes, want %d", len(entries), wantHashes)
+	if int64(len(entries)) < want {
+		t.Fatalf("want at least %d chunks", want)
 	}
+
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Split input file to chunks. Refactored the cmd to 2 subcommands
  - `refs`: outputs only list of refs to file: 
   ```
bee split refs --input-file random.txt --output-file output.txt
  ```
 - `chunks` ouptuts chunks to directory:  
 ```
bee split chunks --input-file random.txt --output-dir ./chunks --r-level 4
```

`--r-level` specifies the redundancy level. It's optional. Default is 0.

closes #4599
