### PR TITLE
refactor: use b.Loop() to simplify the code

### DIFF
--- a/pkg/bmt/benchmark_test.go
+++ b/pkg/bmt/benchmark_test.go
@@ -47,8 +47,8 @@ func benchmarkSHA3(b *testing.B, n int) {
 	testData := testutil.RandBytesWithSeed(b, 4096, seed)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if _, err := bmt.Sha3hash(testData[:n]); err != nil {
 			b.Fatalf("seed %d: %v", seed, err)
 		}
@@ -66,8 +66,8 @@ func benchmarkBMTBaseline(b *testing.B, _ int) {
 	testData := testutil.RandBytesWithSeed(b, 4096, seed)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		eg := new(errgroup.Group)
 		for j := 0; j < testSegmentCount; j++ {
 			eg.Go(func() error {
@@ -92,8 +92,8 @@ func benchmarkBMT(b *testing.B, n int) {
 	defer pool.Put(h)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if _, err := syncHash(h, testData[:n]); err != nil {
 			b.Fatalf("seed %d: %v", seed, err)
 		}
@@ -110,8 +110,8 @@ func benchmarkPool(b *testing.B, poolsize int) {
 	cycles := 100
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		eg := new(errgroup.Group)
 		for j := 0; j < cycles; j++ {
 			eg.Go(func() error {
@@ -136,8 +136,8 @@ func benchmarkRefHasher(b *testing.B, n int) {
 	rbmt := reference.NewRefHasher(swarm.NewHasher(), 128)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := rbmt.Hash(testData[:n])
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/feeds/epochs/lookup_benchmark_test.go
+++ b/pkg/feeds/epochs/lookup_benchmark_test.go
@@ -58,7 +58,7 @@ func BenchmarkFinder(b *testing.B) {
 				} {
 					names := []string{"sync", "async"}
 					b.Run(fmt.Sprintf("%s:prefill=%d, latest=%d, now=%d", names[k], prefill, latest, now), func(b *testing.B) {
-						for n := 0; n < b.N; n++ {
+						for b.Loop() {
 							_, _, _, err := finder.At(ctx, int64(now), after)
 							if err != nil {
 								b.Fatal(err)

--- a/pkg/feeds/sequence/lookup_benchmark_test.go
+++ b/pkg/feeds/sequence/lookup_benchmark_test.go
@@ -54,7 +54,7 @@ func BenchmarkFinder(b *testing.B) {
 		} {
 			names := []string{"sync", "async"}
 			b.Run(fmt.Sprintf("%s:prefill=%d, latest/now=%d", names[k], prefill, now), func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					_, _, _, err := finder.At(ctx, now, 0)
 					if err != nil {
 						b.Fatal(err)

--- a/pkg/file/pipeline/builder/builder_test.go
+++ b/pkg/file/pipeline/builder/builder_test.go
@@ -140,7 +140,7 @@ func BenchmarkPipeline(b *testing.B) {
 		100000000, // 100 mb
 	} {
 		b.Run(strconv.Itoa(count)+"-bytes", func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				benchmarkPipeline(b, count)
 			}
 		})

--- a/pkg/file/splitter/splitter_test.go
+++ b/pkg/file/splitter/splitter_test.go
@@ -223,7 +223,7 @@ func BenchmarkSplitter(b *testing.B) {
 		100000000, // 100 mb
 	} {
 		b.Run(strconv.Itoa(count)+"-bytes", func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				benchmarkSplitter(b, count)
 			}
 		})

--- a/pkg/pss/mining_test.go
+++ b/pkg/pss/mining_test.go
@@ -51,7 +51,7 @@ func BenchmarkWrap(b *testing.B) {
 		name := fmt.Sprintf("length:%d,depth:%d", c.length, c.depth)
 		b.Run(name, func(b *testing.B) {
 			targets := newTargets(c.length, c.depth)
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := pss.Wrap(ctx, topic, msg, pubkey, targets); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/storage/storagetest/benchmark.go
+++ b/pkg/storage/storagetest/benchmark.go
@@ -227,7 +227,7 @@ func maxInt(a int, b int) int {
 func doRead(b *testing.B, db storage.Store, g keyGenerator, allowNotFound bool) {
 	b.Helper()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		key := g.Key(i)
 		item := &obj1{
 			Id: string(key),
@@ -269,7 +269,7 @@ func doWrite(b *testing.B, db storage.Store, g entryGenerator) {
 	b.Helper()
 
 	w := newDBWriter(db)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		if err := w.Put(g.Key(i), g.Value(i)); err != nil {
 			b.Fatalf("write key '%s': %v", string(g.Key(i)), err)
 		}
@@ -280,7 +280,7 @@ func doDelete(b *testing.B, db storage.Store, g keyGenerator) {
 	b.Helper()
 
 	w := newDBWriter(db)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		if err := w.Delete(g.Key(i)); err != nil {
 			b.Fatalf("delete key '%s': %v", string(g.Key(i)), err)
 		}
@@ -304,7 +304,7 @@ func populate(b *testing.B, db storage.Store) {
 func doDeleteChunk(b *testing.B, db storage.ChunkStore, g keyGenerator) {
 	b.Helper()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		addr := swarm.MustParseHexAddress(string(g.Key(i)))
 		if err := db.Delete(context.Background(), addr); err != nil {
 			b.Fatalf("delete key '%s': %v", string(g.Key(i)), err)
@@ -315,7 +315,7 @@ func doDeleteChunk(b *testing.B, db storage.ChunkStore, g keyGenerator) {
 func doWriteChunk(b *testing.B, db storage.Putter, g entryGenerator) {
 	b.Helper()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		buf := make([]byte, swarm.HashSize)
 		if _, err := hex.Decode(buf, g.Key(i)); err != nil {
 			b.Fatalf("decode value: %v", err)
@@ -331,7 +331,7 @@ func doWriteChunk(b *testing.B, db storage.Putter, g entryGenerator) {
 func doReadChunk(b *testing.B, db storage.ChunkStore, g keyGenerator, allowNotFound bool) {
 	b.Helper()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		key := string(g.Key(i))
 		addr := swarm.MustParseHexAddress(key)
 		_, err := db.Get(context.Background(), addr)

--- a/pkg/storage/storagetest/storage.go
+++ b/pkg/storage/storagetest/storage.go
@@ -950,7 +950,7 @@ func BenchmarkWriteInBatches(b *testing.B, bs storage.BatchStore) {
 	g := newSequentialEntryGenerator(b.N)
 	batch := bs.Batch(context.Background())
 	resetBenchmark(b)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		key := g.Key(i)
 		item := &obj1{
 			Id:  string(key),
@@ -969,7 +969,7 @@ func BenchmarkWriteInFixedSizeBatches(b *testing.B, bs storage.BatchStore) {
 	g := newSequentialEntryGenerator(b.N)
 	writer := newBatchDBWriter(bs)
 	resetBenchmark(b)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		writer.Put(g.Key(i), g.Value(i))
 	}
 }
@@ -1021,7 +1021,7 @@ func BenchmarkDeleteInBatches(b *testing.B, bs storage.BatchStore) {
 	doWrite(b, bs, g)
 	resetBenchmark(b)
 	batch := bs.Batch(context.Background())
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		item := &obj1{
 			Id: string(g.Key(i)),
 		}
@@ -1039,7 +1039,7 @@ func BenchmarkDeleteInFixedSizeBatches(b *testing.B, bs storage.BatchStore) {
 	doWrite(b, bs, g)
 	resetBenchmark(b)
 	writer := newBatchDBWriter(bs)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		writer.Delete(g.Key(i))
 	}
 }

--- a/pkg/topology/pslice/pslice_test.go
+++ b/pkg/topology/pslice/pslice_test.go
@@ -435,9 +435,7 @@ func BenchmarkAdd(b *testing.B) {
 
 	addrs := swarm.RandAddresses(b, bins*perBin)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		for _, addr := range addrs {
 			ps.Add(addr)
 		}
@@ -450,9 +448,7 @@ func BenchmarkAddBatch(b *testing.B) {
 
 	addrs := swarm.RandAddresses(b, bins*perBin)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		ps.Add(addrs...)
 	}
 }
@@ -464,9 +460,7 @@ func BenchmarkRemove(b *testing.B) {
 	addrs := swarm.RandAddresses(b, bins*perBin)
 	ps.Add(addrs...)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		for _, addr := range addrs {
 			ps.Remove(addr)
 		}
@@ -480,9 +474,7 @@ func BenchmarkEachBin(b *testing.B) {
 	addrs := swarm.RandAddresses(b, bins*perBin)
 	ps.Add(addrs...)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_ = ps.EachBin(func(a swarm.Address, u uint8) (stop bool, jumpToNext bool, err error) {
 			return false, false, nil
 		})
@@ -496,9 +488,7 @@ func BenchmarkEachBinRev(b *testing.B) {
 	addrs := swarm.RandAddresses(b, bins*perBin)
 	ps.Add(addrs...)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_ = ps.EachBinRev(func(a swarm.Address, u uint8) (stop bool, jumpToNext bool, err error) {
 			return false, false, nil
 		})


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

replace `for i := range b.N` or `for range b.N` in a benchmark with `for b.Loop()`, and remove any preceding calls to `b.StopTimer`,` b.StartTimer`, and `b.ResetTimer`.

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
