### PR TITLE
fix: reset epoch timestamp when the reserve is reset

### DIFF
--- a/pkg/storer/internal/reserve/reserve.go
+++ b/pkg/storer/internal/reserve/reserve.go
@@ -518,9 +518,14 @@ func (r *Reserve) Reset(ctx context.Context) error {
 
 	size := r.Size()
 
+	err := r.st.Run(ctx, func(s transaction.Store) error { return s.IndexStore().Delete(&EpochItem{}) })
+	if err != nil {
+		return err
+	}
+
 	bRitems := make([]*BatchRadiusItem, 0, size)
 
-	err := r.st.IndexStore().Iterate(storage.Query{
+	err = r.st.IndexStore().Iterate(storage.Query{
 		Factory: func() storage.Item { return &BatchRadiusItem{} },
 	}, func(res storage.Result) (bool, error) {
 		bRitems = append(bRitems, res.Entry.(*BatchRadiusItem))

--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -824,6 +824,8 @@ func TestReset(t *testing.T) {
 	}
 	assert.Equal(t, c, total)
 
+	checkStore(t, ts.IndexStore(), &reserve.EpochItem{}, false)
+
 	err = r.Reset(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -850,6 +852,8 @@ func TestReset(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, c, 0)
+
+	checkStore(t, ts.IndexStore(), &reserve.EpochItem{}, true)
 
 	for _, c := range chs {
 		h, err := c.Stamp().Hash()


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
closes #4815

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
