### PR TITLE
fix: pin eviction guard

### DIFF
--- a/pkg/storer/internal/reserve/reserve_test.go
+++ b/pkg/storer/internal/reserve/reserve_test.go
@@ -22,6 +22,7 @@ import (
 	chunk "github.com/ethersphere/bee/v2/pkg/storage/testing"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/chunkstamp"
+	pinstore "github.com/ethersphere/bee/v2/pkg/storer/internal/pinning"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/reserve"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/stampindex"
 	"github.com/ethersphere/bee/v2/pkg/storer/internal/transaction"
@@ -962,6 +963,129 @@ func TestReset(t *testing.T) {
 		_, err = r.Get(context.Background(), c.Address(), c.Stamp().BatchID(), h)
 		if !errors.Is(err, storage.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", storage.ErrNotFound, err)
+		}
+	}
+}
+
+// TestEvictRemovesPinnedContent checks that pinned chunks are protected from eviction.
+func TestEvictRemovesPinnedContent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numChunks       = 5
+		numPinnedChunks = 3
+	)
+
+	ctx := context.Background()
+	baseAddr := swarm.RandAddress(t)
+	ts := internal.NewInmemStorage()
+
+	r, err := reserve.New(
+		baseAddr,
+		ts,
+		0,
+		kademlia.NewTopologyDriver(),
+		log.Noop,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batch := postagetesting.MustNewBatch()
+
+	chunks := make([]swarm.Chunk, numChunks)
+	for i := 0; i < numChunks; i++ {
+		ch := chunk.GenerateTestRandomChunkAt(t, baseAddr, 0).WithStamp(postagetesting.MustNewBatchStamp(batch.ID))
+		chunks[i] = ch
+
+		err := r.Put(ctx, ch)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var pinningPutter internal.PutterCloserWithReference
+	err = ts.Run(ctx, func(store transaction.Store) error {
+		pinningPutter, err = pinstore.NewCollection(store.IndexStore())
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add chunks to pin collection
+	pinnedChunks := chunks[:numPinnedChunks]
+	for _, ch := range pinnedChunks {
+		err = ts.Run(ctx, func(s transaction.Store) error {
+			return pinningPutter.Put(ctx, s, ch)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = ts.Run(ctx, func(s transaction.Store) error {
+		return pinningPutter.Close(s.IndexStore(), pinnedChunks[0].Address())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// evict all chunks from this batch - this should NOT remove pinned chunks
+	evicted, err := r.EvictBatchBin(ctx, batch.ID, numChunks, swarm.MaxBins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evicted != numChunks-len(pinnedChunks) {
+		t.Fatalf("expected %d evicted chunks, got %d", numChunks-len(pinnedChunks), evicted)
+	}
+
+	uuids, err := pinstore.GetCollectionUUIDs(ts.IndexStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(uuids) != 1 {
+		t.Fatalf("expected exactly one pin collection, but found %d", len(uuids))
+	}
+
+	for i, ch := range chunks {
+		stampHash, err := ch.Stamp().Hash()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Try to get the chunk from reserve, error is checked later
+		_, err = r.Get(ctx, ch.Address(), ch.Stamp().BatchID(), stampHash)
+
+		pinned := false
+		for _, uuid := range uuids {
+			has, err := pinstore.IsChunkPinnedInCollection(ts.IndexStore(), ch.Address(), uuid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if has {
+				pinned = true
+			}
+		}
+
+		if i < len(pinnedChunks) {
+			if pinned {
+				// This chunk is pinned, so it should NOT have been evicted
+				if errors.Is(err, storage.ErrNotFound) {
+					t.Errorf("Pinned chunk %s was evicted despite being pinned!", ch.Address())
+				} else if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				t.Errorf("Chunk %s should be pinned", ch.Address())
+			}
+		} else { // unpinned chunks
+			if !pinned {
+				if !errors.Is(err, storage.ErrNotFound) {
+					t.Errorf("Unpinned chunk %s should have been evicted", ch.Address())
+				}
+			} else {
+				t.Errorf("Chunk %s should not be pinned", ch.Address())
+			}
 		}
 	}
 }


### PR DESCRIPTION
The changes implemented comprehensive pin protection for chunk eviction by addressing a critical bug in the `EvictBatchBin` method.

The fix modified the `EvictBatchBin` method to properly check each chunk against all pin collections using the newly created `pinstore.IsChunkPinnedInCollection` function. When a pinned chunk is found, the eviction only removes reserve related records of that chunk. This ensures that non-pinned chunks can still be evicted while maintaining the integrity of pinned content.

Reserve capacity eviction is directly protected through the `EvictBatchBin` method. 
Batch expiry eviction is automatically protected because the entire flow from `EvictBatch` ultimately calls `EvictBatchBin`. 
Cache eviction was determined to not require pin protection because pinned chunks are stored in the main ChunkStore layer. 

Closes #5215

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
