### PR TITLE
fix: save tags when using chunk/stream

### DIFF
--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/postage"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
-	storer "github.com/ethersphere/bee/v2/pkg/storer"
+	"github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/gorilla/websocket"
 )
@@ -56,7 +56,7 @@ func (s *Service) chunkUploadStreamHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	// if tag not specified use direct upload
-	putter, err := s.newStamperPutter(r.Context(), putterOptions{
+	putter, err := s.newStamperPutter(context.Background(), putterOptions{
 		BatchID:  headers.BatchID,
 		TagID:    tag,
 		Deferred: tag != 0,

--- a/pkg/api/chunk_stream.go
+++ b/pkg/api/chunk_stream.go
@@ -56,6 +56,7 @@ func (s *Service) chunkUploadStreamHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	// if tag not specified use direct upload
+	// Using context.Background here because the putter's lifetime extends beyond that of the HTTP request.
 	putter, err := s.newStamperPutter(context.Background(), putterOptions{
 		BatchID:  headers.BatchID,
 		TagID:    tag,


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

Do not use HTTP request context so that tags will be saved when `putter.Done` is called after the HTTP connection is upgraded to websocket.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
closes #4858

### Screenshots (if appropriate):
