### PR TITLE
fix: use correct format for logging slice of bytes

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -293,7 +293,7 @@ func NewBee(
 			}
 
 			if nonceExists {
-				logger.Info("Override nonce %d to %d and clean state for neighborhood %s", nonce, newNonce, targetNeighborhood)
+				logger.Info("Override nonce %x to %x and clean state for neighborhood %s", nonce, newNonce, targetNeighborhood)
 				logger.Warning("you have another 10 seconds to change your mind and kill this process with CTRL-C...")
 				time.Sleep(10 * time.Second)
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Use correct format for logging slice of bytes in `Override nonce...` logger info
