### PR TITLE
fix: rename BEE_RESERVE_CAPACITY_DOUBLING variable using underscores

### DIFF
--- a/packaging/docker/env
+++ b/packaging/docker/env
@@ -80,7 +80,7 @@
 ## minimum radius storage threshold
 # BEE_MINIMUM_STORAGE_RADIUS=
 ## reserve capacity doubling (default 0, maximum 1)
-# BEE_RESERVE-CAPACITY-DOUBLING=0
+# BEE_RESERVE_CAPACITY_DOUBLING=0
 ## allow to advertise private CIDRs to the public network
 # BEE_ALLOW_PRIVATE_CIDRS=false
 ## enable forwarded content caching


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

This environment variable is incorrect, as they must use underscores.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)

According to the [documentation](https://docs.ethswarm.org/docs/bee/working-with-bee/configuration/#environment-variables):

> All available configuration options are available as BEE prefixed, capitalised, and underscored environment variables, e.g. --api-addr becomes BEE_API_ADDR.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
