### PR TITLE
refactor: init metrics

### DIFF
--- a/pkg/node/metrics.go
+++ b/pkg/node/metrics.go
@@ -26,14 +26,20 @@ func newMetrics() nodeMetrics {
 				Subsystem: subsystem,
 				Name:      "warmup_duration_seconds",
 				Help:      "Duration in seconds for node warmup to complete",
+				// middle range should be more infrequent (because of addressbook)
+				Buckets: []float64{10, 12, 14, 16, 18, 20, 30, 45, 60, 90, 120, 180, 240, 300, 400, 420, 440, 460, 480, 550, 600},
 			},
 		),
 		FullSyncDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: metrics.Namespace,
 				Subsystem: subsystem,
-				Name:      "full_sync_duration_seconds",
-				Help:      "Duration in seconds for node warmup to complete",
+				Name:      "full_sync_duration_minutes",
+				Help:      "Duration in minutes for node full sync to complete",
+				// middle range should be more frequent
+				Buckets: []float64{80, 90, 100, 110,
+					120, 125, 130, 135, 140, 145, 150, 155, 160, 165, 170, 175, 180, // 2-3 hours range
+					190, 200, 210, 220, 230, 240},
 			},
 		),
 	}

--- a/pkg/node/metrics.go
+++ b/pkg/node/metrics.go
@@ -27,7 +27,7 @@ func newMetrics() nodeMetrics {
 				Name:      "warmup_duration_seconds",
 				Help:      "Duration in seconds for node warmup to complete",
 				// middle range should be more infrequent (because of addressbook)
-				Buckets: []float64{10, 12, 14, 16, 18, 20, 30, 45, 60, 90, 120, 180, 240, 300, 400, 420, 440, 460, 480, 550, 600},
+				Buckets: []float64{10, 20, 25, 30, 35, 40, 45, 50, 60, 70, 90, 120, 180, 240, 300, 350, 380, 400, 420, 440, 460, 480, 550, 600},
 			},
 		),
 		FullSyncDuration: prometheus.NewHistogram(

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -612,7 +612,6 @@ func NewBee(
 			"totalMonitoredEvents", totalCount,
 			"warmupDurationSeconds", warmupDuration)
 
-		// Record the warmup duration in the prometheus metric
 		nodeMetrics.WarmupDuration.Observe(warmupDuration)
 		pullSyncStartTime = t
 	}
@@ -1167,10 +1166,11 @@ func NewBee(
 						return
 					case <-syncCheckTicker.C:
 						synced := isFullySynced()
-						logger.Debug("sync status check", "synced", synced, "reserveSize", localStore.ReserveSize(), "threshold", reserveTreshold, "syncRate", pullerService.SyncRate())
+						logger.Debug("sync status check", "synced", synced, "reserveSize", localStore.ReserveSize(), "syncRate", pullerService.SyncRate())
 						if synced {
 							fullSyncTime := pullSyncStartTime.Sub(t)
-							nodeMetrics.FullSyncDuration.Observe(fullSyncTime.Seconds())
+							logger.Info("full sync duration", "duration", fullSyncTime)
+							nodeMetrics.FullSyncDuration.Observe(fullSyncTime.Minutes())
 							syncCheckTicker.Stop()
 							return
 						}


### PR DESCRIPTION
default proposed buckets do not fit with current measurements.
Times measurements are collected from the new logs (0.5-7 mins warmup, ~2-3 hours pull sync) by which the buckets could be adjusted.

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
