### PR TITLE
refactor(postage): enable parallel test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,9 +72,6 @@ issues:
       # temporally disable paralleltest in following packages
     - linters:
         - paralleltest
-      path: pkg/postage
-    - linters:
-        - paralleltest
       path: pkg/log
     - linters:
         - paralleltest

--- a/pkg/postage/batch_test.go
+++ b/pkg/postage/batch_test.go
@@ -15,6 +15,8 @@ import (
 // TestBatchMarshalling tests the idempotence  of binary marshal/unmarshal for a
 // Batch.
 func TestBatchMarshalling(t *testing.T) {
+	t.Parallel()
+
 	a := postagetesting.MustNewBatch()
 	buf, err := a.MarshalBinary()
 	if err != nil {

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -252,12 +252,12 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 func TestBatchServiceTopUp(t *testing.T) {
 	t.Parallel()
 
-	testBatch := postagetesting.MustNewBatch()
 	testNormalisedBalance := big.NewInt(2000000000000)
 	testTopUpAmount := big.NewInt(1000)
 	t.Run("expect get error", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -277,6 +277,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	t.Run("expect update error", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -297,6 +298,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	t.Run("passes", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -329,6 +331,7 @@ func TestBatchServiceTopUp(t *testing.T) {
 	t.Run("passes without BatchEventListener update", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		// create an owner different from the batch owner
 		owner := testutil.RandBytes(t, 32)
@@ -365,11 +368,11 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 
 	const testNewDepth = 30
 	testNormalisedBalance := big.NewInt(2000000000000)
-	testBatch := postagetesting.MustNewBatch()
 
 	t.Run("expect get error", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -390,6 +393,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	t.Run("expect put error", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -411,6 +415,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	t.Run("passes", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -442,6 +447,7 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	t.Run("passes without BatchEventListener update", func(t *testing.T) {
 		t.Parallel()
 
+		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		// create an owner different from the batch owner
 		owner := testutil.RandBytes(t, 32)

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -65,6 +65,8 @@ func (m *mockBatchListener) HandleDepthIncrease(_ []byte, _ uint8) {
 var _ postage.BatchEventListener = (*mockBatchListener)(nil)
 
 func TestBatchServiceCreate_FLAKY(t *testing.T) {
+	t.Parallel()
+
 	testChainState := postagetesting.NewChainState()
 
 	validateNoBatch := func(t *testing.T, testBatch *postage.Batch, st *mock.BatchStore) {
@@ -111,6 +113,8 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 	}
 
 	t.Run("expect put create put error", func(t *testing.T) {
+		t.Parallel()
+
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		testAmount := postagetesting.NewBigInt()
@@ -141,6 +145,8 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
+		t.Parallel()
+
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		testAmount := postagetesting.NewBigInt()
@@ -172,6 +178,8 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 	})
 
 	t.Run("passes without recovery", func(t *testing.T) {
+		t.Parallel()
+
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		testAmount := postagetesting.NewBigInt()
@@ -208,6 +216,8 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 	})
 
 	t.Run("batch with near-zero val rejected", func(t *testing.T) {
+		t.Parallel()
+
 		testBatch := postagetesting.MustNewBatch()
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
@@ -240,10 +250,14 @@ func TestBatchServiceCreate_FLAKY(t *testing.T) {
 }
 
 func TestBatchServiceTopUp(t *testing.T) {
+	t.Parallel()
+
 	testBatch := postagetesting.MustNewBatch()
 	testNormalisedBalance := big.NewInt(2000000000000)
 	testTopUpAmount := big.NewInt(1000)
 	t.Run("expect get error", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -261,6 +275,8 @@ func TestBatchServiceTopUp(t *testing.T) {
 	})
 
 	t.Run("expect update error", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -279,6 +295,8 @@ func TestBatchServiceTopUp(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -309,6 +327,8 @@ func TestBatchServiceTopUp(t *testing.T) {
 	// if a batch with a different owner is topped up we should not see any event fired in the
 	// batch service
 	t.Run("passes without BatchEventListener update", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		// create an owner different from the batch owner
 		owner := testutil.RandBytes(t, 32)
@@ -341,11 +361,15 @@ func TestBatchServiceTopUp(t *testing.T) {
 }
 
 func TestBatchServiceUpdateDepth(t *testing.T) {
+	t.Parallel()
+
 	const testNewDepth = 30
 	testNormalisedBalance := big.NewInt(2000000000000)
 	testBatch := postagetesting.MustNewBatch()
 
 	t.Run("expect get error", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, _, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -364,6 +388,8 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	})
 
 	t.Run("expect put error", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -383,6 +409,8 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		svc, batchStore, _ := newTestStoreAndServiceWithListener(
 			t,
@@ -412,6 +440,8 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 	// if a batch with a different owner is diluted we should not see any event fired in the
 	// batch service
 	t.Run("passes without BatchEventListener update", func(t *testing.T) {
+		t.Parallel()
+
 		testBatchListener := &mockBatchListener{}
 		// create an owner different from the batch owner
 		owner := testutil.RandBytes(t, 32)
@@ -443,11 +473,15 @@ func TestBatchServiceUpdateDepth(t *testing.T) {
 }
 
 func TestBatchServiceUpdatePrice(t *testing.T) {
+	t.Parallel()
+
 	testChainState := postagetesting.NewChainState()
 	testChainState.CurrentPrice = big.NewInt(100000)
 	testNewPrice := big.NewInt(20000000)
 
 	t.Run("expect put error", func(t *testing.T) {
+		t.Parallel()
+
 		svc, batchStore, _ := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
@@ -461,6 +495,8 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 	})
 
 	t.Run("passes", func(t *testing.T) {
+		t.Parallel()
+
 		svc, batchStore, _ := newTestStoreAndService(
 			t,
 			mock.WithChainState(testChainState),
@@ -477,6 +513,8 @@ func TestBatchServiceUpdatePrice(t *testing.T) {
 	})
 }
 func TestBatchServiceUpdateBlockNumber(t *testing.T) {
+	t.Parallel()
+
 	testChainState := &postage.ChainState{
 		Block:        1,
 		CurrentPrice: big.NewInt(100),
@@ -501,6 +539,8 @@ func TestBatchServiceUpdateBlockNumber(t *testing.T) {
 }
 
 func TestTransactionOk(t *testing.T) {
+	t.Parallel()
+
 	svc, store, s := newTestStoreAndService(t)
 	if err := svc.Start(context.Background(), 10, nil); err != nil {
 		t.Fatal(err)
@@ -528,6 +568,8 @@ func TestTransactionOk(t *testing.T) {
 }
 
 func TestTransactionError(t *testing.T) {
+	t.Parallel()
+
 	svc, store, s := newTestStoreAndService(t)
 	if err := svc.Start(context.Background(), 10, nil); err != nil {
 		t.Fatal(err)
@@ -551,6 +593,8 @@ func TestTransactionError(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
+	t.Parallel()
+
 	s := mocks.NewStateStore()
 	store := mock.New()
 	mockHash := &hs{}
@@ -572,6 +616,8 @@ func TestChecksum(t *testing.T) {
 }
 
 func TestChecksumResync(t *testing.T) {
+	t.Parallel()
+
 	s := mocks.NewStateStore()
 	store := mock.New()
 	mockHash := &hs{}

--- a/pkg/postage/batchstore/mock/store_test.go
+++ b/pkg/postage/batchstore/mock/store_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestBatchStore(t *testing.T) {
+	t.Parallel()
+
 	const testCnt = 3
 
 	testBatch := postagetesting.MustNewBatch(
@@ -54,6 +56,8 @@ func TestBatchStore(t *testing.T) {
 }
 
 func TestBatchStorePutChainState(t *testing.T) {
+	t.Parallel()
+
 	const testCnt = 3
 
 	testChainState := postagetesting.NewChainState()
@@ -74,6 +78,8 @@ func TestBatchStorePutChainState(t *testing.T) {
 }
 
 func TestBatchStoreWithBatch(t *testing.T) {
+	t.Parallel()
+
 	testBatch := postagetesting.MustNewBatch()
 	batchStore := mock.New(
 		mock.WithBatch(testBatch),

--- a/pkg/postage/batchstore/store_test.go
+++ b/pkg/postage/batchstore/store_test.go
@@ -27,6 +27,8 @@ var noopEvictFn = func([]byte) error { return nil }
 const defaultCapacity = 2 ^ 22
 
 func TestBatchStore_Get(t *testing.T) {
+	t.Parallel()
+
 	testBatch := postagetest.MustNewBatch()
 
 	stateStore := mock.NewStateStore()
@@ -42,6 +44,8 @@ func TestBatchStore_Get(t *testing.T) {
 }
 
 func TestBatchStore_Iterate(t *testing.T) {
+	t.Parallel()
+
 	testBatch := postagetest.MustNewBatch()
 	key := batchstore.BatchKey(testBatch.ID)
 
@@ -63,6 +67,8 @@ func TestBatchStore_Iterate(t *testing.T) {
 }
 
 func TestBatchStore_IterateStopsEarly(t *testing.T) {
+	t.Parallel()
+
 	testBatch1 := postagetest.MustNewBatch()
 	key1 := batchstore.BatchKey(testBatch1.ID)
 
@@ -113,6 +119,8 @@ func TestBatchStore_IterateStopsEarly(t *testing.T) {
 }
 
 func TestBatchStore_SaveAndUpdate(t *testing.T) {
+	t.Parallel()
+
 	testBatch := postagetest.MustNewBatch()
 	key := batchstore.BatchKey(testBatch.ID)
 
@@ -157,6 +165,8 @@ func TestBatchStore_SaveAndUpdate(t *testing.T) {
 }
 
 func TestBatchStore_GetChainState(t *testing.T) {
+	t.Parallel()
+
 	testChainState := postagetest.NewChainState()
 
 	stateStore := mock.NewStateStore()
@@ -171,6 +181,8 @@ func TestBatchStore_GetChainState(t *testing.T) {
 }
 
 func TestBatchStore_PutChainState(t *testing.T) {
+	t.Parallel()
+
 	testChainState := postagetest.NewChainState()
 
 	stateStore := mock.NewStateStore()
@@ -183,6 +195,8 @@ func TestBatchStore_PutChainState(t *testing.T) {
 }
 
 func TestBatchStore_Reset(t *testing.T) {
+	t.Parallel()
+
 	testChainState := postagetest.NewChainState()
 	testBatch := postagetest.MustNewBatch(
 		postagetest.WithValue(15),
@@ -236,6 +250,7 @@ type testBatch struct {
 // TestBatchSave adds batches to the batchstore, and after each batch, checks
 // the reserve state radius.
 func TestBatchSave(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -310,6 +325,7 @@ func TestBatchSave(t *testing.T) {
 // TestBatchUpdate adds an initial group of batches to the batchstore and one by one
 // updates their depth and value fields while checking the batchstore radius values.
 func TestBatchUpdate(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -406,6 +422,7 @@ func TestBatchUpdate(t *testing.T) {
 // TestPutChainState add a group of batches to the batchstore, and after updating the chainstate,
 // checks the batchstore radius reflects the updates.
 func TestPutChainState(t *testing.T) {
+	t.Parallel()
 
 	totalCapacity := batchstore.Exp2(5)
 
@@ -481,6 +498,8 @@ func TestPutChainState(t *testing.T) {
 }
 
 func TestBatchExpiry(t *testing.T) {
+	t.Parallel()
+
 	store := setupBatchStore(t, defaultCapacity)
 
 	batch := postagetest.MustNewBatch(
@@ -512,6 +531,8 @@ func TestBatchExpiry(t *testing.T) {
 }
 
 func TestUnexpiredBatch(t *testing.T) {
+	t.Parallel()
+
 	store := setupBatchStore(t, defaultCapacity)
 
 	batch := postagetest.MustNewBatch(

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -45,6 +45,8 @@ func toBatchBlock(block uint64) uint64 {
 }
 
 func TestListener(t *testing.T) {
+	t.Parallel()
+
 	const (
 		blockNumber = uint64(500)
 		timeout     = 5 * time.Second
@@ -53,6 +55,8 @@ func TestListener(t *testing.T) {
 	// test that when the listener gets a certain event
 	// then we would like to assert the appropriate EventUpdater method was called
 	t.Run("create event", func(t *testing.T) {
+		t.Parallel()
+
 		c := createArgs{
 			id:               hash[:],
 			owner:            addr[:],
@@ -97,6 +101,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("topup event", func(t *testing.T) {
+		t.Parallel()
+
 		topup := topupArgs{
 			id:                hash[:],
 			amount:            big.NewInt(0),
@@ -138,6 +144,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("depthIncrease event", func(t *testing.T) {
+		t.Parallel()
+
 		depthIncrease := depthArgs{
 			id:                hash[:],
 			depth:             200,
@@ -180,6 +188,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("priceUpdate event", func(t *testing.T) {
+		t.Parallel()
+
 		priceUpdate := priceArgs{
 			price: big.NewInt(500),
 		}
@@ -219,6 +229,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("multiple events", func(t *testing.T) {
+		t.Parallel()
+
 		c := createArgs{
 			id:               hash[:],
 			owner:            addr[:],
@@ -327,6 +339,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("do not shutdown on error event", func(t *testing.T) {
+		t.Parallel()
+
 		blockNumber := uint64(500)
 		ev := newEventUpdaterMock()
 		mf := newMockFilterer(
@@ -355,6 +369,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("shutdown on stalling", func(t *testing.T) {
+		t.Parallel()
+
 		ev := newEventUpdaterMock()
 		mf := newMockFilterer(
 			WithBlockNumberError(errors.New("dummy error")),
@@ -382,6 +398,8 @@ func TestListener(t *testing.T) {
 	})
 
 	t.Run("shutdown on processing error", func(t *testing.T) {
+		t.Parallel()
+
 		blockNumber := uint64(500)
 		ev := newEventUpdaterMockWithBlockNumberUpdateError(errors.New("err"))
 		mf := newMockFilterer(
@@ -417,6 +435,8 @@ func TestListener(t *testing.T) {
 }
 
 func TestListenerBatchState(t *testing.T) {
+	t.Parallel()
+
 	ev := newEventUpdaterMock()
 	mf := newMockFilterer()
 

--- a/pkg/postage/postagecontract/contract_test.go
+++ b/pkg/postage/postagecontract/contract_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -26,13 +27,16 @@ import (
 )
 
 var postageStampContractABI = abiutil.MustParseABI(chaincfg.Testnet.PostageStampABI)
+var mu sync.Mutex
 
 func TestCreateBatch(t *testing.T) {
 	t.Parallel()
 
+	mu.Lock()
 	b := postagecontract.BucketDepth
 	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
+		mu.Unlock()
 	})
 
 	postagecontract.BucketDepth = 9
@@ -224,9 +228,11 @@ func newCreateEvent(postageContractAddress common.Address, batchId common.Hash) 
 func TestTopUpBatch(t *testing.T) {
 	t.Parallel()
 
+	mu.Lock()
 	b := postagecontract.BucketDepth
 	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
+		mu.Unlock()
 	})
 
 	postagecontract.BucketDepth = 9
@@ -394,9 +400,11 @@ func newTopUpEvent(postageContractAddress common.Address, batch *postage.Batch) 
 func TestDiluteBatch(t *testing.T) {
 	t.Parallel()
 
+	mu.Lock()
 	b := postagecontract.BucketDepth
 	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
+		mu.Unlock()
 	})
 
 	postagecontract.BucketDepth = 9

--- a/pkg/postage/postagecontract/contract_test.go
+++ b/pkg/postage/postagecontract/contract_test.go
@@ -28,9 +28,13 @@ import (
 var postageStampContractABI = abiutil.MustParseABI(chaincfg.Testnet.PostageStampABI)
 
 func TestCreateBatch(t *testing.T) {
-	defer func(b uint8) {
+	t.Parallel()
+
+	b := postagecontract.BucketDepth
+	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
-	}(postagecontract.BucketDepth)
+	})
+
 	postagecontract.BucketDepth = 9
 	owner := common.HexToAddress("abcd")
 	label := "label"
@@ -40,6 +44,7 @@ func TestCreateBatch(t *testing.T) {
 	initialBalance := big.NewInt(100)
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
 
 		depth := uint8(10)
 		totalAmount := big.NewInt(102400)
@@ -144,6 +149,8 @@ func TestCreateBatch(t *testing.T) {
 	})
 
 	t.Run("invalid depth", func(t *testing.T) {
+		t.Parallel()
+
 		depth := uint8(9)
 
 		contract := postagecontract.New(
@@ -164,6 +171,8 @@ func TestCreateBatch(t *testing.T) {
 	})
 
 	t.Run("insufficient funds", func(t *testing.T) {
+		t.Parallel()
+
 		depth := uint8(10)
 		totalAmount := big.NewInt(102399)
 
@@ -213,9 +222,13 @@ func newCreateEvent(postageContractAddress common.Address, batchId common.Hash) 
 }
 
 func TestTopUpBatch(t *testing.T) {
-	defer func(b uint8) {
+	t.Parallel()
+
+	b := postagecontract.BucketDepth
+	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
-	}(postagecontract.BucketDepth)
+	})
+
 	postagecontract.BucketDepth = 9
 	owner := common.HexToAddress("abcd")
 	postageStampAddress := common.HexToAddress("ffff")
@@ -224,6 +237,7 @@ func TestTopUpBatch(t *testing.T) {
 	topupBalance := big.NewInt(100)
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
 
 		totalAmount := big.NewInt(102400)
 		txHashApprove := common.HexToHash("abb0")
@@ -308,6 +322,8 @@ func TestTopUpBatch(t *testing.T) {
 	})
 
 	t.Run("batch doesnt exist", func(t *testing.T) {
+		t.Parallel()
+
 		errNotFound := errors.New("not found")
 		contract := postagecontract.New(
 			owner,
@@ -327,6 +343,8 @@ func TestTopUpBatch(t *testing.T) {
 	})
 
 	t.Run("insufficient funds", func(t *testing.T) {
+		t.Parallel()
+
 		totalAmount := big.NewInt(102399)
 		batch := postagetesting.MustNewBatch(postagetesting.WithOwner(owner.Bytes()))
 		batchStoreMock := postagestoreMock.New(postagestoreMock.WithBatch(batch))
@@ -374,9 +392,13 @@ func newTopUpEvent(postageContractAddress common.Address, batch *postage.Batch) 
 }
 
 func TestDiluteBatch(t *testing.T) {
-	defer func(b uint8) {
+	t.Parallel()
+
+	b := postagecontract.BucketDepth
+	t.Cleanup(func() {
 		postagecontract.BucketDepth = b
-	}(postagecontract.BucketDepth)
+	})
+
 	postagecontract.BucketDepth = 9
 	owner := common.HexToAddress("abcd")
 	postageStampAddress := common.HexToAddress("ffff")
@@ -384,6 +406,7 @@ func TestDiluteBatch(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
 
 		txHashDilute := common.HexToHash("c3a7")
 		batch := postagetesting.MustNewBatch(postagetesting.WithOwner(owner.Bytes()))
@@ -494,6 +517,8 @@ func TestDiluteBatch(t *testing.T) {
 	})
 
 	t.Run("batch doesnt exist", func(t *testing.T) {
+		t.Parallel()
+
 		errNotFound := errors.New("not found")
 		contract := postagecontract.New(
 			owner,
@@ -513,6 +538,8 @@ func TestDiluteBatch(t *testing.T) {
 	})
 
 	t.Run("invalid depth", func(t *testing.T) {
+		t.Parallel()
+
 		batch := postagetesting.MustNewBatch(postagetesting.WithOwner(owner.Bytes()))
 		batch.Depth = uint8(16)
 		batchStoreMock := postagestoreMock.New(postagestoreMock.WithBatch(batch))
@@ -563,6 +590,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
+
 		expectedRes := big.NewInt(1)
 		expectedFalseRes := big.NewInt(0)
 		counter := 0
@@ -613,6 +641,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("wrong call data for expired batches exist", func(t *testing.T) {
 		t.Parallel()
+
 		expectedCallDataForExpireLimitedBatches, err := postageStampContractABI.Pack("expireLimited", big.NewInt(2))
 		if err != nil {
 			t.Fatal("expected error")
@@ -646,6 +675,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("wrong call data for expired limited batches", func(t *testing.T) {
 		t.Parallel()
+
 		expectedCallDataForExpireLimitedBatches, err := postageStampContractABI.Pack("expiredBatchesExist")
 		if err != nil {
 			t.Fatal("expected error")
@@ -700,6 +730,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("wrong result for expire limited batches", func(t *testing.T) {
 		t.Parallel()
+
 		expectedRes := big.NewInt(1)
 		expectedFalseRes := big.NewInt(0)
 		counter := 0
@@ -754,6 +785,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("wrong result for expired batches exist", func(t *testing.T) {
 		t.Parallel()
+
 		expectedCallDataForExpiredBatches, err := postageStampContractABI.Pack("expiredBatchesExist")
 		if err != nil {
 			t.Fatal(err)
@@ -788,6 +820,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("unpack err for expired batches exist", func(t *testing.T) {
 		t.Parallel()
+
 		expectedRes := big.NewInt(1)
 		expectedCallDataForExpiredBatches, err := postageStampContractABI.Pack("expiredBatchesExist")
 		if err != nil {
@@ -824,6 +857,7 @@ func TestBatchExpirer(t *testing.T) {
 
 	t.Run("tx err for expire limited batches", func(t *testing.T) {
 		t.Parallel()
+
 		expectedRes := big.NewInt(1)
 		expectedFalseRes := big.NewInt(0)
 		counter := 0
@@ -873,6 +907,8 @@ func TestBatchExpirer(t *testing.T) {
 }
 
 func TestLookupERC20Address(t *testing.T) {
+	t.Parallel()
+
 	postageStampContractAddress := common.HexToAddress("ffff")
 	erc20Address := common.HexToAddress("ffff")
 

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -26,6 +26,8 @@ import (
 // TestSaveLoad tests the idempotence of saving and loading the postage.Service
 // with all the active stamp issuers.
 func TestSaveLoad(t *testing.T) {
+	t.Parallel()
+
 	store := inmemstore.New()
 	defer store.Close()
 	pstore := pstoremock.New()
@@ -74,6 +76,8 @@ func TestSaveLoad(t *testing.T) {
 }
 
 func TestGetStampIssuer(t *testing.T) {
+	t.Parallel()
+
 	store := inmemstore.New()
 	defer store.Close()
 	chainID := int64(0)
@@ -117,6 +121,8 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	}
 	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+
 		for _, id := range ids[1:4] {
 			st, save, err := ps.GetStampIssuer(id)
 			if err != nil {
@@ -141,12 +147,16 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	})
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
 		_, _, err := ps.GetStampIssuer(ids[0])
 		if !errors.Is(err, postage.ErrNotFound) {
 			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 	})
 	t.Run("not usable", func(t *testing.T) {
+		t.Parallel()
+
 		for _, id := range ids[4:] {
 			_, _, err := ps.GetStampIssuer(id)
 			if !errors.Is(err, postage.ErrNotUsable) {
@@ -155,6 +165,8 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	})
 	t.Run("recovered", func(t *testing.T) {
+		t.Parallel()
+
 		b := postagetesting.MustNewBatch()
 		b.Start = validBlockNumber
 		testAmount := big.NewInt(1)
@@ -175,6 +187,8 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	})
 	t.Run("topup", func(t *testing.T) {
+		t.Parallel()
+
 		ps.HandleTopUp(ids[1], big.NewInt(10))
 		if err != nil {
 			t.Fatal(err)
@@ -189,6 +203,8 @@ func TestGetStampIssuer(t *testing.T) {
 		}
 	})
 	t.Run("dilute", func(t *testing.T) {
+		t.Parallel()
+
 		ps.HandleDepthIncrease(ids[2], 17)
 		if err != nil {
 			t.Fatal(err)
@@ -208,6 +224,8 @@ func TestGetStampIssuer(t *testing.T) {
 }
 
 func TestSetExpired(t *testing.T) {
+	t.Parallel()
+
 	store := inmemstore.New()
 	testutil.CleanupCloser(t, store)
 

--- a/pkg/postage/stamp_test.go
+++ b/pkg/postage/stamp_test.go
@@ -20,6 +20,8 @@ import (
 
 // TestStampMarshalling tests the idempotence  of binary marshal/unmarshals for Stamps.
 func TestStampMarshalling(t *testing.T) {
+	t.Parallel()
+
 	sExp := postagetesting.MustNewStamp()
 	buf, _ := sExp.MarshalBinary()
 	if len(buf) != postage.StampSize {
@@ -34,6 +36,8 @@ func TestStampMarshalling(t *testing.T) {
 
 // TestStampMarshalling tests the idempotence  of binary marshal/unmarshals for Stamps.
 func TestStampJsonMarshalling(t *testing.T) {
+	t.Parallel()
+
 	sExp := postagetesting.MustNewStamp()
 
 	b, err := json.Marshal(sExp)
@@ -69,6 +73,8 @@ func compareStamps(t *testing.T, s1, s2 *postage.Stamp) {
 
 // TestStampIndexMarshalling tests the idempotence of stamp index serialisation.
 func TestStampIndexMarshalling(t *testing.T) {
+	t.Parallel()
+
 	var (
 		expBucket uint32 = 11789
 		expIndex  uint32 = 199999
@@ -84,6 +90,8 @@ func TestStampIndexMarshalling(t *testing.T) {
 }
 
 func TestValidStamp(t *testing.T) {
+	t.Parallel()
+
 	privKey, err := crypto.GenerateSecp256k1Key()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -27,6 +27,8 @@ import (
 
 // TestStampIssuerMarshalling tests the idempotence  of binary marshal/unmarshal.
 func TestStampIssuerMarshalling(t *testing.T) {
+	t.Parallel()
+
 	want := newTestStampIssuer(t, 1000)
 	buf, err := want.MarshalBinary()
 	if err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Enable parallel testing in pkg/postage by adding `t.Parallel()` to test functions, convert some code to helper functions to fix scope issues, use `t.Cleanup()` instead of `defer` in Parallel tests, and remove disable paralleltest on `pkg/postage` from `.golangci.yml`.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
closes https://github.com/ethersphere/bee/issues/3831

### Screenshots (if appropriate):
