### PR TITLE
fix(cmd): set sepolia block-time to 12s

### DIFF
--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -475,7 +475,7 @@ func getConfigByNetworkID(networkID uint64, defaultBlockTimeInSeconds uint64) *n
 		config.chainID = chaincfg.Testnet.ChainID
 	case chaincfg.Testnet.NetworkID:
 		config.bootNodes = []string{"/dnsaddr/testnet.ethswarm.org"}
-		config.blockTime = 15 * time.Second
+		config.blockTime = 12 * time.Second
 		config.chainID = chaincfg.Testnet.ChainID
 	default: // Will use the value provided by the chain.
 		config.chainID = -1


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The block time for the testnet (Sepolia) has been updated to 12 seconds.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
Sepolia's block time was previously 15 seconds but has since been changed to 12 seconds. The current implementation still reflects the outdated 15-second value. This update ensures that the correct 12-second block time is used going forward.

### Related Issue (Optional)
[Update Sepolia Testnet Block Time to 12 Seconds #4968
](https://github.com/ethersphere/bee/issues/4968)

### Screenshots (if appropriate):
