### PR TITLE
fix(transaction): use EstimateGasAtBlock instead of EstimateGas

### DIFF
--- a/pkg/node/chain.go
+++ b/pkg/node/chain.go
@@ -372,8 +372,8 @@ func (m noOpChainBackend) SuggestGasTipCap(context.Context) (*big.Int, error) {
 	panic("chain no op: SuggestGasTipCap")
 }
 
-func (m noOpChainBackend) EstimateGas(context.Context, ethereum.CallMsg) (uint64, error) {
-	panic("chain no op: EstimateGas")
+func (m noOpChainBackend) EstimateGasAtBlock(context.Context, ethereum.CallMsg, *big.Int) (uint64, error) {
+	panic("chain no op: EstimateGasAtBlock")
 }
 
 func (m noOpChainBackend) SendTransaction(context.Context, *types.Transaction) error {

--- a/pkg/transaction/backend/backend.go
+++ b/pkg/transaction/backend/backend.go
@@ -20,7 +20,7 @@ type Geth interface {
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	ChainID(ctx context.Context) (*big.Int, error)
 	Close()
-	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
+	EstimateGasAtBlock(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (uint64, error)
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)

--- a/pkg/transaction/backendmock/backend.go
+++ b/pkg/transaction/backendmock/backend.go
@@ -20,7 +20,7 @@ type backendMock struct {
 	sendTransaction    func(ctx context.Context, tx *types.Transaction) error
 	suggestedFeeAndTip func(ctx context.Context, gasPrice *big.Int, boostPercent int) (*big.Int, *big.Int, error)
 	suggestGasTipCap   func(ctx context.Context) (*big.Int, error)
-	estimateGas        func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)
+	estimateGasAtBlock func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error)
 	transactionReceipt func(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	pendingNonceAt     func(ctx context.Context, account common.Address) (uint64, error)
 	transactionByHash  func(ctx context.Context, hash common.Hash) (tx *types.Transaction, isPending bool, err error)
@@ -51,9 +51,9 @@ func (m *backendMock) SuggestedFeeAndTip(ctx context.Context, gasPrice *big.Int,
 	return nil, nil, errors.New("not implemented")
 }
 
-func (m *backendMock) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-	if m.estimateGas != nil {
-		return m.estimateGas(ctx, call)
+func (m *backendMock) EstimateGasAtBlock(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (uint64, error) {
+	if m.estimateGasAtBlock != nil {
+		return m.estimateGasAtBlock(ctx, msg, blockNumber)
 	}
 	return 0, errors.New("not implemented")
 }
@@ -171,9 +171,9 @@ func WithSuggestGasTipCapFunc(f func(ctx context.Context) (*big.Int, error)) Opt
 	})
 }
 
-func WithEstimateGasFunc(f func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error)) Option {
+func WithEstimateGasAtBlockFunc(f func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error)) Option {
 	return optionFunc(func(s *backendMock) {
-		s.estimateGas = f
+		s.estimateGasAtBlock = f
 	})
 }
 

--- a/pkg/transaction/backendsimulation/backend.go
+++ b/pkg/transaction/backendsimulation/backend.go
@@ -95,7 +95,7 @@ func (m *simulatedBackend) SuggestedFeeAndTip(ctx context.Context, gasPrice *big
 	return nil, nil, errors.New("not implemented")
 }
 
-func (m *simulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+func (m *simulatedBackend) EstimateGasAtBlock(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -31,7 +31,6 @@ import (
 const loggerName = "transaction"
 
 const (
-	noncePrefix              = "transaction_nonce_"
 	storedTransactionPrefix  = "transaction_stored_"
 	pendingTransactionPrefix = "transaction_pending_"
 )
@@ -275,11 +274,11 @@ func (t *transactionService) StoredTransaction(txHash common.Hash) (*StoredTrans
 func (t *transactionService) prepareTransaction(ctx context.Context, request *TxRequest, nonce uint64, boostPercent int) (tx *types.Transaction, err error) {
 	var gasLimit uint64
 	if request.GasLimit == 0 {
-		gasLimit, err = t.backend.EstimateGas(ctx, ethereum.CallMsg{
+		gasLimit, err = t.backend.EstimateGasAtBlock(ctx, ethereum.CallMsg{
 			From: t.sender,
 			To:   request.To,
 			Data: request.Data,
-		})
+		}, nil) // nil for latest block
 		if err != nil {
 			t.logger.Debug("estimate gas failed", "error", err)
 			gasLimit = request.MinEstimatedGasLimit

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -151,11 +151,11 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
-						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
+					if !bytes.Equal(msg.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, msg.To)
 					}
-					if !bytes.Equal(call.Data, txData) {
+					if !bytes.Equal(msg.Data, txData) {
 						t.Fatal("estimating with wrong data")
 					}
 					return estimatedGasLimit, nil
@@ -234,7 +234,7 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
 					return 0, errors.New("estimate failure")
 				}),
 				backendmock.WithPendingNonceAtFunc(func(ctx context.Context, account common.Address) (uint64, error) {
@@ -314,11 +314,11 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
-						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
+					if !bytes.Equal(msg.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, msg.To)
 					}
-					if !bytes.Equal(call.Data, txData) {
+					if !bytes.Equal(msg.Data, txData) {
 						t.Fatal("estimating with wrong data")
 					}
 					return estimatedGasLimit, nil
@@ -396,11 +396,11 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
-						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
+					if !bytes.Equal(msg.To.Bytes(), recipient.Bytes()) {
+						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, msg.To)
 					}
-					if !bytes.Equal(call.Data, txData) {
+					if !bytes.Equal(msg.Data, txData) {
 						t.Fatal("estimating with wrong data")
 					}
 					return estimatedGasLimit, nil
@@ -461,7 +461,7 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
 					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
 						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
 					}
@@ -527,7 +527,7 @@ func TestTransactionSend(t *testing.T) {
 					}
 					return nil
 				}),
-				backendmock.WithEstimateGasFunc(func(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+				backendmock.WithEstimateGasAtBlockFunc(func(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) (gas uint64, err error) {
 					if !bytes.Equal(call.To.Bytes(), recipient.Bytes()) {
 						t.Fatalf("estimating with wrong recipient. wanted %x, got %x", recipient, call.To)
 					}

--- a/pkg/transaction/wrapped/wrapped.go
+++ b/pkg/transaction/wrapped/wrapped.go
@@ -138,11 +138,10 @@ func (b *wrappedBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	}
 	return gasTipCap, nil
 }
-
-func (b *wrappedBackend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
+func (b *wrappedBackend) EstimateGasAtBlock(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (uint64, error) {
 	b.metrics.TotalRPCCalls.Inc()
 	b.metrics.EstimateGasCalls.Inc()
-	gas, err = b.backend.EstimateGas(ctx, call)
+	gas, err := b.backend.EstimateGasAtBlock(ctx, msg, blockNumber)
 	if err != nil {
 		b.metrics.TotalRPCErrors.Inc()
 		return 0, err


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
- Replace EstimateGas with EstimateGasAtBlock across all backend implementations
- Use latest confirmed block (nil) for gas estimation to improve accuracy
- Addresses Claims failures due to low GasLimit on bee-light-testnet
- Update interface, mock, simulation, and wrapped backend implementations
- Update all related tests to use new method signature

This change ensures gas estimation uses the latest confirmed block state
rather than relying on the RPC provider's EstimateGas implementation,
which should resolve gas limit issues on testnet environments.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
