### PR TITLE
fix: do not init chequebook in ultra light mode

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -492,19 +492,19 @@ func NewBee(
 		}
 	}
 
-	chequebookFactory, err = InitChequebookFactory(logger, chainBackend, chainID, transactionService, o.SwapFactoryAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	erc20Address, err := chequebookFactory.ERC20Address(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("factory fail: %w", err)
-	}
-
-	erc20Service = erc20.New(transactionService, erc20Address)
-
 	if o.SwapEnable {
+		chequebookFactory, err = InitChequebookFactory(logger, chainBackend, chainID, transactionService, o.SwapFactoryAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		erc20Address, err := chequebookFactory.ERC20Address(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("factory fail: %w", err)
+		}
+
+		erc20Service = erc20.New(transactionService, erc20Address)
+
 		if o.ChequebookEnable && chainEnabled {
 			chequebookService, err = InitChequebookService(
 				ctx,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

I checked the `/wallet` endpoint that was also changed in [the relevant commit](https://github.com/ethersphere/bee/commit/1f0c3f6747b2f3fb9ed89727c06158dae99eb92d#diff-515b2d0691202c4ea5e578ec896258ae9c440c381b608ed1eb7116a27847057d):

```
curl http://localhost:1633/wallet
{"code":501,"message":"Chequebook is disabled. This endpoint is unavailable."}
```

This is in ultra-light mode. Seems OK.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/4937

### Screenshots (if appropriate):
