### PR TITLE
fix(joiner): resolve race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ endif
 .PHONY: test-ci-race
 test-ci-race:
 ifdef cover
-	$(GO) test -race -run "[^FLAKY]$$" -coverprofile=cover.out ./...
+	@bash -c '$(GO) test -count=1 -race -run "[^FLAKY]$$" -coverprofile=cover.out ./... 2>&1 | grep -v "malformed LC_DYSYMTAB" || true; exit $${PIPESTATUS[0]}'
 else
-	$(GO) test -race -run "[^FLAKY]$$" ./...
+	@bash -c '$(GO) test -count=1 -race -run "[^FLAKY]$$" ./... 2>&1 | grep -v "malformed LC_DYSYMTAB" || true; exit $${PIPESTATUS[0]}'
 endif
 
 .PHONY: test-ci-flaky


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixes a race condition in pkg/file/joiner that caused CI test timeouts. Refactored decoderCache.GetOrCreate to prevent deadlocks by correctly managing mutex locks around getter.New calls.

Makefile: Filter linker warnings and disable test caching for test-ci-race

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
