### PR TITLE
feat: add structured histogram to status proto for up/down speeds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.0 // indirect
+	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.47.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -71,14 +71,14 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "upload_speed",
-			Help:      "Histogram of upload speed in MiB/s.",
+			Help:      "Histogram of upload speed in B/s.",
 			Buckets:   []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5},
 		}),
 		DownloadSpeed: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "download_speed",
-			Help:      "Histogram of download speed in MiB/s.",
+			Help:      "Histogram of download speed in B/s.",
 			Buckets:   []float64{0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 7, 8, 9},
 		}),
 	}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -301,6 +301,7 @@ func (s *Service) mountAPI() {
 		"POST": web.ChainHandlers(
 			s.contentLengthMetricMiddleware(),
 			s.newTracingHandler("bzz-upload"),
+			s.uploadSpeedMetricMiddleware(),
 			web.FinalHandlerFunc(s.bzzUploadHandler),
 		),
 	})
@@ -325,6 +326,7 @@ func (s *Service) mountAPI() {
 			s.contentLengthMetricMiddleware(),
 			s.newTracingHandler("bzz-download"),
 			s.actDecryptionHandler(),
+			s.downloadSpeedMetricMiddleware(),
 			web.FinalHandlerFunc(s.bzzDownloadHandler),
 		),
 		"HEAD": web.ChainHandlers(

--- a/pkg/api/status_test.go
+++ b/pkg/api/status_test.go
@@ -60,6 +60,7 @@ func TestGetStatus(t *testing.T) {
 			mode.String(),
 			ssMock,
 			ssMock,
+			status.Metrics{},
 		)
 
 		statusSvc.SetSync(ssMock)
@@ -86,6 +87,7 @@ func TestGetStatus(t *testing.T) {
 				"",
 				nil,
 				nil,
+				status.Metrics{},
 			),
 		})
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -910,7 +910,7 @@ func NewBee(
 
 	validStamp := postage.ValidStamp(batchStore)
 
-	nodeStatus := status.NewService(logger, p2ps, kad, beeNodeMode.String(), batchStore, localStore)
+	nodeStatus := status.NewService(logger, p2ps, kad, beeNodeMode.String(), batchStore, localStore, apiService.StatusMetrics())
 	if err = p2ps.AddProtocol(nodeStatus.Protocol()); err != nil {
 		return nil, fmt.Errorf("status service: %w", err)
 	}

--- a/pkg/status/export_test.go
+++ b/pkg/status/export_test.go
@@ -9,3 +9,5 @@ const (
 	ProtocolVersion = protocolVersion
 	StreamName      = streamName
 )
+
+var NewHistogram = newHistogram

--- a/pkg/status/internal/pb/status.pb.go
+++ b/pkg/status/internal/pb/status.pb.go
@@ -64,17 +64,19 @@ var xxx_messageInfo_Get proto.InternalMessageInfo
 // the appropriate values that are a snapshot of the current state
 // of the running node.
 type Snapshot struct {
-	ReserveSize             uint64  `protobuf:"varint,1,opt,name=ReserveSize,proto3" json:"ReserveSize,omitempty"`
-	PullsyncRate            float64 `protobuf:"fixed64,2,opt,name=PullsyncRate,proto3" json:"PullsyncRate,omitempty"`
-	StorageRadius           uint32  `protobuf:"varint,3,opt,name=StorageRadius,proto3" json:"StorageRadius,omitempty"`
-	ConnectedPeers          uint64  `protobuf:"varint,4,opt,name=ConnectedPeers,proto3" json:"ConnectedPeers,omitempty"`
-	NeighborhoodSize        uint64  `protobuf:"varint,5,opt,name=NeighborhoodSize,proto3" json:"NeighborhoodSize,omitempty"`
-	BeeMode                 string  `protobuf:"bytes,6,opt,name=BeeMode,proto3" json:"BeeMode,omitempty"`
-	BatchCommitment         uint64  `protobuf:"varint,7,opt,name=BatchCommitment,proto3" json:"BatchCommitment,omitempty"`
-	IsReachable             bool    `protobuf:"varint,8,opt,name=IsReachable,proto3" json:"IsReachable,omitempty"`
-	ReserveSizeWithinRadius uint64  `protobuf:"varint,9,opt,name=ReserveSizeWithinRadius,proto3" json:"ReserveSizeWithinRadius,omitempty"`
-	LastSyncedBlock         uint64  `protobuf:"varint,10,opt,name=LastSyncedBlock,proto3" json:"LastSyncedBlock,omitempty"`
-	CommittedDepth          uint32  `protobuf:"varint,11,opt,name=CommittedDepth,proto3" json:"CommittedDepth,omitempty"`
+	ReserveSize             uint64     `protobuf:"varint,1,opt,name=ReserveSize,proto3" json:"ReserveSize,omitempty"`
+	PullsyncRate            float64    `protobuf:"fixed64,2,opt,name=PullsyncRate,proto3" json:"PullsyncRate,omitempty"`
+	StorageRadius           uint32     `protobuf:"varint,3,opt,name=StorageRadius,proto3" json:"StorageRadius,omitempty"`
+	ConnectedPeers          uint64     `protobuf:"varint,4,opt,name=ConnectedPeers,proto3" json:"ConnectedPeers,omitempty"`
+	NeighborhoodSize        uint64     `protobuf:"varint,5,opt,name=NeighborhoodSize,proto3" json:"NeighborhoodSize,omitempty"`
+	BeeMode                 string     `protobuf:"bytes,6,opt,name=BeeMode,proto3" json:"BeeMode,omitempty"`
+	BatchCommitment         uint64     `protobuf:"varint,7,opt,name=BatchCommitment,proto3" json:"BatchCommitment,omitempty"`
+	IsReachable             bool       `protobuf:"varint,8,opt,name=IsReachable,proto3" json:"IsReachable,omitempty"`
+	ReserveSizeWithinRadius uint64     `protobuf:"varint,9,opt,name=ReserveSizeWithinRadius,proto3" json:"ReserveSizeWithinRadius,omitempty"`
+	LastSyncedBlock         uint64     `protobuf:"varint,10,opt,name=LastSyncedBlock,proto3" json:"LastSyncedBlock,omitempty"`
+	CommittedDepth          uint32     `protobuf:"varint,11,opt,name=CommittedDepth,proto3" json:"CommittedDepth,omitempty"`
+	UploadSpeed             *Histogram `protobuf:"bytes,12,opt,name=UploadSpeed,proto3" json:"UploadSpeed,omitempty"`
+	DownloadSpeed           *Histogram `protobuf:"bytes,13,opt,name=DownloadSpeed,proto3" json:"DownloadSpeed,omitempty"`
 }
 
 func (m *Snapshot) Reset()         { *m = Snapshot{} }
@@ -187,36 +189,245 @@ func (m *Snapshot) GetCommittedDepth() uint32 {
 	return 0
 }
 
+func (m *Snapshot) GetUploadSpeed() *Histogram {
+	if m != nil {
+		return m.UploadSpeed
+	}
+	return nil
+}
+
+func (m *Snapshot) GetDownloadSpeed() *Histogram {
+	if m != nil {
+		return m.DownloadSpeed
+	}
+	return nil
+}
+
+type Histogram struct {
+	// Optional.
+	Labels []*Label `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty"`
+	// Optional.
+	SampleSum float64 `protobuf:"fixed64,2,opt,name=SampleSum,proto3" json:"SampleSum,omitempty"`
+	// Optional.
+	SampleCount uint64 `protobuf:"varint,3,opt,name=SampleCount,proto3" json:"SampleCount,omitempty"`
+	// Optional.
+	Buckets []*Histogram_Bucket `protobuf:"bytes,4,rep,name=Buckets,proto3" json:"Buckets,omitempty"`
+}
+
+func (m *Histogram) Reset()         { *m = Histogram{} }
+func (m *Histogram) String() string { return proto.CompactTextString(m) }
+func (*Histogram) ProtoMessage()    {}
+func (*Histogram) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dfe4fce6682daf5b, []int{2}
+}
+func (m *Histogram) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Histogram) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Histogram.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Histogram) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Histogram.Merge(m, src)
+}
+func (m *Histogram) XXX_Size() int {
+	return m.Size()
+}
+func (m *Histogram) XXX_DiscardUnknown() {
+	xxx_messageInfo_Histogram.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Histogram proto.InternalMessageInfo
+
+func (m *Histogram) GetLabels() []*Label {
+	if m != nil {
+		return m.Labels
+	}
+	return nil
+}
+
+func (m *Histogram) GetSampleSum() float64 {
+	if m != nil {
+		return m.SampleSum
+	}
+	return 0
+}
+
+func (m *Histogram) GetSampleCount() uint64 {
+	if m != nil {
+		return m.SampleCount
+	}
+	return 0
+}
+
+func (m *Histogram) GetBuckets() []*Histogram_Bucket {
+	if m != nil {
+		return m.Buckets
+	}
+	return nil
+}
+
+type Histogram_Bucket struct {
+	// Required.
+	CumulativeCount uint64 `protobuf:"varint,1,opt,name=CumulativeCount,proto3" json:"CumulativeCount,omitempty"`
+	// Optional.
+	UpperBound float64 `protobuf:"fixed64,2,opt,name=UpperBound,proto3" json:"UpperBound,omitempty"`
+}
+
+func (m *Histogram_Bucket) Reset()         { *m = Histogram_Bucket{} }
+func (m *Histogram_Bucket) String() string { return proto.CompactTextString(m) }
+func (*Histogram_Bucket) ProtoMessage()    {}
+func (*Histogram_Bucket) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dfe4fce6682daf5b, []int{2, 0}
+}
+func (m *Histogram_Bucket) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Histogram_Bucket) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Histogram_Bucket.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Histogram_Bucket) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Histogram_Bucket.Merge(m, src)
+}
+func (m *Histogram_Bucket) XXX_Size() int {
+	return m.Size()
+}
+func (m *Histogram_Bucket) XXX_DiscardUnknown() {
+	xxx_messageInfo_Histogram_Bucket.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Histogram_Bucket proto.InternalMessageInfo
+
+func (m *Histogram_Bucket) GetCumulativeCount() uint64 {
+	if m != nil {
+		return m.CumulativeCount
+	}
+	return 0
+}
+
+func (m *Histogram_Bucket) GetUpperBound() float64 {
+	if m != nil {
+		return m.UpperBound
+	}
+	return 0
+}
+
+type Label struct {
+	// Required.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Required.
+	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *Label) Reset()         { *m = Label{} }
+func (m *Label) String() string { return proto.CompactTextString(m) }
+func (*Label) ProtoMessage()    {}
+func (*Label) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dfe4fce6682daf5b, []int{3}
+}
+func (m *Label) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Label) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Label.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Label) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Label.Merge(m, src)
+}
+func (m *Label) XXX_Size() int {
+	return m.Size()
+}
+func (m *Label) XXX_DiscardUnknown() {
+	xxx_messageInfo_Label.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Label proto.InternalMessageInfo
+
+func (m *Label) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Label) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*Get)(nil), "status.Get")
 	proto.RegisterType((*Snapshot)(nil), "status.Snapshot")
+	proto.RegisterType((*Histogram)(nil), "status.Histogram")
+	proto.RegisterType((*Histogram_Bucket)(nil), "status.Histogram.Bucket")
+	proto.RegisterType((*Label)(nil), "status.Label")
 }
 
 func init() { proto.RegisterFile("status.proto", fileDescriptor_dfe4fce6682daf5b) }
 
 var fileDescriptor_dfe4fce6682daf5b = []byte{
-	// 332 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0xd1, 0x4f, 0x4b, 0xc3, 0x30,
-	0x18, 0x06, 0xf0, 0x65, 0xff, 0x97, 0x6d, 0x2a, 0xb9, 0x98, 0x83, 0x94, 0x32, 0x44, 0x8a, 0x07,
-	0x2f, 0x5e, 0x3c, 0x77, 0x82, 0x08, 0x2a, 0x23, 0x3d, 0x08, 0xde, 0xd2, 0xf6, 0x65, 0x29, 0x76,
-	0x49, 0x69, 0xde, 0x09, 0xf3, 0x53, 0xf8, 0x81, 0xfc, 0x00, 0x1e, 0x77, 0xf4, 0x28, 0xdb, 0x17,
-	0x91, 0x65, 0x0a, 0x5b, 0xc5, 0xe3, 0xfb, 0x6b, 0x79, 0xf3, 0xe4, 0x09, 0x1d, 0x58, 0x94, 0x38,
-	0xb7, 0x17, 0x45, 0x69, 0xd0, 0xb0, 0xf6, 0x76, 0x1a, 0xb5, 0x68, 0xe3, 0x06, 0x70, 0xf4, 0xde,
-	0xa0, 0xdd, 0x48, 0xcb, 0xc2, 0x2a, 0x83, 0xcc, 0xa7, 0x7d, 0x01, 0x16, 0xca, 0x17, 0x88, 0xb2,
-	0x57, 0xe0, 0xc4, 0x27, 0x41, 0x53, 0xec, 0x12, 0x1b, 0xd1, 0xc1, 0x64, 0x9e, 0xe7, 0x76, 0xa1,
-	0x13, 0x21, 0x11, 0x78, 0xdd, 0x27, 0x01, 0x11, 0x7b, 0xc6, 0x4e, 0xe9, 0x30, 0x42, 0x53, 0xca,
-	0x29, 0x08, 0x99, 0x66, 0x73, 0xcb, 0x1b, 0x3e, 0x09, 0x86, 0x62, 0x1f, 0xd9, 0x19, 0x3d, 0x18,
-	0x1b, 0xad, 0x21, 0x41, 0x48, 0x27, 0x00, 0xa5, 0xe5, 0x4d, 0x77, 0x5c, 0x45, 0xd9, 0x39, 0x3d,
-	0x7a, 0x80, 0x6c, 0xaa, 0x62, 0x53, 0x2a, 0x63, 0x52, 0x17, 0xac, 0xe5, 0xfe, 0xfc, 0xe3, 0x8c,
-	0xd3, 0x4e, 0x08, 0x70, 0x6f, 0x52, 0xe0, 0x6d, 0x9f, 0x04, 0x3d, 0xf1, 0x3b, 0xb2, 0x80, 0x1e,
-	0x86, 0x12, 0x13, 0x35, 0x36, 0xb3, 0x59, 0x86, 0x33, 0xd0, 0xc8, 0x3b, 0x6e, 0x49, 0x95, 0x37,
-	0x1d, 0xdc, 0x5a, 0x01, 0x32, 0x51, 0x32, 0xce, 0x81, 0x77, 0x7d, 0x12, 0x74, 0xc5, 0x2e, 0xb1,
-	0x2b, 0x7a, 0xbc, 0x53, 0xc9, 0x63, 0x86, 0x2a, 0xd3, 0x3f, 0x37, 0xed, 0xb9, 0x9d, 0xff, 0x7d,
-	0xde, 0xa4, 0xb8, 0x93, 0x16, 0xa3, 0x85, 0x4e, 0x20, 0x0d, 0x73, 0x93, 0x3c, 0x73, 0xba, 0x4d,
-	0x51, 0xe1, 0x6d, 0x3b, 0x9b, 0x4c, 0x08, 0xe9, 0x35, 0x14, 0xa8, 0x78, 0xdf, 0x95, 0x58, 0xd1,
-	0xf0, 0xe4, 0x63, 0xe5, 0x91, 0xe5, 0xca, 0x23, 0x5f, 0x2b, 0x8f, 0xbc, 0xad, 0xbd, 0xda, 0x72,
-	0xed, 0xd5, 0x3e, 0xd7, 0x5e, 0xed, 0xa9, 0x5e, 0xc4, 0x71, 0xdb, 0x3d, 0xf9, 0xe5, 0x77, 0x00,
-	0x00, 0x00, 0xff, 0xff, 0x97, 0x7e, 0x47, 0xd4, 0x02, 0x02, 0x00, 0x00,
+	// 520 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x93, 0xcf, 0x6a, 0xdb, 0x4e,
+	0x10, 0xc7, 0xbd, 0xf1, 0x5f, 0x8d, 0xed, 0xdf, 0xaf, 0x5d, 0x0a, 0x5d, 0x4a, 0x10, 0xc2, 0xb4,
+	0x45, 0xf4, 0x60, 0xa8, 0x73, 0x68, 0xcf, 0x72, 0xa0, 0x2d, 0xa4, 0x25, 0xac, 0x08, 0x85, 0xde,
+	0xd6, 0xd2, 0x60, 0x89, 0x48, 0xbb, 0x42, 0xbb, 0x72, 0x49, 0x9f, 0xa2, 0xcf, 0xd1, 0x27, 0xe9,
+	0x31, 0xc7, 0x1e, 0x8b, 0xfd, 0x16, 0x3d, 0x15, 0xfd, 0x71, 0x23, 0x3b, 0xe4, 0xa6, 0xf9, 0xec,
+	0xcc, 0xce, 0x77, 0xbf, 0x9a, 0x81, 0x89, 0x36, 0xc2, 0x14, 0x7a, 0x9e, 0xe5, 0xca, 0x28, 0x3a,
+	0xa8, 0xa3, 0x59, 0x1f, 0xba, 0xef, 0xd0, 0xcc, 0x7e, 0xf4, 0x60, 0xe4, 0x4b, 0x91, 0xe9, 0x48,
+	0x19, 0xea, 0xc0, 0x98, 0xa3, 0xc6, 0x7c, 0x83, 0x7e, 0xfc, 0x0d, 0x19, 0x71, 0x88, 0xdb, 0xe3,
+	0x6d, 0x44, 0x67, 0x30, 0xb9, 0x2c, 0x92, 0x44, 0xdf, 0xc8, 0x80, 0x0b, 0x83, 0xec, 0xc4, 0x21,
+	0x2e, 0xe1, 0x07, 0x8c, 0x3e, 0x87, 0xa9, 0x6f, 0x54, 0x2e, 0xd6, 0xc8, 0x45, 0x18, 0x17, 0x9a,
+	0x75, 0x1d, 0xe2, 0x4e, 0xf9, 0x21, 0xa4, 0x2f, 0xe1, 0xbf, 0xa5, 0x92, 0x12, 0x03, 0x83, 0xe1,
+	0x25, 0x62, 0xae, 0x59, 0xaf, 0x6a, 0x77, 0x44, 0xe9, 0x2b, 0x78, 0xf4, 0x09, 0xe3, 0x75, 0xb4,
+	0x52, 0x79, 0xa4, 0x54, 0x58, 0x09, 0xeb, 0x57, 0x99, 0xf7, 0x38, 0x65, 0x30, 0xf4, 0x10, 0x3f,
+	0xaa, 0x10, 0xd9, 0xc0, 0x21, 0xae, 0xc5, 0xf7, 0x21, 0x75, 0xe1, 0x7f, 0x4f, 0x98, 0x20, 0x5a,
+	0xaa, 0x34, 0x8d, 0x4d, 0x8a, 0xd2, 0xb0, 0x61, 0x75, 0xc9, 0x31, 0x2e, 0x3d, 0xf8, 0xa0, 0x39,
+	0x8a, 0x20, 0x12, 0xab, 0x04, 0xd9, 0xc8, 0x21, 0xee, 0x88, 0xb7, 0x11, 0x7d, 0x0b, 0x4f, 0x5b,
+	0x96, 0x7c, 0x8e, 0x4d, 0x14, 0xcb, 0xe6, 0xa5, 0x56, 0x75, 0xe7, 0x43, 0xc7, 0xa5, 0x8a, 0x0b,
+	0xa1, 0x8d, 0x7f, 0x23, 0x03, 0x0c, 0xbd, 0x44, 0x05, 0xd7, 0x0c, 0x6a, 0x15, 0x47, 0xb8, 0x76,
+	0xa7, 0xd4, 0x64, 0x30, 0x3c, 0xc7, 0xcc, 0x44, 0x6c, 0x5c, 0x99, 0x78, 0x44, 0xe9, 0x19, 0x8c,
+	0xaf, 0xb2, 0x44, 0x89, 0xd0, 0xcf, 0x10, 0x43, 0x36, 0x71, 0x88, 0x3b, 0x5e, 0x3c, 0x9e, 0x37,
+	0x7f, 0xfc, 0x7d, 0xac, 0x8d, 0x5a, 0xe7, 0x22, 0xe5, 0xed, 0x2c, 0xfa, 0x06, 0xa6, 0xe7, 0xea,
+	0xab, 0xbc, 0x2b, 0x9b, 0x3e, 0x54, 0x76, 0x98, 0x37, 0xfb, 0x43, 0xc0, 0xfa, 0x77, 0x48, 0x5f,
+	0xc0, 0x20, 0x11, 0x2b, 0x4c, 0x34, 0x23, 0x4e, 0xd7, 0x1d, 0x2f, 0xa6, 0xfb, 0xfa, 0x8b, 0x92,
+	0xf2, 0xe6, 0x90, 0x9e, 0x82, 0xe5, 0x8b, 0x34, 0x4b, 0xd0, 0x2f, 0xd2, 0x66, 0x5e, 0xee, 0x40,
+	0x69, 0x77, 0x1d, 0x2c, 0x55, 0x21, 0x4d, 0x35, 0x2a, 0x3d, 0xde, 0x46, 0x74, 0x01, 0x43, 0xaf,
+	0x08, 0xae, 0xd1, 0x94, 0x13, 0x52, 0xf6, 0x61, 0xf7, 0x74, 0xce, 0xeb, 0x04, 0xbe, 0x4f, 0x7c,
+	0xc6, 0x61, 0x50, 0x7f, 0x96, 0x96, 0x2f, 0x8b, 0xb4, 0x48, 0x84, 0x89, 0x37, 0x4d, 0x8f, 0x7a,
+	0xac, 0x8f, 0x31, 0xb5, 0x01, 0xae, 0xb2, 0x0c, 0x73, 0x4f, 0x15, 0x32, 0x6c, 0x84, 0xb6, 0xc8,
+	0xec, 0x35, 0xf4, 0xab, 0x87, 0x51, 0x0a, 0x3d, 0x29, 0xd2, 0x7a, 0x3d, 0x2c, 0x5e, 0x7d, 0xd3,
+	0x27, 0xd0, 0xdf, 0x88, 0xa4, 0xa8, 0x17, 0xc2, 0xe2, 0x75, 0xe0, 0x9d, 0xfe, 0xdc, 0xda, 0xe4,
+	0x76, 0x6b, 0x93, 0xdf, 0x5b, 0x9b, 0x7c, 0xdf, 0xd9, 0x9d, 0xdb, 0x9d, 0xdd, 0xf9, 0xb5, 0xb3,
+	0x3b, 0x5f, 0x4e, 0xb2, 0xd5, 0x6a, 0x50, 0x2d, 0xe4, 0xd9, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff,
+	0xb2, 0x02, 0x35, 0x35, 0xa0, 0x03, 0x00, 0x00,
 }
 
 func (m *Get) Marshal() (dAtA []byte, err error) {
@@ -262,6 +473,30 @@ func (m *Snapshot) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.DownloadSpeed != nil {
+		{
+			size, err := m.DownloadSpeed.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStatus(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x6a
+	}
+	if m.UploadSpeed != nil {
+		{
+			size, err := m.UploadSpeed.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStatus(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x62
+	}
 	if m.CommittedDepth != 0 {
 		i = encodeVarintStatus(dAtA, i, uint64(m.CommittedDepth))
 		i--
@@ -328,6 +563,139 @@ func (m *Snapshot) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Histogram) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Histogram) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Buckets) > 0 {
+		for iNdEx := len(m.Buckets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Buckets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintStatus(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if m.SampleCount != 0 {
+		i = encodeVarintStatus(dAtA, i, uint64(m.SampleCount))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.SampleSum != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.SampleSum))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if len(m.Labels) > 0 {
+		for iNdEx := len(m.Labels) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Labels[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintStatus(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Histogram_Bucket) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Histogram_Bucket) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Histogram_Bucket) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.UpperBound != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.UpperBound))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if m.CumulativeCount != 0 {
+		i = encodeVarintStatus(dAtA, i, uint64(m.CumulativeCount))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Label) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Label) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Label) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintStatus(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintStatus(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintStatus(dAtA []byte, offset int, v uint64) int {
 	offset -= sovStatus(v)
 	base := offset
@@ -388,6 +756,73 @@ func (m *Snapshot) Size() (n int) {
 	if m.CommittedDepth != 0 {
 		n += 1 + sovStatus(uint64(m.CommittedDepth))
 	}
+	if m.UploadSpeed != nil {
+		l = m.UploadSpeed.Size()
+		n += 1 + l + sovStatus(uint64(l))
+	}
+	if m.DownloadSpeed != nil {
+		l = m.DownloadSpeed.Size()
+		n += 1 + l + sovStatus(uint64(l))
+	}
+	return n
+}
+
+func (m *Histogram) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Labels) > 0 {
+		for _, e := range m.Labels {
+			l = e.Size()
+			n += 1 + l + sovStatus(uint64(l))
+		}
+	}
+	if m.SampleSum != 0 {
+		n += 9
+	}
+	if m.SampleCount != 0 {
+		n += 1 + sovStatus(uint64(m.SampleCount))
+	}
+	if len(m.Buckets) > 0 {
+		for _, e := range m.Buckets {
+			l = e.Size()
+			n += 1 + l + sovStatus(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *Histogram_Bucket) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.CumulativeCount != 0 {
+		n += 1 + sovStatus(uint64(m.CumulativeCount))
+	}
+	if m.UpperBound != 0 {
+		n += 9
+	}
+	return n
+}
+
+func (m *Label) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovStatus(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovStatus(uint64(l))
+	}
 	return n
 }
 
@@ -432,10 +867,7 @@ func (m *Get) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStatus
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStatus
 			}
 			if (iNdEx + skippy) > l {
@@ -694,16 +1126,427 @@ func (m *Snapshot) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UploadSpeed", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.UploadSpeed == nil {
+				m.UploadSpeed = &Histogram{}
+			}
+			if err := m.UploadSpeed.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DownloadSpeed", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DownloadSpeed == nil {
+				m.DownloadSpeed = &Histogram{}
+			}
+			if err := m.DownloadSpeed.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStatus(dAtA[iNdEx:])
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStatus
 			}
-			if (iNdEx + skippy) < 0 {
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Histogram) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStatus
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Histogram: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Histogram: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Labels = append(m.Labels, &Label{})
+			if err := m.Labels[len(m.Labels)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SampleSum", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.SampleSum = float64(math.Float64frombits(v))
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SampleCount", wireType)
+			}
+			m.SampleCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SampleCount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Buckets", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Buckets = append(m.Buckets, &Histogram_Bucket{})
+			if err := m.Buckets[len(m.Buckets)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStatus(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Histogram_Bucket) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStatus
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Bucket: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Bucket: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CumulativeCount", wireType)
+			}
+			m.CumulativeCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CumulativeCount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UpperBound", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.UpperBound = float64(math.Float64frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStatus(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Label) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStatus
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Label: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Label: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStatus
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStatus
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStatus
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStatus(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStatus
 			}
 			if (iNdEx + skippy) > l {

--- a/pkg/status/internal/pb/status.proto
+++ b/pkg/status/internal/pb/status.proto
@@ -26,4 +26,36 @@ message Snapshot {
   uint64 ReserveSizeWithinRadius = 9;
   uint64 LastSyncedBlock = 10;
   uint32 CommittedDepth = 11;
+  Histogram UploadSpeed = 12;
+  Histogram DownloadSpeed = 13;
+}
+
+message Histogram {
+  // Optional.
+  repeated Label labels = 1;
+
+  // Optional.
+  double SampleSum = 2;
+
+  // Optional.
+  uint64 SampleCount = 3;
+
+  // Optional.
+  repeated Bucket Buckets = 4;
+
+  message Bucket {
+    // Required.
+    uint64 CumulativeCount = 1;
+
+    // Optional.
+    double UpperBound = 2;
+  }
+}
+
+message Label {
+  // Required.
+  string name = 1;
+
+  // Required.
+  string value = 2;
 }

--- a/pkg/status/prometheus.go
+++ b/pkg/status/prometheus.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package status
+
+import (
+	"github.com/ethersphere/bee/v2/pkg/status/internal/pb"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func newHistogram(m *dto.Metric) *pb.Histogram {
+	if m == nil {
+		return nil
+	}
+	if m.Histogram == nil {
+		return nil
+	}
+	return &pb.Histogram{
+		Labels:      newLabels(m.Label),
+		SampleSum:   m.Histogram.GetSampleSum(),
+		SampleCount: m.Histogram.GetSampleCount(),
+		Buckets:     newHistogramBuckets(m.Histogram.Bucket),
+	}
+}
+
+func newLabels(labels []*dto.LabelPair) []*pb.Label {
+	out := make([]*pb.Label, 0, len(labels))
+	for _, l := range labels {
+		out = append(out, &pb.Label{
+			Name:  l.GetName(),
+			Value: l.GetValue(),
+		})
+	}
+	return out
+}
+
+func newHistogramBuckets(buckets []*dto.Bucket) []*pb.Histogram_Bucket {
+	out := make([]*pb.Histogram_Bucket, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, &pb.Histogram_Bucket{
+			CumulativeCount: b.GetCumulativeCount(),
+			UpperBound:      b.GetUpperBound(),
+		})
+	}
+	return out
+}
+
+func getMetric(m prometheus.Metric) (*dto.Metric, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	out := new(dto.Metric)
+	if err := m.Write(out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/pkg/status/prometheus_test.go
+++ b/pkg/status/prometheus_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package status_test
+
+import (
+	"testing"
+
+	"github.com/ethersphere/bee/v2/pkg/status"
+	"github.com/ethersphere/bee/v2/pkg/status/internal/pb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestHistogram(t *testing.T) {
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "test",
+		Name:      "response_duration_seconds",
+		Help:      "Histogram of API response durations.",
+		Buckets:   []float64{0.01, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		ConstLabels: prometheus.Labels{
+			"test": "label",
+		},
+	})
+
+	points := []float64{0.25, 5.2, 1.5, 1, 5.2, 0, 65}
+	var sum float64
+	for _, p := range points {
+		h.Observe(p)
+		sum += p
+	}
+
+	m := new(dto.Metric)
+	if err := h.Write(m); err != nil {
+		t.Fatal(err)
+	}
+
+	got := status.NewHistogram(m)
+
+	want := &pb.Histogram{
+		Labels: []*pb.Label{
+			{
+				Name:  "test",
+				Value: "label",
+			},
+		},
+		SampleCount: uint64(len(points)),
+		SampleSum:   sum,
+		Buckets: []*pb.Histogram_Bucket{
+			{CumulativeCount: 1, UpperBound: 0.01},
+			{CumulativeCount: 1, UpperBound: 0.1},
+			{CumulativeCount: 2, UpperBound: 0.25},
+			{CumulativeCount: 2, UpperBound: 0.5},
+			{CumulativeCount: 3, UpperBound: 1},
+			{CumulativeCount: 4, UpperBound: 2.5},
+			{CumulativeCount: 4, UpperBound: 5},
+			{CumulativeCount: 6, UpperBound: 10},
+		},
+	}
+
+	if !proto.Equal(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -47,13 +47,14 @@ func TestStatus(t *testing.T) {
 		want.BeeMode,
 		sssMock,
 		sssMock,
+		status.Metrics{},
 	)
 
 	peer1.SetSync(sssMock)
 
 	recorder := streamtest.New(streamtest.WithProtocols(peer1.Protocol()))
 
-	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil)
+	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil, status.Metrics{})
 
 	address := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 
@@ -127,11 +128,12 @@ func TestStatusLightNode(t *testing.T) {
 		want.BeeMode,
 		sssMock,
 		nil,
+		status.Metrics{},
 	)
 
 	recorder := streamtest.New(streamtest.WithProtocols(peer1.Protocol()))
 
-	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil)
+	peer2 := status.NewService(log.Noop, recorder, peersIterMock, "", nil, nil, status.Metrics{})
 
 	address := swarm.MustParseHexAddress("ca1e9f3938cc1425c6061b96ad9eb93e134dfe8734ad490164ef20af9d1cf59c")
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR adds metrics to the status protocol for analysing upload and download speeds on different nodes.

#### Upload and download speed metrics

Upload and download metrics for speed are new ones so that they are measuring only the /bzz uploads and downloads, not /bytes or any other POST methods, making them more specific than content api duration metric which aggregates measurements from all endpoints into one metric.

#### Status protocol fields

##### Structured approach (Histogram type)

This approach uses the structured histogram. This comes with a few drawbacks. One is the complexity and more important one is the inability to add vectors in such way because of the restrictions in the prometheus client for directly getting all labels form a vector metric.

##### Alternative (string field with all metrics)

To overcome both drawbacks, approach where all metrics are sent in a form of a string field in prometheus format. This is more flexible (easier to expose metrics) and convenient, but less transparent and less pretty by my opinion.

It is up for a discussion on both approaches.

### Open API Spec Version Changes (if applicable)
TODO: add new fields to the status response.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
#5005

### Screenshots (if appropriate):
