### PR TITLE
fix: rename only withdrawable stake response

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -14,7 +14,7 @@ env:
   SETUP_CONTRACT_IMAGE: "ethersphere/bee-localchain"
   SETUP_CONTRACT_IMAGE_TAG: "0.9.1-rc4"
   BEELOCAL_BRANCH: "main"
-  BEEKEEPER_BRANCH: "fix/withdrawable-stake-rename"
+  BEEKEEPER_BRANCH: "master"
   BEEKEEPER_METRICS_ENABLED: false
   REACHABILITY_OVERRIDE_PUBLIC: true
   BATCHFACTOR_OVERRIDE_PUBLIC: 2

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -14,7 +14,7 @@ env:
   SETUP_CONTRACT_IMAGE: "ethersphere/bee-localchain"
   SETUP_CONTRACT_IMAGE_TAG: "0.9.1-rc4"
   BEELOCAL_BRANCH: "main"
-  BEEKEEPER_BRANCH: "master"
+  BEEKEEPER_BRANCH: "fix/withdrawable-stake-rename"
   BEEKEEPER_METRICS_ENABLED: false
   REACHABILITY_OVERRIDE_PUBLIC: true
   BATCHFACTOR_OVERRIDE_PUBLIC: 2

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -2224,7 +2224,7 @@ paths:
         - Staking
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/GetStakeResponse"
+          $ref: "SwarmCommon.yaml#/components/schemas/GetWithdrawableResponse"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -641,7 +641,7 @@ components:
       type: object
       properties:
         withdrawableAmount:
-          $ref: "#/components/schemas/BigInt"      
+          $ref: "#/components/schemas/BigInt"
 
     StakeTransactionResponse:
       type: object

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -634,8 +634,14 @@ components:
     GetStakeResponse:
       type: object
       properties:
-        withdrawableStake:
+        stakedAmount:
           $ref: "#/components/schemas/BigInt"
+
+    GetWithdrawableResponse:
+      type: object
+      properties:
+        withdrawableAmount:
+          $ref: "#/components/schemas/BigInt"      
 
     StakeTransactionResponse:
       type: object

--- a/pkg/api/export_test.go
+++ b/pkg/api/export_test.go
@@ -97,6 +97,7 @@ type (
 	WalletResponse                    = walletResponse
 	WalletTxResponse                  = walletTxResponse
 	GetStakeResponse                  = getStakeResponse
+	GetWithdrawableResponse           = getWithdrawableResponse
 	StakeTransactionReponse           = stakeTransactionReponse
 	StatusSnapshotResponse            = statusSnapshotResponse
 	StatusResponse                    = statusResponse

--- a/pkg/api/staking.go
+++ b/pkg/api/staking.go
@@ -31,7 +31,11 @@ func (s *Service) stakingAccessHandler(h http.Handler) http.Handler {
 }
 
 type getStakeResponse struct {
-	WithdrawableStake *bigint.BigInt `json:"withdrawableStake"`
+	StakedAmount *bigint.BigInt `json:"stakedAmount"`
+}
+
+type getWithdrawableResponse struct {
+	WithdrawableAmount *bigint.BigInt `json:"withdrawableAmount"`
 }
 type stakeTransactionReponse struct {
 	TxHash string `json:"txHash"`
@@ -81,7 +85,7 @@ func (s *Service) stakingDepositHandler(w http.ResponseWriter, r *http.Request) 
 func (s *Service) getPotentialStake(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithName("get_stake").Build()
 
-	withdrawableStake, err := s.stakingContract.GetPotentialStake(r.Context())
+	stakedAmount, err := s.stakingContract.GetPotentialStake(r.Context())
 	if err != nil {
 		logger.Debug("get staked amount failed", "overlayAddr", s.overlay, "error", err)
 		logger.Error(nil, "get staked amount failed")
@@ -89,13 +93,13 @@ func (s *Service) getPotentialStake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonhttp.OK(w, getStakeResponse{WithdrawableStake: bigint.Wrap(withdrawableStake)})
+	jsonhttp.OK(w, getStakeResponse{StakedAmount: bigint.Wrap(stakedAmount)})
 }
 
 func (s *Service) getWithdrawableStakeHandler(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithName("get_stake").Build()
 
-	withdrawableStake, err := s.stakingContract.GetWithdrawableStake(r.Context())
+	withdrawableAmount, err := s.stakingContract.GetWithdrawableStake(r.Context())
 	if err != nil {
 		logger.Debug("get staked amount failed", "overlayAddr", s.overlay, "error", err)
 		logger.Error(nil, "get staked amount failed")
@@ -103,7 +107,7 @@ func (s *Service) getWithdrawableStakeHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	jsonhttp.OK(w, getStakeResponse{WithdrawableStake: bigint.Wrap(withdrawableStake)})
+	jsonhttp.OK(w, getWithdrawableResponse{WithdrawableAmount: bigint.Wrap(withdrawableAmount)})
 }
 
 func (s *Service) withdrawStakeHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/staking_test.go
+++ b/pkg/api/staking_test.go
@@ -35,7 +35,7 @@ func TestDepositStake(t *testing.T) {
 		t.Parallel()
 
 		contract := stakingContractMock.New(
-			stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+			stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 				return txHash, nil
 			}),
 		)
@@ -48,7 +48,7 @@ func TestDepositStake(t *testing.T) {
 
 		invalidMinStake := big.NewInt(0).String()
 		contract := stakingContractMock.New(
-			stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+			stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 				return common.Hash{}, staking.ErrInsufficientStakeAmount
 			}),
 		)
@@ -61,7 +61,7 @@ func TestDepositStake(t *testing.T) {
 		t.Parallel()
 
 		contract := stakingContractMock.New(
-			stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+			stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 				return common.Hash{}, staking.ErrInsufficientFunds
 			}),
 		)
@@ -74,7 +74,7 @@ func TestDepositStake(t *testing.T) {
 		t.Parallel()
 
 		contract := stakingContractMock.New(
-			stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+			stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 				return common.Hash{}, fmt.Errorf("some error")
 			}),
 		)
@@ -87,7 +87,7 @@ func TestDepositStake(t *testing.T) {
 		t.Parallel()
 
 		contract := stakingContractMock.New(
-			stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+			stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 				gasLimit := sctx.GetGasLimit(ctx)
 				if gasLimit != 2000000 {
 					t.Fatalf("want 2000000, got %d", gasLimit)
@@ -118,7 +118,7 @@ func TestGetStakeCommitted(t *testing.T) {
 		)
 		ts, _, _, _ := newTestServer(t, testServerOptions{StakingContract: contract})
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stake", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.GetStakeResponse{WithdrawableStake: bigint.Wrap(big.NewInt(1))}))
+			jsonhttptest.WithExpectedJSONResponse(&api.GetStakeResponse{StakedAmount: bigint.Wrap(big.NewInt(1))}))
 	})
 
 	t.Run("with error", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestGetStakeWithdrawable(t *testing.T) {
 		)
 		ts, _, _, _ := newTestServer(t, testServerOptions{StakingContract: contract})
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stake/withdrawable", http.StatusOK,
-			jsonhttptest.WithExpectedJSONResponse(&api.GetStakeResponse{WithdrawableStake: bigint.Wrap(big.NewInt(1))}))
+			jsonhttptest.WithExpectedJSONResponse(&api.GetWithdrawableResponse{WithdrawableAmount: bigint.Wrap(big.NewInt(1))}))
 	})
 
 	t.Run("with error", func(t *testing.T) {

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -316,7 +316,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 	mockSteward := new(mockSteward.Steward)
 
 	mockStaking := stakingContractMock.New(
-		stakingContractMock.WithDepositStake(func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
+		stakingContractMock.WithDepositStake(func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
 			return common.Hash{}, staking.ErrNotImplemented
 		}),
 		stakingContractMock.WithGetStake(func(ctx context.Context) (*big.Int, error) {

--- a/pkg/storageincentives/staking/contract_test.go
+++ b/pkg/storageincentives/staking/contract_test.go
@@ -87,7 +87,7 @@ func TestDepositStake(t *testing.T) {
 	bzzTokenAddress := common.HexToAddress("eeee")
 	nonce := common.BytesToHash(make([]byte, 32))
 	txHashDeposited := common.HexToHash("c3a7")
-	withdrawableStake := big.NewInt(100000000000000000)
+	stakedAmount := big.NewInt(100000000000000000)
 	txHashApprove := common.HexToHash("abb0")
 
 	t.Run("ok", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestDepositStake(t *testing.T) {
 
 		totalAmount := big.NewInt(100000000000000000)
 		prevStake := big.NewInt(0)
-		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, withdrawableStake)
+		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -145,7 +145,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err = contract.DepositStake(ctx, withdrawableStake)
+		_, err = contract.DepositStake(ctx, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -206,16 +206,16 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err = contract.DepositStake(ctx, withdrawableStake)
+		_, err = contract.DepositStake(ctx, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
-		withdrawableStake, err := contract.GetPotentialStake(ctx)
+		stakedAmount, err := contract.GetPotentialStake(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if withdrawableStake.Cmp(big.NewInt(13)) == 0 {
-			t.Fatalf("expected %v, got %v", big.NewInt(13), withdrawableStake)
+		if stakedAmount.Cmp(big.NewInt(13)) == 0 {
+			t.Fatalf("expected %v, got %v", big.NewInt(13), stakedAmount)
 		}
 	})
 
@@ -347,7 +347,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err := contract.DepositStake(ctx, withdrawableStake)
+		_, err := contract.DepositStake(ctx, stakedAmount)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -396,7 +396,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err = contract.DepositStake(ctx, withdrawableStake)
+		_, err = contract.DepositStake(ctx, stakedAmount)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -407,7 +407,7 @@ func TestDepositStake(t *testing.T) {
 
 		totalAmount := big.NewInt(100000000000000000)
 		prevStake := big.NewInt(0)
-		expectedCallData, err := staking.Erc20ABI.Pack("approve", stakingContractAddress, withdrawableStake)
+		expectedCallData, err := staking.Erc20ABI.Pack("approve", stakingContractAddress, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -458,7 +458,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err = contract.DepositStake(ctx, withdrawableStake)
+		_, err = contract.DepositStake(ctx, stakedAmount)
 		if !errors.Is(err, transaction.ErrTransactionReverted) {
 			t.Fatalf("expected %v, got %v", transaction.ErrTransactionReverted, err)
 		}
@@ -469,7 +469,7 @@ func TestDepositStake(t *testing.T) {
 
 		totalAmount := big.NewInt(102400)
 		prevStake := big.NewInt(0)
-		expectedCallData, err := staking.Erc20ABI.Pack("approve", stakingContractAddress, withdrawableStake)
+		expectedCallData, err := staking.Erc20ABI.Pack("approve", stakingContractAddress, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -518,7 +518,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err = contract.DepositStake(ctx, withdrawableStake)
+		_, err = contract.DepositStake(ctx, stakedAmount)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -544,7 +544,7 @@ func TestDepositStake(t *testing.T) {
 			false,
 		)
 
-		_, err := contract.DepositStake(ctx, withdrawableStake)
+		_, err := contract.DepositStake(ctx, stakedAmount)
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -560,13 +560,13 @@ func TestChangeStakeOverlay(t *testing.T) {
 	bzzTokenAddress := common.HexToAddress("eeee")
 	nonce := common.BytesToHash(make([]byte, 32))
 	txHashOverlayChanged := common.HexToHash("c3a7")
-	withdrawableStake := big.NewInt(0)
+	stakedAmount := big.NewInt(0)
 	txHashApprove := common.HexToHash("abb0")
 
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
-		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, withdrawableStake)
+		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -634,7 +634,7 @@ func TestChangeStakeOverlay(t *testing.T) {
 	t.Run("invalid call data", func(t *testing.T) {
 		t.Parallel()
 
-		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, withdrawableStake)
+		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -671,7 +671,7 @@ func TestChangeStakeOverlay(t *testing.T) {
 	t.Run("transaction reverted", func(t *testing.T) {
 		t.Parallel()
 
-		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, withdrawableStake)
+		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -713,7 +713,7 @@ func TestChangeStakeOverlay(t *testing.T) {
 	t.Run("transaction error", func(t *testing.T) {
 		t.Parallel()
 
-		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, withdrawableStake)
+		expectedCallData, err := stakingContractABI.Pack("manageStake", nonce, stakedAmount)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -790,13 +790,13 @@ func TestGetCommittedStake(t *testing.T) {
 			false,
 		)
 
-		withdrawableStake, err := contract.GetPotentialStake(ctx)
+		stakedAmount, err := contract.GetPotentialStake(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if withdrawableStake.Cmp(prevStake) != 0 {
-			t.Fatalf("expected %v got %v", prevStake, withdrawableStake)
+		if stakedAmount.Cmp(prevStake) != 0 {
+			t.Fatalf("expected %v got %v", prevStake, stakedAmount)
 		}
 	})
 
@@ -1254,7 +1254,7 @@ func TestMigrateStake(t *testing.T) {
 	stakingContractAddress := common.HexToAddress("ffff")
 	bzzTokenAddress := common.HexToAddress("eeee")
 	nonce := common.BytesToHash(make([]byte, 32))
-	withdrawableStake := big.NewInt(100000000000000000)
+	stakedAmount := big.NewInt(100000000000000000)
 
 	t.Run("ok", func(t *testing.T) {
 
@@ -1304,7 +1304,7 @@ func TestMigrateStake(t *testing.T) {
 							return expected.FillBytes(make([]byte, 32)), nil
 						}
 						if bytes.Equal(expectedCallDataForGetStake[:64], request.Data[:64]) {
-							return withdrawableStake.FillBytes(make([]byte, 32)), nil
+							return stakedAmount.FillBytes(make([]byte, 32)), nil
 						}
 					}
 					return nil, errors.New("unexpected call")
@@ -1365,7 +1365,7 @@ func TestMigrateStake(t *testing.T) {
 			t.Fatalf("expected non nil error, got nil")
 		}
 
-		_, err = stakingContractABI.Pack("nodeEffectiveStake", withdrawableStake)
+		_, err = stakingContractABI.Pack("nodeEffectiveStake", stakedAmount)
 		if err == nil {
 			t.Fatalf("expected non nil error, got nil")
 		}
@@ -1418,7 +1418,7 @@ func TestMigrateStake(t *testing.T) {
 							return expected.FillBytes(make([]byte, 32)), nil
 						}
 						if bytes.Equal(expectedCallDataForGetStake[:64], request.Data[:64]) {
-							return withdrawableStake.FillBytes(make([]byte, 32)), nil
+							return stakedAmount.FillBytes(make([]byte, 32)), nil
 						}
 					}
 					return nil, errors.New("unexpected call")
@@ -1482,7 +1482,7 @@ func TestMigrateStake(t *testing.T) {
 							return expected.FillBytes(make([]byte, 32)), nil
 						}
 						if bytes.Equal(expectedCallDataForGetStake[:64], request.Data[:64]) {
-							return withdrawableStake.FillBytes(make([]byte, 32)), nil
+							return stakedAmount.FillBytes(make([]byte, 32)), nil
 						}
 					}
 					return nil, errors.New("unexpected call")

--- a/pkg/storageincentives/staking/mock/contract.go
+++ b/pkg/storageincentives/staking/mock/contract.go
@@ -13,15 +13,15 @@ import (
 )
 
 type stakingContractMock struct {
-	depositStake     func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error)
+	depositStake     func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error)
 	getStake         func(ctx context.Context) (*big.Int, error)
 	withdrawAllStake func(ctx context.Context) (common.Hash, error)
 	migrateStake     func(ctx context.Context) (common.Hash, error)
 	isFrozen         func(ctx context.Context, block uint64) (bool, error)
 }
 
-func (s *stakingContractMock) DepositStake(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error) {
-	return s.depositStake(ctx, withdrawableStake)
+func (s *stakingContractMock) DepositStake(ctx context.Context, stakedAmount *big.Int) (common.Hash, error) {
+	return s.depositStake(ctx, stakedAmount)
 }
 
 func (s *stakingContractMock) ChangeStakeOverlay(_ context.Context, h common.Hash) (common.Hash, error) {
@@ -62,7 +62,7 @@ func New(opts ...Option) staking.Contract {
 	return bs
 }
 
-func WithDepositStake(f func(ctx context.Context, withdrawableStake *big.Int) (common.Hash, error)) Option {
+func WithDepositStake(f func(ctx context.Context, stakedAmount *big.Int) (common.Hash, error)) Option {
 	return func(mock *stakingContractMock) {
 		mock.depositStake = f
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Rename only the response for 'withdrawablestake' api  
