### PR TITLE
feat: mine new overlay

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/storer/migration"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/ethersphere/bee/v2/pkg/util/ioutil"
 	"github.com/spf13/cobra"
 )
 
@@ -159,7 +160,7 @@ func dbCompactCmd(cmd *cobra.Command) {
 			time.Sleep(10 * time.Second)
 			logger.Warning("proceeding with database compaction...")
 
-			localstorePath := path.Join(dataDir, "localstore")
+			localstorePath := path.Join(dataDir, ioutil.DataPathLocalstore)
 
 			err = storer.Compact(context.Background(), localstorePath, &storer.Options{
 				Logger:          logger,
@@ -214,7 +215,7 @@ func dbValidatePinsCmd(cmd *cobra.Command) {
 				return fmt.Errorf("read location option: %w", err)
 			}
 
-			localstorePath := path.Join(dataDir, "localstore")
+			localstorePath := path.Join(dataDir, ioutil.DataPathLocalstore)
 
 			err = storer.ValidatePinCollectionChunks(context.Background(), localstorePath, providedPin, outputLoc, &storer.Options{
 				Logger:          logger,
@@ -340,7 +341,7 @@ func dbValidateCmd(cmd *cobra.Command) {
 			logger.Warning("    Progress logged at Info level.")
 			logger.Warning("    SOC chunks logged at Debug level.")
 
-			localstorePath := path.Join(dataDir, "localstore")
+			localstorePath := path.Join(dataDir, ioutil.DataPathLocalstore)
 
 			err = storer.ValidateRetrievalIndex(context.Background(), localstorePath, &storer.Options{
 				Logger:          logger,
@@ -768,8 +769,8 @@ func dbNukeCmd(cmd *cobra.Command) {
 		optionNameForgetOverlay = "forget-overlay"
 		optionNameForgetStamps  = "forget-stamps"
 
-		localstore   = "localstore"
-		kademlia     = "kademlia-metrics"
+		localstore   = ioutil.DataPathLocalstore
+		kademlia     = ioutil.DataPathKademlia
 		statestore   = "statestore"
 		stamperstore = "stamperstore"
 	)

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -425,7 +425,7 @@ func (b *DevBee) Shutdown() error {
 	tryClose(b.pssCloser, "pss")
 	tryClose(b.tracerCloser, "tracer")
 	tryClose(b.stateStoreCloser, "statestore")
-	tryClose(b.localstoreCloser, "localstore")
+	tryClose(b.localstoreCloser, ioutil.DataPathLocalstore)
 
 	return mErr
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -321,21 +321,12 @@ func NewBee(
 			if err != nil {
 				return nil, fmt.Errorf("statestore: save new overlay: %w", err)
 			}
-		} else if !nonceExists {
-			err = setOverlay(stateStore, swarmAddress, nonce)
-			if err != nil {
-				return nil, fmt.Errorf("statestore: save new overlay: %w", err)
-			}
-		}
-	} else if targetNeighborhood == "" && !nonceExists {
-		err = setOverlay(stateStore, swarmAddress, nonce)
-		if err != nil {
-			return nil, fmt.Errorf("statestore: save new overlay: %w", err)
 		}
 	}
 
 	logger.Info("using overlay address", "address", swarmAddress)
 
+	// this will set overlay if it was not set before
 	if err = checkOverlay(stateStore, swarmAddress); err != nil {
 		return nil, fmt.Errorf("check overlay address: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -284,8 +284,9 @@ func NewBee(
 			const (
 				localstore = "localstore"
 				kademlia   = "kademlia-metrics"
+				statestore = "statestore"
 			)
-			dirsToNuke := []string{localstore, kademlia}
+			dirsToNuke := []string{localstore, kademlia, statestore}
 			for _, dir := range dirsToNuke {
 				err = removeContent(filepath.Join(o.DataDir, dir))
 				if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -283,7 +283,6 @@ func NewBee(
 		}
 	}
 
-	// set overlay if nonce is not saved or mine
 	if targetNeighborhood != "" {
 		neighborhood, err := swarm.ParseBitStrAddress(targetNeighborhood)
 		if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -295,25 +295,20 @@ func NewBee(
 				const (
 					localstore = "localstore"
 					kademlia   = "kademlia-metrics"
-					statestore = "statestore"
 				)
-				dirsToNuke := []string{localstore, kademlia, statestore}
+				dirsToNuke := []string{localstore, kademlia}
 				for _, dir := range dirsToNuke {
 					err := ioutil.RemoveContent(filepath.Join(o.DataDir, dir))
 					if err != nil {
 						return nil, fmt.Errorf("delete %s: %w", dir, err)
 					}
 				}
+
+				stateStore.ClearForHopping()
 			}
 
-			// reinit states variables
 			swarmAddress = newSwarmAddress
 			nonce = newNonce
-			stateStore, stateStoreMetrics, err = InitStateStore(logger, o.DataDir, o.StatestoreCacheCapacity)
-			if err != nil {
-				return nil, err
-			}
-
 			err = setOverlay(stateStore, swarmAddress, nonce)
 			if err != nil {
 				return nil, fmt.Errorf("statestore: save new overlay: %w", err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -292,11 +292,7 @@ func NewBee(
 				logger.Warning("you have another 10 seconds to change your mind and kill this process with CTRL-C...")
 				time.Sleep(10 * time.Second)
 
-				const (
-					localstore = "localstore"
-					kademlia   = "kademlia-metrics"
-				)
-				dirsToNuke := []string{localstore, kademlia}
+				dirsToNuke := []string{ioutil.DataPathLocalstore, ioutil.DataPathKademlia}
 				for _, dir := range dirsToNuke {
 					err := ioutil.RemoveContent(filepath.Join(o.DataDir, dir))
 					if err != nil {
@@ -698,7 +694,7 @@ func NewBee(
 
 	if o.DataDir != "" {
 		logger.Info("using datadir", "path", o.DataDir)
-		path = filepath.Join(o.DataDir, "localstore")
+		path = filepath.Join(o.DataDir, ioutil.DataPathLocalstore)
 	}
 
 	lo := &storer.Options{

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -304,7 +304,9 @@ func NewBee(
 					}
 				}
 
-				stateStore.ClearForHopping()
+				if err := stateStore.ClearForHopping(); err != nil {
+					return nil, fmt.Errorf("clearing stateStore %w", err)
+				}
 			}
 
 			swarmAddress = newSwarmAddress

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -275,7 +275,7 @@ func NewBee(
 	}
 
 	targetNeighborhood := o.TargetNeighborhood
-	if targetNeighborhood == "" && o.NeighborhoodSuggester != "" {
+	if targetNeighborhood == "" && !nonceExists && o.NeighborhoodSuggester != "" {
 		logger.Info("fetching target neighborhood from suggester", "url", o.NeighborhoodSuggester)
 		targetNeighborhood, err = nbhdutil.FetchNeighborhood(&http.Client{}, o.NeighborhoodSuggester)
 		if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -17,7 +17,6 @@ import (
 	"math/big"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -288,7 +287,7 @@ func NewBee(
 			)
 			dirsToNuke := []string{localstore, kademlia, statestore}
 			for _, dir := range dirsToNuke {
-				err = removeContent(filepath.Join(o.DataDir, dir))
+				err = ioutil.RemoveContent(filepath.Join(o.DataDir, dir))
 				if err != nil {
 					return nil, fmt.Errorf("delete %s: %w", dir, err)
 				}
@@ -1252,29 +1251,4 @@ func isChainEnabled(o *Options, swapEndpoint string, logger log.Logger) bool {
 
 	logger.Info("starting with an enabled chain backend")
 	return true // all other modes operate require chain enabled
-}
-
-// removeContent removes all files in path. Copied function from cmd/db.go
-func removeContent(path string) error {
-	dir, err := os.Open(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	subpaths, err := dir.Readdirnames(0)
-	if err != nil {
-		return err
-	}
-
-	for _, sub := range subpaths {
-		err = os.RemoveAll(filepath.Join(path, sub))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/node/statestore.go
+++ b/pkg/node/statestore.go
@@ -21,7 +21,7 @@ import (
 // InitStateStore will initialize the stateStore with the given path to the
 // data directory. When given an empty directory path, the function will instead
 // initialize an in-memory state store that will not be persisted.
-func InitStateStore(logger log.Logger, dataDir string, cacheCapacity uint64) (storage.StateStorer, metrics.Collector, error) {
+func InitStateStore(logger log.Logger, dataDir string, cacheCapacity uint64) (storage.StateStorerManager, metrics.Collector, error) {
 	if dataDir == "" {
 		logger.Warning("using in-mem state store, no node state will be persisted")
 	} else {

--- a/pkg/statestore/storeadapter/storeadapter.go
+++ b/pkg/statestore/storeadapter/storeadapter.go
@@ -201,7 +201,9 @@ func (s *StateStorerAdapter) Nuke() error {
 func (s *StateStorerAdapter) ClearForHopping() error {
 	var (
 		prefixesToPreserve = []string{
-			"swap_chequebook",
+			"swap_chequebook", // to not redeploy chequebook contract
+			"batchstore",      // avoid unnecessary syncing
+			"transaction",     // to not resync blockchain transactions
 		}
 		keys []string
 		err  error

--- a/pkg/statestore/storeadapter/storeadapter.go
+++ b/pkg/statestore/storeadapter/storeadapter.go
@@ -198,6 +198,22 @@ func (s *StateStorerAdapter) Nuke() error {
 	return s.deleteKeys(keys)
 }
 
+func (s *StateStorerAdapter) ClearForHopping() error {
+	var (
+		prefixesToPreserve = []string{
+			"swap_chequebook",
+		}
+		keys []string
+		err  error
+	)
+
+	keys, err = s.collectKeysExcept(prefixesToPreserve)
+	if err != nil {
+		return fmt.Errorf("collect keys except: %w", err)
+	}
+	return s.deleteKeys(keys)
+}
+
 func (s *StateStorerAdapter) collectKeysExcept(prefixesToPreserve []string) (keys []string, err error) {
 	if err := s.Iterate("", func(k, v []byte) (bool, error) {
 		stk := string(k)

--- a/pkg/storage/statestore.go
+++ b/pkg/storage/statestore.go
@@ -32,4 +32,12 @@ type StateStorer interface {
 type StateStorerCleaner interface {
 	// Nuke the store so that only the bare essential entries are left.
 	Nuke() error
+	// ClearForHopping removes all data not required in a new neighborhood
+	ClearForHopping() error
+}
+
+// StateStorerManager defines all external methods of the state storage
+type StateStorerManager interface {
+	StateStorer
+	StateStorerCleaner
 }

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -26,6 +26,7 @@ import (
 	im "github.com/ethersphere/bee/v2/pkg/topology/kademlia/internal/metrics"
 	"github.com/ethersphere/bee/v2/pkg/topology/kademlia/internal/waitnext"
 	"github.com/ethersphere/bee/v2/pkg/topology/pslice"
+	"github.com/ethersphere/bee/v2/pkg/util/ioutil"
 	ma "github.com/multiformats/go-multiaddr"
 	"golang.org/x/sync/errgroup"
 )
@@ -209,7 +210,7 @@ func New(
 	if o.DataDir == "" {
 		logger.Warning("using in-mem store for kademlia metrics, no state will be persisted")
 	} else {
-		o.DataDir = filepath.Join(o.DataDir, "kademlia-metrics")
+		o.DataDir = filepath.Join(o.DataDir, ioutil.DataPathKademlia)
 	}
 	sdb, err := shed.NewDB(o.DataDir, nil)
 	if err != nil {

--- a/pkg/util/ioutil/ioutil.go
+++ b/pkg/util/ioutil/ioutil.go
@@ -4,6 +4,12 @@
 
 package ioutil
 
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
 // The WriterFunc type is an adapter to allow the use of
 // ordinary functions as io.Writer Write method. If f is
 // a function with the appropriate signature, WriterFunc(f)
@@ -13,4 +19,29 @@ type WriterFunc func([]byte) (int, error)
 // WriterFunc calls f(p).
 func (f WriterFunc) Write(p []byte) (n int, err error) {
 	return f(p)
+}
+
+// RemoveContent removes all files in path. Copied function from cmd/db.go
+func RemoveContent(path string) error {
+	dir, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	subpaths, err := dir.Readdirnames(0)
+	if err != nil {
+		return err
+	}
+
+	for _, sub := range subpaths {
+		err = os.RemoveAll(filepath.Join(path, sub))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/util/ioutil/ioutil.go
+++ b/pkg/util/ioutil/ioutil.go
@@ -10,6 +10,12 @@ import (
 	"path/filepath"
 )
 
+// DB folders paths from bee datadir
+const (
+	DataPathLocalstore = "localstore"
+	DataPathKademlia   = "kademlia-metrics"
+)
+
 // The WriterFunc type is an adapter to allow the use of
 // ordinary functions as io.Writer Write method. If f is
 // a function with the appropriate signature, WriterFunc(f)


### PR DESCRIPTION
Allowing the overlay address mining even when nonce exists. That case, `localstore` and `kademlia-metrics` folders will be removed and `statestore` will be cleared to start a clean state in the new neighborhood. Before the wipe, 10 seconds wait time allows the user to change their mind.

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
