### PR TITLE
fix: store dir error info

### DIFF
--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -93,26 +93,6 @@ func TestDirs(t *testing.T) {
 		)
 	})
 
-	t.Run("missing content type", func(t *testing.T) {
-		tarReader, mwBoundary := multipartFiles(t, []f{{
-			data: []byte("robots text"),
-			name: "robots.txt",
-			// header left empty on purpose
-		}})
-
-		jsonhttptest.Request(t, client, http.MethodPost, dirUploadResource, http.StatusBadRequest,
-			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
-			jsonhttptest.WithRequestBody(tarReader),
-			jsonhttptest.WithRequestHeader(api.SwarmCollectionHeader, "True"),
-			jsonhttptest.WithRequestHeader(api.ContentTypeHeader, fmt.Sprintf("multipart/form-data; boundary=%q", mwBoundary)),
-			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{
-				Message: "missing Content-Type header",
-				Code:    http.StatusBadRequest,
-			}),
-			jsonhttptest.WithRequestHeader(api.ContentTypeHeader, "multipart/form-data"),
-		)
-	})
-
 	// valid tars
 	for _, tc := range []struct {
 		name                string

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -75,8 +75,7 @@ func TestDirs(t *testing.T) {
 	t.Run("wrong content type", func(t *testing.T) {
 		tarReader := tarFiles(t, []f{{
 			data: []byte("some data"),
-			name: "some-name",
-			dir:  "./dir",
+			name: "binary-file",
 		}})
 
 		// submit valid tar, but with wrong content-type


### PR DESCRIPTION
### Checklist

- [X] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).

### Description
We are doing checks on `Content-Type` or `Content-Length` when iterating folders, checks that are not aligned with http RFCs.
 
As a result bee returns status code `500` although it should accept the payload.

Closes: #4464 