### PR TITLE
fix: move pullsync rate limiter and remove reserve epoch in migration

### DIFF
--- a/pkg/storer/migration/step_06.go
+++ b/pkg/storer/migration/step_06.go
@@ -54,6 +54,14 @@ func addStampHash(logger log.Logger, st transaction.Storage) (int64, int64, erro
 		return 0, 0, fmt.Errorf("pre-migration check: index counts do not match, %d vs %d. It's recommended that the repair-reserve cmd is run first", preBatchRadiusCnt, preChunkBinCnt)
 	}
 
+	// Delete epoch timestamp
+	err = st.Run(context.Background(), func(s transaction.Store) error {
+		return s.IndexStore().Delete(&reserve.EpochItem{})
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+
 	itemC := make(chan *reserve.BatchRadiusItemV1)
 
 	errC := make(chan error, 1)

--- a/pkg/storer/migration/step_06_test.go
+++ b/pkg/storer/migration/step_06_test.go
@@ -101,6 +101,12 @@ func Test_Step_06(t *testing.T) {
 	err = localmigration.Step_06(store)()
 	require.NoError(t, err)
 
+	has, err := store.IndexStore().Has(&reserve.EpochItem{})
+	if has {
+		t.Fatal("epoch item should be deleted")
+	}
+	require.NoError(t, err)
+
 	checkBatchRadiusItems(t, store.IndexStore(), len(chunks), batchRadiusItems)
 	checkChunkBinItems(t, store.IndexStore(), len(chunks), chunkBinItems)
 	checkStampIndex(t, store.IndexStore(), len(chunks), stampIndexItems)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
