### PR TITLE
fix: Eliminate local transaction nonce cache.

### DIFF
--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -30,10 +30,6 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/util/testutil"
 )
 
-func nonceKey(sender common.Address) string {
-	return fmt.Sprintf("transaction_nonce_%x", sender)
-}
-
 func signerMockForTransaction(t *testing.T, signedTx *types.Transaction, sender common.Address, signerChainID *big.Int) crypto.Signer {
 	t.Helper()
 	return signermock.New(
@@ -64,10 +60,6 @@ func signerMockForTransaction(t *testing.T, signedTx *types.Transaction, sender 
 			}
 			if transaction.GasPrice().Cmp(signedTx.GasPrice()) != 0 {
 				t.Fatalf("signing transaction with wrong gasprice. wanted %d, got %d", signedTx.GasPrice(), transaction.GasPrice())
-			}
-
-			if transaction.Nonce() != signedTx.Nonce() {
-				t.Fatalf("signing transaction with wrong nonce. wanted %d, got %d", signedTx.Nonce(), transaction.Nonce())
 			}
 
 			return signedTx, nil
@@ -112,10 +104,6 @@ func TestTransactionSend(t *testing.T) {
 			Value: value,
 		}
 		store := storemock.NewStateStore()
-		err := store.Put(nonceKey(sender), nonce)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
@@ -165,15 +153,6 @@ func TestTransactionSend(t *testing.T) {
 
 		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
 			t.Fatal("returning wrong transaction hash")
-		}
-
-		var storedNonce uint64
-		err = store.Get(nonceKey(sender), &storedNonce)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if storedNonce != nonce+1 {
-			t.Fatalf("nonce not stored correctly: want %d, got %d", nonce+1, storedNonce)
 		}
 
 		storedTransaction, err := transactionService.StoredTransaction(txHash)
@@ -238,10 +217,6 @@ func TestTransactionSend(t *testing.T) {
 			MinEstimatedGasLimit: estimatedGasLimit,
 		}
 		store := storemock.NewStateStore()
-		err := store.Put(nonceKey(sender), nonce)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
@@ -285,15 +260,6 @@ func TestTransactionSend(t *testing.T) {
 
 		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
 			t.Fatal("returning wrong transaction hash")
-		}
-
-		var storedNonce uint64
-		err = store.Get(nonceKey(sender), &storedNonce)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if storedNonce != nonce+1 {
-			t.Fatalf("nonce not stored correctly: want %d, got %d", nonce+1, storedNonce)
 		}
 
 		storedTransaction, err := transactionService.StoredTransaction(txHash)
@@ -363,10 +329,6 @@ func TestTransactionSend(t *testing.T) {
 			Value: value,
 		}
 		store := storemock.NewStateStore()
-		err := store.Put(nonceKey(sender), nonce)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
@@ -416,15 +378,6 @@ func TestTransactionSend(t *testing.T) {
 
 		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
 			t.Fatal("returning wrong transaction hash")
-		}
-
-		var storedNonce uint64
-		err = store.Get(nonceKey(sender), &storedNonce)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if storedNonce != nonce+1 {
-			t.Fatalf("nonce not stored correctly: want %d, got %d", nonce+1, storedNonce)
 		}
 
 		storedTransaction, err := transactionService.StoredTransaction(txHash)
@@ -534,15 +487,6 @@ func TestTransactionSend(t *testing.T) {
 		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
 			t.Fatal("returning wrong transaction hash")
 		}
-
-		var storedNonce uint64
-		err = store.Get(nonceKey(sender), &storedNonce)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if storedNonce != nonce+1 {
-			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nonce+1, storedNonce)
-		}
 	})
 
 	t.Run("send_skipped_nonce", func(t *testing.T) {
@@ -565,10 +509,6 @@ func TestTransactionSend(t *testing.T) {
 			Value: value,
 		}
 		store := storemock.NewStateStore()
-		err := store.Put(nonceKey(sender), nonce)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		transactionService, err := transaction.NewService(logger, sender,
 			backendmock.New(
@@ -613,15 +553,6 @@ func TestTransactionSend(t *testing.T) {
 
 		if !bytes.Equal(txHash.Bytes(), signedTx.Hash().Bytes()) {
 			t.Fatal("returning wrong transaction hash")
-		}
-
-		var storedNonce uint64
-		err = store.Get(nonceKey(sender), &storedNonce)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if storedNonce != nextNonce+1 {
-			t.Fatalf("did not store nonce correctly. wanted %d, got %d", nextNonce+1, storedNonce)
 		}
 	})
 }


### PR DESCRIPTION
**WARNING:** i'm not experienced in golang, and i don't know the bee internals either. this commit requires review by someone who understands the codebase.

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Stop keeping the next nonce in our local state. Instead we always calculate it from the blockchain nonce and the local list of pending transactions.

#### Motivation and Context (Optional)
Fixes issue [#4826](https://github.com/ethersphere/bee/issues/4826) where the local nonce cache was out of sync with the blockchain for an unknown reason. Because of that no transactions got incorporated into the blockchain. This made it impossible to unstake or to participation in the reserve incentives, probably forever (until fixed).

It only became apparent when i tried to unstake my nodes at the v2.2.0 upgrade, and some of them got stuck. It also explains why i stopped seeing rewards on my nodes.

With this commit on top of v2.1.0 i've successfully unstaked a previously hung node.

And an eternal guiding principle: do not optimize any program until it works as specified. And the only exception is when it's so slow that it substantially hinders development.

#### A potential unaddressed issue
If a third party creates a transaction, then the bee's transactions may get stuck. There should be a check that the blockchain nonce is lower than the lowest nonce in our pending tx list. If not, then the nonce of the pending tx'es should be updated.
