### PR TITLE
fix: use hex encoded values in stamerindex.Item.String()

### DIFF
--- a/pkg/storer/internal/stampindex/stampindex.go
+++ b/pkg/storer/internal/stampindex/stampindex.go
@@ -138,7 +138,7 @@ func (i *Item) Clone() storage.Item {
 
 // String implements the fmt.Stringer interface.
 func (i Item) String() string {
-	return storageutil.JoinFields(i.Namespace(), i.ID())
+	return storageutil.JoinFields(i.Namespace(), fmt.Sprintf("%s/%x/%x", string(i.scope), i.BatchID, i.StampIndex))
 }
 
 // LoadOrStore tries to first load a stamp index related record from the store.


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This change fixes how stamperindex.Item is printed in logs by changing its String() method. Item.ID() method takes just converts []byte to string making the string not so readable. Example:

```
"time"="2025-11-25 15:49:54.859680" "level"="debug" "logger"="node/storer" "msg"="reserve put error" "error"="load or store stamp index for chunk Address: 6b5e44a43b325a48ba6bb2533b4d1e62f145ffe4be0ad7321667a4da15a6e91c Chunksize: 4104 has fail: failed to put stampindex.Item stampIndex/reserve/_-\xa0\x13cQ\xdcX#\xafQŏ\xafP@QX\xdb\a\xfd\r\xcch`\x91\x83\xa9\xd0w\x1b\xf9/\x00\x00k^\x00\x00\x00\x15: context deadline exceeded"
```

The ID() method cannot be changed as the storage requires to stay the same, but the String() method can be adjusted. Now the String() method just hex encodes the values and does not try to decode the index to uint64 for safety.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
