### PR TITLE
fix(kademlia): confusing filters operations renamed and extra regression test

### DIFF
--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -23,8 +23,8 @@ const (
 	DefaultOverSaturationPeers = defaultOverSaturationPeers
 )
 
-type PeerFilterFunc = peerFilterFunc
-type FilterFunc = filtersFunc
+type PeerExcludeFunc = peerExcludeFunc
+type ExcludeFunc = excludeFunc
 
 func (k *Kad) IsWithinConnectionDepth(addr swarm.Address) bool {
 	return swarm.Proximity(k.base.Bytes(), addr.Bytes()) >= k.ConnectionDepth()

--- a/pkg/topology/kademlia/internal/metrics/metrics.go
+++ b/pkg/topology/kademlia/internal/metrics/metrics.go
@@ -305,11 +305,11 @@ func (c *Collector) IsUnreachable(addr swarm.Address) bool {
 	return cs.ReachabilityStatus != p2p.ReachabilityStatusPublic
 }
 
-// FilterOp is a function type used to filter peers on certain fields.
-type FilterOp func(*Counters) bool
+// ExcludeOp is a function type used to filter peers on certain fields.
+type ExcludeOp func(*Counters) bool
 
 // Reachable is used to filter reachable or unreachable peers based on r.
-func Reachability(filterReachable bool) FilterOp {
+func Reachability(filterReachable bool) ExcludeOp {
 	return func(cs *Counters) bool {
 		reachble := cs.ReachabilityStatus == p2p.ReachabilityStatusPublic
 		if filterReachable {
@@ -320,7 +320,7 @@ func Reachability(filterReachable bool) FilterOp {
 }
 
 // Unreachable is used to filter unhealthy peers.
-func Health(filterHealthy bool) FilterOp {
+func Health(filterHealthy bool) ExcludeOp {
 	return func(cs *Counters) bool {
 		if filterHealthy {
 			return cs.Healthy
@@ -329,8 +329,8 @@ func Health(filterHealthy bool) FilterOp {
 	}
 }
 
-// Filter returns true if the addr does not pass any filter operation.
-func (c *Collector) Filter(addr swarm.Address, fop ...FilterOp) bool {
+// Exclude returns false if the addr passes all exclusion operations.
+func (c *Collector) Exclude(addr swarm.Address, fop ...ExcludeOp) bool {
 	val, ok := c.counters.Load(addr.ByteString())
 	if !ok {
 		return true

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -67,13 +67,13 @@ var (
 )
 
 type (
-	binSaturationFunc  func(bin uint8, connected *pslice.PSlice, filter peerFilterFunc) bool
+	binSaturationFunc  func(bin uint8, connected *pslice.PSlice, exclude peerExcludeFunc) bool
 	sanctionedPeerFunc func(peer swarm.Address) bool
 	pruneFunc          func(depth uint8)
-	pruneCountFunc     func(bin uint8, connected *pslice.PSlice, filter peerFilterFunc) (int, int)
+	pruneCountFunc     func(bin uint8, connected *pslice.PSlice, exclude peerExcludeFunc) (int, int)
 	staticPeerFunc     func(peer swarm.Address) bool
-	peerFilterFunc     func(peer swarm.Address) bool
-	filtersFunc        func(...im.FilterOp) peerFilterFunc
+	peerExcludeFunc    func(peer swarm.Address) bool
+	excludeFunc        func(...im.ExcludeOp) peerExcludeFunc
 )
 
 var noopSanctionedPeerFn = func(_ swarm.Address) bool { return false }
@@ -86,7 +86,7 @@ type Options struct {
 	BootnodeMode   bool
 	PruneFunc      pruneFunc
 	StaticNodes    []swarm.Address
-	FilterFunc     filtersFunc
+	FilterFunc     excludeFunc
 	DataDir        string
 
 	BitSuffixLength             *int
@@ -107,7 +107,7 @@ type kadOptions struct {
 	PruneCountFunc pruneCountFunc
 	PruneFunc      pruneFunc
 	StaticNodes    []swarm.Address
-	FilterFunc     filtersFunc
+	ExcludeFunc    excludeFunc
 
 	TimeToRetry                 time.Duration
 	ShortRetry                  time.Duration
@@ -127,7 +127,7 @@ func newKadOptions(o Options) kadOptions {
 		BootnodeMode:   o.BootnodeMode,
 		PruneFunc:      o.PruneFunc,
 		StaticNodes:    o.StaticNodes,
-		FilterFunc:     o.FilterFunc,
+		ExcludeFunc:    o.FilterFunc,
 		// copy or use default
 		TimeToRetry:                 defaultValDuration(o.TimeToRetry, defaultTimeToRetry),
 		ShortRetry:                  defaultValDuration(o.ShortRetry, defaultShortRetry),
@@ -258,10 +258,10 @@ func New(
 	}
 	k.opt.PruneCountFunc = binPruneCount(os, isStaticPeer(k.opt.StaticNodes))
 
-	if k.opt.FilterFunc == nil {
-		k.opt.FilterFunc = func(f ...im.FilterOp) peerFilterFunc {
+	if k.opt.ExcludeFunc == nil {
+		k.opt.ExcludeFunc = func(f ...im.ExcludeOp) peerExcludeFunc {
 			return func(peer swarm.Address) bool {
-				return k.collector.Filter(peer, f...)
+				return k.collector.Exclude(peer, f...)
 			}
 		}
 	}
@@ -663,7 +663,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 		}
 
 		// skip to next bin if prune count is zero or fewer
-		oldCount, pruneCount := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.FilterFunc(im.Reachability(false)))
+		oldCount, pruneCount := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.ExcludeFunc(im.Reachability(false)))
 		if pruneCount <= 0 {
 			continue
 		}
@@ -671,7 +671,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 		for j := 0; j < len(k.commonBinPrefixes[i]); j++ {
 
 			// skip to next bin if prune count is zero or fewer
-			_, pruneCount := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.FilterFunc(im.Reachability(false)))
+			_, pruneCount := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.ExcludeFunc(im.Reachability(false)))
 			if pruneCount <= 0 {
 				break
 			}
@@ -710,7 +710,7 @@ func (k *Kad) pruneOversaturatedBins(depth uint8) {
 			}
 		}
 
-		newCount, _ := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.FilterFunc(im.Reachability(false)))
+		newCount, _ := k.opt.PruneCountFunc(uint8(i), k.connectedPeers, k.opt.ExcludeFunc(im.Reachability(false)))
 
 		k.logger.Debug("pruning", "bin", i, "oldBinSize", oldCount, "newBinSize", newCount)
 	}
@@ -721,8 +721,7 @@ func (k *Kad) balancedSlotPeers(pseudoAddr swarm.Address, peers []swarm.Address,
 	var ret []swarm.Address
 
 	for _, peer := range peers {
-		peerPo := swarm.ExtendedProximity(peer.Bytes(), pseudoAddr.Bytes())
-		if int(peerPo) >= po+k.opt.BitSuffixLength+1 {
+		if int(swarm.ExtendedProximity(peer.Bytes(), pseudoAddr.Bytes())) >= po+k.opt.BitSuffixLength+1 {
 			ret = append(ret, peer)
 		}
 	}
@@ -847,10 +846,10 @@ func (k *Kad) connectBootNodes(ctx context.Context) {
 // when a bin is not saturated it means we would like to proactively
 // initiate connections to other peers in the bin.
 func binSaturated(oversaturationAmount int, staticNode staticPeerFunc) binSaturationFunc {
-	return func(bin uint8, connected *pslice.PSlice, filter peerFilterFunc) bool {
+	return func(bin uint8, connected *pslice.PSlice, exclude peerExcludeFunc) bool {
 		size := 0
 		_ = connected.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
-			if po == bin && !filter(addr) && !staticNode(addr) {
+			if po == bin && !exclude(addr) && !staticNode(addr) {
 				size++
 			}
 			return false, false, nil
@@ -862,10 +861,10 @@ func binSaturated(oversaturationAmount int, staticNode staticPeerFunc) binSatura
 
 // binPruneCount counts how many peers should be pruned from a bin.
 func binPruneCount(oversaturationAmount int, staticNode staticPeerFunc) pruneCountFunc {
-	return func(bin uint8, connected *pslice.PSlice, filter peerFilterFunc) (int, int) {
+	return func(bin uint8, connected *pslice.PSlice, exclude peerExcludeFunc) (int, int) {
 		size := 0
 		_ = connected.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
-			if po == bin && !filter(addr) && !staticNode(addr) {
+			if po == bin && !exclude(addr) && !staticNode(addr) {
 				size++
 			}
 			return false, false, nil
@@ -883,7 +882,7 @@ func (k *Kad) recalcDepth() {
 
 	var (
 		peers                 = k.connectedPeers
-		filter                = k.opt.FilterFunc(im.Reachability(false))
+		exclude               = k.opt.ExcludeFunc(im.Reachability(false))
 		binCount              = 0
 		shallowestUnsaturated = uint8(0)
 		depth                 uint8
@@ -896,7 +895,7 @@ func (k *Kad) recalcDepth() {
 	}
 
 	_ = peers.EachBinRev(func(addr swarm.Address, bin uint8) (bool, bool, error) {
-		if filter(addr) {
+		if exclude(addr) {
 			return false, false, nil
 		}
 		if bin == shallowestUnsaturated {
@@ -928,7 +927,7 @@ func (k *Kad) recalcDepth() {
 		candidate = uint8(0)
 	)
 	_ = peers.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
-		if filter(addr) {
+		if exclude(addr) {
 			return false, false, nil
 		}
 		peersCtr++
@@ -1117,7 +1116,7 @@ func (k *Kad) Pick(peer p2p.Peer) bool {
 		return true
 	}
 	po := swarm.Proximity(k.base.Bytes(), peer.Address.Bytes())
-	oversaturated := k.opt.SaturationFunc(po, k.connectedPeers, k.opt.FilterFunc(im.Reachability(false)))
+	oversaturated := k.opt.SaturationFunc(po, k.connectedPeers, k.opt.ExcludeFunc(im.Reachability(false)))
 	// pick the peer if we are not oversaturated
 	if !oversaturated {
 		return true
@@ -1165,7 +1164,7 @@ func (k *Kad) Connected(ctx context.Context, peer p2p.Peer, forceConnection bool
 	address := peer.Address
 	po := swarm.Proximity(k.base.Bytes(), address.Bytes())
 
-	if overSaturated := k.opt.SaturationFunc(po, k.connectedPeers, k.opt.FilterFunc(im.Reachability(false))); overSaturated {
+	if overSaturated := k.opt.SaturationFunc(po, k.connectedPeers, k.opt.ExcludeFunc(im.Reachability(false))); overSaturated {
 		if k.bootnode {
 			randPeer, err := k.randomPeer(po)
 			if err != nil {
@@ -1300,10 +1299,9 @@ func (k *Kad) ClosestPeer(addr swarm.Address, includeSelf bool, filter topology.
 
 // EachConnectedPeer implements topology.PeerIterator interface.
 func (k *Kad) EachConnectedPeer(f topology.EachPeerFunc, filter topology.Select) error {
-	filters := filterOps(filter)
-
+	filters := excludeOps(filter)
 	return k.connectedPeers.EachBin(func(addr swarm.Address, po uint8) (bool, bool, error) {
-		if len(filters) > 0 && k.opt.FilterFunc(filters...)(addr) {
+		if len(filters) > 0 && k.opt.ExcludeFunc(filters...)(addr) {
 			return false, false, nil
 		}
 		return f(addr, po)
@@ -1312,16 +1310,13 @@ func (k *Kad) EachConnectedPeer(f topology.EachPeerFunc, filter topology.Select)
 
 // EachConnectedPeerRev implements topology.PeerIterator interface.
 func (k *Kad) EachConnectedPeerRev(f topology.EachPeerFunc, filter topology.Select) error {
-	filters := filterOps(filter)
+	filters := excludeOps(filter)
 	return k.connectedPeers.EachBinRev(func(addr swarm.Address, po uint8) (bool, bool, error) {
-		if len(filters) > 0 && k.opt.FilterFunc(filters...)(addr) {
+		if len(filters) > 0 && k.opt.ExcludeFunc(filters...)(addr) {
 			return false, false, nil
 		}
 		return f(addr, po)
 	})
-}
-func (k *Kad) PeersCount(filter topology.Select) int {
-	return k.connectedPeers.Length()
 }
 
 // Reachable sets the peer reachability status.
@@ -1381,9 +1376,9 @@ func (k *Kad) SubscribeTopologyChange() (c <-chan struct{}, unsubscribe func()) 
 	return channel, unsubscribe
 }
 
-func filterOps(filter topology.Select) []im.FilterOp {
+func excludeOps(filter topology.Select) []im.ExcludeOp {
 
-	ops := make([]im.FilterOp, 0, 2)
+	ops := make([]im.ExcludeOp, 0, 2)
 
 	if filter.Reachable {
 		ops = append(ops, im.Reachability(false))

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -86,7 +86,7 @@ type Options struct {
 	BootnodeMode   bool
 	PruneFunc      pruneFunc
 	StaticNodes    []swarm.Address
-	FilterFunc     excludeFunc
+	ExcludeFunc    excludeFunc
 	DataDir        string
 
 	BitSuffixLength             *int
@@ -127,7 +127,7 @@ func newKadOptions(o Options) kadOptions {
 		BootnodeMode:   o.BootnodeMode,
 		PruneFunc:      o.PruneFunc,
 		StaticNodes:    o.StaticNodes,
-		ExcludeFunc:    o.FilterFunc,
+		ExcludeFunc:    o.ExcludeFunc,
 		// copy or use default
 		TimeToRetry:                 defaultValDuration(o.TimeToRetry, defaultTimeToRetry),
 		ShortRetry:                  defaultValDuration(o.ShortRetry, defaultShortRetry),

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -55,7 +55,7 @@ func TestNeighborhoodDepth(t *testing.T) {
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			SaturationPeers: ptrInt(4),
-			FilterFunc:      defaultExcludeFunc,
+			ExcludeFunc:     defaultExcludeFunc,
 		})
 	)
 	kad.SetStorageRadius(0)
@@ -351,7 +351,7 @@ func TestManage(t *testing.T) {
 		saturation               = kademlia.DefaultSaturationPeers
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			BitSuffixLength: ptrInt(-1),
-			FilterFunc:      defaultExcludeFunc,
+			ExcludeFunc:     defaultExcludeFunc,
 		})
 	)
 
@@ -404,7 +404,7 @@ func TestManageWithBalancing(t *testing.T) {
 			SaturationFunc:  saturationFunc,
 			SaturationPeers: ptrInt(4),
 			BitSuffixLength: ptrInt(2),
-			FilterFunc:      defaultExcludeFunc,
+			ExcludeFunc:     defaultExcludeFunc,
 		})
 	)
 
@@ -450,7 +450,7 @@ func TestBinSaturation(t *testing.T) {
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			SaturationPeers: ptrInt(2),
 			BitSuffixLength: ptrInt(-1),
-			FilterFunc:      defaultExcludeFunc,
+			ExcludeFunc:     defaultExcludeFunc,
 		})
 	)
 
@@ -503,7 +503,7 @@ func TestOversaturation(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			FilterFunc: defaultExcludeFunc,
+			ExcludeFunc: defaultExcludeFunc,
 		})
 	)
 
@@ -555,7 +555,7 @@ func TestOversaturationBootnode(t *testing.T) {
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			SaturationPeers:     ptrInt(4),
 			BootnodeMode:        true,
-			FilterFunc:          defaultExcludeFunc,
+			ExcludeFunc:         defaultExcludeFunc,
 		})
 	)
 
@@ -613,7 +613,7 @@ func TestBootnodeMaxConnections(t *testing.T) {
 			BootnodeOverSaturationPeers: ptrInt(bootnodeOverSaturationPeers),
 			SaturationPeers:             ptrInt(4),
 			BootnodeMode:                true,
-			FilterFunc:                  defaultExcludeFunc,
+			ExcludeFunc:                 defaultExcludeFunc,
 		})
 	)
 
@@ -704,7 +704,7 @@ func TestDiscoveryHooks(t *testing.T) {
 	var (
 		conns                    int32
 		_, kad, ab, disc, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			FilterFunc: defaultExcludeFunc,
+			ExcludeFunc: defaultExcludeFunc,
 		})
 		p1, p2, p3 = swarm.RandAddress(t), swarm.RandAddress(t), swarm.RandAddress(t)
 	)
@@ -1277,7 +1277,7 @@ func TestOutofDepthPrune(t *testing.T) {
 			SaturationPeers:     ptrInt(saturationPeers),
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			PruneFunc:           pruneFunc,
-			FilterFunc:          defaultExcludeFunc,
+			ExcludeFunc:         defaultExcludeFunc,
 		})
 	)
 
@@ -1357,6 +1357,115 @@ func TestOutofDepthPrune(t *testing.T) {
 	waitBalanced(t, kad, 1)
 }
 
+// TestPruneExcludeOps tests that the prune bin func counts peers in each bin correctly using the peer's reachability status and does not over prune.
+func TestPruneExcludeOps(t *testing.T) {
+	t.Parallel()
+
+	var (
+		conns, failedConns int32 // how many connect calls were made to the p2p mock
+
+		saturationPeers     = 4
+		overSaturationPeers = 16
+		perBin              = 20
+		pruneFuncImpl       *func(uint8)
+		pruneMux            = sync.Mutex{}
+		pruneFunc           = func(depth uint8) {
+			pruneMux.Lock()
+			defer pruneMux.Unlock()
+			f := *pruneFuncImpl
+			f(depth)
+		}
+
+		base, kad, ab, _, signer = newTestKademlia(t, &conns, &failedConns, kademlia.Options{
+			SaturationPeers:     ptrInt(saturationPeers),
+			OverSaturationPeers: ptrInt(overSaturationPeers),
+			PruneFunc:           pruneFunc,
+		})
+	)
+
+	kad.SetStorageRadius(0)
+
+	// implement empty prune func
+	pruneMux.Lock()
+	pruneImpl := func(uint8) {}
+	pruneFuncImpl = &(pruneImpl)
+	pruneMux.Unlock()
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	testutil.CleanupCloser(t, kad)
+
+	// bin 0,1 balanced, rest not
+	for i := 0; i < 6; i++ {
+		var peers []swarm.Address
+		if i < 2 {
+			peers = mineBin(t, base, i, perBin, true)
+		} else {
+			peers = mineBin(t, base, i, perBin, false)
+		}
+		for i, peer := range peers {
+			addOne(t, signer, kad, ab, peer)
+			if i < 4 {
+				kad.Reachable(peers[i], p2p.ReachabilityStatusPrivate)
+			} else {
+				kad.Reachable(peers[i], p2p.ReachabilityStatusPublic)
+			}
+		}
+		for i := 0; i < 4; i++ {
+		}
+		time.Sleep(time.Millisecond * 10)
+		kDepth(t, kad, i)
+	}
+
+	// check that bin 0, 1 are balanced, but not 2
+	waitBalanced(t, kad, 0)
+	waitBalanced(t, kad, 1)
+	if kad.IsBalanced(2) {
+		t.Fatal("bin 2 should not be balanced")
+	}
+
+	// wait for kademlia connectors and pruning to finish
+	time.Sleep(time.Millisecond * 500)
+
+	// check that no pruning has happened
+	bins := binSizes(kad)
+	for i := 0; i < 6; i++ {
+		if bins[i] <= overSaturationPeers {
+			t.Fatalf("bin %d, got %d, want more than %d", i, bins[i], overSaturationPeers)
+		}
+	}
+
+	kad.SetStorageRadius(6)
+
+	// set prune func to the default
+	pruneMux.Lock()
+	pruneImpl = func(depth uint8) {
+		kademlia.PruneOversaturatedBinsFunc(kad)(depth)
+	}
+	pruneFuncImpl = &(pruneImpl)
+	pruneMux.Unlock()
+
+	// add a peer to kick start pruning
+	addr := swarm.RandAddressAt(t, base, 6)
+	addOne(t, signer, kad, ab, addr)
+
+	// wait for kademlia connectors and pruning to finish
+	time.Sleep(time.Millisecond * 500)
+
+	// check bins have NOT been pruned because the peer count func excluded unreachable peers
+	bins = binSizes(kad)
+	for i := uint8(0); i < 5; i++ {
+		if bins[i] != perBin {
+			t.Fatalf("bin %d, got %d, want %d", i, bins[i], perBin)
+		}
+	}
+
+	// check that bin 0,1 remains balanced after pruning
+	waitBalanced(t, kad, 0)
+	waitBalanced(t, kad, 1)
+}
+
 func TestBootnodeProtectedNodes(t *testing.T) {
 	t.Parallel()
 
@@ -1378,7 +1487,7 @@ func TestBootnodeProtectedNodes(t *testing.T) {
 			LowWaterMark:                ptrInt(0),
 			BootnodeMode:                true,
 			StaticNodes:                 protected,
-			FilterFunc:                  defaultExcludeFunc,
+			ExcludeFunc:                 defaultExcludeFunc,
 		})
 	)
 
@@ -1468,7 +1577,7 @@ func TestAnnounceBgBroadcast_FLAKY(t *testing.T) {
 			}),
 		)
 		_, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			FilterFunc: defaultExcludeFunc,
+			ExcludeFunc: defaultExcludeFunc,
 		})
 	)
 
@@ -1537,7 +1646,7 @@ func TestAnnounceNeighborhoodToNeighbor(t *testing.T) {
 			}),
 		)
 		base, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			FilterFunc:          defaultExcludeFunc,
+			ExcludeFunc:         defaultExcludeFunc,
 			OverSaturationPeers: ptrInt(4),
 			SaturationPeers:     ptrInt(4),
 		})

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -38,7 +38,7 @@ import (
 const spinLockWaitTime = time.Second * 5
 
 var nonConnectableAddress, _ = ma.NewMultiaddr(underlayBase + "16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA")
-var defaultFilterFunc kademlia.FilterFunc = func(...im.FilterOp) kademlia.PeerFilterFunc {
+var defaultExcludeFunc kademlia.ExcludeFunc = func(...im.ExcludeOp) kademlia.PeerExcludeFunc {
 	return func(swarm.Address) bool { return false }
 }
 
@@ -55,7 +55,7 @@ func TestNeighborhoodDepth(t *testing.T) {
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			SaturationPeers: ptrInt(4),
-			FilterFunc:      defaultFilterFunc,
+			FilterFunc:      defaultExcludeFunc,
 		})
 	)
 	kad.SetStorageRadius(0)
@@ -351,7 +351,7 @@ func TestManage(t *testing.T) {
 		saturation               = kademlia.DefaultSaturationPeers
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			BitSuffixLength: ptrInt(-1),
-			FilterFunc:      defaultFilterFunc,
+			FilterFunc:      defaultExcludeFunc,
 		})
 	)
 
@@ -395,8 +395,8 @@ func TestManageWithBalancing(t *testing.T) {
 	var (
 		conns int32 // how many connect calls were made to the p2p mock
 
-		saturationFuncImpl *func(bin uint8, connected *pslice.PSlice, _ kademlia.PeerFilterFunc) bool
-		saturationFunc     = func(bin uint8, connected *pslice.PSlice, filter kademlia.PeerFilterFunc) bool {
+		saturationFuncImpl *func(bin uint8, connected *pslice.PSlice, _ kademlia.PeerExcludeFunc) bool
+		saturationFunc     = func(bin uint8, connected *pslice.PSlice, filter kademlia.PeerExcludeFunc) bool {
 			f := *saturationFuncImpl
 			return f(bin, connected, filter)
 		}
@@ -404,12 +404,12 @@ func TestManageWithBalancing(t *testing.T) {
 			SaturationFunc:  saturationFunc,
 			SaturationPeers: ptrInt(4),
 			BitSuffixLength: ptrInt(2),
-			FilterFunc:      defaultFilterFunc,
+			FilterFunc:      defaultExcludeFunc,
 		})
 	)
 
 	// implement saturation function (while having access to Kademlia instance)
-	sfImpl := func(bin uint8, connected *pslice.PSlice, _ kademlia.PeerFilterFunc) bool {
+	sfImpl := func(bin uint8, connected *pslice.PSlice, _ kademlia.PeerExcludeFunc) bool {
 		return false
 	}
 	saturationFuncImpl = &sfImpl
@@ -450,7 +450,7 @@ func TestBinSaturation(t *testing.T) {
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
 			SaturationPeers: ptrInt(2),
 			BitSuffixLength: ptrInt(-1),
-			FilterFunc:      defaultFilterFunc,
+			FilterFunc:      defaultExcludeFunc,
 		})
 	)
 
@@ -503,7 +503,7 @@ func TestOversaturation(t *testing.T) {
 	var (
 		conns                    int32 // how many connect calls were made to the p2p mock
 		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			FilterFunc: defaultFilterFunc,
+			FilterFunc: defaultExcludeFunc,
 		})
 	)
 
@@ -555,7 +555,7 @@ func TestOversaturationBootnode(t *testing.T) {
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			SaturationPeers:     ptrInt(4),
 			BootnodeMode:        true,
-			FilterFunc:          defaultFilterFunc,
+			FilterFunc:          defaultExcludeFunc,
 		})
 	)
 
@@ -613,7 +613,7 @@ func TestBootnodeMaxConnections(t *testing.T) {
 			BootnodeOverSaturationPeers: ptrInt(bootnodeOverSaturationPeers),
 			SaturationPeers:             ptrInt(4),
 			BootnodeMode:                true,
-			FilterFunc:                  defaultFilterFunc,
+			FilterFunc:                  defaultExcludeFunc,
 		})
 	)
 
@@ -704,7 +704,7 @@ func TestDiscoveryHooks(t *testing.T) {
 	var (
 		conns                    int32
 		_, kad, ab, disc, signer = newTestKademlia(t, &conns, nil, kademlia.Options{
-			FilterFunc: defaultFilterFunc,
+			FilterFunc: defaultExcludeFunc,
 		})
 		p1, p2, p3 = swarm.RandAddress(t), swarm.RandAddress(t), swarm.RandAddress(t)
 	)
@@ -1277,7 +1277,7 @@ func TestOutofDepthPrune(t *testing.T) {
 			SaturationPeers:     ptrInt(saturationPeers),
 			OverSaturationPeers: ptrInt(overSaturationPeers),
 			PruneFunc:           pruneFunc,
-			FilterFunc:          defaultFilterFunc,
+			FilterFunc:          defaultExcludeFunc,
 		})
 	)
 
@@ -1378,7 +1378,7 @@ func TestBootnodeProtectedNodes(t *testing.T) {
 			LowWaterMark:                ptrInt(0),
 			BootnodeMode:                true,
 			StaticNodes:                 protected,
-			FilterFunc:                  defaultFilterFunc,
+			FilterFunc:                  defaultExcludeFunc,
 		})
 	)
 
@@ -1468,7 +1468,7 @@ func TestAnnounceBgBroadcast_FLAKY(t *testing.T) {
 			}),
 		)
 		_, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			FilterFunc: defaultFilterFunc,
+			FilterFunc: defaultExcludeFunc,
 		})
 	)
 
@@ -1537,7 +1537,7 @@ func TestAnnounceNeighborhoodToNeighbor(t *testing.T) {
 			}),
 		)
 		base, kad, ab, _, signer = newTestKademliaWithDiscovery(t, disc, &conns, nil, kademlia.Options{
-			FilterFunc:          defaultFilterFunc,
+			FilterFunc:          defaultExcludeFunc,
 			OverSaturationPeers: ptrInt(4),
 			SaturationPeers:     ptrInt(4),
 		})


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Terminology and wording around the peer filtering is confusing. This PR aims to clear it up a bit more.

Adds a new regression test that checks that the pruning process counts peers correctly.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
