### PR TITLE
fix: stewardship with erasure encoding

### DIFF
--- a/pkg/file/joiner/joiner.go
+++ b/pkg/file/joiner/joiner.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy/getter"
 	"github.com/ethersphere/bee/v2/pkg/replicas"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"golang.org/x/sync/errgroup"
 )
@@ -408,9 +408,9 @@ func (j *joiner) processChunkAddresses(ctx context.Context, fn swarm.AddressIter
 			}
 
 			// not a shard
-			if i >= shardCnt {
-				return nil
-			}
+			//if i >= shardCnt {
+			//	return nil
+			//}
 
 			ch, err := g.Get(ectx, addr)
 			if err != nil {

--- a/pkg/file/joiner/joiner.go
+++ b/pkg/file/joiner/joiner.go
@@ -408,9 +408,9 @@ func (j *joiner) processChunkAddresses(ctx context.Context, fn swarm.AddressIter
 			}
 
 			// not a shard
-			//if i >= shardCnt {
-			//	return nil
-			//}
+			if i >= shardCnt {
+				return nil
+			}
 
 			ch, err := g.Get(ectx, addr)
 			if err != nil {

--- a/pkg/file/joiner/joiner.go
+++ b/pkg/file/joiner/joiner.go
@@ -406,6 +406,12 @@ func (j *joiner) processChunkAddresses(ctx context.Context, fn swarm.AddressIter
 			if j.refLength == encryption.ReferenceSize && i < shardCnt {
 				addr = swarm.NewAddress(data[cursor : cursor+swarm.HashSize*2])
 			}
+
+			// not a shard
+			if i >= shardCnt {
+				return nil
+			}
+
 			ch, err := g.Get(ectx, addr)
 			if err != nil {
 				return err


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

When iterating over chunks, parity chunks were incorrectly attempted to be fetched from the redundancy getter, which only supports shards.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
closes #4948

### Screenshots (if appropriate):
