### PR TITLE
feat: add reserveCapacityDoubling to /reservestate

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -50,6 +50,8 @@ components:
           type: integer
         commitment:
           type: integer
+        reserveCapacityDoubling:
+          type: integer
 
     ChainState:
       type: object

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -394,7 +394,7 @@ func (s *Service) reserveStateHandler(w http.ResponseWriter, _ *http.Request) {
 		Radius:                  s.batchStore.Radius(),
 		StorageRadius:           s.storer.StorageRadius(),
 		Commitment:              commitment,
-		ReserveCapacityDoubling: s.storer.CommittedDepth() - s.storer.StorageRadius(),
+		ReserveCapacityDoubling: s.storer.CapacityDoubling(),
 	})
 }
 

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -366,9 +366,10 @@ func (s *Service) postageGetStampHandler(w http.ResponseWriter, r *http.Request)
 }
 
 type reserveStateResponse struct {
-	Radius        uint8  `json:"radius"`
-	StorageRadius uint8  `json:"storageRadius"`
-	Commitment    uint64 `json:"commitment"`
+	Radius                  uint8  `json:"radius"`
+	StorageRadius           uint8  `json:"storageRadius"`
+	Commitment              uint64 `json:"commitment"`
+	ReserveCapacityDoubling uint8  `json:"reserveCapacityDoubling"`
 }
 
 type chainStateResponse struct {
@@ -390,9 +391,10 @@ func (s *Service) reserveStateHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	jsonhttp.OK(w, reserveStateResponse{
-		Radius:        s.batchStore.Radius(),
-		StorageRadius: s.storer.StorageRadius(),
-		Commitment:    commitment,
+		Radius:                  s.batchStore.Radius(),
+		StorageRadius:           s.storer.StorageRadius(),
+		Commitment:              commitment,
+		ReserveCapacityDoubling: s.storer.CommittedDepth() - s.storer.StorageRadius(),
 	})
 }
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -374,13 +374,18 @@ func TestReserveState(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
+		s := mockstorer.New()
+		s.SetStorageRadius(3)
+		s.SetCommittedDepth(5)
 		ts, _, _, _ := newTestServer(t, testServerOptions{
 			BatchStore: mock.New(mock.WithRadius(5)),
-			Storer:     mockstorer.New(),
+			Storer:     s,
 		})
 		jsonhttptest.Request(t, ts, http.MethodGet, "/reservestate", http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.ReserveStateResponse{
-				Radius: 5,
+				Radius:                  5,
+				StorageRadius:           3,
+				ReserveCapacityDoubling: 2,
 			}),
 		)
 	})

--- a/pkg/storer/mock/mockreserve.go
+++ b/pkg/storer/mock/mockreserve.go
@@ -152,6 +152,12 @@ func (s *ReserveStore) CommittedDepth() uint8 {
 	return s.radius + uint8(s.capacityDoubling)
 }
 
+func (s *ReserveStore) CapacityDoubling() uint8 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return uint8(s.capacityDoubling)
+}
+
 // IntervalChunks returns a set of chunk in a requested interval.
 func (s *ReserveStore) SubscribeBin(ctx context.Context, bin uint8, start uint64) (<-chan *storer.BinC, func(), <-chan error) {
 	s.mtx.Lock()

--- a/pkg/storer/mock/mockstorer.go
+++ b/pkg/storer/mock/mockstorer.go
@@ -28,6 +28,9 @@ type mockStorer struct {
 	activeSessions map[uint64]*storer.SessionInfo
 	chunkPushC     chan *pusher.Op
 	debugInfo      storer.Info
+
+	storageRadius  uint8
+	committedDepth uint8
 }
 
 type putterSession struct {
@@ -218,9 +221,9 @@ func (m *mockStorer) ChunkStore() storage.ReadOnlyChunkStore {
 	return m.chunkStore
 }
 
-func (m *mockStorer) StorageRadius() uint8 { return 0 }
+func (m *mockStorer) StorageRadius() uint8 { return m.storageRadius }
 
-func (m *mockStorer) CommittedDepth() uint8 { return 0 }
+func (m *mockStorer) CommittedDepth() uint8 { return m.committedDepth }
 
 func (m *mockStorer) IsWithinStorageRadius(_ swarm.Address) bool { return true }
 
@@ -234,4 +237,16 @@ func (m *mockStorer) NeighborhoodsStat(ctx context.Context) ([]*storer.Neighborh
 
 func (m *mockStorer) Put(ctx context.Context, ch swarm.Chunk) error {
 	return m.chunkStore.Put(ctx, ch)
+}
+
+func (m *mockStorer) SetStorageRadius(radius uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.storageRadius = radius
+}
+
+func (m *mockStorer) SetCommittedDepth(depth uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.committedDepth = depth
 }

--- a/pkg/storer/mock/mockstorer.go
+++ b/pkg/storer/mock/mockstorer.go
@@ -225,6 +225,10 @@ func (m *mockStorer) StorageRadius() uint8 { return m.storageRadius }
 
 func (m *mockStorer) CommittedDepth() uint8 { return m.committedDepth }
 
+func (m *mockStorer) CapacityDoubling() uint8 {
+	return m.committedDepth - m.storageRadius
+}
+
 func (m *mockStorer) IsWithinStorageRadius(_ swarm.Address) bool { return true }
 
 func (m *mockStorer) DebugInfo(_ context.Context) (storer.Info, error) {

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -428,6 +428,13 @@ func (db *DB) CommittedDepth() uint8 {
 	return uint8(db.reserveOptions.capacityDoubling) + db.reserve.Radius()
 }
 
+func (db *DB) CapacityDoubling() uint8 {
+	if db.reserve == nil {
+		return 0
+	}
+	return uint8(db.reserveOptions.capacityDoubling)
+}
+
 func (db *DB) ReserveSize() int {
 	if db.reserve == nil {
 		return 0

--- a/pkg/storer/storer.go
+++ b/pkg/storer/storer.go
@@ -165,6 +165,7 @@ type RadiusChecker interface {
 	IsWithinStorageRadius(addr swarm.Address) bool
 	StorageRadius() uint8
 	CommittedDepth() uint8
+	CapacityDoubling() uint8
 }
 
 // LocalStore is a read-only ChunkStore. It can be used to check if chunk is known


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Adds `reserveCapacityDoubling` to `/reservestate` response

### Related Issue (Optional)
closes #5126

### Screenshots (if appropriate):
