### PR TITLE
fix: reduce reserve cnt on same chunk and index collision

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: temp-artifacts
+          include-hidden-files: true
           path: |
             Dockerfile.goreleaser
             Makefile

--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -165,6 +165,7 @@ func (r *Reserve) Put(ctx context.Context, chunk swarm.Chunk) error {
 					if err != nil {
 						return fmt.Errorf("failed removing older chunk %s: %w", oldStampIndex.ChunkAddress, err)
 					}
+					r.size.Add(-1)
 				}
 			}
 


### PR DESCRIPTION

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Reduce the reserve count when putting the same address chunk that has an index collision with a different chunk

