### PR TITLE
fix(api): replace ethereum with chain_address in /addresses response

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -29,6 +29,8 @@ components:
             $ref: "#/components/schemas/P2PUnderlay"
         ethereum:
           $ref: "#/components/schemas/EthereumAddress"
+        chain_address:
+          $ref: "#/components/schemas/EthereumAddress"
         publicKey:
           $ref: "#/components/schemas/PublicKey"
         pssPublicKey:

--- a/pkg/api/p2p.go
+++ b/pkg/api/p2p.go
@@ -18,7 +18,8 @@ import (
 type addressesResponse struct {
 	Overlay      *swarm.Address        `json:"overlay"`
 	Underlay     []multiaddr.Multiaddr `json:"underlay"`
-	Ethereum     common.Address        `json:"ethereum"`
+	Ethereum     common.Address        `json:"ethereum"` // deprecated
+	ChainAddress common.Address        `json:"chain_address"`
 	PublicKey    string                `json:"publicKey"`
 	PSSPublicKey string                `json:"pssPublicKey"`
 }
@@ -43,6 +44,7 @@ func (s *Service) addressesHandler(w http.ResponseWriter, _ *http.Request) {
 		Overlay:      s.overlay,
 		Underlay:     underlay,
 		Ethereum:     s.ethereumAddress,
+		ChainAddress: s.ethereumAddress,
 		PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.publicKey)),
 		PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&s.pssPublicKey)),
 	})

--- a/pkg/api/p2p_test.go
+++ b/pkg/api/p2p_test.go
@@ -57,6 +57,7 @@ func TestAddresses(t *testing.T) {
 				Overlay:      &overlay,
 				Underlay:     addresses,
 				Ethereum:     ethereumAddress,
+				ChainAddress: ethereumAddress,
 				PublicKey:    hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&privateKey.PublicKey)),
 				PSSPublicKey: hex.EncodeToString(crypto.EncodeSecp256k1PublicKey(&pssPrivateKey.PublicKey)),
 			}),


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR will add `chain_address` to `/addresses` response. The idea is to deprecate `ethereum` field in response of that endpoint.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
