### PR TITLE
fix(openapi): leave only one tag for /gsoc/subscribe/{address}

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -839,8 +839,6 @@ paths:
       summary: Subscribe to GSOC payloads
       tags:
         - GSOC
-        - Subscribe
-        - Websocket
       parameters:
         - in: path
           name: reference


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR will remove 2 tags from OpenAPI `/gsoc/subscribe/{address}` endpoint, and use only one. 
This will enable to show this endpoint only once.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
[GSOC is triplicated in Bee API sidebar #4967](https://github.com/ethersphere/bee/issues/4967)

### Screenshots (if appropriate):
