### PR TITLE
fix(node): support basic auth in blockchain RPC endpoint URLs

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	optionNameValidation     = "validate"
-	optionNameValidationPin  = "validate-pin"
 	optionNameCollectionPin  = "pin"
 	optionNameOutputLocation = "output"
 )


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->
This PR adds support for blockchain RPC endpoints that require basic authentication.

It parses credentials from the endpoint URL and sets the appropriate Authorization header for all RPC requests. The header is built using base64 encoding of the username and password in the format `Authorization: Basic {base64(username:password)}`. This resolves `401 Unauthorized` errors when using providers that require HTTP basic auth. No effect if credentials are not present in the URL.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
