### PR TITLE
revert: "feat(libp2p): enable websockets transport by default (#5095)"

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -244,7 +244,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().String(optionNameAPIAddr, "127.0.0.1:1633", "HTTP API listen address")
 	cmd.Flags().String(optionNameP2PAddr, ":1634", "P2P listen address")
 	cmd.Flags().String(optionNameNATAddr, "", "NAT exposed address")
-	cmd.Flags().Bool(optionNameP2PWSEnable, true, "enable P2P WebSocket transport")
+	cmd.Flags().Bool(optionNameP2PWSEnable, false, "enable P2P WebSocket transport")
 	cmd.Flags().StringSlice(optionNameBootnodes, []string{"/dnsaddr/mainnet.ethswarm.org"}, "initial nodes to connect to")
 	cmd.Flags().Uint64(optionNameNetworkID, chaincfg.Mainnet.NetworkID, "ID of the Swarm network")
 	cmd.Flags().StringSlice(optionCORSAllowedOrigins, []string{}, "origins with CORS headers enabled")

--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -49,7 +49,7 @@ data-dir: "/var/lib/bee"
 ## P2P listen address
 # p2p-addr: :1634
 ## enable P2P WebSocket transport
-# p2p-ws-enable: true
+# p2p-ws-enable: false
 ## password for decrypting keys
 # password: ""
 ## path to a file that contains password for decrypting keys

--- a/packaging/homebrew-amd64/bee.yaml
+++ b/packaging/homebrew-amd64/bee.yaml
@@ -49,7 +49,7 @@ data-dir: "/usr/local/var/lib/swarm-bee"
 ## P2P listen address
 # p2p-addr: :1634
 ## enable P2P WebSocket transport
-# p2p-ws-enable: true
+# p2p-ws-enable: false
 ## password for decrypting keys
 # password: ""
 ## path to a file that contains password for decrypting keys

--- a/packaging/homebrew-arm64/bee.yaml
+++ b/packaging/homebrew-arm64/bee.yaml
@@ -49,7 +49,7 @@ data-dir: "/opt/homebrew/var/lib/swarm-bee"
 ## P2P listen address
 # p2p-addr: :1634
 ## enable P2P WebSocket transport
-# p2p-ws-enable: true
+# p2p-ws-enable: false
 ## password for decrypting keys
 # password: ""
 ## path to a file that contains password for decrypting keys

--- a/packaging/scoop/bee.yaml
+++ b/packaging/scoop/bee.yaml
@@ -49,7 +49,7 @@ data-dir: "./data"
 ## P2P listen address
 # p2p-addr: :1634
 ## enable P2P WebSocket transport
-# p2p-ws-enable: true
+# p2p-ws-enable: false
 ## password for decrypting keys
 # password: ""
 ## path to a file that contains password for decrypting keys


### PR DESCRIPTION
This reverts commit 9c0554636f315a071ce8fd17053053f936771d2c.

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

https://github.com/ethersphere/bee/pull/5101#issuecomment-2901490207

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
