### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -6,6 +6,7 @@ package api_test
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -427,7 +428,7 @@ func TestEndpointOptions(t *testing.T) {
 					actualMethods := strings.Split(allowHeader, ", ")
 
 					for _, expectedMethod := range tt.expectedMethods {
-						if !contains(actualMethods, expectedMethod) {
+						if !slices.Contains(actualMethods, expectedMethod) {
 							t.Errorf("expected method %s not found for route %s", expectedMethod, tt.route)
 						}
 					}
@@ -435,13 +436,4 @@ func TestEndpointOptions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/storer/netstore_test.go
+++ b/pkg/storer/netstore_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -52,13 +53,7 @@ func testNetStore(t *testing.T, newStorer func(r retrieval.Interface) (*storer.D
 				for {
 					select {
 					case op := <-lstore.PusherFeed():
-						found := false
-						for _, ch := range chunks {
-							if op.Chunk.Equal(ch) {
-								found = true
-								break
-							}
-						}
+						found := slices.ContainsFunc(chunks, op.Chunk.Equal)
 						if !found {
 							op.Err <- fmt.Errorf("incorrect chunk for push: have %s", op.Chunk.Address())
 							continue
@@ -110,13 +105,7 @@ func testNetStore(t *testing.T, newStorer func(r retrieval.Interface) (*storer.D
 				for {
 					select {
 					case op := <-lstore.PusherFeed():
-						found := false
-						for _, ch := range chunks {
-							if op.Chunk.Equal(ch) {
-								found = true
-								break
-							}
-						}
+						found := slices.ContainsFunc(chunks, op.Chunk.Equal)
 						if !found {
 							op.Err <- fmt.Errorf("incorrect chunk for push: have %s", op.Chunk.Address())
 							continue


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
