### PR TITLE
feat(docker): add debugging and networking tools to dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,13 +18,19 @@ FROM debian:12.12-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates; \
+    ca-certificates \
+    iputils-ping \
+    netcat-openbsd \
+    telnet \
+    curl \
+    wget \
+    jq \
+    net-tools; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     groupadd -r bee --gid 999; \
     useradd -r -g bee --uid 999 --no-log-init -m bee;
 
-# make sure mounted volumes have correct permissions
 RUN mkdir -p /home/bee/.bee && chown 999:999 /home/bee/.bee
 
 COPY --from=build /src/dist/bee /usr/local/bin/bee


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
- Add iputils-ping for network connectivity testing
- Add netcat-openbsd for network debugging
- Add telnet for remote connection testing
- Add curl and wget for HTTP testing
- Add jq for JSON processing
- Add net-tools for network utilities

These tools enhance the development container's debugging capabilities for network troubleshooting and API testing.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
