### PR TITLE
refactor: set level in ctx

### DIFF
--- a/cmd/bee/cmd/split.go
+++ b/cmd/bee/cmd/split.go
@@ -110,8 +110,7 @@ func splitRefs(cmd *cobra.Command) {
 			defer writer.Close()
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			ctx := redundancy.SetLevelInContext(cmd.Context(), redundancy.Level(rLevel))
-			rootRef, err := p(ctx, reader)
+			rootRef, err := p(cmd.Context(), reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)
 			}
@@ -201,8 +200,7 @@ func splitChunks(cmd *cobra.Command) {
 			})
 
 			p := requestPipelineFn(store, false, redundancy.Level(rLevel))
-			ctx := redundancy.SetLevelInContext(cmd.Context(), redundancy.Level(rLevel))
-			rootRef, err := p(ctx, reader)
+			rootRef, err := p(cmd.Context(), reader)
 			if err != nil {
 				return fmt.Errorf("pipeline: %w", err)
 			}

--- a/cmd/bee/cmd/split_test.go
+++ b/cmd/bee/cmd/split_test.go
@@ -100,8 +100,7 @@ func TestDBSplitChunks(t *testing.T) {
 	// split the file manually and compare output with the split commands output.
 	putter := &putter{chunks: make(map[string]swarm.Chunk)}
 	p := requestPipelineFn(putter, false, redundancy.Level(3))
-	ctx := redundancy.SetLevelInContext(context.Background(), redundancy.Level(3))
-	_, err = p(ctx, bytes.NewReader(buf))
+	_, err = p(context.Background(), bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/accesscontrol/controller_test.go
+++ b/pkg/accesscontrol/controller_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ethersphere/bee/v2/pkg/accesscontrol"
 	"github.com/ethersphere/bee/v2/pkg/accesscontrol/kvs"
-	encryption "github.com/ethersphere/bee/v2/pkg/encryption"
+	"github.com/ethersphere/bee/v2/pkg/encryption"
 	"github.com/ethersphere/bee/v2/pkg/file"
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
@@ -182,7 +182,7 @@ func TestController_UpdateHandler(t *testing.T) {
 	assertNoError(t, "Session key", err)
 	refCipher := encryption.New(keys[0], 0, 0, sha3.NewLegacyKeccak256)
 	ls := createLs()
-	gls := loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), true, redundancy.NONE))
+	gls := loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), true, redundancy.NONE), redundancy.DefaultLevel)
 	c := accesscontrol.NewController(al)
 	href, err := getHistoryFixture(t, ctx, ls, al, &publisher.PublicKey)
 	assertNoError(t, "history fixture create", err)
@@ -307,7 +307,7 @@ func TestController_Get(t *testing.T) {
 	al1 := accesscontrol.NewLogic(diffieHellman1)
 	al2 := accesscontrol.NewLogic(diffieHellman2)
 	ls := createLs()
-	gls := loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), true, redundancy.NONE))
+	gls := loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), true, redundancy.NONE), redundancy.DefaultLevel)
 	c1 := accesscontrol.NewController(al1)
 	c2 := accesscontrol.NewController(al2)
 

--- a/pkg/accesscontrol/grantee_test.go
+++ b/pkg/accesscontrol/grantee_test.go
@@ -32,7 +32,7 @@ func requestPipelineFactory(ctx context.Context, s storage.Putter, encrypt bool,
 }
 
 func createLs() file.LoadSaver {
-	return loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), false, redundancy.NONE))
+	return loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), false, redundancy.NONE), redundancy.DefaultLevel)
 }
 
 func generateKeyListFixture() ([]*ecdsa.PublicKey, error) {

--- a/pkg/accesscontrol/history_test.go
+++ b/pkg/accesscontrol/history_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline/builder"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/storage"
 	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -37,7 +38,7 @@ func TestSingleNodeHistoryLookup(t *testing.T) {
 	t.Parallel()
 	storer := mockstorer.New()
 	ctx := context.Background()
-	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false))
+	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false), redundancy.DefaultLevel)
 
 	h, err := accesscontrol.NewHistory(ls)
 	assertNoError(t, "create history", err)
@@ -61,7 +62,7 @@ func TestMultiNodeHistoryLookup(t *testing.T) {
 	t.Parallel()
 	storer := mockstorer.New()
 	ctx := context.Background()
-	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false))
+	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false), redundancy.DefaultLevel)
 
 	h, err := accesscontrol.NewHistory(ls)
 	assertNoError(t, "create history", err)
@@ -133,7 +134,7 @@ func TestHistoryStore(t *testing.T) {
 	t.Parallel()
 	storer := mockstorer.New()
 	ctx := context.Background()
-	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false))
+	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false), redundancy.DefaultLevel)
 
 	h1, err := accesscontrol.NewHistory(ls)
 	assertNoError(t, "create history", err)

--- a/pkg/accesscontrol/kvs/kvs_test.go
+++ b/pkg/accesscontrol/kvs/kvs_test.go
@@ -31,7 +31,7 @@ func requestPipelineFactory(ctx context.Context, s storage.Putter, encrypt bool,
 }
 
 func createLs() file.LoadSaver {
-	return loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), false, redundancy.NONE))
+	return loadsave.New(mockStorer.ChunkStore(), mockStorer.Cache(), requestPipelineFactory(context.Background(), mockStorer.Cache(), false, redundancy.NONE), redundancy.DefaultLevel)
 }
 
 func keyValuePair(t *testing.T) ([]byte, []byte) {

--- a/pkg/accesscontrol/mock/controller.go
+++ b/pkg/accesscontrol/mock/controller.go
@@ -55,7 +55,7 @@ func New(o ...Option) accesscontrol.Controller {
 		refMap:     make(map[string]swarm.Address),
 		publisher:  "",
 		encrypter:  encryption.New(encryption.Key("b6ee086390c280eeb9824c331a4427596f0c8510d5564bc1b6168d0059a46e2b"), 0, 0, sha3.NewLegacyKeccak256),
-		ls:         loadsave.New(storer.ChunkStore(), storer.Cache(), requestPipelineFactory(context.Background(), storer.Cache(), false, redundancy.NONE)),
+		ls:         loadsave.New(storer.ChunkStore(), storer.Cache(), requestPipelineFactory(context.Background(), storer.Cache(), false, redundancy.NONE), redundancy.DefaultLevel),
 	}
 	for _, v := range o {
 		v.apply(m)

--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -126,7 +126,7 @@ func (s *Service) actDecryptionHandler() func(h http.Handler) http.Handler {
 				cache = *headers.Cache
 			}
 			ctx := r.Context()
-			ls := loadsave.NewReadonly(s.storer.Download(cache))
+			ls := loadsave.NewReadonly(s.storer.Download(cache), redundancy.DefaultLevel)
 			reference, err := s.accesscontrol.DownloadHandler(ctx, ls, paths.Address, headers.Publisher, *headers.HistoryAddress, timestamp)
 			if err != nil {
 				logger.Debug("access control download failed", "error", err)
@@ -160,7 +160,7 @@ func (s *Service) actEncryptionHandler(
 	historyRootHash swarm.Address,
 ) (swarm.Address, error) {
 	publisherPublicKey := &s.publicKey
-	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE))
+	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE), redundancy.DefaultLevel)
 	storageReference, historyReference, encryptedReference, err := s.accesscontrol.UploadHandler(ctx, ls, reference, publisherPublicKey, historyRootHash)
 	if err != nil {
 		return swarm.ZeroAddress, err
@@ -206,7 +206,7 @@ func (s *Service) actListGranteesHandler(w http.ResponseWriter, r *http.Request)
 		cache = *headers.Cache
 	}
 	publisher := &s.publicKey
-	ls := loadsave.NewReadonly(s.storer.Download(cache))
+	ls := loadsave.NewReadonly(s.storer.Download(cache), redundancy.DefaultLevel)
 	grantees, err := s.accesscontrol.Get(r.Context(), ls, publisher, paths.GranteesAddress)
 	if err != nil {
 		logger.Debug("could not get grantees", "error", err)
@@ -346,8 +346,8 @@ func (s *Service) actGrantRevokeHandler(w http.ResponseWriter, r *http.Request) 
 
 	granteeref := paths.GranteesAddress
 	publisher := &s.publicKey
-	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE))
-	gls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, granteeListEncrypt, redundancy.NONE))
+	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE), redundancy.DefaultLevel)
+	gls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, granteeListEncrypt, redundancy.NONE), redundancy.DefaultLevel)
 	granteeref, encryptedglref, historyref, actref, err := s.accesscontrol.UpdateHandler(ctx, ls, gls, granteeref, historyAddress, publisher, grantees.Addlist, grantees.Revokelist)
 	if err != nil {
 		logger.Debug("failed to update grantee list", "error", err)
@@ -500,8 +500,8 @@ func (s *Service) actCreateGranteesHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	publisher := &s.publicKey
-	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE))
-	gls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, granteeListEncrypt, redundancy.NONE))
+	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, false, redundancy.NONE), redundancy.DefaultLevel)
+	gls := loadsave.New(s.storer.Download(true), s.storer.Cache(), requestPipelineFactory(ctx, putter, granteeListEncrypt, redundancy.NONE), redundancy.DefaultLevel)
 	granteeref, encryptedglref, historyref, actref, err := s.accesscontrol.UpdateHandler(ctx, ls, gls, swarm.ZeroAddress, historyAddress, publisher, list, nil)
 	if err != nil {
 		logger.Debug("failed to create grantee list", "error", err)

--- a/pkg/api/accesscontrol_test.go
+++ b/pkg/api/accesscontrol_test.go
@@ -35,7 +35,7 @@ import (
 //nolint:ireturn
 func prepareHistoryFixture(storer api.Storer) (accesscontrol.History, swarm.Address) {
 	ctx := context.Background()
-	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false, redundancy.NONE))
+	ls := loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false, redundancy.NONE), redundancy.DefaultLevel)
 
 	h, _ := accesscontrol.NewHistory(ls)
 

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -54,8 +54,6 @@ func (s *Service) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 		deferred = defaultUploadMethod(headers.Deferred)
 	)
 
-	ctx = redundancy.SetLevelInContext(ctx, headers.RLevel)
-
 	if deferred || headers.Pin {
 		tag, err = s.getOrCreateSessionID(headers.SwarmTag)
 		if err != nil {

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -818,7 +818,7 @@ func TestFeedIndirection(t *testing.T) {
 		t.Fatal(err)
 	}
 	m, err := manifest.NewDefaultManifest(
-		loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false, 0)),
+		loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false, 0), redundancy.DefaultLevel),
 		false,
 	)
 	if err != nil {

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -25,8 +25,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/manifest"
 	"github.com/ethersphere/bee/v2/pkg/postage"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
-	storer "github.com/ethersphere/bee/v2/pkg/storer"
+	"github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/tracing"
 	"github.com/opentracing/opentracing-go"
@@ -157,7 +157,7 @@ func storeDir(
 	loggerV1 := logger.V(1).Build()
 
 	p := requestPipelineFn(putter, encrypt, rLevel)
-	ls := loadsave.New(getter, putter, requestPipelineFactory(ctx, putter, encrypt, rLevel))
+	ls := loadsave.New(getter, putter, requestPipelineFactory(ctx, putter, encrypt, rLevel), rLevel)
 
 	dirManifest, err := manifest.NewDefaultManifest(ls, encrypt)
 	if err != nil {

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ethersphere/bee/v2/pkg/api"
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/v2/pkg/manifest"
@@ -282,7 +283,7 @@ func TestDirs(t *testing.T) {
 			// verify manifest content
 			verifyManifest, err := manifest.NewDefaultManifestReference(
 				resp.Reference,
-				loadsave.NewReadonly(storer.ChunkStore()),
+				loadsave.NewReadonly(storer.ChunkStore(), redundancy.DefaultLevel),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/accesscontrol"
 	"github.com/ethersphere/bee/v2/pkg/feeds"
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/manifest"
 	"github.com/ethersphere/bee/v2/pkg/manifest/mantaray"
@@ -229,7 +230,7 @@ func (s *Service) feedPostHandler(w http.ResponseWriter, r *http.Request) {
 		logger:         logger,
 	}
 
-	l := loadsave.New(s.storer.ChunkStore(), s.storer.Cache(), requestPipelineFactory(r.Context(), putter, false, 0))
+	l := loadsave.New(s.storer.ChunkStore(), s.storer.Cache(), requestPipelineFactory(r.Context(), putter, false, 0), redundancy.DefaultLevel)
 	feedManifest, err := manifest.NewDefaultManifest(l, false)
 	if err != nil {
 		logger.Debug("create manifest failed", "error", err)

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/api"
 	"github.com/ethersphere/bee/v2/pkg/feeds"
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/file/splitter"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
@@ -245,7 +246,7 @@ func TestFeed_Post(t *testing.T) {
 			}),
 		)
 
-		ls := loadsave.NewReadonly(mockStorer.ChunkStore())
+		ls := loadsave.NewReadonly(mockStorer.ChunkStore(), redundancy.DefaultLevel)
 		i, err := manifest.NewMantarayManifestReference(expReference, ls)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/api/pin.go
+++ b/pkg/api/pin.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/storage"
-	storer "github.com/ethersphere/bee/v2/pkg/storer"
+	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/traversal"
 	"github.com/gorilla/mux"
@@ -52,7 +53,7 @@ func (s *Service) pinRootHash(w http.ResponseWriter, r *http.Request) {
 	}
 
 	getter := s.storer.Download(true)
-	traverser := traversal.New(getter, s.storer.Cache(), 0)
+	traverser := traversal.New(getter, s.storer.Cache(), redundancy.DefaultLevel)
 
 	sem := semaphore.NewWeighted(100)
 	var errTraverse error

--- a/pkg/api/pin.go
+++ b/pkg/api/pin.go
@@ -52,7 +52,7 @@ func (s *Service) pinRootHash(w http.ResponseWriter, r *http.Request) {
 	}
 
 	getter := s.storer.Download(true)
-	traverser := traversal.New(getter, s.storer.Cache())
+	traverser := traversal.New(getter, s.storer.Cache(), 0)
 
 	sem := semaphore.NewWeighted(100)
 	var errTraverse error

--- a/pkg/file/addresses/addresses_getter_test.go
+++ b/pkg/file/addresses/addresses_getter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file"
 	"github.com/ethersphere/bee/v2/pkg/file/addresses"
 	"github.com/ethersphere/bee/v2/pkg/file/joiner"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	filetest "github.com/ethersphere/bee/v2/pkg/file/testing"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -63,7 +64,7 @@ func TestAddressesGetterIterateChunkAddresses(t *testing.T) {
 
 	addressesGetter := addresses.NewGetter(store, addressIterFunc)
 
-	j, _, err := joiner.New(ctx, addressesGetter, store, rootChunk.Address())
+	j, _, err := joiner.New(ctx, addressesGetter, store, rootChunk.Address(), redundancy.DefaultLevel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file"
 	"github.com/ethersphere/bee/v2/pkg/file/joiner"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline/builder"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	test "github.com/ethersphere/bee/v2/pkg/file/testing"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -62,7 +63,7 @@ func testSplitThenJoin(t *testing.T) {
 	}
 
 	// then join
-	r, l, err := joiner.New(ctx, store, store, resultAddress, 0)
+	r, l, err := joiner.New(ctx, store, store, resultAddress, redundancy.DefaultLevel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -62,7 +62,7 @@ func testSplitThenJoin(t *testing.T) {
 	}
 
 	// then join
-	r, l, err := joiner.New(ctx, store, store, resultAddress)
+	r, l, err := joiner.New(ctx, store, store, resultAddress, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/file/io.go
+++ b/pkg/file/io.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"io"
 
 	"github.com/ethersphere/bee/v2/pkg/swarm"

--- a/pkg/file/joiner/joiner.go
+++ b/pkg/file/joiner/joiner.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy/getter"
 	"github.com/ethersphere/bee/v2/pkg/replicas"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"golang.org/x/sync/errgroup"
 )
@@ -104,9 +104,8 @@ func (g *decoderCache) GetOrCreate(addrs []swarm.Address, shardCnt int) storage.
 }
 
 // New creates a new Joiner. A Joiner provides Read, Seek and Size functionalities.
-func New(ctx context.Context, g storage.Getter, putter storage.Putter, address swarm.Address) (file.Joiner, int64, error) {
+func New(ctx context.Context, g storage.Getter, putter storage.Putter, address swarm.Address, rLevel redundancy.Level) (file.Joiner, int64, error) {
 	// retrieve the root chunk to read the total data length the be retrieved
-	rLevel := redundancy.GetLevelFromContext(ctx)
 	rootChunkGetter := store.New(g)
 	if rLevel != redundancy.NONE {
 		rootChunkGetter = store.New(replicas.NewGetter(g, rLevel))

--- a/pkg/file/loadsave/loadsave_test.go
+++ b/pkg/file/loadsave/loadsave_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline/builder"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 )
@@ -28,7 +29,7 @@ func TestLoadSave(t *testing.T) {
 	t.Parallel()
 
 	store := inmemchunkstore.New()
-	ls := loadsave.New(store, store, pipelineFn(store))
+	ls := loadsave.New(store, store, pipelineFn(store), redundancy.DefaultLevel)
 	ref, err := ls.Save(context.Background(), data)
 
 	if err != nil {
@@ -51,7 +52,7 @@ func TestReadonlyLoadSave(t *testing.T) {
 
 	store := inmemchunkstore.New()
 	factory := pipelineFn(store)
-	ls := loadsave.NewReadonly(store)
+	ls := loadsave.NewReadonly(store, redundancy.DefaultLevel)
 	_, err := ls.Save(context.Background(), data)
 	if !errors.Is(err, loadsave.ErrReadonlyLoadSave) {
 		t.Fatal("expected error but got none")

--- a/pkg/file/pipeline/hashtrie/hashtrie.go
+++ b/pkg/file/pipeline/hashtrie/hashtrie.go
@@ -39,13 +39,7 @@ type hashTrieWriter struct {
 	replicaPutter          storage.Putter // putter to save dispersed replicas of the root chunk
 }
 
-func NewHashTrieWriter(
-	ctx context.Context,
-	refLen int,
-	rParams redundancy.RedundancyParams,
-	pipelineFn pipeline.PipelineFunc,
-	replicaPutter storage.Putter,
-) pipeline.ChainWriter {
+func NewHashTrieWriter(ctx context.Context, refLen int, rParams redundancy.RedundancyParams, pipelineFn pipeline.PipelineFunc, replicaPutter storage.Putter, rLevel redundancy.Level, ) pipeline.ChainWriter {
 	h := &hashTrieWriter{
 		ctx:                    ctx,
 		refSize:                refLen,
@@ -56,7 +50,7 @@ func NewHashTrieWriter(
 		chunkCounters:          make([]uint8, 9),
 		effectiveChunkCounters: make([]uint8, 9),
 		maxChildrenChunks:      uint8(rParams.MaxShards() + rParams.Parities(rParams.MaxShards())),
-		replicaPutter:          replicas.NewPutter(replicaPutter),
+		replicaPutter:          replicas.NewPutter(replicaPutter, rLevel),
 	}
 	h.parityChunkFn = func(level int, span, address []byte) error {
 		return h.writeToIntermediateLevel(level, true, span, address, []byte{})

--- a/pkg/file/pipeline/hashtrie/hashtrie.go
+++ b/pkg/file/pipeline/hashtrie/hashtrie.go
@@ -39,7 +39,7 @@ type hashTrieWriter struct {
 	replicaPutter          storage.Putter // putter to save dispersed replicas of the root chunk
 }
 
-func NewHashTrieWriter(ctx context.Context, refLen int, rParams redundancy.RedundancyParams, pipelineFn pipeline.PipelineFunc, replicaPutter storage.Putter, rLevel redundancy.Level, ) pipeline.ChainWriter {
+func NewHashTrieWriter(ctx context.Context, refLen int, rParams redundancy.RedundancyParams, pipelineFn pipeline.PipelineFunc, replicaPutter storage.Putter, rLevel redundancy.Level) pipeline.ChainWriter {
 	h := &hashTrieWriter{
 		ctx:                    ctx,
 		refSize:                refLen,

--- a/pkg/file/pipeline/hashtrie/hashtrie_test.go
+++ b/pkg/file/pipeline/hashtrie/hashtrie_test.go
@@ -194,7 +194,7 @@ func TestLevels_TrieFull(t *testing.T) {
 			Params: *r,
 		}
 
-		ht = hashtrie.NewHashTrieWriter(ctx, hashSize, rMock, pf, s, 0)
+		ht = hashtrie.NewHashTrieWriter(ctx, hashSize, rMock, pf, s, redundancy.DefaultLevel)
 	)
 
 	// to create a level wrap we need to do branching^(level-1) writes

--- a/pkg/file/redundancy/level.go
+++ b/pkg/file/redundancy/level.go
@@ -5,7 +5,6 @@
 package redundancy
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -165,18 +164,5 @@ func GetReplicaCounts() [5]int {
 // we use an approximation as the successive powers of 2
 var replicaCounts = [5]int{0, 2, 4, 8, 16}
 
-type levelKey struct{}
-
-// SetLevelInContext sets the redundancy level in the context
-func SetLevelInContext(ctx context.Context, level Level) context.Context {
-	return context.WithValue(ctx, levelKey{}, level)
-}
-
-// GetLevelFromContext is a helper function to extract the redundancy level from the context
-func GetLevelFromContext(ctx context.Context) Level {
-	rlevel := PARANOID
-	if val := ctx.Value(levelKey{}); val != nil {
-		rlevel = val.(Level)
-	}
-	return rlevel
-}
+// DefaultLevel is the default redundancy level
+const DefaultLevel = PARANOID

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file"
 	"github.com/ethersphere/bee/v2/pkg/file/joiner"
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/hive"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/manifest"
@@ -35,7 +36,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/settlement/pseudosettle"
 	"github.com/ethersphere/bee/v2/pkg/spinlock"
 	"github.com/ethersphere/bee/v2/pkg/storage"
-	storer "github.com/ethersphere/bee/v2/pkg/storer"
+	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/topology"
 	"github.com/ethersphere/bee/v2/pkg/topology/kademlia"
@@ -279,7 +280,7 @@ func getLatestSnapshot(
 	st storage.Getter,
 	address swarm.Address,
 ) (swarm.Chunk, error) {
-	ls := loadsave.NewReadonly(st)
+	ls := loadsave.NewReadonly(st, redundancy.DefaultLevel)
 	feedFactory := factory.New(st)
 
 	m, err := manifest.NewDefaultManifestReference(

--- a/pkg/replicas/putter_test.go
+++ b/pkg/replicas/putter_test.go
@@ -75,15 +75,13 @@ func TestPutter(t *testing.T) {
 				t.Fatal(err)
 			}
 			ctx := context.Background()
-			ctx = redundancy.SetLevelInContext(ctx, tc.level)
-
 			ch, err := cac.New(buf)
 			if err != nil {
 				t.Fatal(err)
 			}
 			store := inmemchunkstore.New()
 			defer store.Close()
-			p := replicas.NewPutter(store)
+			p := replicas.NewPutter(store, tc.level)
 
 			// original chunk
 			if err := store.Put(ctx, ch); err != nil {
@@ -178,14 +176,13 @@ func TestPutter(t *testing.T) {
 				ctx := context.Background()
 				ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 				defer cancel()
-				ctx = redundancy.SetLevelInContext(ctx, tc.level)
 				ch, err := cac.New(buf)
 				if err != nil {
 					t.Fatal(err)
 				}
 				store := inmemchunkstore.New()
 				defer store.Close()
-				p := replicas.NewPutter(tc.f(&testBasePutter{store: store}))
+				p := replicas.NewPutter(tc.f(&testBasePutter{store: store}), tc.level)
 				errs := p.Put(ctx, ch)
 				for _, err := range tc.err {
 					if !errors.Is(errs, err) {

--- a/pkg/steward/steward.go
+++ b/pkg/steward/steward.go
@@ -40,8 +40,8 @@ type steward struct {
 func New(ns storer.NetStore, r retrieval.Interface, joinerPutter storage.Putter) Interface {
 	return &steward{
 		netStore:     ns,
-		traverser:    traversal.New(ns.Download(true), joinerPutter),
-		netTraverser: traversal.New(&netGetter{r}, joinerPutter),
+		traverser:    traversal.New(ns.Download(true), joinerPutter, 0),
+		netTraverser: traversal.New(&netGetter{r}, joinerPutter, 0),
 		netGetter:    r,
 	}
 }

--- a/pkg/steward/steward.go
+++ b/pkg/steward/steward.go
@@ -11,10 +11,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/postage"
 	"github.com/ethersphere/bee/v2/pkg/retrieval"
 	"github.com/ethersphere/bee/v2/pkg/storage"
-	storer "github.com/ethersphere/bee/v2/pkg/storer"
+	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/topology"
 	"github.com/ethersphere/bee/v2/pkg/traversal"
@@ -40,8 +41,8 @@ type steward struct {
 func New(ns storer.NetStore, r retrieval.Interface, joinerPutter storage.Putter) Interface {
 	return &steward{
 		netStore:     ns,
-		traverser:    traversal.New(ns.Download(true), joinerPutter, 0),
-		netTraverser: traversal.New(&netGetter{r}, joinerPutter, 0),
+		traverser:    traversal.New(ns.Download(true), joinerPutter, redundancy.DefaultLevel),
+		netTraverser: traversal.New(&netGetter{r}, joinerPutter, redundancy.DefaultLevel),
 		netGetter:    r,
 	}
 }

--- a/pkg/steward/steward_test.go
+++ b/pkg/steward/steward_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	postagetesting "github.com/ethersphere/bee/v2/pkg/postage/mock"
 	"github.com/ethersphere/bee/v2/pkg/steward"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -48,8 +48,6 @@ func TestSteward(t *testing.T) {
 		s              = steward.New(store, localRetrieval, inmem)
 		stamper        = postagetesting.NewStamper()
 	)
-	ctx = redundancy.SetLevelInContext(ctx, redundancy.NONE)
-
 	n, err := rand.Read(data)
 	if n != cap(data) {
 		t.Fatal("short read")
@@ -58,7 +56,7 @@ func TestSteward(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pipe := builder.NewPipelineBuilder(ctx, chunkStore, false, 0)
+	pipe := builder.NewPipelineBuilder(ctx, chunkStore, false, redundancy.NONE)
 	addr, err := builder.FeedPipeline(ctx, pipe, bytes.NewReader(data))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/steward/steward_test.go
+++ b/pkg/steward/steward_test.go
@@ -125,6 +125,11 @@ type localRetriever struct {
 }
 
 func (lr *localRetriever) RetrieveChunk(ctx context.Context, addr, sourceAddr swarm.Address) (chunk swarm.Chunk, err error) {
+	ch, err := lr.Get(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+
 	lr.mu.Lock()
 	defer lr.mu.Unlock()
 
@@ -132,5 +137,5 @@ func (lr *localRetriever) RetrieveChunk(ctx context.Context, addr, sourceAddr sw
 		lr.retrievedChunks = make(map[string]struct{})
 	}
 	lr.retrievedChunks[addr.String()] = struct{}{}
-	return lr.Get(ctx, addr)
+	return ch, nil
 }

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -167,7 +167,7 @@ func TestTraversalBytes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, redundancy.DefaultLevel).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -293,7 +293,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, redundancy.DefaultLevel).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -450,7 +450,7 @@ func TestTraversalManifest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, redundancy.DefaultLevel).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -17,9 +17,10 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline"
 	"github.com/ethersphere/bee/v2/pkg/file/pipeline/builder"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/manifest"
 	testingsoc "github.com/ethersphere/bee/v2/pkg/soc/testing"
-	storage "github.com/ethersphere/bee/v2/pkg/storage"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/traversal"
@@ -166,7 +167,7 @@ func TestTraversalBytes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -260,7 +261,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ls := loadsave.New(storerMock, storerMock, pipelineFactory(storerMock, false))
+			ls := loadsave.New(storerMock, storerMock, pipelineFactory(storerMock, false), redundancy.DefaultLevel)
 			fManifest, err := manifest.NewDefaultManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -292,7 +293,7 @@ func TestTraversalFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -418,7 +419,7 @@ func TestTraversalManifest(t *testing.T) {
 			}
 			wantHashes = append(wantHashes, tc.manifestHashes...)
 
-			ls := loadsave.New(storerMock, storerMock, pipelineFactory(storerMock, false))
+			ls := loadsave.New(storerMock, storerMock, pipelineFactory(storerMock, false), redundancy.DefaultLevel)
 			dirManifest, err := manifest.NewMantarayManifest(ls, false)
 			if err != nil {
 				t.Fatal(err)
@@ -449,7 +450,7 @@ func TestTraversalManifest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = traversal.New(storerMock, storerMock).Traverse(ctx, address, iter.Next)
+			err = traversal.New(storerMock, storerMock, 0).Traverse(ctx, address, iter.Next)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -487,7 +488,7 @@ func TestTraversalSOC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = traversal.New(store, store).Traverse(ctx, sch.Address(), iter.Next)
+	err = traversal.New(store, store, 0).Traverse(ctx, sch.Address(), iter.Next)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Pass r-level to required methods via function arg instead of using ctx.
This allows us to be more consistent and less prone to omitting  the `setLevelInContext` call

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
