### PR TITLE
fix: provide putter to loadsave

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -126,7 +126,7 @@ func (s *Service) actDecryptionHandler() func(h http.Handler) http.Handler {
 				cache = *headers.Cache
 			}
 			ctx := r.Context()
-			ls := loadsave.NewReadonly(s.storer.Download(cache), redundancy.DefaultLevel)
+			ls := loadsave.NewReadonly(s.storer.Download(cache), s.storer.Cache(), redundancy.DefaultLevel)
 			reference, err := s.accesscontrol.DownloadHandler(ctx, ls, paths.Address, headers.Publisher, *headers.HistoryAddress, timestamp)
 			if err != nil {
 				logger.Debug("access control download failed", "error", err)
@@ -206,7 +206,7 @@ func (s *Service) actListGranteesHandler(w http.ResponseWriter, r *http.Request)
 		cache = *headers.Cache
 	}
 	publisher := &s.publicKey
-	ls := loadsave.NewReadonly(s.storer.Download(cache), redundancy.DefaultLevel)
+	ls := loadsave.NewReadonly(s.storer.Download(cache), s.storer.Cache(), redundancy.DefaultLevel)
 	grantees, err := s.accesscontrol.Get(r.Context(), ls, publisher, paths.GranteesAddress)
 	if err != nil {
 		logger.Debug("could not get grantees", "error", err)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -382,10 +382,10 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 		rLevel = *headers.RLevel
 	}
 
-	ls := loadsave.NewReadonly(s.storer.Download(cache), rLevel)
+	ctx := r.Context()
+	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), nil, redundancy.DefaultLevel)
 	feedDereferenced := false
 
-	ctx := r.Context()
 	ctx, err := getter.SetConfigInContext(ctx, headers.Strategy, headers.FallbackMode, headers.ChunkRetrievalTimeout, logger)
 	if err != nil {
 		logger.Error(err, err.Error())

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -383,7 +383,7 @@ func (s *Service) serveReference(logger log.Logger, address swarm.Address, pathV
 	}
 
 	ctx := r.Context()
-	ls := loadsave.New(s.storer.Download(true), s.storer.Cache(), nil, redundancy.DefaultLevel)
+	ls := loadsave.NewReadonly(s.storer.Download(cache), s.storer.Cache(), redundancy.DefaultLevel)
 	feedDereferenced := false
 
 	ctx, err := getter.SetConfigInContext(ctx, headers.Strategy, headers.FallbackMode, headers.ChunkRetrievalTimeout, logger)
@@ -435,7 +435,7 @@ FETCH:
 			}
 			address = wc.Address()
 			// modify ls and init with non-existing wrapped chunk
-			ls = loadsave.NewReadonlyWithRootCh(s.storer.Download(cache), wc, rLevel)
+			ls = loadsave.NewReadonlyWithRootCh(s.storer.Download(cache), s.storer.Cache(), wc, rLevel)
 
 			feedDereferenced = true
 			curBytes, err := cur.MarshalBinary()

--- a/pkg/api/dirs_test.go
+++ b/pkg/api/dirs_test.go
@@ -283,7 +283,7 @@ func TestDirs(t *testing.T) {
 			// verify manifest content
 			verifyManifest, err := manifest.NewDefaultManifestReference(
 				resp.Reference,
-				loadsave.NewReadonly(storer.ChunkStore(), redundancy.DefaultLevel),
+				loadsave.NewReadonly(storer.ChunkStore(), storer.Cache(), redundancy.DefaultLevel),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -246,7 +246,7 @@ func TestFeed_Post(t *testing.T) {
 			}),
 		)
 
-		ls := loadsave.NewReadonly(mockStorer.ChunkStore(), redundancy.DefaultLevel)
+		ls := loadsave.NewReadonly(mockStorer.ChunkStore(), mockStorer.Cache(), redundancy.DefaultLevel)
 		i, err := manifest.NewMantarayManifestReference(expReference, ls)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/file/loadsave/loadsave.go
+++ b/pkg/file/loadsave/loadsave.go
@@ -46,18 +46,20 @@ func New(getter storage.Getter, putter storage.Putter, pipelineFn func() pipelin
 
 // NewReadonly returns a new read-only load-saver
 // which will error on write.
-func NewReadonly(getter storage.Getter, rLevel redundancy.Level) file.LoadSaver {
+func NewReadonly(getter storage.Getter, putter storage.Putter, rLevel redundancy.Level) file.LoadSaver {
 	return &loadSave{
 		getter: getter,
+		putter: putter,
 		rLevel: rLevel,
 	}
 }
 
 // NewReadonlyWithRootCh returns a new read-only load-saver
 // which will error on write.
-func NewReadonlyWithRootCh(getter storage.Getter, rootCh swarm.Chunk, rLevel redundancy.Level) file.LoadSaver {
+func NewReadonlyWithRootCh(getter storage.Getter, putter storage.Putter, rootCh swarm.Chunk, rLevel redundancy.Level) file.LoadSaver {
 	return &loadSave{
 		getter: getter,
+		putter: putter,
 		rootCh: rootCh,
 		rLevel: rLevel,
 	}

--- a/pkg/file/loadsave/loadsave_test.go
+++ b/pkg/file/loadsave/loadsave_test.go
@@ -52,7 +52,7 @@ func TestReadonlyLoadSave(t *testing.T) {
 
 	store := inmemchunkstore.New()
 	factory := pipelineFn(store)
-	ls := loadsave.NewReadonly(store, redundancy.DefaultLevel)
+	ls := loadsave.NewReadonly(store, store, redundancy.DefaultLevel)
 	_, err := ls.Save(context.Background(), data)
 	if !errors.Is(err, loadsave.ErrReadonlyLoadSave) {
 		t.Fatal("expected error but got none")

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -211,7 +211,7 @@ func bootstrapNode(
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		snapshotRootCh, err = getLatestSnapshot(ctx, localStore.Download(true), snapshotFeed)
+		snapshotRootCh, err = getLatestSnapshot(ctx, localStore.Download(true), localStore.Cache(), snapshotFeed)
 		if err != nil {
 			logger.Warning("bootstrap: fetching snapshot failed", "error", err)
 			continue
@@ -278,9 +278,10 @@ func waitPeers(kad *kademlia.Kad) error {
 func getLatestSnapshot(
 	ctx context.Context,
 	st storage.Getter,
+	putter storage.Putter,
 	address swarm.Address,
 ) (swarm.Chunk, error) {
-	ls := loadsave.NewReadonly(st, redundancy.DefaultLevel)
+	ls := loadsave.NewReadonly(st, putter, redundancy.DefaultLevel)
 	feedFactory := factory.New(st)
 
 	m, err := manifest.NewDefaultManifestReference(

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -77,7 +77,7 @@ func (s *service) Traverse(ctx context.Context, addr swarm.Address, iterFn swarm
 	// then the reference is likely a manifest reference. This is because manifest holds metadata
 	// that points to the actual data file, and this metadata is assumed to be small - Less than or equal to swarm.ChunkSize.
 	if j.Size() <= swarm.ChunkSize {
-		ls := loadsave.NewReadonly(s.getter, s.rLevel)
+		ls := loadsave.NewReadonly(s.getter, s.putter, s.rLevel)
 		switch mf, err := manifest.NewDefaultManifestReference(addr, ls); {
 		case errors.Is(err, manifest.ErrInvalidManifestType):
 			break


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Since the read-only `loadsaver` didn't have a putter, the redundancy getter could not save recovered chunks.
This fixes that issue by providing a putter to the load saver. 


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
fixes #5001

### Screenshots (if appropriate):
