### PR TITLE
fix(api): return empty array for pins instead of null

### DIFF
--- a/pkg/api/pin_test.go
+++ b/pkg/api/pin_test.go
@@ -100,6 +100,16 @@ func TestPinHandlers(t *testing.T) {
 		checkPinHandlers(t, client, rootHash, true)
 	})
 
+	t.Run("no pins", func(t *testing.T) {
+		jsonhttptest.Request(t, client, http.MethodGet, "/pins", http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(struct {
+				References []swarm.Address `json:"references"`
+			}{
+				References: make([]swarm.Address, 0),
+			}),
+		)
+	})
+
 	t.Run("bytes missing", func(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodPost, "/pins/"+swarm.RandAddress(t).String(), http.StatusNotFound)
 	})

--- a/pkg/storer/internal/pinning/pinning.go
+++ b/pkg/storer/internal/pinning/pinning.go
@@ -86,7 +86,6 @@ type collectionPutter struct {
 // Put adds a chunk to the pin collection.
 // The user of the putter MUST mutex lock the call to prevent data-races across multiple upload sessions.
 func (c *collectionPutter) Put(ctx context.Context, st transaction.Store, ch swarm.Chunk) error {
-
 	// do not allow any Puts after putter was closed
 	if c.closed {
 		return errPutterAlreadyClosed
@@ -129,7 +128,6 @@ func (c *collectionPutter) Close(st storage.IndexStore, root swarm.Address) erro
 
 	collection := &pinCollectionItem{Addr: root}
 	has, err := st.Has(collection)
-
 	if err != nil {
 		return fmt.Errorf("pin store: check previous root: %w", err)
 	}
@@ -176,7 +174,6 @@ func (c *collectionPutter) Cleanup(st transaction.Storage) error {
 
 // CleanupDirty will iterate over all the dirty collections and delete them.
 func CleanupDirty(st transaction.Storage) error {
-
 	dirtyCollections := make([]*dirtyCollection, 0)
 	err := st.IndexStore().Iterate(
 		storage.Query{
@@ -212,7 +209,7 @@ func HasPin(st storage.Reader, root swarm.Address) (bool, error) {
 
 // Pins lists all the added pinning collections.
 func Pins(st storage.Reader) ([]swarm.Address, error) {
-	var pins []swarm.Address
+	pins := make([]swarm.Address, 0)
 	err := st.Iterate(storage.Query{
 		Factory:      func() storage.Item { return new(pinCollectionItem) },
 		ItemProperty: storage.QueryItemID,
@@ -258,7 +255,6 @@ func deleteCollectionChunks(ctx context.Context, st transaction.Storage, collect
 					)
 				})
 			})
-
 		}(item)
 	}
 

--- a/pkg/storer/internal/pinning/pinning_test.go
+++ b/pkg/storer/internal/pinning/pinning_test.go
@@ -359,6 +359,20 @@ func TestPinStore(t *testing.T) {
 			t.Fatalf("unexpected error on close, want: %v, got: %v", pinstore.ErrCollectionRootAddressIsZero, err)
 		}
 	})
+
+	t.Run("have 0 pins", func(t *testing.T) {
+		pins, err := pinstore.Pins(internal.NewInmemStorage().IndexStore())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pins) != 0 {
+			t.Fatalf("expected 0 pins, found %d", len(pins))
+		}
+
+		if pins == nil {
+			t.Fatal("pins is nil")
+		}
+	})
 }
 
 func TestCleanup(t *testing.T) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Ensures that `GET /pins` endpoint will now return empty array (`{"references":[]}`) instead of null (`{"references":null}`).

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
This change is important for consistency in API responses across different endpoints, ensuring that all endpoints return empty arrays instead of null when there are no items.

### Related Issue (Optional)
[GET /pins should return empty array instead of null when there are no items #4964](https://github.com/ethersphere/bee/issues/4964)

### Screenshots (if appropriate):
