### PR TITLE
fix(api): add api initialization notice

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -179,6 +179,7 @@ type Service struct {
 	ethereumAddress   common.Address
 	chequebookEnabled bool
 	swapEnabled       bool
+	fullAPIEnabled    bool
 
 	topologyDriver topology.Driver
 	p2p            p2p.DebugService
@@ -216,8 +217,6 @@ type Service struct {
 	redistributionAgent *storageincentives.Agent
 
 	statusService *status.Service
-
-	isFullAPIEnabled bool
 }
 
 func (s *Service) SetP2P(p2p p2p.DebugService) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -217,7 +217,7 @@ type Service struct {
 
 	statusService *status.Service
 
-	isFullApiAvailable bool
+	isFullAPIEnabled bool
 }
 
 func (s *Service) SetP2P(p2p p2p.DebugService) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -216,6 +216,8 @@ type Service struct {
 	redistributionAgent *storageincentives.Agent
 
 	statusService *status.Service
+
+	isFullApiAvailable bool
 }
 
 func (s *Service) SetP2P(p2p p2p.DebugService) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -179,7 +179,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 	erc20 := erc20mock.New(o.Erc20Opts...)
 	backend := backendmock.New(o.BackendOpts...)
 
-	var extraOpts = api.ExtraOptions{
+	extraOpts := api.ExtraOptions{
 		TopologyDriver:  topologyDriver,
 		Accounting:      acc,
 		Pseudosettle:    recipient,
@@ -231,9 +231,8 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		WsPingPeriod:       o.WsPingPeriod,
 	}, extraOpts, 1, erc20)
 
-	s.MountTechnicalDebug()
-	s.MountDebug()
 	s.MountAPI()
+	s.EnableFullAPIAvailability()
 
 	if o.DirectUpload {
 		chanStore = newChanStore(o.Storer.PusherFeed())
@@ -316,7 +315,7 @@ func TestParseName(t *testing.T) {
 	const bzzHash = "89c17d0d8018a19057314aa035e61c9d23c47581a61dd3a79a7839692c617e4d"
 	log := log.Noop
 
-	var errInvalidNameOrAddress = errors.New("invalid name or bzz address")
+	errInvalidNameOrAddress := errors.New("invalid name or bzz address")
 
 	testCases := []struct {
 		desc       string
@@ -378,6 +377,7 @@ func TestParseName(t *testing.T) {
 		s := api.New(pk.PublicKey, pk.PublicKey, common.Address{}, nil, log, nil, nil, 1, false, false, nil, []string{"*"}, inmemstore.New())
 		s.Configure(signer, nil, api.Options{}, api.ExtraOptions{Resolver: tC.res}, 1, nil)
 		s.MountAPI()
+		s.EnableFullAPIAvailability()
 
 		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
@@ -503,9 +503,7 @@ func TestPostageHeaderError(t *testing.T) {
 func TestOptions(t *testing.T) {
 	t.Parallel()
 
-	var (
-		client, _, _, _ = newTestServer(t, testServerOptions{})
-	)
+	client, _, _, _ := newTestServer(t, testServerOptions{})
 	for _, tc := range []struct {
 		endpoint        string
 		expectedMethods string // expectedMethods contains HTTP methods like GET, POST, HEAD, PATCH, DELETE, OPTIONS. These are in alphabetical sorted order

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -231,8 +231,7 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		WsPingPeriod:       o.WsPingPeriod,
 	}, extraOpts, 1, erc20)
 
-	s.MountAPI()
-	s.EnableFullAPIAvailability()
+	s.Mount(api.WithFullAPI())
 
 	if o.DirectUpload {
 		chanStore = newChanStore(o.Storer.PusherFeed())
@@ -376,8 +375,7 @@ func TestParseName(t *testing.T) {
 
 		s := api.New(pk.PublicKey, pk.PublicKey, common.Address{}, nil, log, nil, nil, 1, false, false, nil, []string{"*"}, inmemstore.New())
 		s.Configure(signer, nil, api.Options{}, api.ExtraOptions{Resolver: tC.res}, 1, nil)
-		s.MountAPI()
-		s.EnableFullAPIAvailability()
+		s.Mount(api.WithFullAPI())
 
 		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -528,9 +528,11 @@ func (s *Service) mountBusinessDebug() {
 	handle("/wallet/withdraw/{coin}", web.ChainHandlers(
 		s.checkChequebookAvailability,
 		s.checkSwapAvailability,
-		s.gasConfigMiddleware("wallet withdraw"),
 		web.FinalHandler(jsonhttp.MethodHandler{
-			"GET": http.HandlerFunc(s.walletWithdrawHandler),
+			"POST": web.ChainHandlers(
+				s.gasConfigMiddleware("wallet withdraw"),
+				web.FinalHandlerFunc(s.walletWithdrawHandler),
+			),
 		}),
 	))
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -26,6 +26,10 @@ const (
 )
 
 func (s *Service) Mount() {
+	if s == nil {
+		return
+	}
+
 	router := mux.NewRouter()
 
 	router.NotFoundHandler = http.HandlerFunc(jsonhttp.NotFoundHandler)
@@ -35,23 +39,6 @@ func (s *Service) Mount() {
 	s.mountTechnicalDebug()
 	s.mountBusinessDebug()
 	s.mountAPI()
-
-	s.Handler = web.ChainHandlers(
-		httpaccess.NewHTTPAccessLogHandler(s.logger, s.tracer, "api access"),
-		handlers.CompressHandler,
-		s.corsHandler,
-		web.NoCacheHeadersHandler,
-		web.FinalHandler(s.router),
-	)
-}
-
-// EnableFullAPI will enable all available endpoints, because some endpoints are not available during syncing.
-func (s *Service) EnableFullAPI() {
-	if s == nil {
-		return
-	}
-
-	s.fullAPIEnabled = true
 
 	compressHandler := func(h http.Handler) http.Handler {
 		downloadEndpoints := []string{
@@ -97,6 +84,15 @@ func (s *Service) EnableFullAPI() {
 		s.corsHandler,
 		web.FinalHandler(s.router),
 	)
+}
+
+// EnableFullAPI will enable all available endpoints, because some endpoints are not available during syncing.
+func (s *Service) EnableFullAPI() {
+	if s == nil {
+		return
+	}
+
+	s.fullAPIEnabled = true
 }
 
 func (s *Service) mountTechnicalDebug() {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -40,6 +40,23 @@ func (s *Service) Mount() {
 	s.mountBusinessDebug()
 	s.mountAPI()
 
+	s.Handler = web.ChainHandlers(
+		httpaccess.NewHTTPAccessLogHandler(s.logger, s.tracer, "api access"),
+		handlers.CompressHandler,
+		s.corsHandler,
+		web.NoCacheHeadersHandler,
+		web.FinalHandler(router),
+	)
+}
+
+// EnableFullAPI will enable all available endpoints, because some endpoints are not available during syncing.
+func (s *Service) EnableFullAPI() {
+	if s == nil {
+		return
+	}
+
+	s.fullAPIEnabled = true
+
 	compressHandler := func(h http.Handler) http.Handler {
 		downloadEndpoints := []string{
 			"/bzz",
@@ -84,15 +101,6 @@ func (s *Service) Mount() {
 		s.corsHandler,
 		web.FinalHandler(s.router),
 	)
-}
-
-// EnableFullAPI will enable all available endpoints, because some endpoints are not available during syncing.
-func (s *Service) EnableFullAPI() {
-	if s == nil {
-		return
-	}
-
-	s.fullAPIEnabled = true
 }
 
 func (s *Service) mountTechnicalDebug() {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -504,17 +504,21 @@ func (s *Service) mountBusinessDebug() {
 
 	handle("/chequebook/deposit", web.ChainHandlers(
 		s.checkChequebookAvailability,
-		s.gasConfigMiddleware("chequebook deposit"),
 		web.FinalHandler(jsonhttp.MethodHandler{
-			"POST": http.HandlerFunc(s.chequebookDepositHandler),
+			"POST": web.ChainHandlers(
+				s.gasConfigMiddleware("chequebook deposit"),
+				web.FinalHandlerFunc(s.chequebookDepositHandler),
+			),
 		}),
 	))
 
 	handle("/chequebook/withdraw", web.ChainHandlers(
 		s.checkChequebookAvailability,
-		s.gasConfigMiddleware("chequebook withdraw"),
 		web.FinalHandler(jsonhttp.MethodHandler{
-			"POST": http.HandlerFunc(s.chequebookWithdrawHandler),
+			"POST": web.ChainHandlers(
+				s.gasConfigMiddleware("chequebook withdraw"),
+				web.FinalHandlerFunc(s.chequebookWithdrawHandler),
+			),
 		}),
 	))
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package api_test
 
 import (

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -407,6 +407,7 @@ func TestEndpointOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -420,6 +421,7 @@ func TestEndpointOptions(t *testing.T) {
 			}
 
 			for _, tt := range tc.expectedStatuses {
+				tt := tt
 				t.Run(tc.name+routeToName(tt.route), func(t *testing.T) {
 					resp := jsonhttptest.Request(t, testServer, http.MethodOptions, tt.route, tt.expectedStatus)
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -407,7 +407,6 @@ func TestEndpointOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -421,7 +420,6 @@ func TestEndpointOptions(t *testing.T) {
 			}
 
 			for _, tt := range tc.expectedStatuses {
-				tt := tt
 				t.Run(tc.name+routeToName(tt.route), func(t *testing.T) {
 					resp := jsonhttptest.Request(t, testServer, http.MethodOptions, tt.route, tt.expectedStatus)
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -100,7 +100,7 @@ func TestEndpointOptions(t *testing.T) {
 				{"/chequebook/deposit", []string{"POST"}, http.StatusNoContent},
 				{"/chequebook/withdraw", []string{"POST"}, http.StatusNoContent},
 				{"/wallet", []string{"GET"}, http.StatusNoContent},
-				{"/wallet/withdraw/{coin}", []string{"GET"}, http.StatusNoContent},
+				{"/wallet/withdraw/{coin}", []string{"POST"}, http.StatusNoContent},
 				{"/stamps", []string{"GET"}, http.StatusNoContent},
 				{"/stamps/{batch_id}", []string{"GET"}, http.StatusNoContent},
 				{"/stamps/{batch_id}/buckets", []string{"GET"}, http.StatusNoContent},

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -1,0 +1,447 @@
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
+)
+
+func TestEndpointOptions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		serverOptions    testServerOptions
+		expectedStatuses []struct {
+			route           string
+			expectedMethods []string
+			expectedStatus  int
+		}
+	}{
+		{
+			name: "full_api_enabled",
+			serverOptions: testServerOptions{
+				FullAPIDisabled:    false,
+				SwapDisabled:       false,
+				ChequebookDisabled: false,
+			},
+			expectedStatuses: []struct {
+				route           string
+				expectedMethods []string
+				expectedStatus  int
+			}{
+				// routes from mountTechnicalDebug
+				{"/node", []string{"GET"}, http.StatusNoContent},
+				{"/addresses", []string{"GET"}, http.StatusNoContent},
+				{"/chainstate", []string{"GET"}, http.StatusNoContent},
+				{"/debugstore", []string{"GET"}, http.StatusNoContent},
+				{"/loggers", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp/1", []string{"PUT"}, http.StatusNoContent},
+				{"/readiness", nil, http.StatusBadRequest},
+				{"/health", nil, http.StatusOK},
+				{"/metrics", nil, http.StatusOK},
+				{"/not_found", nil, http.StatusNotFound},
+
+				// routes from mountAPI
+				{"/", nil, http.StatusOK},
+				{"/robots.txt", nil, http.StatusOK},
+				{"/bytes", []string{"POST"}, http.StatusNoContent},
+				{"/bytes/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/chunks", []string{"POST"}, http.StatusNoContent},
+				{"/chunks/stream", nil, http.StatusBadRequest},
+				{"/chunks/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/envelope/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/soc/{owner}/{id}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/feeds/{owner}/{topic}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/bzz", []string{"POST"}, http.StatusNoContent},
+				{"/grantee", []string{"POST"}, http.StatusNoContent},
+				{"/grantee/{address}", []string{"GET", "PATCH"}, http.StatusNoContent},
+				{"/bzz/{address}", []string{"GET"}, http.StatusNoContent},
+				{"/bzz/{address}/{path:.*}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/pss/send/{topic}/{targets}", []string{"POST"}, http.StatusNoContent},
+				{"/pss/subscribe/{topic}", nil, http.StatusBadRequest},
+				{"/tags", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/tags/{id}", []string{"GET", "DELETE", "PATCH"}, http.StatusNoContent},
+				{"/pins", []string{"GET"}, http.StatusNoContent},
+				{"/pins/check", []string{"GET"}, http.StatusNoContent},
+				{"/pins/{reference}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/stewardship/{address}", []string{"GET", "PUT"}, http.StatusNoContent},
+
+				// routes from mountBusinessDebug
+				{"/transactions", []string{"GET"}, http.StatusNoContent},
+				{"/transactions/{hash}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/peers", []string{"GET"}, http.StatusNoContent},
+				{"/pingpong/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/reservestate", []string{"GET"}, http.StatusNoContent},
+				{"/connect/{multi-address:.+}", []string{"POST"}, http.StatusNoContent},
+				{"/blocklist", []string{"GET"}, http.StatusNoContent},
+				{"/peers/{address}", []string{"DELETE"}, http.StatusNoContent},
+				{"/topology", []string{"GET"}, http.StatusNoContent},
+				{"/welcome-message", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/balances", []string{"GET"}, http.StatusNoContent},
+				{"/balances/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/consumed", []string{"GET"}, http.StatusNoContent},
+				{"/consumed/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/timesettlements", []string{"GET"}, http.StatusNoContent},
+				{"/settlements", []string{"GET"}, http.StatusNoContent},
+				{"/settlements/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cheque/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cheque", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cashout/{peer}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/chequebook/balance", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/address", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/deposit", []string{"POST"}, http.StatusNoContent},
+				{"/chequebook/withdraw", []string{"POST"}, http.StatusNoContent},
+				{"/wallet", []string{"GET"}, http.StatusNoContent},
+				{"/wallet/withdraw/{coin}", []string{"GET"}, http.StatusNoContent},
+				{"/stamps", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}/buckets", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{amount}/{depth}", []string{"POST"}, http.StatusNoContent},
+				{"/stamps/topup/{batch_id}/{amount}", []string{"PATCH"}, http.StatusNoContent},
+				{"/stamps/dilute/{batch_id}/{depth}", []string{"PATCH"}, http.StatusNoContent},
+				{"/batches", []string{"GET"}, http.StatusNoContent},
+				{"/accounting", []string{"GET"}, http.StatusNoContent},
+				{"/stake/withdrawable", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/stake/{amount}", []string{"POST"}, http.StatusNoContent},
+				{"/stake", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/redistributionstate", []string{"GET"}, http.StatusNoContent},
+				{"/status", []string{"GET"}, http.StatusNoContent},
+				{"/status/peers", []string{"GET"}, http.StatusNoContent},
+				{"/status/neighborhoods", []string{"GET"}, http.StatusNoContent},
+				{"/rchash/{depth}/{anchor1}/{anchor2}", []string{"GET"}, http.StatusNoContent},
+			},
+		},
+		{
+			name: "full_api_disabled",
+			serverOptions: testServerOptions{
+				FullAPIDisabled:    true,
+				SwapDisabled:       false,
+				ChequebookDisabled: false,
+			},
+			expectedStatuses: []struct {
+				route           string
+				expectedMethods []string
+				expectedStatus  int
+			}{
+				// routes from mountTechnicalDebug
+				{"/node", []string{"GET"}, http.StatusNoContent},
+				{"/addresses", []string{"GET"}, http.StatusNoContent},
+				{"/chainstate", []string{"GET"}, http.StatusNoContent},
+				{"/debugstore", []string{"GET"}, http.StatusNoContent},
+				{"/loggers", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp/1", []string{"PUT"}, http.StatusNoContent},
+				{"/readiness", nil, http.StatusBadRequest},
+				{"/health", nil, http.StatusOK},
+				{"/metrics", nil, http.StatusOK},
+				{"/not_found", nil, http.StatusNotFound},
+
+				// routes from mountAPI
+				{"/", nil, http.StatusOK},
+				{"/robots.txt", nil, http.StatusOK},
+				{"/bytes", nil, http.StatusServiceUnavailable},
+				{"/bytes/{address}", nil, http.StatusServiceUnavailable},
+				{"/chunks", nil, http.StatusServiceUnavailable},
+				{"/chunks/stream", nil, http.StatusServiceUnavailable},
+				{"/chunks/{address}", nil, http.StatusServiceUnavailable},
+				{"/envelope/{address}", nil, http.StatusServiceUnavailable},
+				{"/soc/{owner}/{id}", nil, http.StatusServiceUnavailable},
+				{"/feeds/{owner}/{topic}", nil, http.StatusServiceUnavailable},
+				{"/bzz", nil, http.StatusServiceUnavailable},
+				{"/grantee", nil, http.StatusServiceUnavailable},
+				{"/grantee/{address}", nil, http.StatusServiceUnavailable},
+				{"/bzz/{address}", nil, http.StatusServiceUnavailable},
+				{"/bzz/{address}/{path:.*}", nil, http.StatusServiceUnavailable},
+				{"/pss/send/{topic}/{targets}", nil, http.StatusServiceUnavailable},
+				{"/pss/subscribe/{topic}", nil, http.StatusServiceUnavailable},
+				{"/tags", nil, http.StatusServiceUnavailable},
+				{"/tags/{id}", nil, http.StatusServiceUnavailable},
+				{"/pins", nil, http.StatusServiceUnavailable},
+				{"/pins/check", nil, http.StatusServiceUnavailable},
+				{"/pins/{reference}", nil, http.StatusServiceUnavailable},
+				{"/stewardship/{address}", nil, http.StatusServiceUnavailable},
+
+				// routes from mountBusinessDebug
+				{"/transactions", nil, http.StatusServiceUnavailable},
+				{"/transactions/{hash}", nil, http.StatusServiceUnavailable},
+				{"/peers", nil, http.StatusServiceUnavailable},
+				{"/pingpong/{address}", nil, http.StatusServiceUnavailable},
+				{"/reservestate", nil, http.StatusServiceUnavailable},
+				{"/connect/{multi-address:.+}", nil, http.StatusServiceUnavailable},
+				{"/blocklist", nil, http.StatusServiceUnavailable},
+				{"/peers/{address}", nil, http.StatusServiceUnavailable},
+				{"/topology", nil, http.StatusServiceUnavailable},
+				{"/welcome-message", nil, http.StatusServiceUnavailable},
+				{"/balances", nil, http.StatusServiceUnavailable},
+				{"/balances/{peer}", nil, http.StatusServiceUnavailable},
+				{"/consumed", nil, http.StatusServiceUnavailable},
+				{"/consumed/{peer}", nil, http.StatusServiceUnavailable},
+				{"/timesettlements", nil, http.StatusServiceUnavailable},
+				{"/settlements", nil, http.StatusServiceUnavailable},
+				{"/settlements/{peer}", nil, http.StatusServiceUnavailable},
+				{"/chequebook/cheque/{peer}", nil, http.StatusServiceUnavailable},
+				{"/chequebook/cheque", nil, http.StatusServiceUnavailable},
+				{"/chequebook/cashout/{peer}", nil, http.StatusServiceUnavailable},
+				{"/chequebook/balance", nil, http.StatusServiceUnavailable},
+				{"/chequebook/address", nil, http.StatusServiceUnavailable},
+				{"/chequebook/deposit", nil, http.StatusServiceUnavailable},
+				{"/chequebook/withdraw", nil, http.StatusServiceUnavailable},
+				{"/wallet", nil, http.StatusServiceUnavailable},
+				{"/wallet/withdraw/{coin}", nil, http.StatusServiceUnavailable},
+				{"/stamps", nil, http.StatusServiceUnavailable},
+				{"/stamps/{batch_id}", nil, http.StatusServiceUnavailable},
+				{"/stamps/{batch_id}/buckets", nil, http.StatusServiceUnavailable},
+				{"/stamps/{amount}/{depth}", nil, http.StatusServiceUnavailable},
+				{"/stamps/topup/{batch_id}/{amount}", nil, http.StatusServiceUnavailable},
+				{"/stamps/dilute/{batch_id}/{depth}", nil, http.StatusServiceUnavailable},
+				{"/batches", nil, http.StatusServiceUnavailable},
+				{"/accounting", nil, http.StatusServiceUnavailable},
+				{"/stake/withdrawable", nil, http.StatusServiceUnavailable},
+				{"/stake/{amount}", nil, http.StatusServiceUnavailable},
+				{"/stake", nil, http.StatusServiceUnavailable},
+				{"/redistributionstate", nil, http.StatusServiceUnavailable},
+				{"/status", nil, http.StatusServiceUnavailable},
+				{"/status/peers", nil, http.StatusServiceUnavailable},
+				{"/status/neighborhoods", nil, http.StatusServiceUnavailable},
+				{"/rchash/{depth}/{anchor1}/{anchor2}", nil, http.StatusServiceUnavailable},
+			},
+		},
+		{
+			name: "swap_disabled",
+			serverOptions: testServerOptions{
+				FullAPIDisabled:    false,
+				SwapDisabled:       true,
+				ChequebookDisabled: false,
+			},
+			expectedStatuses: []struct {
+				route           string
+				expectedMethods []string
+				expectedStatus  int
+			}{
+				// routes from mountTechnicalDebug
+				{"/node", []string{"GET"}, http.StatusNoContent},
+				{"/addresses", []string{"GET"}, http.StatusNoContent},
+				{"/chainstate", []string{"GET"}, http.StatusNoContent},
+				{"/debugstore", []string{"GET"}, http.StatusNoContent},
+				{"/loggers", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp/1", []string{"PUT"}, http.StatusNoContent},
+				{"/readiness", nil, http.StatusBadRequest},
+				{"/health", nil, http.StatusOK},
+				{"/metrics", nil, http.StatusOK},
+				{"/not_found", nil, http.StatusNotFound},
+
+				// routes from mountAPI
+				{"/", nil, http.StatusOK},
+				{"/robots.txt", nil, http.StatusOK},
+				{"/bytes", []string{"POST"}, http.StatusNoContent},
+				{"/bytes/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/chunks", []string{"POST"}, http.StatusNoContent},
+				{"/chunks/stream", nil, http.StatusBadRequest},
+				{"/chunks/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/envelope/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/soc/{owner}/{id}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/feeds/{owner}/{topic}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/bzz", []string{"POST"}, http.StatusNoContent},
+				{"/grantee", []string{"POST"}, http.StatusNoContent},
+				{"/grantee/{address}", []string{"GET", "PATCH"}, http.StatusNoContent},
+				{"/bzz/{address}", []string{"GET"}, http.StatusNoContent},
+				{"/bzz/{address}/{path:.*}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/pss/send/{topic}/{targets}", []string{"POST"}, http.StatusNoContent},
+				{"/pss/subscribe/{topic}", nil, http.StatusBadRequest},
+				{"/tags", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/tags/{id}", []string{"GET", "DELETE", "PATCH"}, http.StatusNoContent},
+				{"/pins", []string{"GET"}, http.StatusNoContent},
+				{"/pins/check", []string{"GET"}, http.StatusNoContent},
+				{"/pins/{reference}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/stewardship/{address}", []string{"GET", "PUT"}, http.StatusNoContent},
+
+				// routes from mountBusinessDebug
+				{"/transactions", []string{"GET"}, http.StatusNoContent},
+				{"/transactions/{hash}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/peers", []string{"GET"}, http.StatusNoContent},
+				{"/pingpong/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/reservestate", []string{"GET"}, http.StatusNoContent},
+				{"/connect/{multi-address:.+}", []string{"POST"}, http.StatusNoContent},
+				{"/blocklist", []string{"GET"}, http.StatusNoContent},
+				{"/peers/{address}", []string{"DELETE"}, http.StatusNoContent},
+				{"/topology", []string{"GET"}, http.StatusNoContent},
+				{"/welcome-message", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/balances", []string{"GET"}, http.StatusNoContent},
+				{"/balances/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/consumed", []string{"GET"}, http.StatusNoContent},
+				{"/consumed/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/timesettlements", []string{"GET"}, http.StatusNoContent},
+				{"/settlements", nil, http.StatusNotImplemented},
+				{"/settlements/{peer}", nil, http.StatusNotImplemented},
+				{"/chequebook/cheque/{peer}", nil, http.StatusNotImplemented},
+				{"/chequebook/cheque", nil, http.StatusNotImplemented},
+				{"/chequebook/cashout/{peer}", nil, http.StatusNotImplemented},
+				{"/chequebook/balance", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/address", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/deposit", []string{"POST"}, http.StatusNoContent},
+				{"/chequebook/withdraw", []string{"POST"}, http.StatusNoContent},
+				{"/wallet", []string{"GET"}, http.StatusNoContent},
+				{"/wallet/withdraw/{coin}", nil, http.StatusNotImplemented},
+				{"/stamps", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}/buckets", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{amount}/{depth}", []string{"POST"}, http.StatusNoContent},
+				{"/stamps/topup/{batch_id}/{amount}", []string{"PATCH"}, http.StatusNoContent},
+				{"/stamps/dilute/{batch_id}/{depth}", []string{"PATCH"}, http.StatusNoContent},
+				{"/batches", []string{"GET"}, http.StatusNoContent},
+				{"/accounting", []string{"GET"}, http.StatusNoContent},
+				{"/stake/withdrawable", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/stake/{amount}", []string{"POST"}, http.StatusNoContent},
+				{"/stake", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/redistributionstate", []string{"GET"}, http.StatusNoContent},
+				{"/status", []string{"GET"}, http.StatusNoContent},
+				{"/status/peers", []string{"GET"}, http.StatusNoContent},
+				{"/status/neighborhoods", []string{"GET"}, http.StatusNoContent},
+				{"/rchash/{depth}/{anchor1}/{anchor2}", []string{"GET"}, http.StatusNoContent},
+			},
+		},
+		{
+			name: "chechebook_disabled",
+			serverOptions: testServerOptions{
+				FullAPIDisabled:    false,
+				SwapDisabled:       false,
+				ChequebookDisabled: true,
+			},
+			expectedStatuses: []struct {
+				route           string
+				expectedMethods []string
+				expectedStatus  int
+			}{
+				// routes from mountTechnicalDebug
+				{"/node", []string{"GET"}, http.StatusNoContent},
+				{"/addresses", []string{"GET"}, http.StatusNoContent},
+				{"/chainstate", []string{"GET"}, http.StatusNoContent},
+				{"/debugstore", []string{"GET"}, http.StatusNoContent},
+				{"/loggers", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp", []string{"GET"}, http.StatusNoContent},
+				{"/loggers/some-exp/1", []string{"PUT"}, http.StatusNoContent},
+				{"/readiness", nil, http.StatusBadRequest},
+				{"/health", nil, http.StatusOK},
+				{"/metrics", nil, http.StatusOK},
+				{"/not_found", nil, http.StatusNotFound},
+
+				// routes from mountAPI
+				{"/", nil, http.StatusOK},
+				{"/robots.txt", nil, http.StatusOK},
+				{"/bytes", []string{"POST"}, http.StatusNoContent},
+				{"/bytes/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/chunks", []string{"POST"}, http.StatusNoContent},
+				{"/chunks/stream", nil, http.StatusBadRequest},
+				{"/chunks/{address}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/envelope/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/soc/{owner}/{id}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/feeds/{owner}/{topic}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/bzz", []string{"POST"}, http.StatusNoContent},
+				{"/grantee", []string{"POST"}, http.StatusNoContent},
+				{"/grantee/{address}", []string{"GET", "PATCH"}, http.StatusNoContent},
+				{"/bzz/{address}", []string{"GET"}, http.StatusNoContent},
+				{"/bzz/{address}/{path:.*}", []string{"GET", "HEAD"}, http.StatusNoContent},
+				{"/pss/send/{topic}/{targets}", []string{"POST"}, http.StatusNoContent},
+				{"/pss/subscribe/{topic}", nil, http.StatusBadRequest},
+				{"/tags", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/tags/{id}", []string{"GET", "DELETE", "PATCH"}, http.StatusNoContent},
+				{"/pins", []string{"GET"}, http.StatusNoContent},
+				{"/pins/check", []string{"GET"}, http.StatusNoContent},
+				{"/pins/{reference}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/stewardship/{address}", []string{"GET", "PUT"}, http.StatusNoContent},
+
+				// routes from mountBusinessDebug
+				{"/transactions", []string{"GET"}, http.StatusNoContent},
+				{"/transactions/{hash}", []string{"GET", "POST", "DELETE"}, http.StatusNoContent},
+				{"/peers", []string{"GET"}, http.StatusNoContent},
+				{"/pingpong/{address}", []string{"POST"}, http.StatusNoContent},
+				{"/reservestate", []string{"GET"}, http.StatusNoContent},
+				{"/connect/{multi-address:.+}", []string{"POST"}, http.StatusNoContent},
+				{"/blocklist", []string{"GET"}, http.StatusNoContent},
+				{"/peers/{address}", []string{"DELETE"}, http.StatusNoContent},
+				{"/topology", []string{"GET"}, http.StatusNoContent},
+				{"/welcome-message", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/balances", []string{"GET"}, http.StatusNoContent},
+				{"/balances/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/consumed", []string{"GET"}, http.StatusNoContent},
+				{"/consumed/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/timesettlements", []string{"GET"}, http.StatusNoContent},
+				{"/settlements", []string{"GET"}, http.StatusNoContent},
+				{"/settlements/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cheque/{peer}", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cheque", []string{"GET"}, http.StatusNoContent},
+				{"/chequebook/cashout/{peer}", []string{"GET", "POST"}, http.StatusNoContent},
+				{"/chequebook/balance", nil, http.StatusNotImplemented},
+				{"/chequebook/address", nil, http.StatusNotImplemented},
+				{"/chequebook/deposit", nil, http.StatusNotImplemented},
+				{"/chequebook/withdraw", nil, http.StatusNotImplemented},
+				{"/wallet", nil, http.StatusNotImplemented},
+				{"/wallet/withdraw/{coin}", nil, http.StatusNotImplemented},
+				{"/stamps", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{batch_id}/buckets", []string{"GET"}, http.StatusNoContent},
+				{"/stamps/{amount}/{depth}", []string{"POST"}, http.StatusNoContent},
+				{"/stamps/topup/{batch_id}/{amount}", []string{"PATCH"}, http.StatusNoContent},
+				{"/stamps/dilute/{batch_id}/{depth}", []string{"PATCH"}, http.StatusNoContent},
+				{"/batches", []string{"GET"}, http.StatusNoContent},
+				{"/accounting", []string{"GET"}, http.StatusNoContent},
+				{"/stake/withdrawable", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/stake/{amount}", []string{"POST"}, http.StatusNoContent},
+				{"/stake", []string{"GET", "DELETE"}, http.StatusNoContent},
+				{"/redistributionstate", []string{"GET"}, http.StatusNoContent},
+				{"/status", []string{"GET"}, http.StatusNoContent},
+				{"/status/peers", []string{"GET"}, http.StatusNoContent},
+				{"/status/neighborhoods", []string{"GET"}, http.StatusNoContent},
+				{"/rchash/{depth}/{anchor1}/{anchor2}", []string{"GET"}, http.StatusNoContent},
+			},
+		},
+	}
+
+	// Loop through each test case
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Initialize the test server with the current testServerOptions
+			testServer, _, _, _ := newTestServer(t, tc.serverOptions)
+
+			routeToName := func(route string) string {
+				if route == "/" {
+					return "root"
+				}
+				return strings.ReplaceAll(route, "/", "_")
+			}
+
+			for _, tt := range tc.expectedStatuses {
+				tt := tt
+				t.Run(tc.name+routeToName(tt.route), func(t *testing.T) {
+					resp := jsonhttptest.Request(t, testServer, http.MethodOptions, tt.route, tt.expectedStatus)
+
+					allowHeader := resp.Get("Allow")
+					actualMethods := strings.Split(allowHeader, ", ")
+
+					for _, expectedMethod := range tt.expectedMethods {
+						if !contains(actualMethods, expectedMethod) {
+							t.Errorf("expected method %s not found for route %s", expectedMethod, tt.route)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -407,6 +407,7 @@ func TestEndpointOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -406,13 +406,10 @@ func TestEndpointOptions(t *testing.T) {
 		},
 	}
 
-	// Loop through each test case
 	for _, tc := range testCases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Initialize the test server with the current testServerOptions
 			testServer, _, _, _ := newTestServer(t, tc.serverOptions)
 
 			routeToName := func(route string) string {
@@ -423,7 +420,6 @@ func TestEndpointOptions(t *testing.T) {
 			}
 
 			for _, tt := range tc.expectedStatuses {
-				tt := tt
 				t.Run(tc.name+routeToName(tt.route), func(t *testing.T) {
 					resp := jsonhttptest.Request(t, testServer, http.MethodOptions, tt.route, tt.expectedStatus)
 

--- a/pkg/jsonhttp/handlers.go
+++ b/pkg/jsonhttp/handlers.go
@@ -45,7 +45,6 @@ func HandleMethods(methods map[string]http.Handler, body string, contentType str
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	fmt.Fprintln(w, body)
-
 }
 
 func NotFoundHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -365,7 +365,8 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		WsPingPeriod:       60 * time.Second,
 	}, debugOpts, 1, erc20)
 
-	apiService.Mount(api.WithFullAPI())
+	apiService.Mount()
+	apiService.EnableFullAPI()
 	apiService.SetProbe(probe)
 	apiService.SetP2P(p2ps)
 	apiService.SetSwarmAddress(&swarmAddress)

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -137,7 +137,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		return nil, fmt.Errorf("blockchain address: %w", err)
 	}
 
-	var mockTransaction = transactionmock.New(transactionmock.WithPendingTransactionsFunc(func() ([]common.Hash, error) {
+	mockTransaction := transactionmock.New(transactionmock.WithPendingTransactionsFunc(func() ([]common.Hash, error) {
 		return []common.Hash{common.HexToHash("abcd")}, nil
 	}), transactionmock.WithResendTransactionFunc(func(ctx context.Context, txHash common.Hash) error {
 		return nil
@@ -303,13 +303,11 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		))
 	)
 
-	var (
-		// syncStatusFn mocks sync status because complete sync is required in order to curl certain apis e.g. /stamps.
-		// this allows accessing those apis by passing true to isDone in devNode.
-		syncStatusFn = func() (isDone bool, err error) {
-			return true, nil
-		}
-	)
+	// syncStatusFn mocks sync status because complete sync is required in order to curl certain apis e.g. /stamps.
+	// this allows accessing those apis by passing true to isDone in devNode.
+	syncStatusFn := func() (isDone bool, err error) {
+		return true, nil
+	}
 
 	mockFeeds := factory.New(localStore.Download(true))
 	mockResolver := resolverMock.NewResolver()
@@ -351,7 +349,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		SyncStatus:      syncStatusFn,
 	}
 
-	var erc20 = erc20mock.New(
+	erc20 := erc20mock.New(
 		erc20mock.WithBalanceOfFunc(func(ctx context.Context, address common.Address) (*big.Int, error) {
 			return big.NewInt(0), nil
 		}),
@@ -366,10 +364,9 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		CORSAllowedOrigins: o.CORSAllowedOrigins,
 		WsPingPeriod:       60 * time.Second,
 	}, debugOpts, 1, erc20)
-	apiService.MountTechnicalDebug()
-	apiService.MountDebug()
-	apiService.MountAPI()
 
+	apiService.MountAPI()
+	apiService.EnableFullAPIAvailability()
 	apiService.SetProbe(probe)
 	apiService.SetP2P(p2ps)
 	apiService.SetSwarmAddress(&swarmAddress)
@@ -444,7 +441,6 @@ func pong(_ context.Context, _ swarm.Address, _ ...string) (rtt time.Duration, e
 }
 
 func randomAddress() (swarm.Address, error) {
-
 	b := make([]byte, 32)
 
 	_, err := rand.Read(b)
@@ -453,5 +449,4 @@ func randomAddress() (swarm.Address, error) {
 	}
 
 	return swarm.NewAddress(b), nil
-
 }

--- a/pkg/node/devnode.go
+++ b/pkg/node/devnode.go
@@ -365,8 +365,7 @@ func NewDevBee(logger log.Logger, o *DevOptions) (b *DevBee, err error) {
 		WsPingPeriod:       60 * time.Second,
 	}, debugOpts, 1, erc20)
 
-	apiService.MountAPI()
-	apiService.EnableFullAPIAvailability()
+	apiService.Mount(api.WithFullAPI())
 	apiService.SetProbe(probe)
 	apiService.SetP2P(p2ps)
 	apiService.SetSwarmAddress(&swarmAddress)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -451,7 +451,7 @@ func NewBee(
 			stamperStore,
 		)
 
-		apiService.MountAPI()
+		apiService.Mount()
 		apiService.SetProbe(probe)
 
 		apiService.SetSwarmAddress(&swarmAddress)
@@ -1185,7 +1185,7 @@ func NewBee(
 			WsPingPeriod:       60 * time.Second,
 		}, extraOpts, chainID, erc20Service)
 
-		apiService.EnableFullAPIAvailability()
+		apiService.EnableFullAPI()
 
 		apiService.SetRedistributionAgent(agent)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -450,7 +450,8 @@ func NewBee(
 			o.CORSAllowedOrigins,
 			stamperStore,
 		)
-		apiService.MountTechnicalDebug()
+
+		apiService.MountAPI()
 		apiService.SetProbe(probe)
 
 		apiService.SetSwarmAddress(&swarmAddress)
@@ -1184,8 +1185,7 @@ func NewBee(
 			WsPingPeriod:       60 * time.Second,
 		}, extraOpts, chainID, erc20Service)
 
-		apiService.MountDebug()
-		apiService.MountAPI()
+		apiService.EnableFullAPIAvailability()
 
 		apiService.SetRedistributionAgent(agent)
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

This PR addresses issue #4734 by improving the behavior of the Bee API during the node initialization process. Previously, when the node was syncing batch data, the API appeared to be inaccessible, providing no indication of the ongoing sync process. Now, all routes are mounted immediately, but some may be temporarily disabled during initialization, returning appropriate status codes.

### Changes

- **503 Service Unavailable**: Routes that are disabled during the syncing phase now return a `503 Service Unavailable` status with the message:  
  *"Node is syncing. This endpoint is unavailable. Try again later."*  
  Once the syncing is complete, the routes will be enabled and respond normally.

- **501 Not Implemented**: If the `swapEnabled` or `chequebookEnabled` flags are set to `false`, routes that depend on these features will now return a `501 Not Implemented` status.

- **404 Not Found**: Any routes that do not exist will return a `404 Not Found` status.

### Open API Spec Version Changes (if applicable)

#### Motivation and Context (Optional)

This change improves the user experience by providing clear feedback during node initialization, preventing confusion when the API appears to be inaccessible. It ensures that users are informed about the node's state and can understand why certain API routes may not be available temporarily.

### How it works

- All routes are mounted immediately but may not be active depending on the node's state.
- Disabled routes return `503` until they are enabled once the sync is complete.
- Feature-dependent routes (like those for Swap and Chequebook) return `501` if the corresponding feature is disabled.
- Invalid or non-existent routes return a `404` as expected.

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/4734

### Screenshots (if appropriate):
