### PR TITLE
fix: proper display of go code in codingstyle doc

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -189,18 +189,22 @@ Name tests with a compact name that reflects their scenario. Don't try to specif
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
 <tr><td>
+	
 ```go
 func TestSomethingBySettingVarToFive(t *testing.T) {
   ...
 }
 ```
+
 </td><td>
+	
 ```go
 // TestSomething tests that something works correctly by doing this and that.
 func TestSomething(t *testing.T) {
   ...
 }
 ```
+
 </td>
 </td></tr>
 </tbody></table>

--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -189,7 +189,7 @@ Name tests with a compact name that reflects their scenario. Don't try to specif
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
 <tr><td>
-	
+
 ```go
 func TestSomethingBySettingVarToFive(t *testing.T) {
   ...
@@ -197,7 +197,7 @@ func TestSomethingBySettingVarToFive(t *testing.T) {
 ```
 
 </td><td>
-	
+
 ```go
 // TestSomething tests that something works correctly by doing this and that.
 func TestSomething(t *testing.T) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Small change to the look and feel in the coding style document.

### Open API Spec Version Changes (if applicable)


#### Motivation and Context (Optional)


### Related Issue (Optional)


### Screenshots (if appropriate):
