### PR TITLE
fix: rename swarm key

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -468,6 +468,16 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 			return nil, err
 		}
 	} else {
+		oldSwarmKeyExists, err := keystore.Exists("swarm")
+		if err != nil {
+			return nil, err
+		}
+		if oldSwarmKeyExists {
+			err := keystore.RenameKey("swarm", "wallet")
+			if err != nil {
+				return nil, err
+			}
+		}
 		walletPrivateKey, _, err := keystore.Key("wallet", password, crypto.EDGSecp256_K1)
 		if err != nil {
 			return nil, fmt.Errorf("swarm wallet key: %w", err)

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -468,15 +468,15 @@ func (c *command) configureSigner(cmd *cobra.Command, logger log.Logger) (config
 			return nil, err
 		}
 	} else {
-		swarmPrivateKey, _, err := keystore.Key("swarm", password, crypto.EDGSecp256_K1)
+		walletPrivateKey, _, err := keystore.Key("wallet", password, crypto.EDGSecp256_K1)
 		if err != nil {
-			return nil, fmt.Errorf("swarm key: %w", err)
+			return nil, fmt.Errorf("swarm wallet key: %w", err)
 		}
-		signer = crypto.NewDefaultSigner(swarmPrivateKey)
-		publicKey = &swarmPrivateKey.PublicKey
+		signer = crypto.NewDefaultSigner(walletPrivateKey)
+		publicKey = &walletPrivateKey.PublicKey
 	}
 
-	logger.Info("swarm public key", "public_key", hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(publicKey)))
+	logger.Info("swarm wallet public key", "public_key", hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(publicKey)))
 
 	libp2pPrivateKey, created, err := keystore.Key(libp2pPKFilename, password, crypto.EDGSecp256_R1)
 	if err != nil {

--- a/pkg/keystore/file/service.go
+++ b/pkg/keystore/file/service.go
@@ -83,6 +83,18 @@ func (s *Service) Key(name, password string, edg keystore.EDG) (pk *ecdsa.Privat
 	return pk, false, nil
 }
 
+func (s *Service) RenameKey(oldName, newName string) error {
+	oldFilename := s.keyFilename(oldName)
+	newFilename := s.keyFilename(newName)
+
+	err := os.Rename(oldFilename, newFilename)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Service) keyFilename(name string) string {
 	return filepath.Join(s.dir, fmt.Sprintf("%s.key", name))
 }

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -31,4 +31,6 @@ type Service interface {
 	Exists(name string) (bool, error)
 	// SetKey generates and persists a new private key
 	SetKey(name, password string, edg EDG) (*ecdsa.PrivateKey, error)
+	// RenameKey renames a key
+	RenameKey(oldName, newName string) error
 }

--- a/pkg/keystore/mem/service.go
+++ b/pkg/keystore/mem/service.go
@@ -81,6 +81,21 @@ func (s *Service) Key(name, password string, edg keystore.EDG) (pk *ecdsa.Privat
 	return k.pk, created, nil
 }
 
+func (s *Service) RenameKey(oldName, newName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	k, ok := s.m[oldName]
+	if !ok {
+		return fmt.Errorf("key with name %s does not exist", oldName)
+	}
+
+	delete(s.m, oldName)
+	s.m[newName] = k
+
+	return nil
+}
+
 type key struct {
 	pk       *ecdsa.PrivateKey
 	password string

--- a/pkg/keystore/test/test.go
+++ b/pkg/keystore/test/test.go
@@ -29,7 +29,7 @@ func Service(t *testing.T, s keystore.Service) {
 
 	edg := crypto.EDGSecp256_K1
 	// create a new swarm wallet key
-	k1, created, err := s.Key("wallet", "pass123456", edg)
+	k1, created, err := s.Key("swarm", "pass123456", edg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,13 +37,28 @@ func Service(t *testing.T, s keystore.Service) {
 		t.Fatal("key is not created")
 	}
 
-	exists, err = s.Exists("wallet")
+	exists, err = s.Exists("swarm")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !exists {
 		t.Fatal("should exist")
+	}
+
+	// rename swarm key to wallet
+	err = s.RenameKey("swarm", "wallet")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err = s.Exists("swarm")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exists {
+		t.Fatal("shouldn't exist")
 	}
 
 	// get swarm key

--- a/pkg/keystore/test/test.go
+++ b/pkg/keystore/test/test.go
@@ -18,7 +18,7 @@ import (
 func Service(t *testing.T, s keystore.Service) {
 	t.Helper()
 
-	exists, err := s.Exists("swarm")
+	exists, err := s.Exists("wallet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,8 +28,8 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	edg := crypto.EDGSecp256_K1
-	// create a new swarm key
-	k1, created, err := s.Key("swarm", "pass123456", edg)
+	// create a new swarm wallet key
+	k1, created, err := s.Key("wallet", "pass123456", edg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func Service(t *testing.T, s keystore.Service) {
 		t.Fatal("key is not created")
 	}
 
-	exists, err = s.Exists("swarm")
+	exists, err = s.Exists("wallet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	// get swarm key
-	k2, created, err := s.Key("swarm", "pass123456", edg)
+	k2, created, err := s.Key("wallet", "pass123456", edg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func Service(t *testing.T, s keystore.Service) {
 	}
 
 	// invalid password
-	_, _, err = s.Key("swarm", "invalid password", edg)
+	_, _, err = s.Key("wallet", "invalid password", edg)
 	if !errors.Is(err, keystore.ErrInvalidPassword) {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
In a new node `wallet.key` will be created instead of `swarm.key`. In an old node the `swarm.key` will be renamed to `wallet.key` on start. Due to this, downgrading the node won't be possible because of the name change.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
fixes #4023

### Screenshots (if appropriate):
