### PR TITLE
chore: bump handshake version and reset reserve epoch timestamp

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -30,7 +30,7 @@ const (
 	// ProtocolName is the text of the name of the handshake protocol.
 	ProtocolName = "handshake"
 	// ProtocolVersion is the current handshake protocol version.
-	ProtocolVersion = "12.0.0"
+	ProtocolVersion = "13.0.0"
 	// StreamName is the name of the stream used for handshake purposes.
 	StreamName = "handshake"
 	// MaxWelcomeMessageLength is maximum number of characters allowed in the welcome message.

--- a/pkg/storer/migration/all_steps.go
+++ b/pkg/storer/migration/all_steps.go
@@ -25,6 +25,7 @@ func AfterInitSteps(
 		4: step_04(sharkyPath, sharkyNoOfShards, st, logger),
 		5: step_05(st, logger),
 		6: step_06(st, logger),
+		7: resetReserveEpochTimestamp(st),
 	}
 }
 

--- a/pkg/storer/migration/export_test.go
+++ b/pkg/storer/migration/export_test.go
@@ -5,9 +5,10 @@
 package migration
 
 var (
-	Step_01 = step_01
-	Step_02 = step_02
-	Step_04 = step_04
-	Step_05 = step_05
-	Step_06 = step_06
+	Step_01             = step_01
+	Step_02             = step_02
+	Step_04             = step_04
+	Step_05             = step_05
+	Step_06             = step_06
+	ResetEpochTimestamp = resetReserveEpochTimestamp
 )

--- a/pkg/storer/migration/resetEpochTimestamp.go
+++ b/pkg/storer/migration/resetEpochTimestamp.go
@@ -1,0 +1,22 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package migration
+
+import (
+	"context"
+
+	"github.com/ethersphere/bee/v2/pkg/storer/internal/reserve"
+	"github.com/ethersphere/bee/v2/pkg/storer/internal/transaction"
+)
+
+// resetReserveEpochTimestamp is a migration that resets the epoch timestamp of the reserve
+// so that peers in the network can resync chunks.
+func resetReserveEpochTimestamp(st transaction.Storage) func() error {
+	return func() error {
+		return st.Run(context.Background(), func(s transaction.Store) error {
+			return s.IndexStore().Delete(&reserve.EpochItem{})
+		})
+	}
+}

--- a/pkg/storer/migration/resetEpochTimestamp_test.go
+++ b/pkg/storer/migration/resetEpochTimestamp_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package migration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/sharky"
+	"github.com/ethersphere/bee/v2/pkg/storage/inmemstore"
+	"github.com/ethersphere/bee/v2/pkg/storer/internal/reserve"
+	"github.com/ethersphere/bee/v2/pkg/storer/internal/transaction"
+	localmigration "github.com/ethersphere/bee/v2/pkg/storer/migration"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/ethersphere/bee/v2/pkg/util/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResetEpochTimestamp(t *testing.T) {
+	t.Parallel()
+
+	sharkyDir := t.TempDir()
+	sharkyStore, err := sharky.New(&dirFS{basedir: sharkyDir}, 1, swarm.SocMaxChunkSize)
+	assert.NoError(t, err)
+	store := inmemstore.New()
+	storage := transaction.NewStorage(sharkyStore, store)
+	testutil.CleanupCloser(t, storage)
+
+	err = storage.Run(context.Background(), func(s transaction.Store) error {
+		return s.IndexStore().Put(&reserve.EpochItem{Timestamp: uint64(time.Now().Second())})
+	})
+	require.NoError(t, err)
+
+	has, err := storage.IndexStore().Has(&reserve.EpochItem{})
+	require.NoError(t, err)
+	if !has {
+		t.Fatal("epoch item should exist")
+	}
+
+	err = localmigration.ResetEpochTimestamp(storage)()
+	require.NoError(t, err)
+
+	has, err = storage.IndexStore().Has(&reserve.EpochItem{})
+	require.NoError(t, err)
+	if has {
+		t.Fatal("epoch item should be deleted")
+	}
+}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Bumps the handshake version as there are new staking and redis contracts.
Resets the reserve epoch timestamp so that nodes can resync chunks (due to gsoc reserve rule changes).

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
