### PR TITLE
chore: add docker build arguments to Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,24 @@
+FROM golang:1.23 AS build
+
+ARG REACHABILITY_OVERRIDE_PUBLIC=false
+ARG BATCHFACTOR_OVERRIDE_PUBLIC=5
+
+WORKDIR /src
+# enable modules caching in separate layer
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+
+RUN make binary \
+    REACHABILITY_OVERRIDE_PUBLIC=${REACHABILITY_OVERRIDE_PUBLIC} \
+    BATCHFACTOR_OVERRIDE_PUBLIC=${BATCHFACTOR_OVERRIDE_PUBLIC}
+
 FROM debian:12.7-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates; \
+    ca-certificates; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     groupadd -r bee --gid 999; \
@@ -12,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # make sure mounted volumes have correct permissions
 RUN mkdir -p /home/bee/.bee && chown 999:999 /home/bee/.bee
 
-COPY ./tmp/bee /usr/local/bin/bee
+COPY --from=build /src/dist/bee /usr/local/bin/bee
 
 EXPOSE 1633 1634
 USER bee

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ BEEKEEPER_BRANCH ?= master
 REACHABILITY_OVERRIDE_PUBLIC ?= false
 BATCHFACTOR_OVERRIDE_PUBLIC ?= 5
 BEE_IMAGE ?= ethersphere/bee:latest
+PLATFORM ?= linux/amd64
 
 BEE_API_VERSION ?= "$(shell grep '^  version:' openapi/Swarm.yaml | awk '{print $$2}')"
 
@@ -142,13 +143,14 @@ build: export CGO_ENABLED=0
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" ./...
 
+# example: make docker-build PLATFORM=linux/amd64 BEE_IMAGE=ethersphere/bee:latest REACHABILITY_OVERRIDE_PUBLIC=false BATCHFACTOR_OVERRIDE_PUBLIC=5
 .PHONY: docker-build
-docker-build: binary
-	@echo "Build flags: $(LDFLAGS)"
-	mkdir -p ./tmp
-	cp ./dist/bee ./tmp/bee
-	docker build -f Dockerfile.dev -t $(BEE_IMAGE) . --no-cache
-	rm -rf ./tmp
+docker-build:
+	docker build -f Dockerfile.dev \
+		--platform $(PLATFORM) \
+		-t $(BEE_IMAGE) . \
+		--build-arg REACHABILITY_OVERRIDE_PUBLIC=$(REACHABILITY_OVERRIDE_PUBLIC) \
+		--build-arg BATCHFACTOR_OVERRIDE_PUBLIC=$(BATCHFACTOR_OVERRIDE_PUBLIC)
 	@echo "Docker image: $(BEE_IMAGE)"
 
 .PHONY: githooks


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Add support for build arguments (REACHABILITY_OVERRIDE_PUBLIC, BATCHFACTOR_OVERRIDE_PUBLIC) in Dockerfile and PLATFORM in Makefile.

`make docker-build` cmd when needed to build docker image with  REACHABILITY_OVERRIDE_PUBLIC and  BATCHFACTOR_OVERRIDE_PUBLIC flags, and in case when we are deploying cluster using `beelocal`

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
