### PR TITLE
Add bee-get-addr script to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /home/bee/.bee && chown 999:999 /home/bee/.bee
 
 COPY --from=build /src/dist/bee /usr/local/bin/bee
+COPY --from=build /src/packaging/bee-get-addr /usr/local/bin/bee-get-addr
 
 EXPOSE 1633 1634
 USER bee


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

The current docker image only contains the `bee` executable. This PR adds `bee-get-addr` too.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)

When debugging problems in the docker image, it is convenient to have this command to find your Bee node’s Ethereum address.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
