### PR TITLE
fix: panic on printconfig

### DIFF
--- a/cmd/bee/cmd/configurateoptions.go
+++ b/cmd/bee/cmd/configurateoptions.go
@@ -5,9 +5,10 @@
 package cmd
 
 import (
+	"fmt"
 	"sort"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/spf13/cobra"
 )
@@ -36,7 +37,12 @@ func (c *command) initConfigurateOptionsCmd() (err error) {
 				if err != nil {
 					return err
 				}
-				cmd.Println("#", cmd.Flag(k).Usage)
+				f := cmd.Flag(k)
+				if f == nil {
+					return fmt.Errorf("%s is not a valid flag", k)
+				}
+				cmd.Println("#", f.Usage)
+
 				cmd.Print(string(ym))
 			}
 			cmd.Println()


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Return error when an invalid config is encountered instead of panicking 
e.g 
```
> bee printconfig 

...
...
# cause the node to start in full mode
full-node: true
# help for printconfig
help: false
Error: invalid-config is not a valid flag
``` 

closes #4646 
