### PR TITLE
fix: save stamp issuer after failed uploads

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -791,15 +791,11 @@ func (p *putterSessionWrapper) Put(ctx context.Context, chunk swarm.Chunk) error
 }
 
 func (p *putterSessionWrapper) Done(ref swarm.Address) error {
-	err := p.PutterSession.Done(ref)
-	if err != nil {
-		return err
-	}
-	return p.save()
+	return errors.Join(p.PutterSession.Done(ref), p.save())
 }
 
 func (p *putterSessionWrapper) Cleanup() error {
-	return p.PutterSession.Cleanup()
+	return errors.Join(p.PutterSession.Cleanup(), p.save())
 }
 
 func (s *Service) getStamper(batchID []byte) (postage.Stamper, func() error, error) {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
We were not saving the stamp issuer batch indexes after a failed upload.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
