### PR TITLE
fix: apiservice

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1156,9 +1156,8 @@ func NewBee(
 		apiService.MountAPI()
 		apiService.MountDebug()
 
-		debugService.SetP2P(p2ps)
-		debugService.SetSwarmAddress(&swarmAddress)
-		debugService.SetRedistributionAgent(agent)
+		apiService.SetSwarmAddress(&swarmAddress)
+		apiService.SetRedistributionAgent(agent)
 	}
 
 	if o.DebugAPIAddr != "" {


### PR DESCRIPTION
Fix panic when `/redistributionstate` was called on the main API because the redistribution agent was not set.

```
"time"="2024-05-15 13:38:01.362418" "level"="error" "logger"="node" "msg"="http: panic serving 10.3.3.68:33706: runtime error: invalid memory address or nil pointer dereference
goroutine 949893580 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1868 +0xb9
panic({0x13b40c0?, 0x246ef20?})
	runtime/panic.go:920 +0x270
github.com/ethersphere/bee/v2/pkg/storageincentives.(*Agent).Status(...)
	github.com/ethersphere/bee/v2/pkg/storageincentives/agent.go:554
github.com/ethersphere/bee/v2/pkg/api.(*Service).redistributionStatusHandler(0xc000202a80, {0x1a36bc0, 0xc007e82320}, 0xc007d03100)
	github.com/ethersphere/bee/v2/pkg/api/redistribution.go:42 +0xda
net/http.HandlerFunc.ServeHTTP(0x13a12a0?, {0x1a36bc0?, 0xc007e82320?}, 0x3?)
	net/http/server.go:2136 +0x29
github.com/ethersphere/bee/v2/pkg/jsonhttp.HandleMethods(0xc00cd247e0, {0x15e499e, 0x2b}, {0x15cc5ba, 0x1f}, {0x1a36bc0?, 0xc007e82320}, 0xc007d03100)
	github.com/ethersphere/bee/v2/pkg/jsonhttp/handlers.go:25 +0x12c
github.com/ethersphere/bee/v2/pkg/jsonhttp.MethodHandler.ServeHTTP(0xc007d03000?, {0x1a36bc0?, 0xc007e82320?}, 0x1487aa0?)
	github.com/ethersphere/bee/v2/pkg/jsonhttp/handlers.go:17 +0x45
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000000540, {0x1a36bc0, 0xc007e82320}, 0xc007d02f00)
	github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1c5
resenje.org/web.NoCacheHeadersHandler.NewSetHeadersHandler.func1({0x1a36bc0, 0xc007e82320}, 0x6?)
	resenje.org/web@v0.4.3/set_headers.go:28 +0x11e
net/http.HandlerFunc.ServeHTTP(0xc008a4b560?, {0x1a36bc0?, 0xc007e82320?}, 0xc009229830?)
	net/http/server.go:2136 +0x29
github.com/ethersphere/bee/v2/pkg/api.(*Service).corsHandler.func1({0x1a36bc0, 0xc007e82320}, 0xc007d02f00)
	github.com/ethersphere/bee/v2/pkg/api/api.go:640 +0x4ca
net/http.HandlerFunc.ServeHTTP(0x0?, {0x1a36bc0?, 0xc007e82320?}, 0x4e1f6f?)
	net/http/server.go:2136 +0x29
github.com/gorilla/handlers.CompressHandler.CompressHandlerLevel.func1({0x1a36bc0, 0xc007e82320}, 0xc007d02f00)
	github.com/gorilla/handlers@v1.4.2/compress.go:148 +0x69f
net/http.HandlerFunc.ServeHTTP(0x7f52d4a7a418?, {0x1a36bc0?, 0xc007e82320?}, 0xc001ac1ee0?)
	net/http/server.go:2136 +0x29
github.com/ethersphere/bee/v2/pkg/api.(*Service).MountDebug.NewHTTPAccessLogHandler.func1.1({0x1a36a70?, 0xc001ac1ea0?}, 0xc007d02f00)
	github.com/ethersphere/bee/v2/pkg/log/httpaccess/http_access.go:41 +0x13a
net/http.HandlerFunc.ServeHTTP(0xc009229b68?, {0x1a36a70?, 0xc001ac1ea0?}, 0x0?)
	net/http/server.go:2136 +0x29
net/http.serverHandler.ServeHTTP({0xc008a4b530?}, {0x1a36a70?, 0xc001ac1ea0?}, 0x6?)
	net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc003f0f4d0, {0x1a39590, 0xc0001536b0})
	net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 95
	net/http/server.go:3086 +0x5cb
"
```