### PR TITLE
fix(manifest): resolve node persistence after removal

### DIFF
--- a/pkg/manifest/mantaray/marshal.go
+++ b/pkg/manifest/mantaray/marshal.go
@@ -287,6 +287,9 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 		bb.fromBytes(data[offset:])
 		offset += 32 // skip forks
 		return bb.iter(func(b byte) error {
+			if refBytesSize == 0 {
+				return nil
+			}
 			f := &fork{}
 
 			if len(data) < offset+nodeForkTypeBytesSize {
@@ -296,7 +299,6 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 			nodeType := data[offset]
 
 			nodeForkSize := nodeForkPreReferenceSize + refBytesSize
-
 			if nodeTypeIsWithMetadataType(nodeType) {
 				if len(data) < offset+nodeForkPreReferenceSize+refBytesSize+nodeForkMetadataBytesSize {
 					return fmt.Errorf("not enough bytes for node fork: %d (%d) on byte '%x': %w", (len(data) - offset), (nodeForkPreReferenceSize + refBytesSize + nodeForkMetadataBytesSize), []byte{b}, ErrInvalidManifest)

--- a/pkg/manifest/mantaray/node.go
+++ b/pkg/manifest/mantaray/node.go
@@ -313,10 +313,26 @@ func (n *Node) Remove(ctx context.Context, path []byte, ls LoadSaver) error {
 	rest := path[len(f.prefix):]
 	if len(rest) == 0 {
 		// full path matched
+
+		// Make the ref all zeros to indicate that this node needs to re-uploaded
+		n.ref = zero32
+		// Set the refBytesSize to 32 so that unmarshall works properly
+		n.refBytesSize = len(n.ref)
+
+		// remove the fork
 		delete(n.forks, path[0])
 		return nil
 	}
-	return f.Node.Remove(ctx, rest, ls)
+	err := f.Node.Remove(ctx, rest, ls)
+	if err != nil {
+		return err
+	}
+	// Make the ref all zeros to indicate that this node needs to re-uploaded
+	n.ref = zero32
+	// Set the refBytesSize to 32 so that unmarshall works properly
+	n.refBytesSize = len(n.ref)
+
+	return nil
 }
 
 func common(a, b []byte) (c []byte) {

--- a/pkg/manifest/mantaray/node.go
+++ b/pkg/manifest/mantaray/node.go
@@ -311,28 +311,15 @@ func (n *Node) Remove(ctx context.Context, path []byte, ls LoadSaver) error {
 		return ErrNotFound
 	}
 	rest := path[len(f.prefix):]
+	defer func() {
+		n.ref = nil
+	}()
 	if len(rest) == 0 {
-		// full path matched
 
-		// Make the ref all zeros to indicate that this node needs to re-uploaded
-		n.ref = zero32
-		// Set the refBytesSize to 32 so that unmarshall works properly
-		n.refBytesSize = len(n.ref)
-
-		// remove the fork
 		delete(n.forks, path[0])
 		return nil
 	}
-	err := f.Node.Remove(ctx, rest, ls)
-	if err != nil {
-		return err
-	}
-	// Make the ref all zeros to indicate that this node needs to re-uploaded
-	n.ref = zero32
-	// Set the refBytesSize to 32 so that unmarshall works properly
-	n.refBytesSize = len(n.ref)
-
-	return nil
+	return f.Node.Remove(ctx, rest, ls)
 }
 
 func common(a, b []byte) (c []byte) {

--- a/pkg/manifest/mantaray/persist.go
+++ b/pkg/manifest/mantaray/persist.go
@@ -5,9 +5,9 @@
 package mantaray
 
 import (
+	"bytes"
 	"context"
 	"errors"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -61,7 +61,7 @@ func (n *Node) Save(ctx context.Context, s Saver) error {
 }
 
 func (n *Node) save(ctx context.Context, s Saver) error {
-	if n != nil && n.ref != nil {
+	if n != nil && n.ref != nil && !bytes.Equal(n.ref, zero32) {
 		return nil
 	}
 	select {

--- a/pkg/manifest/mantaray/persist.go
+++ b/pkg/manifest/mantaray/persist.go
@@ -5,7 +5,6 @@
 package mantaray
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"golang.org/x/sync/errgroup"
@@ -61,7 +60,7 @@ func (n *Node) Save(ctx context.Context, s Saver) error {
 }
 
 func (n *Node) save(ctx context.Context, s Saver) error {
-	if n != nil && n.ref != nil && !bytes.Equal(n.ref, zero32) {
+	if n != nil && n.ref != nil {
 		return nil
 	}
 	select {

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -97,6 +97,29 @@ func TestPersistRemove(t *testing.T) {
 				[]byte("img/2.png"),
 			},
 		},
+		{
+			name: "nested-prefix-is-not-collapsed",
+			toAdd: []mantaray.NodeEntry{
+				{
+					Path: []byte("index.html"),
+				},
+				{
+					Path: []byte("img/1.png"),
+				},
+				{
+					Path: []byte("img/2/test1.png"),
+				},
+				{
+					Path: []byte("img/2/test2.png"),
+				},
+				{
+					Path: []byte("robots.txt"),
+				},
+			},
+			toRemove: [][]byte{
+				[]byte("img/2/test1.png"),
+			},
+		},
 	} {
 		ctx := context.Background()
 		var ls mantaray.LoadSaver = newMockLoadSaver()
@@ -124,7 +147,6 @@ func TestPersistRemove(t *testing.T) {
 			}
 
 			ref := n.Reference()
-
 			// reload and remove
 			nn := mantaray.NewNodeRef(ref)
 			for i := 0; i < len(tc.toRemove); i++ {
@@ -134,10 +156,12 @@ func TestPersistRemove(t *testing.T) {
 					t.Fatalf("expected no error, got %v", err)
 				}
 			}
+
 			err = nn.Save(ctx, ls)
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
+
 			ref = nn.Reference()
 
 			// reload and lookup removed node

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -168,7 +168,7 @@ func TestPersistRemove(t *testing.T) {
 			nnn := mantaray.NewNodeRef(ref)
 			for i := 0; i < len(tc.toRemove); i++ {
 				c := tc.toRemove[i]
-				n, err = nnn.LookupNode(ctx, c, ls)
+				_, err = nnn.LookupNode(ctx, c, ls)
 				if !errors.Is(err, mantaray.ErrNotFound) {
 					t.Fatalf("expected not found error, got %v", err)
 				}

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -145,7 +145,6 @@ func TestPersistRemove(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
-
 			ref := n.Reference()
 			// reload and remove
 			nn := mantaray.NewNodeRef(ref)
@@ -163,7 +162,6 @@ func TestPersistRemove(t *testing.T) {
 			}
 
 			ref = nn.Reference()
-
 			// reload and lookup removed node
 			nnn := mantaray.NewNodeRef(ref)
 			for i := 0; i < len(tc.toRemove); i++ {

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -123,7 +123,6 @@ func TestPersistRemove(t *testing.T) {
 	} {
 		ctx := context.Background()
 		var ls mantaray.LoadSaver = newMockLoadSaver()
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR fixes https://github.com/ethersphere/bee/issues/4808. Where loading a manifest then removing forks from it would not persist in the next load.
