### PR TITLE
fix: chequebook error msg and `/stake` openapi

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 7.3.0
+  version: 7.4.0
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 7.4.0
+  version: 7.3.0
   title: Bee API
   description: "A list of the currently provided Interfaces to interact with the swarm, implementing file operations and sending messages"
 

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -70,7 +70,7 @@ paths:
               $ref: "SwarmCommon.yaml#/components/schemas/ActGranteesCreateRequest"
       responses:
         "201":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -94,7 +94,7 @@ paths:
           description: Grantee list reference
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -150,7 +150,7 @@ paths:
               $ref: "SwarmCommon.yaml#/components/schemas/ActGranteesPatchRequest"
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -205,7 +205,7 @@ paths:
               format: binary
       responses:
         "201":
-          description: Ok
+          description: OK
           headers:
             "swarm-tag":
               $ref: "SwarmCommon.yaml#/components/headers/SwarmTag"
@@ -318,7 +318,7 @@ paths:
               format: binary
       responses:
         "201":
-          description: Ok
+          description: OK
           headers:
             "swarm-tag":
               description: Tag UID if it was passed to the request `swarm-tag` header.
@@ -405,7 +405,7 @@ paths:
               format: binary
       responses:
         "201":
-          description: Ok
+          description: OK
           headers:
             "swarm-tag":
               $ref: "SwarmCommon.yaml#/components/headers/SwarmTag"
@@ -448,7 +448,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActHistoryAddress"
       responses:
         "200":
-          description: Ok
+          description: OK
           # "swarm-feed-index":
           #   $ref: "SwarmCommon.yaml#/components/headers/SwarmFeedIndex"
           content:
@@ -511,7 +511,7 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmChunkRetrievalTimeoutParameter"
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/octet-stream:
               schema:
@@ -654,7 +654,7 @@ paths:
               $ref: "SwarmCommon.yaml#/components/schemas/Address"
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -1111,7 +1111,7 @@ paths:
           description: Postage batch to use for re-upload. If none is provided and the file was uploaded on the same node before, it will reuse the same batch. If not found, it will return error. If a new batch is provided, the chunks are stamped again with the new batch.
       responses:
         "200":
-          description: Ok
+          description: OK
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
@@ -1392,7 +1392,7 @@ paths:
           required: true
       responses:
         "201":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -2296,7 +2296,11 @@ paths:
         - Staking
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/GetWithdrawableResponse"
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/GetWithdrawableResponse"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -2311,7 +2315,11 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "500":
@@ -2336,7 +2344,11 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "500":
@@ -2352,7 +2364,11 @@ paths:
         - Staking
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/GetStakeResponse"
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/GetStakeResponse"
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -2367,7 +2383,11 @@ paths:
         - $ref: "SwarmCommon.yaml#/components/parameters/GasLimitParameter"
       responses:
         "200":
-          $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/StakeTransactionResponse"
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "500":

--- a/pkg/settlement/swap/chequebook/init.go
+++ b/pkg/settlement/swap/chequebook/init.go
@@ -105,9 +105,9 @@ func checkBalance(
 			case <-time.After(balanceCheckBackoffDuration):
 			case <-timeoutCtx.Done():
 				if insufficientERC20 {
-					return fmt.Errorf("insufficient %s for initial deposit", swarmTokenName)
+					return fmt.Errorf("insufficient %s for deploying chequebook", swarmTokenName)
 				} else {
-					return fmt.Errorf("insufficient %s for initial deposit", nativeTokenName)
+					return fmt.Errorf("insufficient %s for deploying chequebook", nativeTokenName)
 				}
 			}
 			continue


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR will change error msg for intial deposit to `insufficient xDAI for deploying chequebook`.
Also, it will fix openapi spec for `/stake` endpoint.

### Open API Spec Version Changes (if applicable)
version: 7.4.0

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
[POST stake/:amount response type #5004](https://github.com/ethersphere/bee/issues/5004)
[Misleading chequebook init: insufficient xDAI for initial deposit error message #4924](https://github.com/ethersphere/bee/issues/4924)

### Screenshots (if appropriate):
