### PR TITLE
fix: json field in stakeTransactionReponse

### DIFF
--- a/pkg/api/staking.go
+++ b/pkg/api/staking.go
@@ -34,7 +34,7 @@ type getStakeResponse struct {
 	StakedAmount *bigint.BigInt `json:"stakedAmount"`
 }
 type stakeTransactionReponse struct {
-	TxHash string `json:"txhash"`
+	TxHash string `json:"txHash"`
 }
 
 func (s *Service) stakingDepositHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Update `txHash` json field in `stakeTransactionReponse` to be consistent with other tx hashes in the openAPI docs.

