### PR TITLE
fix: allow maxMultiplexForwards to be set to zero

### DIFF
--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -339,7 +339,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 
 	resultChan := make(chan receiptResult)
 
-	retryC := make(chan struct{}, parallelForwards)
+	retryC := make(chan struct{}, max(1,parallelForwards))
 
 	retry := func() {
 		select {

--- a/pkg/pushsync/pushsync.go
+++ b/pkg/pushsync/pushsync.go
@@ -339,7 +339,7 @@ func (ps *PushSync) pushToClosest(ctx context.Context, ch swarm.Chunk, origin bo
 
 	resultChan := make(chan receiptResult)
 
-	retryC := make(chan struct{}, max(1,parallelForwards))
+	retryC := make(chan struct{}, max(1, parallelForwards))
 
 	retry := func() {
 		select {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
If `maxMultipleForwards` is set to zero, pushsync is completely disabled.   This is not good.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
Ensure that future coders don't run into this unintended issue if they set this to zero.

### Related Issue (Optional)
#4681 

### Screenshots (if appropriate):
