### PR TITLE
fix: override same chunk

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/splitter"
 	filetest "github.com/ethersphere/bee/v2/pkg/file/testing"
 	"github.com/ethersphere/bee/v2/pkg/log"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	testingc "github.com/ethersphere/bee/v2/pkg/storage/testing"
 	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
@@ -1409,6 +1409,14 @@ func (c *chunkStore) Put(_ context.Context, ch swarm.Chunk) error {
 	defer c.mu.Unlock()
 	c.chunks[ch.Address().ByteString()] = swarm.NewChunk(ch.Address(), ch.Data()).WithStamp(ch.Stamp())
 	return nil
+}
+
+func (c *chunkStore) Replace(_ context.Context, ch swarm.Chunk) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.chunks[ch.Address().ByteString()] = swarm.NewChunk(ch.Address(), ch.Data()).WithStamp(ch.Stamp())
+	return nil
+
 }
 
 func (c *chunkStore) Has(_ context.Context, addr swarm.Address) (bool, error) {

--- a/pkg/soc/testing/soc.go
+++ b/pkg/soc/testing/soc.go
@@ -32,6 +32,39 @@ func (ms MockSOC) Chunk() swarm.Chunk {
 	return swarm.NewChunk(ms.Address(), append(ms.ID, append(ms.Signature, ms.WrappedChunk.Data()...)...))
 }
 
+// GenerateMockSocWithSigner generates a valid mocked SOC from given data and signer.
+func GenerateMockSocWithSigner(t *testing.T, data []byte, signer crypto.Signer) *MockSOC {
+	t.Helper()
+
+	owner, err := signer.EthereumAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := cac.New(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := make([]byte, swarm.HashSize)
+	hasher := swarm.NewHasher()
+	_, err = hasher.Write(append(id, ch.Address().Bytes()...))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signature, err := signer.Sign(hasher.Sum(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &MockSOC{
+		ID:           id,
+		Owner:        owner.Bytes(),
+		Signature:    signature,
+		WrappedChunk: ch,
+	}
+}
+
 // GenerateMockSOC generates a valid mocked SOC from given data.
 func GenerateMockSOC(t *testing.T, data []byte) *MockSOC {
 	t.Helper()

--- a/pkg/storage/chunkstore.go
+++ b/pkg/storage/chunkstore.go
@@ -39,6 +39,12 @@ type Hasser interface {
 	Has(context.Context, swarm.Address) (bool, error)
 }
 
+// Replacer is the interface that wraps the basic Replace method.
+type Replacer interface {
+	// Replace a chunk in the store.
+	Replace(context.Context, swarm.Chunk) error
+}
+
 // PutterFunc type is an adapter to allow the use of
 // ChunkStore as Putter interface. If f is a function
 // with the appropriate signature, PutterFunc(f) is a
@@ -70,6 +76,7 @@ type ChunkStore interface {
 	Putter
 	Deleter
 	Hasser
+	Replacer
 
 	// Iterate over chunks in no particular order.
 	Iterate(context.Context, IterateChunkFn) error

--- a/pkg/storage/inmemchunkstore/inmemchunkstore.go
+++ b/pkg/storage/inmemchunkstore/inmemchunkstore.go
@@ -77,7 +77,13 @@ func (c *ChunkStore) Delete(_ context.Context, addr swarm.Address) error {
 	return nil
 }
 
-func (c *ChunkStore) Replace(_ context.Context, _ swarm.Chunk) error {
+func (c *ChunkStore) Replace(_ context.Context, ch swarm.Chunk) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	chunkCount := c.chunks[ch.Address().ByteString()]
+	chunkCount.chunk = ch
+	c.chunks[ch.Address().ByteString()] = chunkCount
 	return nil
 }
 

--- a/pkg/storage/inmemchunkstore/inmemchunkstore.go
+++ b/pkg/storage/inmemchunkstore/inmemchunkstore.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"sync"
 
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 )
 
@@ -74,6 +74,10 @@ func (c *ChunkStore) Delete(_ context.Context, addr swarm.Address) error {
 		c.chunks[addr.ByteString()] = chunkCount
 	}
 
+	return nil
+}
+
+func (c *ChunkStore) Replace(_ context.Context, _ swarm.Chunk) error {
 	return nil
 }
 

--- a/pkg/storer/internal/chunkstamp/chunkstamp.go
+++ b/pkg/storer/internal/chunkstamp/chunkstamp.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	"github.com/ethersphere/bee/v2/pkg/postage"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/storage/storageutil"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 )

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -153,6 +153,9 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 						"batch_id", hex.EncodeToString(chunk.Stamp().BatchID()),
 					)
 					err = r.removeChunk(ctx, s, oldItem.ChunkAddress, oldItem.BatchID, oldItem.StampHash)
+					if err != nil {
+						return fmt.Errorf("failed removing older chunk %s: %w", oldItem.ChunkAddress, err)
+					}
 				}
 			}
 

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -123,7 +123,7 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 			return fmt.Errorf("load or store stamp index for chunk %v has fail: %w", chunk, err)
 		}
 
-		sameAddressOldChunkStamp, err := chunkstamp.LoadWithBatchID(s.IndexStore(), reserveNamespace, chunk.Address(), chunk.Stamp().BatchID())
+		sameAddressOldChunkStamp, err := chunkstamp.Load(s.IndexStore(), reserveNamespace, chunk.Address())
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
 			return err
 		}

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -145,13 +145,13 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 					return fmt.Errorf("overwrite same chunk. prev %d cur %d batch %s: %w", prev, curr, hex.EncodeToString(chunk.Stamp().BatchID()), storage.ErrOverwriteNewerChunk)
 				}
 
-				r.logger.Warning(
-					"replacing chunk stamp index",
-					"old_chunk", oldItem.ChunkAddress,
-					"new_chunk", chunk.Address(),
-					"batch_id", hex.EncodeToString(chunk.Stamp().BatchID()),
-				)
 				if !chunk.Address().Equal(oldItem.ChunkAddress) {
+					r.logger.Warning(
+						"replacing chunk stamp index",
+						"old_chunk", oldItem.ChunkAddress,
+						"new_chunk", chunk.Address(),
+						"batch_id", hex.EncodeToString(chunk.Stamp().BatchID()),
+					)
 					err = r.removeChunk(ctx, s, oldItem.ChunkAddress, oldItem.BatchID, oldItem.StampHash)
 				}
 			}

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -159,18 +159,12 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 				}
 			}
 
-			// load item to get the binID
 			oldBatchRadiusItem := &BatchRadiusItem{
 				Bin:       bin,
 				Address:   chunk.Address(),
 				BatchID:   sameAddressOldStampIndex.BatchID,
 				StampHash: sameAddressOldStampIndex.StampHash,
 			}
-			err = s.IndexStore().Get(oldBatchRadiusItem)
-			if err != nil {
-				return err
-			}
-
 			err = r.deleteWithStamp(s, oldBatchRadiusItem, sameAddressOldChunkStamp)
 			if err != nil {
 				return err

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -116,7 +116,7 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 	r.multx.Lock(strconv.Itoa(int(bin)))
 	defer r.multx.Unlock(strconv.Itoa(int(bin)))
 
-	err = r.st.Run(ctx, func(s transaction.Store) error {
+	return r.st.Run(ctx, func(s transaction.Store) error {
 
 		oldItem, loadedStamp, err := stampindex.LoadOrStore(s.IndexStore(), reserveNamespace, chunk)
 		if err != nil {
@@ -207,10 +207,6 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (r *Reserve) Has(addr swarm.Address, batchID []byte, stampHash []byte) (bool, error) {

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -122,14 +122,12 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 		if err != nil {
 			return fmt.Errorf("load or store stamp index for chunk %v has fail: %w", chunk, err)
 		}
-
 		if loadedStamp {
 			prev := binary.BigEndian.Uint64(oldItem.StampTimestamp)
 			curr := binary.BigEndian.Uint64(chunk.Stamp().Timestamp())
 			if prev >= curr {
 				return fmt.Errorf("overwrite prev %d cur %d batch %s: %w", prev, curr, hex.EncodeToString(chunk.Stamp().BatchID()), storage.ErrOverwriteNewerChunk)
 			}
-
 			// An older (same or different) chunk with the same batchID and stamp index has been previously
 			// saved to the reserve. We must do the below before saving the new chunk:
 			// 1. Delete the old chunk from the chunkstore.

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -186,16 +186,15 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 			return err
 		}
 
-		chunkType := storage.ChunkType(chunk)
 		has, err := s.ChunkStore().Has(ctx, chunk.Address())
 		if err != nil {
 			return err
 		}
-		if !has {
-			err = s.ChunkStore().Put(ctx, chunk)
-		} else if chunkType == swarm.ChunkTypeSingleOwner {
-			r.logger.Warning("replacing SOC in chunkstore", "chunk", chunk.Address())
+		if has {
+			r.logger.Warning("replacing chunk in chunkstore", "chunk", chunk.Address())
 			err = s.ChunkStore().Replace(ctx, chunk)
+		} else {
+			err = s.ChunkStore().Put(ctx, chunk)
 		}
 		if err != nil {
 			return err

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -165,6 +165,12 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 				BatchID:   sameAddressOldStampIndex.BatchID,
 				StampHash: sameAddressOldStampIndex.StampHash,
 			}
+			// load item to get the binID
+			err = s.IndexStore().Get(oldBatchRadiusItem)
+			if err != nil {
+				return err
+			}
+
 			err = r.deleteWithStamp(s, oldBatchRadiusItem, sameAddressOldChunkStamp)
 			if err != nil {
 				return err

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -219,6 +219,9 @@ func TestSameChunkAddress(t *testing.T) {
 		bin := swarm.Proximity(baseAddr.Bytes(), ch1.Address().Bytes())
 		checkStore(t, ts.IndexStore(), &reserve.BatchRadiusItem{Bin: bin, BatchID: ch1.Stamp().BatchID(), Address: ch1.Address(), StampHash: ch1StampHash}, true)
 		checkStore(t, ts.IndexStore(), &reserve.BatchRadiusItem{Bin: bin, BatchID: ch2.Stamp().BatchID(), Address: ch2.Address(), StampHash: ch2StampHash}, false)
+		checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: bin, BinID: binID - 1, StampHash: ch1StampHash}, true)
+		checkStore(t, ts.IndexStore(), &reserve.ChunkBinItem{Bin: bin, BinID: binID, StampHash: ch2StampHash}, false)
+
 		chunkBinItem := &reserve.ChunkBinItem{Bin: bin, BinID: binID}
 		err = ts.IndexStore().Get(chunkBinItem)
 		if err != nil {

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -180,7 +180,7 @@ func TestSameChunkAddress(t *testing.T) {
 	t.Run("different stamp index and older timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		s1 := soctesting.GenerateMockSocWithSigner(t, []byte("data"), signer)
-		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
+		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 2))
 		s2 := soctesting.GenerateMockSocWithSigner(t, []byte("update"), signer)
 		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 1, 0))
 		err = r.Put(ctx, ch1)
@@ -240,25 +240,25 @@ func TestSameChunkAddress(t *testing.T) {
 	t.Run("same stamp index and newer timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		s1 := soctesting.GenerateMockSocWithSigner(t, []byte("data"), signer)
-		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
+		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 3))
 		s2 := soctesting.GenerateMockSocWithSigner(t, []byte("update"), signer)
-		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
+		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 4))
 		replace(t, ch1, ch2, 4)
 	})
 
 	t.Run("different stamp index and newer timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		s1 := soctesting.GenerateMockSocWithSigner(t, []byte("data"), signer)
-		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
+		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 5))
 		s2 := soctesting.GenerateMockSocWithSigner(t, []byte("update"), signer)
-		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 1, 1))
+		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 1, 6))
 		replace(t, ch1, ch2, 6)
 	})
 
 	t.Run("not a soc and newer timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
-		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
-		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
+		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 7))
+		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 8))
 		err := r.Put(ctx, ch1)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -135,7 +135,7 @@ func TestReserveChunkType(t *testing.T) {
 	}
 }
 
-func TestSameChunkSameIndex(t *testing.T) {
+func TestSameChunkAddress(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -153,7 +153,7 @@ func TestSameChunkSameIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("same stamp index older timestamp", func(t *testing.T) {
+	t.Run("same stamp index and older timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
@@ -167,7 +167,7 @@ func TestSameChunkSameIndex(t *testing.T) {
 		}
 	})
 
-	t.Run("different stamp index older timestamp", func(t *testing.T) {
+	t.Run("different stamp index and older timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 1, 0))
@@ -218,14 +218,14 @@ func TestSameChunkSameIndex(t *testing.T) {
 		}
 	}
 
-	t.Run("same stamp index newer timestamp", func(t *testing.T) {
+	t.Run("same stamp index and newer timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
 		replace(t, ch1, ch2)
 	})
 
-	t.Run("different stamp index newer timestamp", func(t *testing.T) {
+	t.Run("different stamp index and newer timestamp", func(t *testing.T) {
 		batch := postagetesting.MustNewBatch()
 		ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		ch2 := swarm.NewChunk(ch1.Address(), []byte("update")).WithStamp(postagetesting.MustNewFields(batch.ID, 1, 1))

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -135,49 +135,6 @@ func TestReserveChunkType(t *testing.T) {
 	}
 }
 
-func TestReplaceSameAddress(t *testing.T) {
-	t.Parallel()
-
-	baseAddr := swarm.RandAddress(t)
-	ts := internal.NewInmemStorage()
-	r, err := reserve.New(
-		baseAddr,
-		ts,
-		0, kademlia.NewTopologyDriver(),
-		log.Noop,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	batch := postagetesting.MustNewBatch()
-	ch1 := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
-	ch2 := swarm.NewChunk(ch1.Address(), []byte("new payload")).WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
-
-	err = r.Put(context.Background(), ch1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.Put(context.Background(), ch2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stampHash, err := ch2.Stamp().Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
-	ch3, err := r.Get(context.Background(), ch2.Address(), ch2.Stamp().BatchID(), stampHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(ch3.Data(), ch2.Data()) {
-		t.Fatalf("ch3 and ch2 payloads not equal")
-	}
-}
-
 func TestReplaceOldIndex(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -243,7 +243,7 @@ func TestSameChunkAddress(t *testing.T) {
 		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		s2 := soctesting.GenerateMockSocWithSigner(t, []byte("update"), signer)
 		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 1))
-		replace(t, ch1, ch2, 3)
+		replace(t, ch1, ch2, 4)
 	})
 
 	t.Run("different stamp index and newer timestamp", func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestSameChunkAddress(t *testing.T) {
 		ch1 := s1.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 0, 0))
 		s2 := soctesting.GenerateMockSocWithSigner(t, []byte("update"), signer)
 		ch2 := s2.Chunk().WithStamp(postagetesting.MustNewFields(batch.ID, 1, 1))
-		replace(t, ch1, ch2, 4)
+		replace(t, ch1, ch2, 6)
 	})
 
 	t.Run("not a soc and newer timestamp", func(t *testing.T) {

--- a/pkg/storer/internal/stampindex/stampindex.go
+++ b/pkg/storer/internal/stampindex/stampindex.go
@@ -185,6 +185,12 @@ func Load(s storage.Reader, namespace string, chunk swarm.Chunk) (*Item, error) 
 	return item, nil
 }
 
+// LoadWithStamp returns stamp index record related to the given namespace and stamp.
+func LoadWithStamp(s storage.Reader, namespace string, stamp swarm.Stamp) (*Item, error) {
+	ch := swarm.NewChunk(swarm.EmptyAddress, nil).WithStamp(stamp)
+	return Load(s, namespace, ch)
+}
+
 // Store creates new or updated an existing stamp index
 // record related to the given namespace and chunk.
 func Store(s storage.IndexStore, namespace string, chunk swarm.Chunk) error {

--- a/pkg/storer/internal/transaction/transaction.go
+++ b/pkg/storer/internal/transaction/transaction.go
@@ -242,6 +242,13 @@ func (c *chunkStoreTrx) Iterate(ctx context.Context, fn storage.IterateChunkFn) 
 	return chunkstore.Iterate(ctx, c.indexStore, c.sharkyTrx, fn)
 }
 
+func (c *chunkStoreTrx) Replace(ctx context.Context, ch swarm.Chunk) (err error) {
+	defer handleMetric("chunkstore_replace", c.metrics)(&err)
+	unlock := c.lock(ch.Address())
+	defer unlock()
+	return chunkstore.Replace(ctx, c.indexStore, c.sharkyTrx, ch)
+}
+
 func (c *chunkStoreTrx) lock(addr swarm.Address) func() {
 	// directly lock
 	if c.readOnly {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Override chunk with the same address.

When we attempt to delete the chunk, the delete operation is appended to the current batch. However, since this [Get](https://github.com/ethersphere/bee/blob/master/pkg/storer/internal/chunkstore/chunkstore.go#L77) reads from disk, it returns the old `refCnt`. So it ignores the new chunk.

To fix this, we introduce a new `replace` method that does not relly on `refCnt`.


### Related Issue (Optional)

#4739 