### PR TITLE
fix(api): resolve header overwriting and delimiter issue in Access-Control-Expose-Headers

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -98,13 +98,14 @@ const (
 	GasLimitHeader  = "Gas-Limit"
 	ETagHeader      = "ETag"
 
-	AuthorizationHeader      = "Authorization"
-	AcceptEncodingHeader     = "Accept-Encoding"
-	ContentTypeHeader        = "Content-Type"
-	ContentDispositionHeader = "Content-Disposition"
-	ContentLengthHeader      = "Content-Length"
-	RangeHeader              = "Range"
-	OriginHeader             = "Origin"
+	AuthorizationHeader        = "Authorization"
+	AcceptEncodingHeader       = "Accept-Encoding"
+	ContentTypeHeader          = "Content-Type"
+	ContentDispositionHeader   = "Content-Disposition"
+	ContentLengthHeader        = "Content-Length"
+	RangeHeader                = "Range"
+	OriginHeader               = "Origin"
+	AccessControlExposeHeaders = "Access-Control-Expose-Headers"
 )
 
 const (

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -292,23 +291,6 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 	}
 
 	return httpClient, conn, ts.Listener.Addr().String(), chanStore
-}
-
-func request(t *testing.T, client *http.Client, method, resource string, body io.Reader, responseCode int) *http.Response {
-	t.Helper()
-
-	req, err := http.NewRequestWithContext(context.TODO(), method, resource, body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != responseCode {
-		t.Fatalf("got response status %s, want %v %s", resp.Status, responseCode, http.StatusText(responseCode))
-	}
-	return resp
 }
 
 func pipelineFactory(s storage.Putter, encrypt bool, rLevel redundancy.Level) func() pipeline.Interface {

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -155,7 +155,7 @@ func (s *Service) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	span.LogFields(olog.Bool("success", true))
 
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
+	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
 	jsonhttp.Created(w, bytesPostResponse{
 		Reference: encryptedReference,
 	})
@@ -210,7 +210,7 @@ func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Add("Access-Control-Expose-Headers", "Accept-Ranges, Content-Encoding")
+	w.Header().Add(AccessControlExposeHeaders, "Accept-Ranges, Content-Encoding")
 	w.Header().Add(ContentTypeHeader, "application/octet-stream")
 	var span int64
 

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -113,6 +113,8 @@ func TestBytes(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodGet, resource+"/"+expHash, http.StatusOK,
 			jsonhttptest.WithExpectedContentLength(len(content)),
 			jsonhttptest.WithExpectedResponse(content),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 		)
 	})
 

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -304,7 +304,7 @@ func (s *Service) fileUploadHandler(
 		span.SetTag("tagID", tagID)
 	}
 	w.Header().Set(ETagHeader, fmt.Sprintf("%q", reference.String()))
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
+	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
 
 	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: reference,
@@ -451,7 +451,7 @@ FETCH:
 			// we should implement an append functionality for this specific header,
 			// since different parts of handlers might be overriding others' values
 			// resulting in inconsistent headers in the response.
-			w.Header().Set("Access-Control-Expose-Headers", SwarmFeedIndexHeader)
+			w.Header().Set(AccessControlExposeHeaders, SwarmFeedIndexHeader)
 			goto FETCH
 		}
 	}
@@ -623,7 +623,7 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 		w.Header().Set(ETagHeader, fmt.Sprintf("%q", reference))
 	}
 	w.Header().Set(ContentLengthHeader, strconv.FormatInt(l, 10))
-	w.Header().Add("Access-Control-Expose-Headers", ContentDispositionHeader)
+	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
 	if headersOnly {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -412,7 +412,7 @@ FETCH:
 	// go on normally.
 	if !feedDereferenced {
 		if l, err := s.manifestFeed(ctx, m); err == nil {
-			//we have a feed manifest here
+			// we have a feed manifest here
 			ch, cur, _, err := l.At(ctx, time.Now().Unix(), 0)
 			if err != nil {
 				logger.Debug("bzz download: feed lookup failed", "error", err)
@@ -551,8 +551,7 @@ func (s *Service) serveManifestEntry(
 	mtdt := manifestEntry.Metadata()
 	if fname, ok := mtdt[manifest.EntryMetadataFilenameKey]; ok {
 		fname = filepath.Base(fname) // only keep the file name
-		additionalHeaders[ContentDispositionHeader] =
-			[]string{fmt.Sprintf("inline; filename=\"%s\"", fname)}
+		additionalHeaders[ContentDispositionHeader] = []string{fmt.Sprintf("inline; filename=\"%s\"", fname)}
 	}
 	if mimeType, ok := mtdt[manifest.EntryMetadataContentTypeKey]; ok {
 		additionalHeaders[ContentTypeHeader] = []string{mimeType}
@@ -616,13 +615,15 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 
 	// include additional headers
 	for name, values := range additionalHeaders {
-		w.Header().Set(name, strings.Join(values, "; "))
+		for _, value := range values {
+			w.Header().Add(name, value)
+		}
 	}
 	if etag {
 		w.Header().Set(ETagHeader, fmt.Sprintf("%q", reference))
 	}
 	w.Header().Set(ContentLengthHeader, strconv.FormatInt(l, 10))
-	w.Header().Set("Access-Control-Expose-Headers", ContentDispositionHeader)
+	w.Header().Add("Access-Control-Expose-Headers", ContentDispositionHeader)
 
 	if headersOnly {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -551,7 +551,7 @@ func (s *Service) serveManifestEntry(
 	mtdt := manifestEntry.Metadata()
 	if fname, ok := mtdt[manifest.EntryMetadataFilenameKey]; ok {
 		fname = filepath.Base(fname) // only keep the file name
-		additionalHeaders[ContentDispositionHeader] = []string{fmt.Sprintf("inline; filename=\"%s\"", fname)}
+		additionalHeaders[ContentDispositionHeader] = []string{fmt.Sprintf("inline; filename=\"%s\"", escapeQuotes(fname))}
 	}
 	if mimeType, ok := mtdt[manifest.EntryMetadataContentTypeKey]; ok {
 		additionalHeaders[ContentTypeHeader] = []string{mimeType}

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -1091,24 +1091,54 @@ func TestDirectUploadBzz(t *testing.T) {
 	)
 }
 
-// TODO
-// func TestBzzDownloadHeaders(t *testing.T) {
-// 	mockStorer := mockstorer.New()
-// 	testServer, _, _, _ := newTestServer(t, testServerOptions{
-// 		Storer: mockStorer,
-// 	})
+func TestBzzDownloadHeaders(t *testing.T) {
+	t.Parallel()
+	t.Run("bzzDownloadHandler", func(t *testing.T) {
+		var (
+			data                = []byte("<h1>Swarm Hello World!</h1>")
+			logger              = log.Noop
+			storer              = mockstorer.New()
+			testServer, _, _, _ = newTestServer(t, testServerOptions{
+				Storer: storer,
+				Logger: logger,
+				Post:   mockpost.New(mockpost.WithAcceptAll()),
+			})
+		)
+		// tar all the test case files
+		tarReader := tarFiles(t, []f{
+			{
+				data:     data,
+				name:     "\"index.html\"",
+				dir:      "",
+				filePath: "./index.html",
+			},
+		})
 
-// 	t.Run("bzzDownloadHandler", func(t *testing.T) {
-// 		address := swarm.MustParseHexAddress("7f34a413c060ee777996bce734eaad7a76923fcfa222bf8eab9871812c8ed6a1")
+		var resp api.BzzUploadResponse
 
-// 		value := []byte("data data data")
-// 		if err := mockStorer.Cache().Put(context.Background(), swarm.NewChunk(address, value)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		options := []jsonhttptest.Option{
+			jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
+			jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
+			jsonhttptest.WithRequestBody(tarReader),
+			jsonhttptest.WithRequestHeader(api.ContentTypeHeader, api.ContentTypeTar),
+			jsonhttptest.WithRequestHeader(api.SwarmCollectionHeader, "True"),
+			jsonhttptest.WithUnmarshalJSONResponse(&resp),
+			jsonhttptest.WithRequestHeader(api.SwarmIndexDocumentHeader, "index.html"),
+		}
 
-// 		jsonhttptest.Request(t, testServer, http.MethodGet, "/bzz/"+address.String(), http.StatusOK,
-// 			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
-// 			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
-// 		)
-// 	})
-// }
+		// verify directory tar upload response
+		jsonhttptest.Request(t, testServer, http.MethodPost, "/bzz", http.StatusCreated, options...)
+
+		if resp.Reference.String() == "" {
+			t.Fatalf("expected file reference, did not got any")
+		}
+
+		jsonhttptest.Request(t, testServer, http.MethodGet, "/bzz/"+resp.Reference.String(), http.StatusOK,
+			jsonhttptest.WithExpectedResponse(data),
+			jsonhttptest.WithExpectedContentLength(len(data)),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentDispositionHeader, `inline; filename="index.html"`),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "text/html; charset=utf-8"),
+		)
+	})
+}

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -1090,3 +1090,25 @@ func TestDirectUploadBzz(t *testing.T) {
 		}),
 	)
 }
+
+// TODO
+// func TestBzzDownloadHeaders(t *testing.T) {
+// 	mockStorer := mockstorer.New()
+// 	testServer, _, _, _ := newTestServer(t, testServerOptions{
+// 		Storer: mockStorer,
+// 	})
+
+// 	t.Run("bzzDownloadHandler", func(t *testing.T) {
+// 		address := swarm.MustParseHexAddress("7f34a413c060ee777996bce734eaad7a76923fcfa222bf8eab9871812c8ed6a1")
+
+// 		value := []byte("data data data")
+// 		if err := mockStorer.Cache().Put(context.Background(), swarm.NewChunk(address, value)); err != nil {
+// 			t.Fatal(err)
+// 		}
+
+// 		jsonhttptest.Request(t, testServer, http.MethodGet, "/bzz/"+address.String(), http.StatusOK,
+// 			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+// 			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
+// 		)
+// 	})
+// }

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -841,6 +841,10 @@ func TestFeedIndirection(t *testing.T) {
 	jsonhttptest.Request(t, client, http.MethodGet, bzzDownloadResource(manifRef.String(), ""), http.StatusOK,
 		jsonhttptest.WithExpectedResponse(updateData),
 		jsonhttptest.WithExpectedContentLength(len(updateData)),
+		jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+		jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+		jsonhttptest.WithExpectedResponseHeader(api.ContentDispositionHeader, `inline; filename="index.html"`),
+		jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "text/html; charset=utf-8"),
 	)
 }
 

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -216,7 +216,7 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(SwarmTagHeader, fmt.Sprint(tag))
 	}
 
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
+	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
 	jsonhttp.Created(w, chunkAddressResponse{Reference: reference})
 }
 

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -134,7 +134,7 @@ func (s *Service) dirUploadHandler(
 		w.Header().Set(SwarmTagHeader, fmt.Sprint(tag))
 		span.LogFields(olog.Bool("success", true))
 	}
-	w.Header().Set("Access-Control-Expose-Headers", SwarmTagHeader)
+	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
 	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: encryptedReference,
 	})
@@ -153,7 +153,6 @@ func storeDir(
 	errorFilename string,
 	rLevel redundancy.Level,
 ) (swarm.Address, error) {
-
 	logger := tracing.NewLoggerWithTraceID(ctx, log)
 	loggerV1 := logger.V(1).Build()
 

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -134,18 +133,20 @@ func (s *Service) feedGetHandler(w http.ResponseWriter, r *http.Request) {
 	sig := socCh.Signature()
 
 	additionalHeaders := http.Header{
-		ContentTypeHeader:               {"application/octet-stream"},
-		SwarmFeedIndexHeader:            {hex.EncodeToString(curBytes)},
-		SwarmFeedIndexNextHeader:        {hex.EncodeToString(nextBytes)},
-		SwarmSocSignatureHeader:         {hex.EncodeToString(sig)},
-		"Access-Control-Expose-Headers": {SwarmFeedIndexHeader, SwarmFeedIndexNextHeader, SwarmSocSignatureHeader},
+		ContentTypeHeader:          {"application/octet-stream"},
+		SwarmFeedIndexHeader:       {hex.EncodeToString(curBytes)},
+		SwarmFeedIndexNextHeader:   {hex.EncodeToString(nextBytes)},
+		SwarmSocSignatureHeader:    {hex.EncodeToString(sig)},
+		AccessControlExposeHeaders: {SwarmFeedIndexHeader, SwarmFeedIndexNextHeader, SwarmSocSignatureHeader},
 	}
 
 	if headers.OnlyRootChunk {
 		w.Header().Set(ContentLengthHeader, strconv.Itoa(len(wc.Data())))
 		// include additional headers
 		for name, values := range additionalHeaders {
-			w.Header().Set(name, strings.Join(values, ", "))
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
 		}
 		_, _ = io.Copy(w, bytes.NewReader(wc.Data()))
 		return

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -77,6 +77,11 @@ func TestFeed_Get(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodGet, feedResource(ownerString, "aabbcc", "12"), http.StatusOK,
 			jsonhttptest.WithExpectedResponse(mockWrappedCh.Data()[swarm.SpanSize:]),
 			jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmSocSignatureHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 		)
 	})
 
@@ -100,6 +105,11 @@ func TestFeed_Get(t *testing.T) {
 			jsonhttptest.WithExpectedResponse(mockWrappedCh.Data()[swarm.SpanSize:]),
 			jsonhttptest.WithExpectedContentLength(len(mockWrappedCh.Data()[swarm.SpanSize:])),
 			jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmSocSignatureHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 		)
 	})
 
@@ -124,6 +134,11 @@ func TestFeed_Get(t *testing.T) {
 			jsonhttptest.WithExpectedResponse(testData),
 			jsonhttptest.WithExpectedContentLength(len(testData)),
 			jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmSocSignatureHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+			jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 		)
 	})
 
@@ -181,6 +196,11 @@ func TestFeed_Get(t *testing.T) {
 				jsonhttptest.WithExpectedResponse(testData),
 				jsonhttptest.WithExpectedContentLength(testDataLen),
 				jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmSocSignatureHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.ContentDispositionHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 			)
 		})
 
@@ -190,6 +210,10 @@ func TestFeed_Get(t *testing.T) {
 				jsonhttptest.WithExpectedResponse(testRootCh.Data()),
 				jsonhttptest.WithExpectedContentLength(len(testRootCh.Data())),
 				jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmSocSignatureHeader),
+				jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
 			)
 		})
 	})
@@ -267,7 +291,6 @@ func TestFeed_Post(t *testing.T) {
 			)
 		})
 	})
-
 }
 
 // TestDirectUploadFeed tests that the direct upload endpoint give correct error message in dev mode

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/ethersphere/bee/v2/pkg/accesscontrol"
 	"github.com/ethersphere/bee/v2/pkg/cac"
@@ -257,16 +256,18 @@ func (s *Service) socGetHandler(w http.ResponseWriter, r *http.Request) {
 	wc := socCh.WrappedChunk()
 
 	additionalHeaders := http.Header{
-		ContentTypeHeader:               {"application/octet-stream"},
-		SwarmSocSignatureHeader:         {hex.EncodeToString(sig)},
-		"Access-Control-Expose-Headers": {SwarmSocSignatureHeader},
+		ContentTypeHeader:          {"application/octet-stream"},
+		SwarmSocSignatureHeader:    {hex.EncodeToString(sig)},
+		AccessControlExposeHeaders: {SwarmSocSignatureHeader},
 	}
 
 	if headers.OnlyRootChunk {
 		w.Header().Set(ContentLengthHeader, strconv.Itoa(len(wc.Data())))
 		// include additional headers
 		for name, values := range additionalHeaders {
-			w.Header().Set(name, strings.Join(values, ", "))
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
 		}
 		_, _ = io.Copy(w, bytes.NewReader(wc.Data()))
 		return

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -347,3 +347,9 @@ func flattenValue(val reflect.Value) reflect.Value {
 	}
 	return val
 }
+
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+func escapeQuotes(s string) string {
+	return quoteEscaper.Replace(s)
+}


### PR DESCRIPTION
…response header

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

- Replaced w.Header().Set with w.Header().Add to append headers rather than overwrite them.
- Corrected delimiter for Access-Control-Expose-Headers from `;` to `,` as per MDN documentation.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)

- Browser behavior: The semicolon delimiter (;) was causing issues, particularly in Chromium-based browsers. This was corrected by switching to a comma (,) delimiter for separating multiple header values.
- Header overwriting: The use of w.Header().Set was causing overwriting of Access-Control-Expose-Headers. Replacing it with w.Header().Add ensures headers are appended, resolving inconsistencies in the response headers.

### Related Issue (Optional)

[[2.4.0] Access-Control-Expose-Headers is overridden, breaking browser Swarm apps #4959](https://github.com/ethersphere/bee/issues/4959)

### Screenshots (if appropriate):
