### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/bmt/reference/reference.go
+++ b/pkg/bmt/reference/reference.go
@@ -38,10 +38,7 @@ func NewRefHasher(h hash.Hash, count int) *RefHasher {
 func (rh *RefHasher) Hash(data []byte) ([]byte, error) {
 	// if data is shorter than the base length (maxDataLength), we provide padding with zeros
 	d := make([]byte, rh.maxDataLength)
-	length := len(data)
-	if length > rh.maxDataLength {
-		length = rh.maxDataLength
-	}
+	length := min(len(data), rh.maxDataLength)
 	copy(d, data[:length])
 	return rh.hash(d, rh.maxDataLength)
 }

--- a/pkg/manifest/mantaray/marshal.go
+++ b/pkg/manifest/mantaray/marshal.go
@@ -162,10 +162,7 @@ func (n *Node) MarshalBinary() (bytes []byte, err error) {
 	copy(xorEncryptedBytes, bytes[0:nodeObfuscationKeySize])
 
 	for i := nodeObfuscationKeySize; i < len(bytes); i += nodeObfuscationKeySize {
-		end := i + nodeObfuscationKeySize
-		if end > len(bytes) {
-			end = len(bytes)
-		}
+		end := min(i+nodeObfuscationKeySize, len(bytes))
 
 		encrypted := encryptDecrypt(bytes[i:end], n.obfuscationKey)
 		copy(xorEncryptedBytes[i:end], encrypted)
@@ -228,10 +225,7 @@ func (n *Node) UnmarshalBinary(data []byte) error {
 	copy(xorDecryptedBytes, data[0:nodeObfuscationKeySize])
 
 	for i := nodeObfuscationKeySize; i < len(data); i += nodeObfuscationKeySize {
-		end := i + nodeObfuscationKeySize
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(i+nodeObfuscationKeySize, len(data))
 
 		decrypted := encryptDecrypt(data[i:end], n.obfuscationKey)
 		copy(xorDecryptedBytes[i:end], decrypted)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
