### PR TITLE
fix(openapi): correct response type for PATCH /tags/{uid}

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -658,7 +658,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "SwarmCommon.yaml#/components/schemas/HealthStatus"
+                $ref: "SwarmCommon.yaml#/components/schemas/Response"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
         "500":


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Update OpenAPI to use the correct response for `PATCH /tags/{uid}`

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
[OpenAPI PATCH /tags/{uid} wrong response type #4976](https://github.com/ethersphere/bee/issues/4976)

### Screenshots (if appropriate):
