### PR TITLE
fix: improve the way a node is healthy based on network radius

### DIFF
--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -222,7 +222,7 @@ func (s *service) salud(mode string, minPeersPerbin int, durPercentile float64, 
 	}
 
 	selfHealth := true
-	if s.reserve.StorageRadius() != networkRadius {
+	if nHoodRadius == networkRadius && s.reserve.StorageRadius() != networkRadius {
 		selfHealth = false
 		s.logger.Warning("node is unhealthy due to storage radius discrepency", "self_radius", s.reserve.StorageRadius(), "network_radius", networkRadius)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Issue is described in [salud IsHealthy using wrong radius](https://github.com/ethersphere/bee/issues/4697)

Node radius has to be compared only with network radius because this is the only way of certainty, the only source of truth. Comparing node radius to neighbourhood radius could lead to issues and also to attacks from bad intended actors  in that neighbourhood. 

Hopefully the change is a solution to the particular case from the above issue.
