### PR TITLE
feat: pre-signed chunks

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -149,7 +149,11 @@ paths:
         - Chunk
       parameters:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmTagParameter"
-        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
+        - in: header
+          schema:
+            $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
+          required: false
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageStamp"
       requestBody:
         description: Chunk binary data that has to have at least 8 bytes.
         content:
@@ -689,8 +693,8 @@ paths:
         - in: header
           schema:
             $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageBatchId"
-          name: swarm-postage-batch-id
-          required: true
+          required: false
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmPostageStamp"
       requestBody:
         required: true
         description: The SOC binary data is composed of the span (8 bytes) and the at most 4KB payload.

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -1119,13 +1119,13 @@ components:
     SwarmPostageStamp:
       in: header
       name: swarm-postage-stamp
-      description: >
-        Postage stamp for the corresponding chunk in the request.
-        It is required if Swarm-Postage-Batch-Id header is missing 
-        It consists of:
-        - batch ID - 0:32 bytes
-        - postage index (bucket and bucket index) - 32:40 bytes
-        - timestamp - 40:48 bytes
+      description: |
+        Postage stamp for the corresponding chunk in the request. \
+        It is required if Swarm-Postage-Batch-Id header is missing \
+        It consists of: \
+        - batch ID - 0:32 bytes \
+        - postage index (bucket and bucket index) - 32:40 bytes \
+        - timestamp - 40:48 bytes \
         - signature - 48:113 bytes
       schema:
         $ref: "#/components/schemas/HexString"

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -1116,6 +1116,20 @@ components:
       schema:
         $ref: "#/components/schemas/SwarmAddress"
 
+    SwarmPostageStamp:
+      in: header
+      name: swarm-postage-stamp
+      description: >
+        Postage stamp for the corresponding chunk in the request.
+        It is required if Swarm-Postage-Batch-Id header is missing 
+        It consists of:
+        - batch ID - 0:32 bytes
+        - postage index (bucket and bucket index) - 32:40 bytes
+        - timestamp - 40:48 bytes
+        - signature - 48:113 bytes
+      schema:
+        $ref: "#/components/schemas/HexString"
+
     SwarmDeferredUpload:
       in: header
       name: swarm-deferred-upload

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -116,6 +116,8 @@ var (
 	errBatchUnusable                    = errors.New("batch not usable")
 	errUnsupportedDevNodeOperation      = errors.New("operation not supported in dev mode")
 	errOperationSupportedOnlyInFullMode = errors.New("operation is supported only in full mode")
+
+	batchIdOrStampSig = fmt.Sprintf("Either '%s' or '%s' header must be set in the request", SwarmPostageStampHeader, SwarmPostageBatchIdHeader)
 )
 
 // Storer interface provides the functionality required from the local storage

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -113,7 +113,6 @@ var (
 	errDirectoryStore                   = errors.New("could not store directory")
 	errFileStore                        = errors.New("could not store file")
 	errInvalidPostageBatch              = errors.New("invalid postage batch id")
-	errInvalidPostageStamp              = errors.New("invalid postage stamp")
 	errBatchUnusable                    = errors.New("batch not usable")
 	errUnsupportedDevNodeOperation      = errors.New("operation not supported in dev mode")
 	errOperationSupportedOnlyInFullMode = errors.New("operation is supported only in full mode")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -734,7 +734,7 @@ func (s *Service) newStampedPutter(ctx context.Context, opts putterOptions, stam
 
 	storedBatch, err := s.batchStore.Get(stamp.BatchID())
 	if err != nil {
-		return nil, fmt.Errorf("get batch from batchstore: %w", err)
+		return nil, errInvalidPostageBatch
 	}
 
 	var session storer.PutterSession

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -77,6 +77,7 @@ const (
 	SwarmFeedIndexNextHeader          = "Swarm-Feed-Index-Next"
 	SwarmCollectionHeader             = "Swarm-Collection"
 	SwarmPostageBatchIdHeader         = "Swarm-Postage-Batch-Id"
+	SwarmPostageStampHeader           = "Swarm-Postage-Stamp"
 	SwarmDeferredUploadHeader         = "Swarm-Deferred-Upload"
 	SwarmRedundancyLevelHeader        = "Swarm-Redundancy-Level"
 	SwarmRedundancyStrategyHeader     = "Swarm-Redundancy-Strategy"
@@ -112,6 +113,7 @@ var (
 	errDirectoryStore                   = errors.New("could not store directory")
 	errFileStore                        = errors.New("could not store file")
 	errInvalidPostageBatch              = errors.New("invalid postage batch id")
+	errInvalidPostageStamp              = errors.New("invalid postage stamp")
 	errBatchUnusable                    = errors.New("batch not usable")
 	errUnsupportedDevNodeOperation      = errors.New("operation not supported in dev mode")
 	errOperationSupportedOnlyInFullMode = errors.New("operation is supported only in full mode")
@@ -506,7 +508,7 @@ func (s *Service) corsHandler(h http.Handler) http.Handler {
 	allowedHeaders := []string{
 		"User-Agent", "Accept", "X-Requested-With", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Accept-Ranges", "Content-Encoding",
 		AuthorizationHeader, AcceptEncodingHeader, ContentTypeHeader, ContentDispositionHeader, RangeHeader, OriginHeader,
-		SwarmTagHeader, SwarmPinHeader, SwarmEncryptHeader, SwarmIndexDocumentHeader, SwarmErrorDocumentHeader, SwarmCollectionHeader, SwarmPostageBatchIdHeader, SwarmDeferredUploadHeader, SwarmRedundancyLevelHeader, SwarmRedundancyStrategyHeader, SwarmRedundancyFallbackModeHeader, SwarmChunkRetrievalTimeoutHeader, SwarmLookAheadBufferSizeHeader, SwarmFeedIndexHeader, SwarmFeedIndexNextHeader, GasPriceHeader, GasLimitHeader, ImmutableHeader,
+		SwarmTagHeader, SwarmPinHeader, SwarmEncryptHeader, SwarmIndexDocumentHeader, SwarmErrorDocumentHeader, SwarmCollectionHeader, SwarmPostageBatchIdHeader, SwarmPostageStampHeader, SwarmDeferredUploadHeader, SwarmRedundancyLevelHeader, SwarmRedundancyStrategyHeader, SwarmRedundancyFallbackModeHeader, SwarmChunkRetrievalTimeoutHeader, SwarmLookAheadBufferSizeHeader, SwarmFeedIndexHeader, SwarmFeedIndexNextHeader, GasPriceHeader, GasLimitHeader, ImmutableHeader,
 	}
 	allowedHeadersStr := strings.Join(allowedHeaders, ", ")
 
@@ -722,6 +724,35 @@ func (s *Service) newStamperPutter(ctx context.Context, opts putterOptions) (sto
 		PutterSession: session,
 		stamper:       stamper,
 		save:          save,
+	}, nil
+}
+
+func (s *Service) newStampedPutter(ctx context.Context, opts putterOptions, stamp *postage.Stamp) (storer.PutterSession, error) {
+	if !opts.Deferred && s.beeMode == DevMode {
+		return nil, errUnsupportedDevNodeOperation
+	}
+
+	storedBatch, err := s.batchStore.Get(stamp.BatchID())
+	if err != nil {
+		return nil, fmt.Errorf("get batch from batchstore: %w", err)
+	}
+
+	var session storer.PutterSession
+	if opts.Deferred || opts.Pin {
+		session, err = s.storer.Upload(ctx, opts.Pin, opts.TagID)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating session: %w", err)
+		}
+	} else {
+		session = s.storer.DirectUpload()
+	}
+
+	stamper := postage.NewPresignedStamper(stamp, storedBatch.Owner)
+
+	return &putterSessionWrapper{
+		PutterSession: session,
+		stamper:       stamper,
+		save:          func() error { return nil },
 	}, nil
 }
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -60,9 +60,8 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(headers.BatchID) == 0 && len(headers.StampSig) == 0 {
-		errorMsg := fmt.Sprintf("Either '%s' or '%s' header must be set in the request", SwarmPostageStampHeader, SwarmPostageBatchIdHeader)
-		logger.Error(nil, errorMsg)
-		jsonhttp.BadRequest(w, errorMsg)
+		logger.Error(nil, batchIdOrStampSig)
+		jsonhttp.BadRequest(w, batchIdOrStampSig)
 		return
 	}
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -73,7 +73,6 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	deferred := tag != 0
 
 	var putter storer.PutterSession
-	logger.Debug("heeeeejjjjjj", "headers", headers)
 	if len(headers.StampSig) != 0 {
 		stamp := postage.Stamp{}
 		if err := stamp.UnmarshalBinary(headers.StampSig); err != nil {
@@ -121,11 +120,9 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		logger:         logger,
 	}
 
-	logger.Debug("hello1")
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		if jsonhttp.HandleBodyReadError(err, ow) {
-			logger.Debug("hello2")
 			return
 		}
 		logger.Debug("chunk upload: read chunk data failed", "error", err)
@@ -142,7 +139,6 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	chunk, err := cac.NewWithDataSpan(data)
-	logger.Debug("hello3", "error", err)
 	if err != nil {
 		// not a valid cac chunk. Check if it's a replica soc chunk.
 		logger.Debug("chunk upload: create chunk failed", "error", err)
@@ -171,9 +167,7 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logger.Debug("hello4")
 	err = putter.Put(r.Context(), chunk)
-	logger.Debug("hello5", "error", err)
 	if err != nil {
 		logger.Debug("chunk upload: write chunk failed", "chunk_address", chunk.Address(), "error", err)
 		logger.Error(nil, "chunk upload: write chunk failed")
@@ -188,9 +182,7 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Debug("hello6", "error", err)
 	err = putter.Done(swarm.ZeroAddress)
-	logger.Debug("hello7", "error", err)
 	if err != nil {
 		logger.Debug("done split failed", "error", err)
 		logger.Error(nil, "done split failed")
@@ -203,7 +195,6 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
-	logger.Debug("hello8", "error", err)
 	jsonhttp.Created(w, chunkAddressResponse{Reference: chunk.Address()})
 }
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -180,6 +180,8 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, postage.ErrBucketFull):
 			jsonhttp.PaymentRequired(ow, "batch is overissued")
+		case errors.Is(err, postage.ErrInvalidBatchSignature):
+			jsonhttp.BadRequest(ow, "stamp signature is invalid")
 		default:
 			jsonhttp.InternalServerError(ow, "chunk write error")
 		}

--- a/pkg/api/soc_test.go
+++ b/pkg/api/soc_test.go
@@ -14,8 +14,12 @@ import (
 	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/api"
+	"github.com/ethersphere/bee/v2/pkg/crypto"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/v2/pkg/postage"
+	mockbatchstore "github.com/ethersphere/bee/v2/pkg/postage/batchstore/mock"
+	testingpostage "github.com/ethersphere/bee/v2/pkg/postage/testing"
 	testingsoc "github.com/ethersphere/bee/v2/pkg/soc/testing"
 	"github.com/ethersphere/bee/v2/pkg/spinlock"
 	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
@@ -140,6 +144,41 @@ func TestSOC(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+
+		// TestPreSignedUpload tests that chunk can be uploaded with pre-signed postage stamp
+		t.Run("pre-signed upload", func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				s               = testingsoc.GenerateMockSOC(t, testData)
+				storerMock      = mockstorer.New()
+				batchStore      = mockbatchstore.New()
+				client, _, _, _ = newTestServer(t, testServerOptions{
+					Storer:     storerMock,
+					BatchStore: batchStore,
+				})
+			)
+
+			// generate random postage batch and stamp
+			key, _ := crypto.GenerateSecp256k1Key()
+			signer := crypto.NewDefaultSigner(key)
+			owner, _ := signer.EthereumAddress()
+			stamp := testingpostage.MustNewValidStamp(signer, s.Address())
+			_ = batchStore.Save(&postage.Batch{
+				ID:    stamp.BatchID(),
+				Owner: owner.Bytes(),
+			})
+			stampBytes, _ := stamp.MarshalBinary()
+
+			// read off inserted chunk
+			go func() { <-storerMock.PusherFeed() }()
+
+			jsonhttptest.Request(t, client, http.MethodPost, socResource(hex.EncodeToString(s.Owner), hex.EncodeToString(s.ID), hex.EncodeToString(s.Signature)), http.StatusCreated,
+				jsonhttptest.WithRequestHeader(api.SwarmPostageStampHeader, hex.EncodeToString(stampBytes)),
+				jsonhttptest.WithRequestBody(bytes.NewReader(s.WrappedChunk.Data())),
+			)
+		})
+
 		t.Run("err - batch empty", func(t *testing.T) {
 			s := testingsoc.GenerateMockSOC(t, testData)
 			hexbatch := hex.EncodeToString(batchEmpty)

--- a/pkg/postage/stamper.go
+++ b/pkg/postage/stamper.go
@@ -75,7 +75,6 @@ func (st *stamper) Stamp(addr swarm.Address) (*Stamp, error) {
 		return nil, err
 	}
 	sig, err := st.signer.Sign(toSign)
-	fmt.Printf("\nStamp signature created!! %x", sig)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +99,7 @@ func (st *presignedStamper) Stamp(addr swarm.Address) (*Stamp, error) {
 	}
 
 	if !bytes.Equal(st.owner, signerAddr) {
-		return nil, fmt.Errorf("signature recovery is invalid for stamp")
+		return nil, ErrInvalidBatchSignature
 	}
 
 	return st.stamp, nil

--- a/pkg/postage/testing/stamp.go
+++ b/pkg/postage/testing/stamp.go
@@ -8,6 +8,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"io"
+	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/crypto"
 	"github.com/ethersphere/bee/v2/pkg/postage"
@@ -49,8 +50,10 @@ func MustNewStamp() *postage.Stamp {
 // MustNewValidStamp will generate a valid postage stamp with random data. Panics on errors.
 func MustNewValidStamp(signer crypto.Signer, addr swarm.Address) *postage.Stamp {
 	id := MustNewID()
-	index := MustNewID()[:8]
-	timestamp := MustNewID()[:8]
+	index := make([]byte, 8)
+	copy(index[:4], addr.Bytes()[:4])
+	timestamp := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestamp, uint64(time.Now().UnixNano()))
 	sig := MustNewValidSignature(signer, addr, id, index, timestamp)
 	return postage.NewStamp(id, index, timestamp, sig)
 }


### PR DESCRIPTION
Introducing `Swarm-Postage-Stamp` header on `/chunk` and `/soc` POST endpoints.

It allows to push chunk to the Swarm network with pre-signed postage stamp on the attached chunk by the Bee client.

The header value must be a valid Postage Stamp otherwise error 400 has been thrown.
It means that the stamp is signed against the attached chunk and the signature is created by its on-chain owner.
A correct Postage Stamp value is 113 bytes encoded as hex string and consists of:
- :32 - ID of the batch
- 32:40 - index
- 40:48 - timestamp
- 48: - signature
 

Closes #2905

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
