### PR TITLE
fix: check chunkBinItem during reserve repair

### DIFF
--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -8,6 +8,7 @@ package pullsync
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -466,7 +467,7 @@ func (s *Syncer) processWant(ctx context.Context, o *pb.Offer, w *pb.Want) ([]sw
 			addr := swarm.NewAddress(ch.Address)
 			c, err := s.store.ReserveGet(ctx, addr, ch.BatchID)
 			if err != nil {
-				s.logger.Debug("processing want: unable to find chunk", "chunk_address", addr, "batch_id", ch.BatchID)
+				s.logger.Debug("processing want: unable to find chunk", "chunk_address", addr, "batch_id", hex.EncodeToString(ch.BatchID))
 				chunks = append(chunks, swarm.NewChunk(swarm.ZeroAddress, nil))
 				s.metrics.MissingChunks.Inc()
 				continue

--- a/pkg/storer/migration/reserveRepair.go
+++ b/pkg/storer/migration/reserveRepair.go
@@ -45,10 +45,10 @@ func ReserveRepairer(
 			binIds := make(map[uint8]map[uint64]int)
 			return st.IndexStore().Iterate(
 				storage.Query{
-					Factory: func() storage.Item { return &reserve.ChunkBinItem{} },
+					Factory: func() storage.Item { return &reserve.BatchRadiusItem{} },
 				},
 				func(res storage.Result) (bool, error) {
-					item := res.Entry.(*reserve.ChunkBinItem)
+					item := res.Entry.(*reserve.BatchRadiusItem)
 					if _, ok := binIds[item.Bin]; !ok {
 						binIds[item.Bin] = make(map[uint64]int)
 					}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
For error checking before/after running the reserve repair, we should be checking batchRadiusItem instead of chunkBinItem .

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
