### PR TITLE
fix: proof data race

### DIFF
--- a/pkg/bmt/proof.go
+++ b/pkg/bmt/proof.go
@@ -46,7 +46,8 @@ func (p Prover) Proof(i int) Proof {
 
 	secsize := 2 * p.segmentSize
 	offset := i * secsize
-	section := p.bmt.buffer[offset : offset+secsize]
+	section := make([]byte, secsize)
+	copy(section, p.bmt.buffer[offset:offset+secsize])
 	segment, firstSegmentSister := section[:p.segmentSize], section[p.segmentSize:]
 	if index%2 != 0 {
 		segment, firstSegmentSister = firstSegmentSister, segment

--- a/pkg/storageincentives/proof_test.go
+++ b/pkg/storageincentives/proof_test.go
@@ -104,7 +104,7 @@ func TestMakeInclusionProofsRegression(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := swarm.MustParseHexAddress("193bbea3dd0656d813c2c1e27b821f141286bbe6ab0dbf8e26fc7dd491e8f921"); !sch.Address().Equal(want) {
+	if want := swarm.MustParseHexAddress("b012904b0c3e6462158b4416556caa888031a79bad46d2ffa7012408c9c38aa8"); !sch.Address().Equal(want) {
 		t.Fatalf("expecting sample chunk address %v, got %v", want, sch.Address())
 	}
 

--- a/pkg/storageincentives/proof_test.go
+++ b/pkg/storageincentives/proof_test.go
@@ -43,7 +43,7 @@ var testData []byte
 
 // Test asserts that MakeInclusionProofs will generate the same
 // output for given sample.
-func TestMakeInclusionProofsRegression_FLAKY(t *testing.T) {
+func TestMakeInclusionProofsRegression(t *testing.T) {
 	t.Parallel()
 
 	const sampleSize = 16

--- a/pkg/storageincentives/proof_test.go
+++ b/pkg/storageincentives/proof_test.go
@@ -121,7 +121,7 @@ func TestMakeInclusionProofsRegression_FLAKY(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := cmp.Diff(proofs, expectedProofs); diff != "" {
+	if diff := cmp.Diff(expectedProofs, proofs); diff != "" {
 		t.Fatalf("unexpected inclusion proofs (-want +have):\n%s", diff)
 	}
 }

--- a/pkg/storageincentives/testdata/inclusion-proofs.json
+++ b/pkg/storageincentives/testdata/inclusion-proofs.json
@@ -1,57 +1,11 @@
 {
     "proof1": {
         "proofSegments": [
-            "0x0875605dea48e812c9685ffba220a2b848bdbafdb95e02d087ba4a32925ea34f",
-            "0xf873df729270d5f4064286f3f018385a07cb4228734d8aca794299fee6e3e3e5",
-            "0x1fa8767fe303fe7487f5d58e4d72e5e170cf135f58a91b4fe19e4b19e5b67b5a",
-            "0x0f64ed713e25291e2c5a0561f584fa78c55a399e31919903d215dd622bcfd0ec",
-            "0x34dac0c73538614801c1ad16e272ef57f0b96a972073d15418f38daf9eb401c0",
-            "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
-            "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
-        ],
-        "proveSegment": "0x7133885ac59dca7b97773acb740e978d41a4af45bd563067c8a3d863578488f1",
-        "proofSegments2": [
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5",
-            "0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30",
-            "0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85",
-            "0x2047b070a295f8d517121d9ac9b3d5f9a944bac6cfab72dd5a7c625ab4558b0a",
-            "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
-            "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
-        ],
-        "proveSegment2": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "chunkSpan": 26,
-        "proofSegments3": [
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0xa7f526447b68535121d36909a7585c9610d4fe6d4115540464c70499b0d7136d",
-            "0x066dd7ce6f4f1c97e78ff1c271916db25cb06128c92f8c8520807a0fa2ba93ff",
-            "0xdf43c86b00db2156e769e8a8df1f08dc89ab5661c6fbaa9563f96fb9c051fc63",
-            "0x7327aecc9178bab420bb6fe482e07b65af69775b55666ec1ac8ab3da5bcec6dc",
-            "0xb68323ecaad1185a5e078f41c94c59d0b6dda5d57e109866e64d44acb8702846",
-            "0x478adfa93a7bb904d0aa86ff0d559f43aa915ee7865592e717b72a24452181cb"
-        ],
-        "postageProof": {
-            "signature": "p8jRioJ504AxaevPTlp9vdTf/vpZHqrY0c6qY2p5Otl15/exCHvOpBdlJbAALt3grL/aINvS37vnd8qziWj9xhs=",
-            "postageId": "0x4c8efc14c8e3cee608174f995d7afe155897bf643a31226e4f1363bc97686aef",
-            "index": 525059,
-            "timeStamp": 197384
-        },
-        "socProof": [
-            {
-                "signer": "0x827b44d53df2854057713b25cdd653eb70fe36c4",
-                "signature": "TpV2lJM45MI/RwO/gTZyVquFmzKTT+9Nsu5Gp2v2vjVOlqxii4eEst4Lvq5ZdUaXgxktbRcFSF/Krdje3ebiqhs=",
-                "identifier": "0x6223cfdd75a40440ccd32d0b11b24f08562ec63b1ea3b8cb1a59dfc3e3c33595",
-                "chunkAddr": "0xf32442586d93d8c002372ed41fa2ea1f281f38311c161d535c3665de5d9bfd92"
-            }
-        ]
-    },
-    "proof2": {
-        "proofSegments": [
             "0x463aeb4ca5f000064c082e56eba387004265d2f47bf1226ef2d86cb163bcca3a",
-            "0x829af58b2a2f1c6c156baa196f03be4df510a96419f2dd54c456d3da30166312",
-            "0xdee4815ec42efa507b79cf4eb1f272e07be1b526cbd48137a287d9e5b2b2808a",
-            "0x0f64ed713e25291e2c5a0561f584fa78c55a399e31919903d215dd622bcfd0ec",
-            "0x34dac0c73538614801c1ad16e272ef57f0b96a972073d15418f38daf9eb401c0",
+            "0xbb2419bc6b159691ed6275ad84a1a630030362d9bb5eb2a8c4726444ec551ae1",
+            "0xe6c468a2bef08602c622c6098be35244293462b1093337b5da11a1b8f0a4fad2",
+            "0xdd286362d41440619671ccb426ff03ef83658b67c02afdd2ae7059c6504d9bec",
+            "0xc9c5536a94d977bbd593a0a0db44a7f1ff8ac0eae72da60cf4e6b79ec880d74a",
             "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
             "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
         ],
@@ -84,13 +38,59 @@
         },
         "socProof": []
     },
+    "proof2": {
+        "proofSegments": [
+            "0x5eaf83c8ca6bfa7e341cd8f2daa7acb13ca3c572944fb24a82ccdb7a80da6e78",
+            "0xfb0bd6aa2050f53144af5ccfe80c2634ee838ce9ff0ee57689524e698f7ccbee",
+            "0x9770dbbd96ca20fb8436da185548eaa52518f796c0a37076f0c54abf10e0dbdb",
+            "0xdd286362d41440619671ccb426ff03ef83658b67c02afdd2ae7059c6504d9bec",
+            "0xc9c5536a94d977bbd593a0a0db44a7f1ff8ac0eae72da60cf4e6b79ec880d74a",
+            "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
+            "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
+        ],
+        "proveSegment": "0x04a60acb043bf6af06f8f102e1e7f566603162b471324df5c20234913c7bf878",
+        "proofSegments2": [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5",
+            "0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30",
+            "0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85",
+            "0xa666b3d7c9ca35427c35ddb00e60af6f0ff7c6b168d3d813240448d601f289ff",
+            "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
+            "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
+        ],
+        "proveSegment2": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "chunkSpan": 26,
+        "proofSegments3": [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xa7f526447b68535121d36909a7585c9610d4fe6d4115540464c70499b0d7136d",
+            "0x066dd7ce6f4f1c97e78ff1c271916db25cb06128c92f8c8520807a0fa2ba93ff",
+            "0xdf43c86b00db2156e769e8a8df1f08dc89ab5661c6fbaa9563f96fb9c051fc63",
+            "0xd3a508c3dc9ffdefebdb3b0f7f133bae38be424970983bf28a33f695539d3262",
+            "0xb68323ecaad1185a5e078f41c94c59d0b6dda5d57e109866e64d44acb8702846",
+            "0x478adfa93a7bb904d0aa86ff0d559f43aa915ee7865592e717b72a24452181cb"
+        ],
+        "postageProof": {
+            "signature": "vDAqDnOHRdfydLi+WO47ON2ytdGR8EHCbeVGQkQ/cD1kJQ/cUMvQpLQo4bcgkOSXp6IX8YtVsgTcM9xlqHOxeBs=",
+            "postageId": "0x4c8efc14c8e3cee608174f995d7afe155897bf643a31226e4f1363bc97686aef",
+            "index": 525059,
+            "timeStamp": 197384
+        },
+        "socProof": [
+            {
+                "signer": "0x827b44d53df2854057713b25cdd653eb70fe36c4",
+                "signature": "oSaX7q6fkjyFA+ZgVsvT2TyCys8RFObSOgs8l4Ffs8AIAh6vaE52zZZYnThRkScyi99+YYo87ECxe9CwY9sO1xw=",
+                "identifier": "0x155f4ef901f9a967fe6bd2d9a9e4fca1e43ed948034dcf3be33c454d29689802",
+                "chunkAddr": "0x6f5b3aa1e39c6a916b73424d68cfa2b430a42567e3a875a30ecdb7687413af2e"
+            }
+        ]
+    },
     "proofLast": {
         "proofSegments": [
             "0xfee18543782df46a86f85456e62dc973a4c84369b6b1cd4f93e57fe247f9730e",
             "0x23a0858ee2b8b4cb0ba66d3533f468d6b583a6b77df0cc78fc6df64dc735a917",
-            "0xb6bffa54dec44ad57349f9aef6cb65a1f8807f15447462ec519751220e5a5bc3",
-            "0x553aae9948fc13c33d8b353cf5694ecadc7c40c8316ce09cbd4d864dbb94f026",
-            "0xaf7db874a9b5addf602b3e899194480a32afec6d6cd4ec0fadf9e065db739dd5",
+            "0xcd242c66cbf32e4eaec735fbdf35543972e165b352365a212ac33e9ac20ed8a0",
+            "0xb4cfdaa440e5df2b8a980bda00abcac5d7e5fcfb9400d475cc343bc15197d4e3",
+            "0xc45ed7ea161d9df0134ac82ca61aefc2d133c2275b474e021e8bfd9c4f4677f2",
             "0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d",
             "0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
         ],

--- a/pkg/storer/sample.go
+++ b/pkg/storer/sample.go
@@ -94,10 +94,10 @@ func newStamp(s swarm.Stamp) *postage.Stamp {
 }
 
 func getChunkType(chunk swarm.Chunk) swarm.ChunkType {
-	if soc.Valid(chunk) {
-		return swarm.ChunkTypeSingleOwner
-	} else if cac.Valid(chunk) {
+	if cac.Valid(chunk) {
 		return swarm.ChunkTypeContentAddressed
+	} else if soc.Valid(chunk) {
+		return swarm.ChunkTypeSingleOwner
 	}
 	return swarm.ChunkTypeUnspecified
 }

--- a/pkg/storer/sample.go
+++ b/pkg/storer/sample.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/bmt"
+	"github.com/ethersphere/bee/v2/pkg/cac"
 	"github.com/ethersphere/bee/v2/pkg/postage"
 	"github.com/ethersphere/bee/v2/pkg/soc"
 	chunk "github.com/ethersphere/bee/v2/pkg/storage/testing"
@@ -68,7 +69,7 @@ func MakeSampleUsingChunks(chunks []swarm.Chunk, anchor []byte) (Sample, error) 
 	}
 	items := make([]SampleItem, len(chunks))
 	for i, ch := range chunks {
-		tr, err := transformedAddress(bmt.NewHasher(prefixHasherFactory), ch, swarm.ChunkTypeContentAddressed)
+		tr, err := transformedAddress(bmt.NewHasher(prefixHasherFactory), ch, getChunkType(ch))
 		if err != nil {
 			return Sample{}, err
 		}
@@ -90,6 +91,15 @@ func MakeSampleUsingChunks(chunks []swarm.Chunk, anchor []byte) (Sample, error) 
 
 func newStamp(s swarm.Stamp) *postage.Stamp {
 	return postage.NewStamp(s.BatchID(), s.Index(), s.Timestamp(), s.Sig())
+}
+
+func getChunkType(chunk swarm.Chunk) swarm.ChunkType {
+	if soc.Valid(chunk) {
+		return swarm.ChunkTypeSingleOwner
+	} else if cac.Valid(chunk) {
+		return swarm.ChunkTypeContentAddressed
+	}
+	return swarm.ChunkTypeUnspecified
 }
 
 // ReserveSample generates the sample of reserve storage of a node required for the


### PR DESCRIPTION
Data race appeared by referencing some elements of the buffer of the bmt pool in the `bmt.Prover.Proof` method.

it may resolve inclusion proof related errors as well in the redistribution game.

Other corrections have been made in  `TestMakeInclusionProofsRegression` which is not flaky anymore.

fixes: #4531

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
