### PR TITLE
revert: feed legacy payload header (#5029)

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1036,12 +1036,6 @@ paths:
             $ref: "SwarmCommon.yaml#/components/schemas/FeedType"
           required: false
           description: "Feed indexing scheme (default: sequence)"
-        - in: header
-          name: legacy-feed-resolution
-          schema:
-            type: boolean
-          required: false
-          description: "Resolves feed payloads in legacy structure (timestamp, content address)."
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmOnlyRootChunkParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmCache"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyStrategyParameter"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -78,7 +78,6 @@ const (
 	SwarmSocSignatureHeader           = "Swarm-Soc-Signature"
 	SwarmFeedIndexHeader              = "Swarm-Feed-Index"
 	SwarmFeedIndexNextHeader          = "Swarm-Feed-Index-Next"
-	SwarmLegacyFeedResolve            = "Swarm-Feed-Legacy-Resolve"
 	SwarmOnlyRootChunk                = "Swarm-Only-Root-Chunk"
 	SwarmCollectionHeader             = "Swarm-Collection"
 	SwarmPostageBatchIdHeader         = "Swarm-Postage-Batch-Id"

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -433,7 +433,7 @@ FETCH:
 				jsonhttp.NotFound(w, "no update found")
 				return
 			}
-			wc, err := feeds.GetWrappedChunk(ctx, s.storer.Download(cache), ch, false)
+			wc, err := feeds.GetWrappedChunk(ctx, s.storer.Download(cache), ch)
 			if err != nil {
 				logger.Debug("bzz download: mapStructure feed update failed", "error", err)
 				logger.Error(nil, "bzz download: mapStructure feed update failed")

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/manifest"
 	mockbatchstore "github.com/ethersphere/bee/v2/pkg/postage/batchstore/mock"
 	mockpost "github.com/ethersphere/bee/v2/pkg/postage/mock"
-	testingsoc "github.com/ethersphere/bee/v2/pkg/soc/testing"
 	"github.com/ethersphere/bee/v2/pkg/storage/inmemchunkstore"
 	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -795,22 +794,16 @@ func TestFeedIndirection(t *testing.T) {
 		t.Fatalf("expected file reference, did not got any")
 	}
 
-	// get root chunk of data
-	// and wrap it in a feed
-	rootCh, err := storer.ChunkStore().Get(context.Background(), resp.Reference)
-	if err != nil {
-		t.Fatal(err)
-	}
-	socRootCh := testingsoc.GenerateMockSOC(t, rootCh.Data()[swarm.SpanSize:]).Chunk()
-
-	// now use the "content" root chunk to mock the feed lookup
+	// now use the "content" to mock the feed lookup
 	// also, use the mocked mantaray chunks that unmarshal
 	// into a real manifest with the mocked feed values when
 	// called from the bzz endpoint. then call the bzz endpoint with
 	// the pregenerated feed root manifest hash
 
+	feedUpdate := toChunk(t, 121212, resp.Reference.Bytes())
+
 	var (
-		look                = newMockLookup(-1, 0, socRootCh, nil, &id{}, nil)
+		look                = newMockLookup(-1, 0, feedUpdate, nil, &id{}, nil)
 		factory             = newMockFactory(look)
 		bzzDownloadResource = func(addr, path string) string { return "/bzz/" + addr + "/" + path }
 		ctx                 = context.Background()
@@ -820,6 +813,7 @@ func TestFeedIndirection(t *testing.T) {
 		Logger: logger,
 		Feeds:  factory,
 	})
+	err := storer.Cache().Put(ctx, feedUpdate)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/feed.go
+++ b/pkg/api/feed.go
@@ -65,8 +65,7 @@ func (s *Service) feedGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	headers := struct {
-		OnlyRootChunk     bool `map:"Swarm-Only-Root-Chunk"`
-		LegacyFeedResolve bool `map:"Swarm-Feed-Legacy-Resolve"`
+		OnlyRootChunk bool `map:"Swarm-Only-Root-Chunk"`
 	}{}
 	if response := s.mapStructure(r.Header, &headers); response != nil {
 		response("invalid header params", logger, w)
@@ -103,7 +102,7 @@ func (s *Service) feedGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wc, err := feeds.GetWrappedChunk(r.Context(), s.storer.Download(false), ch, headers.LegacyFeedResolve)
+	wc, err := feeds.GetWrappedChunk(r.Context(), s.storer.Download(false), ch)
 	if err != nil {
 		logger.Error(nil, "wrapped chunk cannot be retrieved")
 		jsonhttp.NotFound(w, "wrapped chunk cannot be retrieved")

--- a/pkg/api/feed_test.go
+++ b/pkg/api/feed_test.go
@@ -77,7 +77,6 @@ func TestFeed_Get(t *testing.T) {
 
 		jsonhttptest.Request(t, client, http.MethodGet, feedResource(ownerString, "aabbcc", "12"), http.StatusOK,
 			jsonhttptest.WithExpectedResponse(mockWrappedCh.Data()[swarm.SpanSize:]),
-			jsonhttptest.WithRequestHeader(api.SwarmLegacyFeedResolve, "true"),
 			jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
 			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexHeader),
 			jsonhttptest.WithExpectedResponseHeader(api.AccessControlExposeHeaders, api.SwarmFeedIndexNextHeader),
@@ -87,7 +86,7 @@ func TestFeed_Get(t *testing.T) {
 		)
 	})
 
-	t.Run("latest with legacy payload", func(t *testing.T) {
+	t.Run("latest", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -104,7 +103,6 @@ func TestFeed_Get(t *testing.T) {
 		)
 
 		jsonhttptest.Request(t, client, http.MethodGet, feedResource(ownerString, "aabbcc", ""), http.StatusOK,
-			jsonhttptest.WithRequestHeader(api.SwarmLegacyFeedResolve, "true"),
 			jsonhttptest.WithExpectedResponse(mockWrappedCh.Data()[swarm.SpanSize:]),
 			jsonhttptest.WithExpectedContentLength(len(mockWrappedCh.Data()[swarm.SpanSize:])),
 			jsonhttptest.WithExpectedResponseHeader(api.SwarmFeedIndexHeader, hex.EncodeToString(idBytes)),
@@ -163,9 +161,7 @@ func TestFeed_Get(t *testing.T) {
 			})
 		)
 
-		jsonhttptest.Request(t, client, http.MethodGet, feedResource(ownerString, "aabbcc", ""), http.StatusNotFound,
-			jsonhttptest.WithRequestHeader(api.SwarmLegacyFeedResolve, "true"),
-		)
+		jsonhttptest.Request(t, client, http.MethodGet, feedResource(ownerString, "aabbcc", ""), http.StatusNotFound)
 	})
 
 	t.Run("bigger payload than one chunk", func(t *testing.T) {

--- a/pkg/feeds/getter.go
+++ b/pkg/feeds/getter.go
@@ -50,7 +50,7 @@ func (f *Getter) Get(ctx context.Context, i Index) (swarm.Chunk, error) {
 	return f.getter.Get(ctx, addr)
 }
 
-func GetWrappedChunk(ctx context.Context, getter storage.Getter, ch swarm.Chunk, legacyResolve bool) (swarm.Chunk, error) {
+func GetWrappedChunk(ctx context.Context, getter storage.Getter, ch swarm.Chunk) (swarm.Chunk, error) {
 	wc, err := FromChunk(ch)
 	if err != nil {
 		return nil, err
@@ -59,15 +59,16 @@ func GetWrappedChunk(ctx context.Context, getter storage.Getter, ch swarm.Chunk,
 	// possible values right now:
 	// unencrypted ref: span+timestamp+ref => 8+8+32=48
 	// encrypted ref: span+timestamp+ref+decryptKey => 8+8+64=80
-	if legacyResolve {
-		ref, err := legacyPayload(wc)
-		if err != nil {
-			return nil, err
+	ref, err := legacyPayload(wc)
+	if err != nil {
+		if errors.Is(err, errNotLegacyPayload) {
+			return wc, nil
 		}
-		wc, err = getter.Get(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	wc, err = getter.Get(ctx, ref)
+	if err != nil {
+		return nil, err
 	}
 
 	return wc, nil

--- a/pkg/node/bootstrap.go
+++ b/pkg/node/bootstrap.go
@@ -336,7 +336,7 @@ func getLatestSnapshot(
 		return nil, err
 	}
 
-	return feeds.GetWrappedChunk(ctx, st, u, false)
+	return feeds.GetWrappedChunk(ctx, st, u)
 }
 
 func batchStoreExists(s storage.StateStorer) (bool, error) {


### PR DESCRIPTION
This reverts PR #5029 in favor of change on the Feed UX affecting legacy payload based on issues #5155 #5156 #5157 in a later release

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
