### PR TITLE
perf(uploadstore): use deletewithstamp instead and tag deletion case …

### DIFF
--- a/pkg/storer/internal/upload/uploadstore.go
+++ b/pkg/storer/internal/upload/uploadstore.go
@@ -459,7 +459,8 @@ func (u *uploadPutter) Close(s storage.IndexStore, addr swarm.Address) error {
 		// If the tag is not found, it might have been removed or never existed.
 		// In this case, there’s no need to update or delete it—so simply return.
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil
+			u.closed = true
+			return s.Delete(&dirtyTagItem{TagID: u.tagID})
 		}
 		return fmt.Errorf("failed reading tag while closing: %w", err)
 	}

--- a/pkg/storer/internal/upload/uploadstore_test.go
+++ b/pkg/storer/internal/upload/uploadstore_test.go
@@ -878,19 +878,6 @@ func TestDeleteTagReporter(t *testing.T) {
 		t.Run("mark sent", func(t *testing.T) {
 			report(chunk, storage.ChunkSent)
 		})
-
-		t.Run("verify internal state", func(t *testing.T) {
-
-			ui := &upload.UploadItem{Address: chunk.Address(), BatchID: chunk.Stamp().BatchID()}
-			err := ts.IndexStore().Get(ui)
-			if err != nil {
-				t.Fatalf("Report(...): unexpected error: %v", err)
-			}
-
-			if diff := cmp.Diff(uint64(0), ui.TagID); diff != "" {
-				t.Fatalf("Get(...): unexpected TagItem (-want +have):\n%s", diff)
-			}
-		})
 	})
 
 	t.Run("delete tag while uploading and not sent", func(t *testing.T) {


### PR DESCRIPTION
…cleanup

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
internal.Uploadstore now uses `DeleteWithStamp` as the regular Delete does an internal load of the stamp, which is unnecessary in this case.
Also, removed the assignment of zero as tagID to the uploadItem in the case that the tag is missing. The item eventually get removed when the chunk is synced, so there is no need to the extra Put operation. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
