### PR TITLE
feat: adding endpoint for node operators to block certain peers from …

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -336,6 +336,16 @@ components:
           duration:
             type: integer
 
+    BlocklistRequest:
+      type: object
+      properties:
+        address:
+          $ref: "#/components/schemas/SwarmAddress"        
+        reason:
+          type: string
+        duration:
+          type: integer
+
     PssRecipient:
       type: string
 

--- a/openapi/SwarmDebug.yaml
+++ b/openapi/SwarmDebug.yaml
@@ -115,6 +115,28 @@ paths:
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
           description: Default response
+    post:
+      summary: Blocklist a peer
+      tags:
+        - Connectivity
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "SwarmCommon.yaml#/components/schemas/BlocklistRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/HealthStatus"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response      
 
   "/consumed":
     get:

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -402,6 +402,7 @@ func (s *Service) mountBusinessDebug(restricted bool) {
 
 	handle("/blocklist", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.blocklistedPeersHandler),
+		"POST": http.HandlerFunc(s.blocklistPeersHandler),
 	})
 
 	handle("/peers/{address}", jsonhttp.MethodHandler{


### PR DESCRIPTION
…joining the node

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
The API needs to be extended by adding a new endpoint that will allow for node operators to block certain peers from joining the node.

