### PR TITLE
feat: additional pullsync handler metrics

### DIFF
--- a/pkg/pullsync/metrics.go
+++ b/pkg/pullsync/metrics.go
@@ -16,6 +16,8 @@ type metrics struct {
 	ReceivedZeroAddress  prometheus.Counter     // number of delivered chunks with invalid address
 	ReceivedInvalidChunk prometheus.Counter     // number of delivered chunks with invalid address
 	Delivered            prometheus.Counter     // number of chunk deliveries
+	SentOffered          prometheus.Counter     // number of chunks offered
+	SentWanted           prometheus.Counter     // number of chunks wanted
 	Sent                 prometheus.Counter     // number of chunks sent
 	DuplicateRuid        prometheus.Counter     // number of duplicate RUID requests we got
 	LastReceived         *prometheus.CounterVec // last timestamp of the received chunks per bin
@@ -60,6 +62,18 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "chunks_delivered",
 			Help:      "Total chunks delivered.",
+		}),
+		SentOffered: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "chunks_sent_offered",
+			Help:      "Total chunks offered to peers.",
+		}),
+		SentWanted: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "chunks_sent_wanted",
+			Help:      "Total chunks wanted by peers.",
 		}),
 		Sent: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,

--- a/pkg/pullsync/pullsync.go
+++ b/pkg/pullsync/pullsync.go
@@ -340,6 +340,8 @@ func (s *Syncer) handler(streamCtx context.Context, p p2p.Peer, stream p2p.Strea
 		return nil
 	}
 
+	s.metrics.SentOffered.Add(float64(len(offer.Chunks)))
+
 	var want pb.Want
 	if err := r.ReadMsgWithContext(ctx, &want); err != nil {
 		return fmt.Errorf("read want: %w", err)
@@ -472,6 +474,7 @@ func (s *Syncer) processWant(ctx context.Context, o *pb.Offer, w *pb.Want) ([]sw
 		if bv.Get(i) {
 			ch := o.Chunks[i]
 			addr := swarm.NewAddress(ch.Address)
+			s.metrics.SentWanted.Inc()
 			c, err := s.store.ReserveGet(ctx, addr, ch.BatchID, ch.StampHash)
 			if err != nil {
 				s.logger.Debug("processing want: unable to find chunk", "chunk_address", addr, "batch_id", hex.EncodeToString(ch.BatchID))


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Adding Offer and Want metrics on the handler side of pullsync to match the ones already available on the client side of the protocol.

### Open API Spec Version Changes (if applicable)
N/A

#### Motivation and Context (Optional)
With only "Sent" metrics on the handler side, you cannot see the peer-generated load of offering chunks via pullsync.

### Related Issue (Optional)
N/A

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/e26c01b1-6eba-4a00-bd7a-1d342af96c65)
