### PR TITLE
feat: stamp hash migration perf

### DIFF
--- a/pkg/storer/internal/reserve/olditems.go
+++ b/pkg/storer/internal/reserve/olditems.go
@@ -1,0 +1,180 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reserve
+
+import (
+	"encoding/binary"
+	"path"
+
+	"github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+)
+
+// BatchRadiusItemV1 allows iteration of the chunks with respect to bin and batchID.
+// Used for batch evictions of certain bins.
+type BatchRadiusItemV1 struct {
+	Bin     uint8
+	BatchID []byte
+	Address swarm.Address
+	BinID   uint64
+}
+
+func (b *BatchRadiusItemV1) Namespace() string {
+	return "batchRadius"
+}
+
+func (b *BatchRadiusItemV1) ID() string {
+	return string(b.BatchID) + string(b.Bin) + b.Address.ByteString()
+}
+
+func (b *BatchRadiusItemV1) String() string {
+	return path.Join(b.Namespace(), b.ID())
+}
+
+func (b *BatchRadiusItemV1) Clone() storage.Item {
+	if b == nil {
+		return nil
+	}
+	return &BatchRadiusItemV1{
+		Bin:     b.Bin,
+		BatchID: copyBytes(b.BatchID),
+		Address: b.Address.Clone(),
+		BinID:   b.BinID,
+	}
+}
+
+const batchRadiusItemSizeV1 = 1 + swarm.HashSize + swarm.HashSize + 8
+
+func (b *BatchRadiusItemV1) Marshal() ([]byte, error) {
+
+	if b.Address.IsZero() {
+		return nil, errMarshalInvalidAddress
+	}
+
+	buf := make([]byte, batchRadiusItemSizeV1)
+
+	i := 0
+
+	buf[i] = b.Bin
+	i += 1
+
+	copy(buf[i:i+swarm.HashSize], b.BatchID)
+	i += swarm.HashSize
+
+	copy(buf[i:i+swarm.HashSize], b.Address.Bytes())
+	i += swarm.HashSize
+
+	binary.BigEndian.PutUint64(buf[i:i+8], b.BinID)
+
+	return buf, nil
+}
+
+func (b *BatchRadiusItemV1) Unmarshal(buf []byte) error {
+
+	if len(buf) != batchRadiusItemSizeV1 {
+		return errUnmarshalInvalidSize
+	}
+
+	i := 0
+	b.Bin = buf[i]
+	i += 1
+
+	b.BatchID = copyBytes(buf[i : i+swarm.HashSize])
+	i += swarm.HashSize
+
+	b.Address = swarm.NewAddress(buf[i : i+swarm.HashSize]).Clone()
+	i += swarm.HashSize
+
+	b.BinID = binary.BigEndian.Uint64(buf[i : i+8])
+
+	return nil
+}
+
+// ChunkBinItemV1 allows for iterating on ranges of bin and binIDs for chunks.
+// BinIDs come in handy when syncing the reserve contents with other peers.
+type ChunkBinItemV1 struct {
+	Bin       uint8
+	BinID     uint64
+	Address   swarm.Address
+	BatchID   []byte
+	ChunkType swarm.ChunkType
+}
+
+func (c *ChunkBinItemV1) Namespace() string {
+	return "chunkBin"
+}
+
+func (c *ChunkBinItemV1) ID() string {
+	return binIDToString(c.Bin, c.BinID)
+}
+
+func (c *ChunkBinItemV1) String() string {
+	return path.Join(c.Namespace(), c.ID())
+}
+
+func (c *ChunkBinItemV1) Clone() storage.Item {
+	if c == nil {
+		return nil
+	}
+	return &ChunkBinItemV1{
+		Bin:       c.Bin,
+		BinID:     c.BinID,
+		Address:   c.Address.Clone(),
+		BatchID:   copyBytes(c.BatchID),
+		ChunkType: c.ChunkType,
+	}
+}
+
+const chunkBinItemSizeV1 = 1 + 8 + swarm.HashSize + swarm.HashSize + 1
+
+func (c *ChunkBinItemV1) Marshal() ([]byte, error) {
+
+	if c.Address.IsZero() {
+		return nil, errMarshalInvalidAddress
+	}
+
+	buf := make([]byte, chunkBinItemSizeV1)
+	i := 0
+
+	buf[i] = c.Bin
+	i += 1
+
+	binary.BigEndian.PutUint64(buf[i:i+8], c.BinID)
+	i += 8
+
+	copy(buf[i:i+swarm.HashSize], c.Address.Bytes())
+	i += swarm.HashSize
+
+	copy(buf[i:i+swarm.HashSize], c.BatchID)
+	i += swarm.HashSize
+
+	buf[i] = uint8(c.ChunkType)
+
+	return buf, nil
+}
+
+func (c *ChunkBinItemV1) Unmarshal(buf []byte) error {
+
+	if len(buf) != chunkBinItemSizeV1 {
+		return errUnmarshalInvalidSize
+	}
+
+	i := 0
+	c.Bin = buf[i]
+	i += 1
+
+	c.BinID = binary.BigEndian.Uint64(buf[i : i+8])
+	i += 8
+
+	c.Address = swarm.NewAddress(buf[i : i+swarm.HashSize]).Clone()
+	i += swarm.HashSize
+
+	c.BatchID = copyBytes(buf[i : i+swarm.HashSize])
+	i += swarm.HashSize
+
+	c.ChunkType = swarm.ChunkType(buf[i])
+
+	return nil
+}

--- a/pkg/storer/internal/stampindex/export_test.go
+++ b/pkg/storer/internal/stampindex/export_test.go
@@ -14,16 +14,15 @@ var (
 )
 
 // NewItemWithValues creates a new Item with given values and fixed keys.
-func NewItemWithValues(batchTimestamp []byte, chunkAddress swarm.Address, chunkIsImmutable bool) *Item {
+func NewItemWithValues(batchTimestamp []byte, chunkAddress swarm.Address) *Item {
 	return &Item{
 		namespace:  []byte("test_namespace"),
 		BatchID:    []byte{swarm.HashSize - 1: 9},
 		StampIndex: []byte{swarm.StampIndexSize - 1: 9},
 		StampHash:  swarm.EmptyAddress.Bytes(),
 
-		StampTimestamp:   batchTimestamp,
-		ChunkAddress:     chunkAddress,
-		ChunkIsImmutable: chunkIsImmutable,
+		StampTimestamp: batchTimestamp,
+		ChunkAddress:   chunkAddress,
 	}
 }
 

--- a/pkg/storer/internal/stampindex/oldstampindex.go
+++ b/pkg/storer/internal/stampindex/oldstampindex.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package stampindex
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage/storageutil"
+	"github.com/ethersphere/bee/v2/pkg/storer/internal"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+)
+
+// ItemV1 is an store.Item that represents data relevant to stamp.
+type ItemV1 struct {
+	// Keys.
+	namespace  []byte // The namespace of other related item.
+	BatchID    []byte
+	StampIndex []byte
+
+	// Values.
+	StampTimestamp   []byte
+	ChunkAddress     swarm.Address
+	ChunkIsImmutable bool
+}
+
+// ID implements the storage.Item interface.
+func (i ItemV1) ID() string {
+	return fmt.Sprintf("%s/%s/%s", string(i.namespace), string(i.BatchID), string(i.StampIndex))
+}
+
+// Namespace implements the storage.Item interface.
+func (i ItemV1) Namespace() string {
+	return "StampIndex"
+}
+
+// Marshal implements the storage.Item interface.
+func (i ItemV1) Marshal() ([]byte, error) {
+	switch {
+	case len(i.namespace) == 0:
+		return nil, errStampItemMarshalNamespaceInvalid
+	case len(i.BatchID) != swarm.HashSize:
+		return nil, errStampItemMarshalBatchIDInvalid
+	case len(i.StampIndex) != swarm.StampIndexSize:
+		return nil, errStampItemMarshalBatchIndexInvalid
+	}
+
+	buf := make([]byte, 8+len(i.namespace)+swarm.HashSize+swarm.StampIndexSize+swarm.StampTimestampSize+swarm.HashSize)
+
+	l := 0
+	binary.LittleEndian.PutUint64(buf[l:l+8], uint64(len(i.namespace)))
+	l += 8
+	copy(buf[l:l+len(i.namespace)], i.namespace)
+	l += len(i.namespace)
+	copy(buf[l:l+swarm.HashSize], i.BatchID)
+	l += swarm.HashSize
+	copy(buf[l:l+swarm.StampIndexSize], i.StampIndex)
+	l += swarm.StampIndexSize
+	copy(buf[l:l+swarm.StampTimestampSize], i.StampTimestamp)
+	l += swarm.StampTimestampSize
+	copy(buf[l:l+swarm.HashSize], internal.AddressBytesOrZero(i.ChunkAddress))
+	return buf, nil
+}
+
+// Unmarshal implements the storage.Item interface.
+func (i *ItemV1) Unmarshal(bytes []byte) error {
+	if len(bytes) < 8 {
+		return errStampItemUnmarshalInvalidSize
+	}
+	nsLen := int(binary.LittleEndian.Uint64(bytes))
+	if len(bytes) != 8+nsLen+swarm.HashSize+swarm.StampIndexSize+swarm.StampTimestampSize+swarm.HashSize {
+		return errStampItemUnmarshalInvalidSize
+	}
+
+	ni := new(ItemV1)
+	l := 8
+	ni.namespace = append(make([]byte, 0, nsLen), bytes[l:l+nsLen]...)
+	l += nsLen
+	ni.BatchID = append(make([]byte, 0, swarm.HashSize), bytes[l:l+swarm.HashSize]...)
+	l += swarm.HashSize
+	ni.StampIndex = append(make([]byte, 0, swarm.StampIndexSize), bytes[l:l+swarm.StampIndexSize]...)
+	l += swarm.StampIndexSize
+	ni.StampTimestamp = append(make([]byte, 0, swarm.StampTimestampSize), bytes[l:l+swarm.StampTimestampSize]...)
+	l += swarm.StampTimestampSize
+	ni.ChunkAddress = internal.AddressOrZero(bytes[l : l+swarm.HashSize])
+	*i = *ni
+	return nil
+}
+
+// Clone  implements the storage.Item interface.
+func (i *ItemV1) Clone() storage.Item {
+	if i == nil {
+		return nil
+	}
+	return &ItemV1{
+		namespace:        append([]byte(nil), i.namespace...),
+		BatchID:          append([]byte(nil), i.BatchID...),
+		StampIndex:       append([]byte(nil), i.StampIndex...),
+		StampTimestamp:   append([]byte(nil), i.StampTimestamp...),
+		ChunkAddress:     i.ChunkAddress.Clone(),
+		ChunkIsImmutable: i.ChunkIsImmutable,
+	}
+}
+
+// String implements the fmt.Stringer interface.
+func (i ItemV1) String() string {
+	return storageutil.JoinFields(i.Namespace(), i.ID())
+}
+
+func (i *ItemV1) SetNamespace(ns []byte) {
+	i.namespace = ns
+}

--- a/pkg/storer/internal/stampindex/oldstampindex.go
+++ b/pkg/storer/internal/stampindex/oldstampindex.go
@@ -34,7 +34,7 @@ func (i ItemV1) ID() string {
 
 // Namespace implements the storage.Item interface.
 func (i ItemV1) Namespace() string {
-	return "StampIndex"
+	return "stampIndex"
 }
 
 // Marshal implements the storage.Item interface.

--- a/pkg/storer/internal/stampindex/stampindex.go
+++ b/pkg/storer/internal/stampindex/stampindex.go
@@ -53,7 +53,7 @@ func (i Item) ID() string {
 
 // Namespace implements the storage.Item interface.
 func (i Item) Namespace() string {
-	return "StampIndex"
+	return "stampIndex"
 }
 
 func (i Item) GetNamespace() []byte {

--- a/pkg/storer/internal/stampindex/stampindex_test.go
+++ b/pkg/storer/internal/stampindex/stampindex_test.go
@@ -62,22 +62,14 @@ func TestStampIndexItem(t *testing.T) {
 	}, {
 		name: "valid values",
 		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: stampindex.NewItemWithValues(
-				[]byte{swarm.StampTimestampSize - 1: 9},
-				swarm.RandAddress(t),
-				false,
-			),
+			Item:    stampindex.NewItemWithValues([]byte{swarm.StampTimestampSize - 1: 9}, swarm.RandAddress(t)),
 			Factory: func() storage.Item { return new(stampindex.Item) },
 			CmpOpts: []cmp.Option{cmp.AllowUnexported(stampindex.Item{})},
 		},
 	}, {
 		name: "max values",
 		test: &storagetest.ItemMarshalAndUnmarshalTest{
-			Item: stampindex.NewItemWithValues(
-				storagetest.MaxBatchTimestampBytes[:],
-				swarm.NewAddress(storagetest.MaxAddressBytes[:]),
-				true,
-			),
+			Item:    stampindex.NewItemWithValues(storagetest.MaxBatchTimestampBytes[:], swarm.NewAddress(storagetest.MaxAddressBytes[:])),
 			Factory: func() storage.Item { return new(stampindex.Item) },
 			CmpOpts: []cmp.Option{cmp.AllowUnexported(stampindex.Item{})},
 		},
@@ -140,7 +132,6 @@ func TestStoreLoadDelete(t *testing.T) {
 				want := stampindex.NewItemWithKeys(ns, chunk.Stamp().BatchID(), chunk.Stamp().Index(), stampHash)
 				want.StampTimestamp = chunk.Stamp().Timestamp()
 				want.ChunkAddress = chunk.Address()
-				want.ChunkIsImmutable = chunk.Immutable()
 
 				have := stampindex.NewItemWithKeys(ns, chunk.Stamp().BatchID(), chunk.Stamp().Index(), stampHash)
 				err = ts.IndexStore().Get(have)
@@ -161,7 +152,6 @@ func TestStoreLoadDelete(t *testing.T) {
 				want := stampindex.NewItemWithKeys(ns, chunk.Stamp().BatchID(), chunk.Stamp().Index(), stampHash)
 				want.StampTimestamp = chunk.Stamp().Timestamp()
 				want.ChunkAddress = chunk.Address()
-				want.ChunkIsImmutable = chunk.Immutable()
 
 				have, err := stampindex.Load(ts.IndexStore(), ns, chunk)
 				if err != nil {
@@ -229,7 +219,6 @@ func TestLoadOrStore(t *testing.T) {
 			want := stampindex.NewItemWithKeys(ns, chunk.Stamp().BatchID(), chunk.Stamp().Index(), stampHash)
 			want.StampTimestamp = chunk.Stamp().Timestamp()
 			want.ChunkAddress = chunk.Address()
-			want.ChunkIsImmutable = chunk.Immutable()
 
 			trx, done := ts.NewTransaction(context.Background())
 

--- a/pkg/storer/migration/reserveRepair_test.go
+++ b/pkg/storer/migration/reserveRepair_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/storage"
 	chunktest "github.com/ethersphere/bee/v2/pkg/storage/testing"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal"
+	"github.com/ethersphere/bee/v2/pkg/storer/internal/chunkstamp"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/reserve"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/transaction"
 	localmigration "github.com/ethersphere/bee/v2/pkg/storer/migration"
@@ -82,6 +83,10 @@ func TestReserveRepair(t *testing.T) {
 			}
 
 			err = store.Run(context.Background(), func(s transaction.Store) error {
+				err := chunkstamp.Store(s.IndexStore(), "reserve", ch)
+				if err != nil {
+					return err
+				}
 				return s.ChunkStore().Put(context.Background(), ch)
 			})
 			if err != nil {

--- a/pkg/storer/migration/step_06.go
+++ b/pkg/storer/migration/step_06.go
@@ -37,7 +37,7 @@ func step_06(st transaction.Storage) func() error {
 }
 
 func addStampHash(logger log.Logger, st transaction.Storage) (int64, int64, error) {
-	itemC := make(chan *reserve.BatchRadiusItemV1)
+	itemC := make(chan *reserve.BatchRadiusItemV1, 1)
 	errC := make(chan error)
 	doneC := make(chan any)
 	defer close(doneC)

--- a/pkg/storer/migration/step_06.go
+++ b/pkg/storer/migration/step_06.go
@@ -37,10 +37,11 @@ func step_06(st transaction.Storage) func() error {
 }
 
 func addStampHash(logger log.Logger, st transaction.Storage) (int64, int64, error) {
-	itemC := make(chan *reserve.BatchRadiusItemV1, 1)
+	itemC := make(chan *reserve.BatchRadiusItemV1)
 	errC := make(chan error)
 	doneC := make(chan any)
 	defer close(doneC)
+	defer close(errC)
 
 	var eg errgroup.Group
 	p := runtime.NumCPU()
@@ -63,101 +64,98 @@ func addStampHash(logger log.Logger, st transaction.Storage) (int64, int64, erro
 	}()
 
 	go func() {
-		for item := range itemC {
-			batchRadiusItemV1 := item
-			eg.Go(func() error {
-				err := st.Run(context.Background(), func(s transaction.Store) error {
-					idxStore := s.IndexStore()
-					stamp, err := chunkstamp.LoadWithBatchID(idxStore, "reserve", batchRadiusItemV1.Address, batchRadiusItemV1.BatchID)
-					if err != nil {
-						return err
-					}
-					stampHash, err := stamp.Hash()
-					if err != nil {
-						return err
-					}
-
-					// Since the ID format has changed, we should delete the old item and put a new one with the new ID format.
-					err = idxStore.Delete(batchRadiusItemV1)
-					if err != nil {
-						return err
-					}
-					err = idxStore.Put(&reserve.BatchRadiusItem{
-						Bin:       batchRadiusItemV1.Bin,
-						BatchID:   batchRadiusItemV1.BatchID,
-						StampHash: stampHash,
-						Address:   batchRadiusItemV1.Address,
-						BinID:     batchRadiusItemV1.BinID,
-					})
-					if err != nil {
-						return err
-					}
-
-					chunkBinItemV1 := &reserve.ChunkBinItemV1{
-						Bin:   batchRadiusItemV1.Bin,
-						BinID: batchRadiusItemV1.BinID,
-					}
-					err = idxStore.Get(chunkBinItemV1)
-					if err != nil {
-						return err
-					}
-
-					// same id. Will replace.
-					err = idxStore.Put(&reserve.ChunkBinItem{
-						Bin:       chunkBinItemV1.Bin,
-						BinID:     chunkBinItemV1.BinID,
-						Address:   chunkBinItemV1.Address,
-						BatchID:   chunkBinItemV1.BatchID,
-						StampHash: stampHash,
-						ChunkType: chunkBinItemV1.ChunkType,
-					})
-					if err != nil {
-						return err
-					}
-
-					// same id. Will replace.
-					stampIndexItem := &stampindex.Item{
-						BatchID:        chunkBinItemV1.BatchID,
-						StampIndex:     stamp.Index(),
-						StampHash:      stampHash,
-						StampTimestamp: stamp.Timestamp(),
-						ChunkAddress:   chunkBinItemV1.Address,
-					}
-					stampIndexItem.SetNamespace([]byte("reserve"))
-					err = idxStore.Put(stampIndexItem)
-					if err != nil {
-						return err
-					}
-					doneCount.Add(1)
-					return nil
-				})
-				if err != nil {
-					errC <- err
-					return err
-				}
-				return nil
-			})
-		}
+		_ = st.IndexStore().Iterate(storage.Query{
+			Factory: func() storage.Item { return new(reserve.BatchRadiusItemV1) },
+		}, func(result storage.Result) (bool, error) {
+			seenCount++
+			item := result.Entry.(*reserve.BatchRadiusItemV1)
+			select {
+			case itemC <- item:
+			case err := <-errC:
+				return true, err
+			}
+			return false, nil
+		})
+		close(itemC)
 	}()
 
-	err := st.IndexStore().Iterate(storage.Query{
-		Factory: func() storage.Item { return new(reserve.BatchRadiusItemV1) },
-	}, func(result storage.Result) (bool, error) {
-		seenCount++
-		item := result.Entry.(*reserve.BatchRadiusItemV1)
-		select {
-		case itemC <- item:
-		case err := <-errC:
-			return true, err
-		}
-		return false, nil
-	})
-	close(itemC)
-	if err != nil {
-		return 0, 0, err
+	for item := range itemC {
+		batchRadiusItemV1 := item
+		eg.Go(func() error {
+			err := st.Run(context.Background(), func(s transaction.Store) error {
+				idxStore := s.IndexStore()
+				stamp, err := chunkstamp.LoadWithBatchID(idxStore, "reserve", batchRadiusItemV1.Address, batchRadiusItemV1.BatchID)
+				if err != nil {
+					return err
+				}
+				stampHash, err := stamp.Hash()
+				if err != nil {
+					return err
+				}
+
+				// Since the ID format has changed, we should delete the old item and put a new one with the new ID format.
+				err = idxStore.Delete(batchRadiusItemV1)
+				if err != nil {
+					return err
+				}
+				err = idxStore.Put(&reserve.BatchRadiusItem{
+					Bin:       batchRadiusItemV1.Bin,
+					BatchID:   batchRadiusItemV1.BatchID,
+					StampHash: stampHash,
+					Address:   batchRadiusItemV1.Address,
+					BinID:     batchRadiusItemV1.BinID,
+				})
+				if err != nil {
+					return err
+				}
+
+				chunkBinItemV1 := &reserve.ChunkBinItemV1{
+					Bin:   batchRadiusItemV1.Bin,
+					BinID: batchRadiusItemV1.BinID,
+				}
+				err = idxStore.Get(chunkBinItemV1)
+				if err != nil {
+					return err
+				}
+
+				// same id. Will replace.
+				err = idxStore.Put(&reserve.ChunkBinItem{
+					Bin:       chunkBinItemV1.Bin,
+					BinID:     chunkBinItemV1.BinID,
+					Address:   chunkBinItemV1.Address,
+					BatchID:   chunkBinItemV1.BatchID,
+					StampHash: stampHash,
+					ChunkType: chunkBinItemV1.ChunkType,
+				})
+				if err != nil {
+					return err
+				}
+
+				// same id. Will replace.
+				stampIndexItem := &stampindex.Item{
+					BatchID:        chunkBinItemV1.BatchID,
+					StampIndex:     stamp.Index(),
+					StampHash:      stampHash,
+					StampTimestamp: stamp.Timestamp(),
+					ChunkAddress:   chunkBinItemV1.Address,
+				}
+				stampIndexItem.SetNamespace([]byte("reserve"))
+				err = idxStore.Put(stampIndexItem)
+				if err != nil {
+					return err
+				}
+				doneCount.Add(1)
+				return nil
+			})
+			if err != nil {
+				errC <- err
+				return err
+			}
+			return nil
+		})
 	}
 
-	err = eg.Wait()
+	err := eg.Wait()
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/storer/migration/step_06.go
+++ b/pkg/storer/migration/step_06.go
@@ -6,19 +6,18 @@ package migration
 
 import (
 	"context"
-	"encoding/binary"
-	"errors"
 	"fmt"
 	"os"
+	"runtime"
+	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/storage"
-	"github.com/ethersphere/bee/v2/pkg/storer/internal"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/chunkstamp"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/reserve"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/stampindex"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/transaction"
-	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"golang.org/x/sync/errgroup"
 )
 
 // step_06 is a migration step that adds a stampHash to all BatchRadiusItems, ChunkBinItems and StampIndexItems.
@@ -27,85 +26,112 @@ func step_06(st transaction.Storage) func() error {
 		logger := log.NewLogger("migration-step-06", log.WithSink(os.Stdout))
 		logger.Info("start adding stampHash to BatchRadiusItems, ChunkBinItems and StampIndexItems")
 
-		err := addStampHashToBatchRadiusAndChunkBinItems(st)
+		err := addStampHash(logger, st)
 		if err != nil {
-			return fmt.Errorf("batch radius and chunk bin item migration: %w", err)
+			return fmt.Errorf("add stamp hash migration: %w", err)
 		}
-		logger.Info("done migrating batch radius and chunk bin items")
-		err = addStampHashToStampIndexItems(st)
-		if err != nil {
-			return fmt.Errorf("stamp index migration: %w", err)
-		}
-		logger.Info("done migrating stamp index items")
 		logger.Info("finished migrating items")
 		return nil
 	}
 }
 
-func addStampHashToBatchRadiusAndChunkBinItems(st transaction.Storage) error {
-	itemC := make(chan *OldBatchRadiusItem)
+func addStampHash(logger log.Logger, st transaction.Storage) error {
+	itemC := make(chan *reserve.BatchRadiusItemV1)
 	errC := make(chan error)
+
+	var eg errgroup.Group
+	p := runtime.NumCPU()
+	eg.SetLimit(p)
+
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				logger.Info("still migrating items...")
+			case <-errC:
+				return
+			}
+		}
+	}()
 
 	go func() {
 		for oldBatchRadiusItem := range itemC {
-			err := st.Run(context.Background(), func(s transaction.Store) error {
-				idxStore := s.IndexStore()
-				stamp, err := chunkstamp.LoadWithBatchID(idxStore, "reserve", oldBatchRadiusItem.Address, oldBatchRadiusItem.BatchID)
-				if err != nil {
-					return err
-				}
-				stampHash, err := stamp.Hash()
-				if err != nil {
-					return err
-				}
+			eg.Go(func() error {
+				err := st.Run(context.Background(), func(s transaction.Store) error {
+					idxStore := s.IndexStore()
+					stamp, err := chunkstamp.LoadWithBatchID(idxStore, "reserve", oldBatchRadiusItem.Address, oldBatchRadiusItem.BatchID)
+					if err != nil {
+						return err
+					}
+					stampHash, err := stamp.Hash()
+					if err != nil {
+						return err
+					}
 
-				// Since the ID format has changed, we should delete the old item and put a new one with the new ID format.
-				err = idxStore.Delete(oldBatchRadiusItem)
-				if err != nil {
-					return err
-				}
-				err = idxStore.Put(&reserve.BatchRadiusItem{
-					Bin:       oldBatchRadiusItem.Bin,
-					BatchID:   oldBatchRadiusItem.BatchID,
-					StampHash: stampHash,
-					Address:   oldBatchRadiusItem.Address,
-					BinID:     oldBatchRadiusItem.BinID,
+					// Since the ID format has changed, we should delete the old item and put a new one with the new ID format.
+					err = idxStore.Delete(oldBatchRadiusItem)
+					if err != nil {
+						return err
+					}
+					err = idxStore.Put(&reserve.BatchRadiusItem{
+						Bin:       oldBatchRadiusItem.Bin,
+						BatchID:   oldBatchRadiusItem.BatchID,
+						StampHash: stampHash,
+						Address:   oldBatchRadiusItem.Address,
+						BinID:     oldBatchRadiusItem.BinID,
+					})
+					if err != nil {
+						return err
+					}
+
+					oldChunkBinItem := &reserve.ChunkBinItemV1{
+						Bin:   oldBatchRadiusItem.Bin,
+						BinID: oldBatchRadiusItem.BinID,
+					}
+					err = idxStore.Get(oldChunkBinItem)
+					if err != nil {
+						return err
+					}
+
+					// same id. Will replace.
+					err = idxStore.Put(&reserve.ChunkBinItem{
+						Bin:       oldChunkBinItem.Bin,
+						BinID:     oldChunkBinItem.BinID,
+						Address:   oldChunkBinItem.Address,
+						BatchID:   oldChunkBinItem.BatchID,
+						StampHash: stampHash,
+						ChunkType: oldChunkBinItem.ChunkType,
+					})
+					if err != nil {
+						return err
+					}
+
+					// same id. Will replace.
+					stampIndexItem := &stampindex.Item{
+						BatchID:        oldChunkBinItem.BatchID,
+						StampIndex:     stamp.Index(),
+						StampHash:      stampHash,
+						StampTimestamp: stamp.Timestamp(),
+						ChunkAddress:   oldChunkBinItem.Address,
+					}
+					stampIndexItem.SetNamespace([]byte("reserve"))
+					return idxStore.Put(stampIndexItem)
 				})
 				if err != nil {
-					return err
+					errC <- err
 				}
-
-				oldChunkBinItem := &OldChunkBinItem{&reserve.ChunkBinItem{
-					Bin:   oldBatchRadiusItem.Bin,
-					BinID: oldBatchRadiusItem.BinID,
-				}}
-				err = idxStore.Get(oldChunkBinItem)
-				if err != nil {
-					return err
-				}
-
-				// same id. Will replace.
-				return idxStore.Put(&reserve.ChunkBinItem{
-					Bin:       oldChunkBinItem.Bin,
-					BinID:     oldChunkBinItem.BinID,
-					Address:   oldChunkBinItem.Address,
-					BatchID:   oldChunkBinItem.BatchID,
-					StampHash: stampHash,
-					ChunkType: oldChunkBinItem.ChunkType,
-				})
+				return err
 			})
-			if err != nil {
-				errC <- err
-				return
-			}
 		}
 		close(errC)
 	}()
 
 	err := st.IndexStore().Iterate(storage.Query{
-		Factory: func() storage.Item { return &OldBatchRadiusItem{&reserve.BatchRadiusItem{}} },
+		Factory: func() storage.Item { return new(reserve.BatchRadiusItemV1) },
 	}, func(result storage.Result) (bool, error) {
-		item := result.Entry.(*OldBatchRadiusItem)
+		item := result.Entry.(*reserve.BatchRadiusItemV1)
 		select {
 		case itemC <- item:
 		case err := <-errC:
@@ -118,154 +144,5 @@ func addStampHashToBatchRadiusAndChunkBinItems(st transaction.Storage) error {
 		return err
 	}
 
-	return <-errC
-}
-
-func addStampHashToStampIndexItems(st transaction.Storage) error {
-	itemC := make(chan *OldStampIndexItem)
-	errC := make(chan error)
-
-	go func() {
-		for oldStampIndexItem := range itemC {
-			err := st.Run(context.Background(), func(s transaction.Store) error {
-				idxStore := s.IndexStore()
-				stamp, err := chunkstamp.LoadWithBatchID(idxStore, string(oldStampIndexItem.GetNamespace()), oldStampIndexItem.ChunkAddress, oldStampIndexItem.BatchID)
-				if err != nil {
-					return err
-				}
-				stampHash, err := stamp.Hash()
-				if err != nil {
-					return err
-				}
-
-				// same id. Will replace.
-				item := &stampindex.Item{
-					BatchID:          oldStampIndexItem.BatchID,
-					StampIndex:       oldStampIndexItem.StampIndex,
-					StampHash:        stampHash,
-					StampTimestamp:   oldStampIndexItem.StampIndex,
-					ChunkAddress:     oldStampIndexItem.ChunkAddress,
-					ChunkIsImmutable: oldStampIndexItem.ChunkIsImmutable,
-				}
-				item.SetNamespace(oldStampIndexItem.GetNamespace())
-				return idxStore.Put(item)
-			})
-			if err != nil {
-				errC <- err
-				return
-			}
-		}
-		close(errC)
-	}()
-
-	err := st.IndexStore().Iterate(storage.Query{
-		Factory: func() storage.Item { return &OldStampIndexItem{&stampindex.Item{}} },
-	}, func(result storage.Result) (bool, error) {
-		item := result.Entry.(*OldStampIndexItem)
-		select {
-		case itemC <- item:
-		case err := <-errC:
-			return true, err
-		}
-		return false, nil
-	})
-	close(itemC)
-	if err != nil {
-		return err
-	}
-
-	return <-errC
-}
-
-type OldChunkBinItem struct {
-	*reserve.ChunkBinItem
-}
-
-// Unmarshal unmarshals the old chunk bin item that does not include a stamp hash.
-func (c *OldChunkBinItem) Unmarshal(buf []byte) error {
-	i := 0
-	c.Bin = buf[i]
-	i += 1
-
-	c.BinID = binary.BigEndian.Uint64(buf[i : i+8])
-	i += 8
-
-	c.Address = swarm.NewAddress(buf[i : i+swarm.HashSize]).Clone()
-	i += swarm.HashSize
-
-	c.BatchID = copyBytes(buf[i : i+swarm.HashSize])
-	i += swarm.HashSize
-
-	c.ChunkType = swarm.ChunkType(buf[i])
-	c.StampHash = swarm.EmptyAddress.Bytes()
-
-	return nil
-}
-
-type OldBatchRadiusItem struct {
-	*reserve.BatchRadiusItem
-}
-
-// ID returns the old ID format for BatchRadiusItem ID. (batchId/bin/ChunkAddr).
-func (b *OldBatchRadiusItem) ID() string {
-	return string(b.BatchID) + string(b.Bin) + b.Address.ByteString()
-}
-
-// Unmarshal unmarshals the old batch radius item that does not include a stamp hash.
-func (b *OldBatchRadiusItem) Unmarshal(buf []byte) error {
-	i := 0
-	b.Bin = buf[i]
-	i += 1
-
-	b.BatchID = copyBytes(buf[i : i+swarm.HashSize])
-	i += swarm.HashSize
-
-	b.Address = swarm.NewAddress(buf[i : i+swarm.HashSize]).Clone()
-	i += swarm.HashSize
-
-	b.BinID = binary.BigEndian.Uint64(buf[i : i+8])
-	b.StampHash = swarm.EmptyAddress.Bytes()
-	return nil
-}
-
-type OldStampIndexItem struct {
-	*stampindex.Item
-}
-
-// Unmarshal unmarhsals the old stamp index item that does not include a stamp hash.
-func (i *OldStampIndexItem) Unmarshal(bytes []byte) error {
-	nsLen := int(binary.LittleEndian.Uint64(bytes))
-	ni := &OldStampIndexItem{&stampindex.Item{}}
-	l := 8
-	namespace := append(make([]byte, 0, nsLen), bytes[l:l+nsLen]...)
-	l += nsLen
-	ni.BatchID = append(make([]byte, 0, swarm.HashSize), bytes[l:l+swarm.HashSize]...)
-	l += swarm.HashSize
-	ni.StampIndex = append(make([]byte, 0, swarm.StampIndexSize), bytes[l:l+swarm.StampIndexSize]...)
-	l += swarm.StampIndexSize
-	ni.StampTimestamp = append(make([]byte, 0, swarm.StampTimestampSize), bytes[l:l+swarm.StampTimestampSize]...)
-	l += swarm.StampTimestampSize
-	ni.ChunkAddress = internal.AddressOrZero(bytes[l : l+swarm.HashSize])
-	l += swarm.HashSize
-	switch bytes[l] {
-	case '0':
-		ni.ChunkIsImmutable = false
-	case '1':
-		ni.ChunkIsImmutable = true
-	default:
-		return errors.New("immutable invalid")
-	}
-	ni.StampHash = swarm.EmptyAddress.Bytes()
-	*i = *ni
-	i.SetNamespace(namespace)
-	return nil
-}
-
-func copyBytes(src []byte) []byte {
-	if src == nil {
-		return nil
-	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
+	return eg.Wait()
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Previous stamp hash migration took ~30 mins to migrate a reserve size of 3.5m chunks.
This iteration takes ~7mins

```
"time"="2024-07-24 22:38:55.579963" "level"="info" "logger"="migration-step-06" "msg"="start adding stampHash to BatchRadiusItems, ChunkBinItems and StampIndexItems"
"time"="2024-07-24 22:39:55.580311" "level"="info" "logger"="migration-step-06" "msg"="still migrating items..."
...
"time"="2024-07-24 22:45:16.067493" "level"="info" "logger"="migration-step-06" "msg"="finished migrating items" "seen"=3426797 "migrated"=3426797
```

