### PR TITLE
fix: TestJoinerRedundancy failing flaky test 

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1248,7 +1248,8 @@ func TestJoinerRedundancyMultilevel(t *testing.T) {
 		buf := make([]byte, expRead)
 		offset := mrand.Intn(size) * expRead
 		canReadRange := func(t *testing.T, s getter.Strategy, fallback bool, canRead bool) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			decodingTimeoutStr := (200 * time.Millisecond).String()
 

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1262,7 +1262,7 @@ func TestJoinerRedundancyMultilevel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			decodingTimeoutStr := (200 * time.Millisecond).String()
+			decodingTimeoutStr := time.Second.String()
 
 			ctx, err := getter.SetConfigInContext(ctx, &s, &fallback, &decodingTimeoutStr, log.Noop)
 			if err != nil {

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1011,6 +1011,8 @@ func (m *mockPutter) wait(ctx context.Context) {
 
 func (m *mockPutter) store(cnt int) error {
 	n := 0
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for ch := range m.parities {
 		if err := m.ChunkStore.Put(context.Background(), ch); err != nil {
 			return err

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1024,7 +1024,7 @@ func (m *mockPutter) store(cnt int) error {
 }
 
 // nolint:thelper
-func TestJoinerRedundancy_FLAKY(t *testing.T) {
+func TestJoinerRedundancy(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		rLevel       redundancy.Level
@@ -1111,7 +1111,8 @@ func TestJoinerRedundancy_FLAKY(t *testing.T) {
 			}
 			// all data can be read back
 			readCheck := func(t *testing.T, expErr error) {
-				ctx := context.Background()
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
 				decodeTimeoutStr := time.Second.String()
 				fallback := true

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1118,7 +1118,7 @@ func TestJoinerRedundancy(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				decodeTimeoutStr := (2 * time.Second).String()
+				decodeTimeoutStr := (200 * time.Millisecond).String()
 				fallback := true
 				s := getter.RACE
 
@@ -1257,7 +1257,7 @@ func TestJoinerRedundancyMultilevel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			decodingTimeoutStr := (2 * time.Second).String()
+			decodingTimeoutStr := (200 * time.Millisecond).String()
 
 			ctx, err := getter.SetConfigInContext(ctx, &s, &fallback, &decodingTimeoutStr, log.Noop)
 			if err != nil {

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -254,7 +254,8 @@ func TestEncryptDecrypt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			pipe := builder.NewPipelineBuilder(ctx, store, true, 0)
 			testDataReader := bytes.NewReader(testData)
 			resultAddress, err := builder.FeedPipeline(ctx, pipe, testDataReader)
@@ -336,7 +337,8 @@ func TestSeek(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			store := inmemchunkstore.New()
 			testutil.CleanupCloser(t, store)
@@ -613,7 +615,8 @@ func TestPrefetch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			store := inmemchunkstore.New()
 			testutil.CleanupCloser(t, store)
@@ -917,7 +920,8 @@ func TestJoinerIterateChunkAddresses_Encrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	pipe := builder.NewPipelineBuilder(ctx, store, true, 0)
 	testDataReader := bytes.NewReader(testData)
 	resultAddress, err := builder.FeedPipeline(ctx, pipe, testDataReader)
@@ -1236,7 +1240,8 @@ func TestJoinerRedundancyMultilevel(t *testing.T) {
 			t.Fatal(err)
 		}
 		dataReader := pseudorand.NewReader(seed, size*swarm.ChunkSize)
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		// ctx = redundancy.SetLevelInContext(ctx, rLevel)
 		ctx = redundancy.SetLevelInContext(ctx, redundancy.NONE)
 		pipe := builder.NewPipelineBuilder(ctx, store, encrypt, rLevel)

--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1118,7 +1118,7 @@ func TestJoinerRedundancy(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				decodeTimeoutStr := time.Second.String()
+				decodeTimeoutStr := (2 * time.Second).String()
 				fallback := true
 				s := getter.RACE
 
@@ -1138,6 +1138,7 @@ func TestJoinerRedundancy(t *testing.T) {
 				}
 				i := 0
 				eg, ectx := errgroup.WithContext(ctx)
+
 			scnt:
 				for ; i < shardCnt; i++ {
 					select {
@@ -1256,7 +1257,7 @@ func TestJoinerRedundancyMultilevel(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			decodingTimeoutStr := (200 * time.Millisecond).String()
+			decodingTimeoutStr := (2 * time.Second).String()
 
 			ctx, err := getter.SetConfigInContext(ctx, &s, &fallback, &decodingTimeoutStr, log.Noop)
 			if err != nil {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Fail 1: 
```
--- FAIL: TestJoinerRedundancy (0.00s)
    --- FAIL: TestJoinerRedundancy/redundancy=2_encryption=false (0.19s)
        --- FAIL: TestJoinerRedundancy/redundancy=2_encryption=false/recover_from_replica_if_root_deleted (0.01s)
            joiner_test.go:1147: unexpected error reading chunkdata at chunk position 107: expected <nil>. got storage: not found
```

Fail 2:
```
--- FAIL: TestJoinerRedundancyMultilevel (0.00s)
    --- FAIL: TestJoinerRedundancyMultilevel/rLevel=1 (8.60s)
        --- FAIL: TestJoinerRedundancyMultilevel/rLevel=1/encrypt=true_levels=2_chunks=3481_full (2.54s)
            --- FAIL: TestJoinerRedundancyMultilevel/rLevel=1/encrypt=true_levels=2_chunks=3481_full/DATA_w_fallback_CAN_retrieve (0.00s)
                joiner_test.go:1280: storage: not found
            --- FAIL: TestJoinerRedundancyMultilevel/rLevel=1/encrypt=true_levels=2_chunks=3481_full/after_recovery,_NONE_w/o_fallback_CAN_retrieve (0.00s)
                joiner_test.go:1280: storage: not found
```
