### PR TITLE
docs(tags): remove body from `POST /tags`

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -565,12 +565,6 @@ paths:
       tags:
         - Tag
       description: Tags can be thought of as upload sessions which can be tracked using the tags endpoint. It will keep track of the chunks that are uploaded as part of the tag and will push them out to the network once a done split is called on the Tag. This happens internally if you use the `Swarm-Deferred-Upload` header.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "SwarmCommon.yaml#/components/schemas/NewTagRequest"
       responses:
         "201":
           description: New Tag Info

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -295,12 +295,6 @@ components:
     MultiAddress:
       type: string
 
-    NewTagRequest:
-      type: object
-      properties:
-        address:
-          $ref: "#/components/schemas/SwarmAddress"
-
     NewTagResponse:
       type: object
       properties:


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This update cleans up the Swarm API documentation by removing the NewTagRequest schema and the associated requestBody from the /tags endpoint. These elements are no longer used in the current API implementation.

Changes:

- Deleted NewTagRequest schema definition.

- Removed requestBody section from the /tags endpoint.



### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/5191
### Screenshots (if appropriate):
