### PR TITLE
fix: act expose headers

### DIFF
--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -118,8 +118,9 @@ func (s *Service) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	encryptedReference := reference
+	historyReference := swarm.ZeroAddress
 	if headers.Act {
-		encryptedReference, err = s.actEncryptionHandler(r.Context(), w, putter, reference, headers.HistoryAddress)
+		encryptedReference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, reference, headers.HistoryAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -154,6 +155,10 @@ func (s *Service) bytesUploadHandler(w http.ResponseWriter, r *http.Request) {
 	span.LogFields(olog.Bool("success", true))
 
 	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
+	if headers.Act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Add(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
+	}
 	jsonhttp.Created(w, bytesPostResponse{
 		Reference: encryptedReference,
 	})

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -267,8 +267,9 @@ func (s *Service) fileUploadHandler(
 	logger.Debug("store", "manifest_reference", manifestReference)
 
 	reference := manifestReference
+	historyReference := swarm.ZeroAddress
 	if act {
-		reference, err = s.actEncryptionHandler(r.Context(), w, putter, reference, historyAddress)
+		reference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, reference, historyAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -303,6 +304,10 @@ func (s *Service) fileUploadHandler(
 	}
 	w.Header().Set(ETagHeader, fmt.Sprintf("%q", reference.String()))
 	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
+	if act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Add(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
+	}
 
 	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: reference,

--- a/pkg/api/chunk.go
+++ b/pkg/api/chunk.go
@@ -185,8 +185,9 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reference := chunk.Address()
+	historyReference := swarm.ZeroAddress
 	if headers.Act {
-		reference, err = s.actEncryptionHandler(r.Context(), w, putter, reference, headers.HistoryAddress)
+		reference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, reference, headers.HistoryAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -217,6 +218,10 @@ func (s *Service) chunkUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
+	if headers.Act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Add(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
+	}
 	jsonhttp.Created(w, chunkAddressResponse{Reference: reference})
 }
 

--- a/pkg/api/dirs.go
+++ b/pkg/api/dirs.go
@@ -102,8 +102,9 @@ func (s *Service) dirUploadHandler(
 	}
 
 	encryptedReference := reference
+	historyReference := swarm.ZeroAddress
 	if act {
-		encryptedReference, err = s.actEncryptionHandler(r.Context(), w, putter, reference, historyAddress)
+		encryptedReference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, reference, historyAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -135,6 +136,10 @@ func (s *Service) dirUploadHandler(
 		span.LogFields(olog.Bool("success", true))
 	}
 	w.Header().Set(AccessControlExposeHeaders, SwarmTagHeader)
+	if act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Add(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
+	}
 	jsonhttp.Created(w, bzzUploadResponse{
 		Reference: encryptedReference,
 	})

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -280,8 +280,9 @@ func (s *Service) feedPostHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	encryptedReference := ref
+	historyReference := swarm.ZeroAddress
 	if headers.Act {
-		encryptedReference, err = s.actEncryptionHandler(r.Context(), w, putter, ref, headers.HistoryAddress)
+		encryptedReference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, ref, headers.HistoryAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -307,5 +308,9 @@ func (s *Service) feedPostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if headers.Act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Set(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
+	}
 	jsonhttp.Created(w, feedReferenceResponse{Reference: encryptedReference})
 }

--- a/pkg/api/soc.go
+++ b/pkg/api/soc.go
@@ -181,8 +181,9 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reference := sch.Address()
+	historyReference := swarm.ZeroAddress
 	if headers.Act {
-		reference, err = s.actEncryptionHandler(r.Context(), w, putter, reference, headers.HistoryAddress)
+		reference, historyReference, err = s.actEncryptionHandler(r.Context(), putter, reference, headers.HistoryAddress)
 		if err != nil {
 			logger.Debug("access control upload failed", "error", err)
 			logger.Error(nil, "access control upload failed")
@@ -206,6 +207,10 @@ func (s *Service) socUploadHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Error(nil, "done split failed")
 		jsonhttp.InternalServerError(ow, "done split failed")
 		return
+	}
+	if headers.Act {
+		w.Header().Set(SwarmActHistoryAddressHeader, historyReference.String())
+		w.Header().Set(AccessControlExposeHeaders, SwarmActHistoryAddressHeader)
 	}
 
 	jsonhttp.Created(w, socPostResponse{Reference: reference})


### PR DESCRIPTION
### Checklist
- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
When uploading to any of the api endpoints the ACT relevant headers, i.e.: history address, are not added to the expose headers.
Adds the **SwarmActHistoryAddressHeader** to the **AccessControlExposeHeaders**, only if the **Swarm-Act** is set.

### Open API Spec Version Changes (if applicable)
-
#### Motivation and Context (Optional)
-
### Related Issue (Optional)
fixes #5023 

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/cc90f270-dde7-47ae-9c0d-9674831edb1a)

