### PR TITLE
fix: chunkstamp load with hash, replace to increase refCnt, new soc eviction unit test, index collision check changes

### DIFF
--- a/pkg/file/joiner/joiner_test.go
+++ b/pkg/file/joiner/joiner_test.go
@@ -1405,7 +1405,7 @@ func (c *chunkStore) Put(_ context.Context, ch swarm.Chunk) error {
 	return nil
 }
 
-func (c *chunkStore) Replace(_ context.Context, ch swarm.Chunk) error {
+func (c *chunkStore) Replace(_ context.Context, ch swarm.Chunk, emplace bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.chunks[ch.Address().ByteString()] = swarm.NewChunk(ch.Address(), ch.Data()).WithStamp(ch.Stamp())

--- a/pkg/storage/chunkstore.go
+++ b/pkg/storage/chunkstore.go
@@ -42,7 +42,7 @@ type Hasser interface {
 // Replacer is the interface that wraps the basic Replace method.
 type Replacer interface {
 	// Replace a chunk in the store.
-	Replace(context.Context, swarm.Chunk) error
+	Replace(context.Context, swarm.Chunk, bool) error
 }
 
 // PutterFunc type is an adapter to allow the use of

--- a/pkg/storage/inmemchunkstore/inmemchunkstore.go
+++ b/pkg/storage/inmemchunkstore/inmemchunkstore.go
@@ -77,13 +77,17 @@ func (c *ChunkStore) Delete(_ context.Context, addr swarm.Address) error {
 	return nil
 }
 
-func (c *ChunkStore) Replace(_ context.Context, ch swarm.Chunk) error {
+func (c *ChunkStore) Replace(_ context.Context, ch swarm.Chunk, emplace bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	chunkCount := c.chunks[ch.Address().ByteString()]
 	chunkCount.chunk = ch
+	if emplace {
+		chunkCount.count++
+	}
 	c.chunks[ch.Address().ByteString()] = chunkCount
+
 	return nil
 }
 

--- a/pkg/storer/internal/chunkstamp/chunkstamp_test.go
+++ b/pkg/storer/internal/chunkstamp/chunkstamp_test.go
@@ -185,10 +185,24 @@ func TestStoreLoadDelete(t *testing.T) {
 				}
 			})
 
-			t.Run("load stored chunk stamp with batch id", func(t *testing.T) {
+			t.Run("load stored chunk stamp with batch id and hash", func(t *testing.T) {
 				want := chunk.Stamp()
 
 				have, err := chunkstamp.LoadWithBatchID(ts.IndexStore(), ns, chunk.Address(), chunk.Stamp().BatchID())
+				if err != nil {
+					t.Fatalf("LoadWithBatchID(...): unexpected error: %v", err)
+				}
+
+				if diff := cmp.Diff(want, have, cmp.AllowUnexported(postage.Stamp{})); diff != "" {
+					t.Fatalf("LoadWithBatchID(...): mismatch (-want +have):\n%s", diff)
+				}
+
+				h, err := want.Hash()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				have, err = chunkstamp.LoadWithStampHash(ts.IndexStore(), ns, chunk.Address(), h)
 				if err != nil {
 					t.Fatalf("LoadWithBatchID(...): unexpected error: %v", err)
 				}

--- a/pkg/storer/internal/chunkstore/chunkstore.go
+++ b/pkg/storer/internal/chunkstore/chunkstore.go
@@ -94,7 +94,7 @@ func Put(ctx context.Context, s storage.IndexStore, sh storage.Sharky, ch swarm.
 	return s.Put(rIdx)
 }
 
-func Replace(ctx context.Context, s storage.IndexStore, sh storage.Sharky, ch swarm.Chunk) error {
+func Replace(ctx context.Context, s storage.IndexStore, sh storage.Sharky, ch swarm.Chunk, emplace bool) error {
 	rIdx := &RetrievalIndexItem{Address: ch.Address()}
 	err := s.Get(rIdx)
 	if err != nil {
@@ -112,6 +112,9 @@ func Replace(ctx context.Context, s storage.IndexStore, sh storage.Sharky, ch sw
 	}
 	rIdx.Location = loc
 	rIdx.Timestamp = uint64(time.Now().Unix())
+	if emplace {
+		rIdx.RefCnt++
+	}
 	return s.Put(rIdx)
 }
 

--- a/pkg/storer/internal/transaction/transaction.go
+++ b/pkg/storer/internal/transaction/transaction.go
@@ -242,11 +242,11 @@ func (c *chunkStoreTrx) Iterate(ctx context.Context, fn storage.IterateChunkFn) 
 	return chunkstore.Iterate(ctx, c.indexStore, c.sharkyTrx, fn)
 }
 
-func (c *chunkStoreTrx) Replace(ctx context.Context, ch swarm.Chunk) (err error) {
+func (c *chunkStoreTrx) Replace(ctx context.Context, ch swarm.Chunk, emplace bool) (err error) {
 	defer handleMetric("chunkstore_replace", c.metrics)(&err)
 	unlock := c.lock(ch.Address())
 	defer unlock()
-	return chunkstore.Replace(ctx, c.indexStore, c.sharkyTrx, ch)
+	return chunkstore.Replace(ctx, c.indexStore, c.sharkyTrx, ch, emplace)
 }
 
 func (c *chunkStoreTrx) lock(addr swarm.Address) func() {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
	
wrote a new reserve eviction test for SOCs.

fixed:
chunkstamp expects that the chunk address and batch id are unique entries
anywhere we use chunkstamp.LoadWithBatchID, we can't reliably tell it's the correct stamp
i wrote a unit test that uploads 10 gsoc chunks and the chunkstamp.LoadWithBatchID was an issue

the chunkstore.Replace is also supposed to increment the refCnt as each SOC creates a new reserve entry.

fixed index collision checks

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
