### PR TITLE
fix(salud): use exponential backoff for wake up of salud check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/ethersphere/bee/v2
 
 go 1.24.0
 
-toolchain go1.24.2
-
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/armon/go-radix v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ethersphere/bee/v2
 
 go 1.24.0
 
+toolchain go1.24.2
+
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/armon/go-radix v1.0.0

--- a/pkg/pingpong/pingpong.go
+++ b/pkg/pingpong/pingpong.go
@@ -22,7 +22,7 @@ import (
 )
 
 // loggerName is the tree path name of the logger for this package.
-const loggerName = "pinpong"
+const loggerName = "pingpong"
 
 const (
 	protocolName    = "pingpong"

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -26,7 +26,7 @@ const loggerName = "salud"
 
 const (
 	requestTimeout         = time.Second * 10
-	initialBackoffDelay    = 5 * time.Second
+	initialBackoffDelay    = 10 * time.Second
 	maxBackoffDelay        = 5 * time.Minute
 	backoffFactor          = 2
 	DefaultMinPeersPerBin  = 4

--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -194,7 +194,7 @@ func (s *service) salud(mode string, minPeersPerbin int, durPercentile float64, 
 	s.metrics.NetworkRadius.Set(float64(networkRadius))
 	s.metrics.NeighborhoodRadius.Set(float64(nHoodRadius))
 	s.metrics.Commitment.Set(float64(commitment))
-	
+
 	s.logger.Debug("computed", "avg_dur", avgDur, "pDur", pDur, "pConns", pConns, "network_radius", networkRadius, "neighborhood_radius", nHoodRadius, "batch_commitment", commitment)
 
 	// sort peers by duration, highest first to give priority to the fastest peers

--- a/pkg/storer/internal/stampindex/stampindex.go
+++ b/pkg/storer/internal/stampindex/stampindex.go
@@ -213,7 +213,7 @@ func Delete(s storage.Writer, scope string, stamp swarm.Stamp) error {
 		StampIndex: stamp.Index(),
 	}
 	if err := s.Delete(item); err != nil {
-		return fmt.Errorf("failed to delete stampindex.Item %s: %w", item, err)
+		return fmt.Errorf("failed to delete stampindex.Item %s: %w", item.ID(), err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Idea is to reduce the time that salud spends to update the peer status. This will help the light node spin time and readiness. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
