### PR TITLE
Fix Readme - Broken installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read the [coding guidelines](CODING.md) and [style guide](CODINGSTYLE.md)
 
 ## Installing
 
-[Install instructions](https://docs.ethswarm.org/docs/installation/quick-start)
+[Install instructions](https://docs.ethswarm.org/docs/bee/installation/quick-start)
 
 ## Get in touch
 


### PR DESCRIPTION
### Checklist

- [X ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [X ] My change requires a documentation update, and I have done it.
- [X ] I have added tests to cover my changes.
- [X ] I have filled out the description and linked the related issues.

### Description
The installation link in the readme is broken and has been updated to https://docs.ethswarm.org/docs/bee/installation/quick-start

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
