### PR TITLE
feat: specify retrieval redundancy level via api

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 7.1.0
+  version: 7.1.1
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 
@@ -237,6 +237,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmCache"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyStrategyParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyFallbackModeParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyLevelParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmChunkRetrievalTimeoutParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActTimestamp"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActPublisher"
@@ -424,6 +425,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmCache"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyStrategyParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyFallbackModeParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyLevelParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmChunkRetrievalTimeoutParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActTimestamp"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActPublisher"

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -362,11 +362,11 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 	loggerV1 := logger.V(1).Build()
 
 	headers := struct {
-		Cache                 *bool            `map:"Swarm-Cache"`
-		Strategy              *getter.Strategy `map:"Swarm-Redundancy-Strategy"`
-		FallbackMode          *bool            `map:"Swarm-Redundancy-Fallback-Mode"`
-		RLevel                redundancy.Level `map:"Swarm-Redundancy-Level"`
-		ChunkRetrievalTimeout *string          `map:"Swarm-Chunk-Retrieval-Timeout"`
+		Cache                 *bool             `map:"Swarm-Cache"`
+		Strategy              *getter.Strategy  `map:"Swarm-Redundancy-Strategy"`
+		FallbackMode          *bool             `map:"Swarm-Redundancy-Fallback-Mode"`
+		RLevel                *redundancy.Level `map:"Swarm-Redundancy-Level"`
+		ChunkRetrievalTimeout *string           `map:"Swarm-Chunk-Retrieval-Timeout"`
 	}{}
 
 	if response := s.mapStructure(r.Header, &headers); response != nil {
@@ -388,7 +388,9 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 		jsonhttp.BadRequest(w, "could not parse headers")
 		return
 	}
-	ctx = redundancy.SetLevelInContext(ctx, headers.RLevel)
+	if headers.RLevel != nil {
+		ctx = redundancy.SetLevelInContext(ctx, *headers.RLevel)
+	}
 
 FETCH:
 	// read manifest entry
@@ -558,12 +560,12 @@ func (s *Service) serveManifestEntry(
 // downloadHandler contains common logic for downloading Swarm file from API
 func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *http.Request, reference swarm.Address, additionalHeaders http.Header, etag, headersOnly bool) {
 	headers := struct {
-		Strategy              *getter.Strategy `map:"Swarm-Redundancy-Strategy"`
-		RLevel                redundancy.Level `map:"Swarm-Redundancy-Level"`
-		FallbackMode          *bool            `map:"Swarm-Redundancy-Fallback-Mode"`
-		ChunkRetrievalTimeout *string          `map:"Swarm-Chunk-Retrieval-Timeout"`
-		LookaheadBufferSize   *int             `map:"Swarm-Lookahead-Buffer-Size"`
-		Cache                 *bool            `map:"Swarm-Cache"`
+		Strategy              *getter.Strategy  `map:"Swarm-Redundancy-Strategy"`
+		RLevel                *redundancy.Level `map:"Swarm-Redundancy-Level"`
+		FallbackMode          *bool             `map:"Swarm-Redundancy-Fallback-Mode"`
+		ChunkRetrievalTimeout *string           `map:"Swarm-Chunk-Retrieval-Timeout"`
+		LookaheadBufferSize   *int              `map:"Swarm-Lookahead-Buffer-Size"`
+		Cache                 *bool             `map:"Swarm-Cache"`
 	}{}
 
 	if response := s.mapStructure(r.Header, &headers); response != nil {
@@ -582,7 +584,9 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 		jsonhttp.BadRequest(w, "could not parse headers")
 		return
 	}
-	ctx = redundancy.SetLevelInContext(ctx, headers.RLevel)
+	if headers.RLevel != nil {
+		ctx = redundancy.SetLevelInContext(ctx, *headers.RLevel)
+	}
 
 	reader, l, err := joiner.New(ctx, s.storer.Download(cache), s.storer.Cache(), reference)
 	if err != nil {

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -365,6 +365,7 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 		Cache                 *bool            `map:"Swarm-Cache"`
 		Strategy              *getter.Strategy `map:"Swarm-Redundancy-Strategy"`
 		FallbackMode          *bool            `map:"Swarm-Redundancy-Fallback-Mode"`
+		RLevel                redundancy.Level `map:"Swarm-Redundancy-Level"`
 		ChunkRetrievalTimeout *string          `map:"Swarm-Chunk-Retrieval-Timeout"`
 	}{}
 
@@ -387,6 +388,7 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 		jsonhttp.BadRequest(w, "could not parse headers")
 		return
 	}
+	ctx = redundancy.SetLevelInContext(ctx, headers.RLevel)
 
 FETCH:
 	// read manifest entry
@@ -557,6 +559,7 @@ func (s *Service) serveManifestEntry(
 func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *http.Request, reference swarm.Address, additionalHeaders http.Header, etag, headersOnly bool) {
 	headers := struct {
 		Strategy              *getter.Strategy `map:"Swarm-Redundancy-Strategy"`
+		RLevel                redundancy.Level `map:"Swarm-Redundancy-Level"`
 		FallbackMode          *bool            `map:"Swarm-Redundancy-Fallback-Mode"`
 		ChunkRetrievalTimeout *string          `map:"Swarm-Chunk-Retrieval-Timeout"`
 		LookaheadBufferSize   *int             `map:"Swarm-Lookahead-Buffer-Size"`
@@ -579,6 +582,7 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 		jsonhttp.BadRequest(w, "could not parse headers")
 		return
 	}
+	ctx = redundancy.SetLevelInContext(ctx, headers.RLevel)
 
 	reader, l, err := joiner.New(ctx, s.storer.Download(cache), s.storer.Cache(), reference)
 	if err != nil {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
1. Retrieval redundancy level defaults to 0
2. Allow user to specify the retrieval redundancy level in the download headers

fixes #4694
