### PR TITLE
feat: layer2 websocket

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline/builder"
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
+	"github.com/ethersphere/bee/v2/pkg/layer2"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/pingpong"
@@ -170,6 +171,7 @@ type Service struct {
 
 	topologyDriver topology.Driver
 	p2p            p2p.DebugService
+	l2p2p          layer2.IP2pService
 	accounting     accounting.Interface
 	chequebook     chequebook.Service
 	pseudosettle   settlement.Interface
@@ -249,6 +251,7 @@ type ExtraOptions struct {
 	SyncStatus      func() (bool, error)
 	NodeStatus      *status.Service
 	PinIntegrity    PinIntegrity
+	Layer2P2p       layer2.IP2pService
 }
 
 func New(
@@ -337,6 +340,7 @@ func (s *Service) Configure(signer crypto.Signer, tracer *tracing.Tracer, o Opti
 	s.lightNodes = e.LightNodes
 	s.pseudosettle = e.Pseudosettle
 	s.blockTime = e.BlockTime
+	s.l2p2p = e.Layer2P2p
 
 	s.statusSem = semaphore.NewWeighted(1)
 	s.postageSem = semaphore.NewWeighted(1)

--- a/pkg/api/layer2.go
+++ b/pkg/api/layer2.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
+	"github.com/ethersphere/bee/v2/pkg/layer2"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"golang.org/x/net/context"
+)
+
+func (s *Service) layer2WsHandler(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.WithName("layer2").Build()
+
+	paths := struct {
+		StreamName string `map:"streamName" validate:"required"`
+	}{}
+	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
+		response("invalid path params", logger, w)
+		return
+	}
+
+	if s.beeMode == DevMode {
+		logger.Warning("layer2 endpoint is disabled in dev mode")
+		jsonhttp.BadRequest(w, errUnsupportedDevNodeOperation)
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  swarm.ChunkWithSpanSize * 128,
+		WriteBufferSize: swarm.ChunkWithSpanSize * 128,
+		CheckOrigin:     s.checkOrigin,
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logger.Debug("upgrade failed", "error", err)
+		logger.Error(nil, "upgrade failed")
+		jsonhttp.InternalServerError(w, "upgrade failed")
+		return
+	}
+
+	pingPeriod := 100 * time.Second //TODO pass it in header
+	ctx, cancel := context.WithCancel(context.Background())
+	protocolService := s.l2p2p.GetProtocol(ctx, paths.StreamName)
+	err = s.p2p.AddProtocol(protocolService.Protocol())
+	if err != nil {
+		logger.Error(err, "upgrade failed")
+		jsonhttp.InternalServerError(w, "upgrade failed")
+		return
+	}
+
+	s.wsWg.Add(1)
+	go func() {
+		layer2.ListeningWs(ctx, conn, layer2.WsOptions{PingPeriod: pingPeriod}, logger, protocolService)
+		s.wsWg.Done()
+		cancel()
+	}()
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -287,6 +287,10 @@ func (s *Service) mountAPI() {
 		})),
 	)
 
+	handle("/layer2/subscribe/{streamName}", web.ChainHandlers(
+		web.FinalHandlerFunc(s.layer2WsHandler),
+	))
+
 	handle("/pss/subscribe/{topic}", web.ChainHandlers(
 		web.FinalHandlerFunc(s.pssWsHandler),
 	))

--- a/pkg/layer2/layer2.go
+++ b/pkg/layer2/layer2.go
@@ -1,0 +1,198 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pingpong exposes the simple ping-pong protocol
+// which measures round-trip-time with other peers.
+package layer2
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/p2p"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	loggerName       = "layer2"
+	protocolName     = "layer2"
+	p2pMessageHeader = "layer2-message-data"
+	protocolVersion  = "1.0.0"
+)
+
+var p2pMessageHeaderBytes = []byte(p2pMessageHeader)
+
+// connection is an active p2p connection with a node with all layer 2 handlers and write interface
+type connection struct {
+	stream   p2p.Stream
+	handlers []msgHandler
+}
+
+func (conn *connection) SendMessage(ctx context.Context, data []byte) error {
+	c := 0
+	lenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len(data)))
+	n, err := conn.stream.Write(lenBytes)
+	if err != nil {
+		return err
+	}
+
+	for c < len(data) {
+		n, err = conn.stream.Write(data[c:])
+		if err != nil {
+			return err
+		}
+		c += n
+	}
+
+	return nil
+}
+
+type msgHandler func(swarm.Address, []byte)
+
+type protocolService struct {
+	mu sync.RWMutex
+
+	streamName string
+	streamer   p2p.Streamer
+	logger     log.Logger
+	conns      map[[32]byte]*connection // byte overlay to connections
+	handlers   []msgHandler
+}
+
+func NewProtocolService(streamName string, streamer p2p.Streamer, logger log.Logger) protocolService {
+	return protocolService{
+		streamName: streamName,
+		streamer:   streamer,
+		logger:     logger.WithName(loggerName + "_" + streamName).Register(),
+		conns:      make(map[[32]byte]*connection),
+		handlers:   make([]msgHandler, 0),
+	}
+}
+
+// GetConnection creates stream to the passed peer address
+func (s *protocolService) GetConnection(ctx context.Context, overlay swarm.Address) (conn connection, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if v, ok := s.conns[[32]byte(overlay.Bytes())]; ok {
+		conn = *v
+	} else {
+		stream, err := s.streamer.NewStream(ctx, overlay, nil, protocolName, protocolVersion, s.streamName)
+		if err != nil {
+			return connection{}, err
+		}
+		conn = connection{
+			stream: stream,
+		}
+		s.conns[[32]byte(overlay.Bytes())] = &conn
+	}
+
+	return conn, nil
+}
+
+func (p *protocolService) Protocol() p2p.ProtocolSpec {
+	return p2p.ProtocolSpec{
+		Name:    protocolName,
+		Version: protocolVersion,
+		StreamSpecs: []p2p.StreamSpec{
+			{
+				Name:    p.streamName,
+				Handler: p.handler,
+			},
+		},
+	}
+}
+
+func (p *protocolService) Broadcast(ctx context.Context, msg []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	group := errgroup.Group{}
+	for _, conn := range p.conns {
+		conn := conn
+		group.Go(func() error { return conn.SendMessage(ctx, msg) })
+	}
+
+	if err := group.Wait(); err != nil {
+		p.logger.Error(err, "broadcasting L2 message")
+	}
+}
+
+func (p *protocolService) AddHandler(handler msgHandler) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.handlers = append(p.handlers, handler)
+}
+
+// handler handles incoming messages from all connected peers and calls registered hook functions
+func (s *protocolService) handler(ctx context.Context, peer p2p.Peer, stream p2p.Stream) error {
+	for {
+		msgSizeBytes := make([]byte, 4)
+		n, err := stream.Read(msgSizeBytes)
+		if err != nil {
+			s.logger.Error(err, "l2 protocol read")
+			return err
+		}
+		if n != 4 {
+			return fmt.Errorf("couldn't read 4 bytes for msgSize")
+		}
+		msgSize := binary.BigEndian.Uint32(msgSizeBytes)
+		msg := make([]byte, msgSize)
+		var c int
+		for c < int(msgSize) {
+			n, err := stream.Read(msg[c:])
+			if err != nil {
+				return err
+			}
+			c += n
+		}
+		s.mu.Lock()
+		for _, handler := range s.handlers {
+			go handler(peer.Address, msg)
+		}
+		s.mu.Unlock()
+	}
+}
+
+type IP2pService interface {
+	GetProtocol(ctx context.Context, streamName string) (protocol *protocolService)
+}
+
+type P2pService struct {
+	IP2pService
+	mu sync.RWMutex
+
+	streamer  p2p.Streamer
+	logger    log.Logger
+	protocols map[string]*protocolService // protocolName to its instance
+}
+
+func NewP2pService(streamer p2p.Streamer, logger log.Logger) P2pService {
+	return P2pService{
+		streamer:  streamer,
+		logger:    logger,
+		protocols: make(map[string]*protocolService),
+	}
+}
+
+// GetService either creates protocolService or returns initiated one
+func (s *P2pService) GetProtocol(ctx context.Context, streamName string) (protocol *protocolService) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if v, ok := s.protocols[streamName]; ok {
+		protocol = v
+	} else {
+		p := NewProtocolService(streamName, s.streamer, s.logger)
+		protocol = &p
+	}
+
+	return protocol
+}

--- a/pkg/layer2/ws.go
+++ b/pkg/layer2/ws.go
@@ -1,0 +1,147 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pingpong exposes the simple ping-pong protocol
+// which measures round-trip-time with other peers.
+package layer2
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/gorilla/websocket"
+)
+
+type WsOptions struct {
+	PingPeriod time.Duration
+}
+
+type actionType uint8
+
+const (
+	atUnicast actionType = iota
+	atBroadcast
+	// TODO atConnect
+	// TODO atDisconnect
+)
+
+type responseType uint8
+
+const (
+	atMsg responseType = iota
+)
+
+func ListeningWs(ctx context.Context, conn *websocket.Conn, options WsOptions, logger log.Logger, protocolService *protocolService) {
+	var (
+		ticker        = time.NewTicker(options.PingPeriod)
+		writeDeadline = options.PingPeriod + 100*time.Millisecond // write deadline. should be smaller than the shutdown timeout on api close
+		readDeadline  = options.PingPeriod + 100*time.Millisecond // write deadline. should be smaller than the shutdown timeout on api close
+		err           error
+	)
+
+	conn.SetCloseHandler(func(code int, text string) error {
+		logger.Debug("L2 ws: client gone", "protocol", protocolService.streamName, "code", code, "message", text)
+		// TODO remove handler
+		return nil
+	})
+
+	protocolService.AddHandler(func(a swarm.Address, b []byte) {
+		space := byte(' ')
+		msg := append([]byte{byte(atMsg + '0'), space}, ([]byte(a.String()))...)
+		msg = append(msg, append([]byte{space}, b...)...)
+		err := conn.WriteMessage(1, msg)
+		if err != nil {
+			logger.Error(err, "L2 ws write message")
+		}
+		// TODO messagetype 2
+	})
+
+	go func() {
+		for {
+			err = conn.SetReadDeadline(time.Now().Add(readDeadline))
+			if err != nil {
+				logger.Debug("L2 ws: set write deadline failed", "error", err)
+				return
+			}
+			messageType, p, err := conn.ReadMessage()
+			if err != nil {
+				logger.Error(err, "L2 ws read message")
+				return
+			}
+			if messageType == 1 {
+				action := actionType(p[0] - '0')
+				offset := 2 // + 1 delimeter
+				if action == atUnicast {
+					overlayBytes := p[offset : swarm.HashSize*2+offset]
+					overlay := swarm.NewAddress(common.HexToHash(string(overlayBytes)).Bytes())
+					offset += swarm.HashSize*2 + 1 // + 1 delimeter
+					msg := p[offset:]
+					conn, err := protocolService.GetConnection(ctx, overlay)
+					if err != nil {
+						logger.Error(err, "L2 get connection")
+					}
+					err = conn.SendMessage(ctx, msg)
+					if err != nil {
+						logger.Error(err, "L2 write message")
+					}
+				}
+			} else if messageType == 2 {
+				action := actionType(p[0])
+				offset := 1
+				if action == atUnicast {
+					overlayBytes := p[offset : swarm.HashSize+offset]
+					overlay := swarm.NewAddress(overlayBytes)
+					offset += swarm.HashSize
+					msg := p[offset:]
+					conn, err := protocolService.GetConnection(ctx, overlay)
+					if err != nil {
+						logger.Error(err, "L2 get connection")
+					}
+					err = conn.SendMessage(ctx, msg)
+					if err != nil {
+						logger.Error(err, "L2 write message")
+					}
+				} else if action == atBroadcast {
+					msg := p[offset:]
+
+					protocolService.Broadcast(ctx, msg)
+				}
+			}
+		}
+	}()
+
+	defer func() {
+		ticker.Stop()
+		_ = conn.Close()
+	}()
+
+	for {
+		err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+		if err != nil {
+			logger.Debug("L2 ws: set write deadline failed", "error", err)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			err = conn.WriteMessage(websocket.CloseMessage, []byte{})
+			if err != nil {
+				logger.Debug("L2 ws: write close message failed", "error", err)
+			}
+			return
+		case <-ticker.C:
+			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+			if err != nil {
+				logger.Debug("L2 ws: set write deadline failed", "error", err)
+				return
+			}
+			if err = conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				// error encountered while pinging client. client probably gone
+				return
+			}
+		}
+	}
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/crypto"
 	"github.com/ethersphere/bee/v2/pkg/feeds/factory"
 	"github.com/ethersphere/bee/v2/pkg/hive"
+	"github.com/ethersphere/bee/v2/pkg/layer2"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/metrics"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
@@ -668,6 +669,8 @@ func NewBee(
 		return nil, err
 	}
 
+	l2P2p := layer2.NewP2pService(p2ps, logger)
+
 	// Construct protocols.
 	pingPong := pingpong.New(p2ps, logger, tracer)
 
@@ -1068,6 +1071,7 @@ func NewBee(
 		SyncStatus:      syncStatusFn,
 		NodeStatus:      nodeStatus,
 		PinIntegrity:    localStore.PinIntegrity(),
+		Layer2P2p:       &l2P2p,
 	}
 
 	if o.APIAddr != "" {


### PR DESCRIPTION
Introducing on-demand stream messaging channels between Bee nodes so that other P2P applications can take advantage of Swarm's bandwidth incentives.

_The PR is experimental in design and discussions are open for the feature._

send message format:
`[actionType] [actionParams]`
available actionTypes:
- [x] 0: unicast - send message to a node
  - actionParams:
    - overlay address of the target node
    - message
- [x] 1: broadcast - send message to all connected node
   - actionParams:
     - message
- [ ] 2: connect
  - actionParams: 
    - overlay address of the target node
- [ ] 3: disconnect
  - actionParams: 
    - overlay address of the target node


received message format
`[responseType] [responseParams]`

available responseType
- [x] 0: message
  - responseParams
    - overlay address of the sender node
    - message

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
