### PR TITLE
revert: defaultBgCacheWorkers from 128 to 32

### DIFF
--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -243,7 +243,7 @@ const (
 	defaultWriteBufferSize        = uint64(32 * 1024 * 1024)
 	defaultDisableSeeksCompaction = false
 	defaultCacheCapacity          = uint64(1_000_000)
-	defaultBgCacheWorkers         = 128
+	defaultBgCacheWorkers         = 16
 	DefaultReserveCapacity        = 1 << 22 // 4194304 chunks
 
 	indexPath  = "indexstore"

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -243,7 +243,7 @@ const (
 	defaultWriteBufferSize        = uint64(32 * 1024 * 1024)
 	defaultDisableSeeksCompaction = false
 	defaultCacheCapacity          = uint64(1_000_000)
-	defaultBgCacheWorkers         = 16
+	defaultBgCacheWorkers         = 32
 	DefaultReserveCapacity        = 1 << 22 // 4194304 chunks
 
 	indexPath  = "indexstore"


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Bump in background cache worker count caused memory spike

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
