### PR TITLE
fix: report sync error after too many shallow receipts

### DIFF
--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -281,10 +281,11 @@ func (s *Service) pushDeferred(ctx context.Context, logger log.Logger, op *Op) (
 		if s.shallowReceipt(op.identityAddress) {
 			return true, err
 		}
-		if err := s.storer.Report(ctx, op.Chunk, storage.ChunkSynced); err != nil {
-			loggerV1.Error(err, "pusher: failed to report sync status")
-			return true, err
-		}
+		loggerV1.Warning(
+			"pusher: shallow receipt got too many times for the chunk, skipping syncing",
+			"chunk_address", op.Chunk.Address(),
+		)
+		return false, s.storer.Report(ctx, op.Chunk, storage.ChunkCouldNotSync)
 	case err == nil:
 		if err := s.storer.Report(ctx, op.Chunk, storage.ChunkSynced); err != nil {
 			loggerV1.Error(err, "pusher: failed to report sync status")


### PR DESCRIPTION
This change does not count chunks as synced after get too many retries on shallow receipts in case of deferred uploads.    

It is required to not sync bins below storage radius with not neighbor peers and thereby optimize pull syncing.

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
