### PR TITLE
fix: salud self check

### DIFF
--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -220,12 +220,10 @@ func (s *service) salud(mode string, minPeersPerbin int, durPercentile float64, 
 		}
 	}
 
-	networkRadiusEstimation := s.reserve.StorageRadius() + s.capacityDoubling
-
 	selfHealth := true
-	if nHoodRadius == networkRadius && networkRadiusEstimation != networkRadius {
+	if nHoodRadius == networkRadius && s.reserve.StorageRadius() < networkRadius-1 {
 		selfHealth = false
-		s.logger.Warning("node is unhealthy due to storage radius discrepancy", "self_radius", networkRadiusEstimation, "network_radius", networkRadius)
+		s.logger.Warning("node is unhealthy due to storage radius discrepancy", "self_radius", s.reserve.StorageRadius(), "network_radius", networkRadius)
 	}
 
 	s.isSelfHealthy.Store(selfHealth)

--- a/pkg/salud/salud_test.go
+++ b/pkg/salud/salud_test.go
@@ -112,7 +112,7 @@ func TestSelfUnhealthyRadius(t *testing.T) {
 	topM := topMock.NewTopologyDriver(topMock.WithPeers(addrs...))
 
 	reserve := mockstorer.NewReserve(
-		mockstorer.WithRadius(7),
+		mockstorer.WithRadius(6),
 		mockstorer.WithReserveSize(100),
 	)
 
@@ -149,7 +149,7 @@ func TestSelfHealthyCapacityDoubling(t *testing.T) {
 	topM := topMock.NewTopologyDriver(topMock.WithPeers(addrs...))
 
 	reserve := mockstorer.NewReserve(
-		mockstorer.WithRadius(6),
+		mockstorer.WithRadius(7),
 		mockstorer.WithReserveSize(100),
 	)
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
mark self as unhealthy only if the local radius is below a certain threshold compared to the network radius.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
