### PR TITLE
fix: prometeus vector variables as pointers

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -28,7 +28,7 @@ type metrics struct {
 	PingRequestCount   prometheus.Counter
 	ResponseCodeCounts *prometheus.CounterVec
 
-	ContentApiDuration prometheus.HistogramVec
+	ContentApiDuration *prometheus.HistogramVec
 	UploadSpeed        *prometheus.HistogramVec
 	DownloadSpeed      *prometheus.HistogramVec
 }
@@ -59,7 +59,7 @@ func newMetrics() metrics {
 			},
 			[]string{"code", "method"},
 		),
-		ContentApiDuration: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		ContentApiDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "content_api_duration",

--- a/pkg/p2p/libp2p/internal/reacher/metrics.go
+++ b/pkg/p2p/libp2p/internal/reacher/metrics.go
@@ -10,21 +10,21 @@ import (
 )
 
 type metrics struct {
-	Pings    prometheus.CounterVec
-	PingTime prometheus.HistogramVec
+	Pings    *prometheus.CounterVec
+	PingTime *prometheus.HistogramVec
 }
 
 func newMetrics() metrics {
 	subsystem := "reacher"
 
 	return metrics{
-		Pings: *prometheus.NewCounterVec(prometheus.CounterOpts{
+		Pings: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "pings",
 			Help:      "Ping counter.",
 		}, []string{"status"}),
-		PingTime: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		PingTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "ping_timer",

--- a/pkg/postage/batchstore/metrics.go
+++ b/pkg/postage/batchstore/metrics.go
@@ -12,7 +12,7 @@ import (
 type metrics struct {
 	Commitment        prometheus.Gauge
 	Radius            prometheus.Gauge
-	UnreserveDuration prometheus.HistogramVec
+	UnreserveDuration *prometheus.HistogramVec
 }
 
 func newMetrics() metrics {
@@ -31,7 +31,7 @@ func newMetrics() metrics {
 			Name:      "radius",
 			Help:      "Radius of responsibility observed by the batchstore.",
 		}),
-		UnreserveDuration: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		UnreserveDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "unreserve_duration",

--- a/pkg/puller/metrics.go
+++ b/pkg/puller/metrics.go
@@ -10,11 +10,11 @@ import (
 )
 
 type metrics struct {
-	SyncWorkerIterCounter prometheus.Counter    // counts the number of syncing iterations
-	SyncWorkerCounter     prometheus.Gauge      // count number of syncing jobs
-	SyncedCounter         prometheus.CounterVec // number of synced chunks
-	SyncWorkerErrCounter  prometheus.Counter    // count number of errors
-	MaxUintErrCounter     prometheus.Counter    // how many times we got maxuint as topmost
+	SyncWorkerIterCounter prometheus.Counter     // counts the number of syncing iterations
+	SyncWorkerCounter     prometheus.Gauge       // count number of syncing jobs
+	SyncedCounter         *prometheus.CounterVec // number of synced chunks
+	SyncWorkerErrCounter  prometheus.Counter     // count number of errors
+	MaxUintErrCounter     prometheus.Counter     // how many times we got maxuint as topmost
 }
 
 func newMetrics() metrics {
@@ -33,7 +33,7 @@ func newMetrics() metrics {
 			Name:      "worker",
 			Help:      "Total active worker jobs.",
 		}),
-		SyncedCounter: *prometheus.NewCounterVec(prometheus.CounterOpts{
+		SyncedCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "synced_chunks",

--- a/pkg/pushsync/metrics.go
+++ b/pkg/pushsync/metrics.go
@@ -19,11 +19,11 @@ type metrics struct {
 	TotalOutgoing           prometheus.Counter
 	TotalOutgoingErrors     prometheus.Counter
 	InvalidStampErrors      prometheus.Counter
-	StampValidationTime     prometheus.HistogramVec
+	StampValidationTime     *prometheus.HistogramVec
 	Forwarder               prometheus.Counter
 	Storer                  prometheus.Counter
-	TotalHandlerTime        prometheus.HistogramVec
-	PushToPeerTime          prometheus.HistogramVec
+	TotalHandlerTime        *prometheus.HistogramVec
+	PushToPeerTime          *prometheus.HistogramVec
 
 	ReceiptDepth        *prometheus.CounterVec
 	ShallowReceiptDepth *prometheus.CounterVec
@@ -88,7 +88,7 @@ func newMetrics() metrics {
 			Name:      "invalid_stamps",
 			Help:      "No of invalid stamp errors.",
 		}),
-		StampValidationTime: *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		StampValidationTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "stamp_validation_time",
@@ -106,7 +106,7 @@ func newMetrics() metrics {
 			Name:      "storer",
 			Help:      "No of times the peer is a storer node.",
 		}),
-		TotalHandlerTime: *prometheus.NewHistogramVec(
+		TotalHandlerTime: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
@@ -114,7 +114,7 @@ func newMetrics() metrics {
 				Help:      "Histogram for time taken for the handler.",
 			}, []string{"status"},
 		),
-		PushToPeerTime: *prometheus.NewHistogramVec(
+		PushToPeerTime: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,

--- a/pkg/storer/metrics.go
+++ b/pkg/storer/metrics.go
@@ -17,8 +17,8 @@ import (
 
 // metrics groups storer related prometheus counters.
 type metrics struct {
-	MethodCalls             prometheus.CounterVec
-	MethodCallsDuration     prometheus.HistogramVec
+	MethodCalls             *prometheus.CounterVec
+	MethodCallsDuration     *prometheus.HistogramVec
 	ReserveSize             prometheus.Gauge
 	ReserveSizeWithinRadius prometheus.Gauge
 	ReserveCleanup          prometheus.Counter
@@ -28,7 +28,7 @@ type metrics struct {
 	ExpiredChunkCount       prometheus.Counter
 	OverCapTriggerCount     prometheus.Counter
 	ExpiredBatchCount       prometheus.Counter
-	LevelDBStats            prometheus.HistogramVec
+	LevelDBStats            *prometheus.HistogramVec
 	ExpiryTriggersCount     prometheus.Counter
 	ExpiryRunsCount         prometheus.Counter
 
@@ -40,7 +40,7 @@ func newMetrics() metrics {
 	const subsystem = "localstore"
 
 	return metrics{
-		MethodCalls: *prometheus.NewCounterVec(
+		MethodCalls: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
@@ -49,7 +49,7 @@ func newMetrics() metrics {
 			},
 			[]string{"component", "method", "status"},
 		),
-		MethodCallsDuration: *prometheus.NewHistogramVec(
+		MethodCallsDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,
@@ -138,7 +138,7 @@ func newMetrics() metrics {
 				Help:      "Number of batches expired, that were processed.",
 			},
 		),
-		LevelDBStats: *prometheus.NewHistogramVec(
+		LevelDBStats: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: m.Namespace,
 				Subsystem: subsystem,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR fixes the issue where prometheus vector variables are concrete values that results in their own lock being copied making them unreliable.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
