### PR TITLE
fix:  set level in ctx

### DIFF
--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -110,7 +110,7 @@ func splitRefs(cmd *cobra.Command) {
 			defer writer.Close()
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(rLevel))
+			ctx := redundancy.SetLevelInContext(cmd.Context(), redundancy.Level(rLevel))
 			rootRef, err := p(ctx, reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)
@@ -201,7 +201,7 @@ func splitChunks(cmd *cobra.Command) {
 			})
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(rLevel))
+			ctx := redundancy.SetLevelInContext(cmd.Context(), redundancy.Level(rLevel))
 			rootRef, err := p(ctx, reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)

--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -110,7 +110,8 @@ func splitRefs(cmd *cobra.Command) {
 			defer writer.Close()
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			rootRef, err := p(context.Background(), reader)
+			ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(rLevel))
+			rootRef, err := p(ctx, reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)
 			}
@@ -200,7 +201,8 @@ func splitChunks(cmd *cobra.Command) {
 			})
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			rootRef, err := p(context.Background(), reader)
+			ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(rLevel))
+			rootRef, err := p(ctx, reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)
 			}

--- a/cmd/bee/cmd/split_test.go
+++ b/cmd/bee/cmd/split_test.go
@@ -100,7 +100,8 @@ func TestDBSplitChunks(t *testing.T) {
 	// split the file manually and compare output with the split commands output.
 	putter := &putter{chunks: make(map[string]swarm.Chunk)}
 	p := requestPipelineFn(putter, false, redundancy.Level(3))
-	_, err = p(context.Background(), bytes.NewReader(buf))
+	ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(3))
+	_, err = p(ctx, bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Sets the right redundancy level in context so the redundancy getter can use the correct r-level instead of defaulting to PARANDOID.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
