### PR TITLE
fix(p2p): add tcp share when ws enabled

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -333,7 +333,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 			// of different registers.
 			storagePath := filepath.Join(o.AutoTLSStorageDir, o.AutoTLSDomain)
 
-			if err := os.MkdirAll(storagePath, 0700); err != nil {
+			if err := os.MkdirAll(storagePath, 0o700); err != nil {
 				return nil, fmt.Errorf("create certificate storage directory %s: %w", storagePath, err)
 			}
 
@@ -428,6 +428,7 @@ func New(ctx context.Context, signer beecrypto.Signer, networkID uint64, overlay
 		transports = append(transports, libp2p.Transport(ws.New, wsOpt))
 	} else if o.EnableWS {
 		transports = append(transports, libp2p.Transport(ws.New))
+		opts = append(opts, libp2p.ShareTCPListener())
 	}
 
 	compositeResolver := newCompositeAddressResolver(tcpResolver, wssResolver)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
libp2p needs a specific option added to the constructor when trying to reuse the existing TCP port listener both for normal TCP connections _and_ for incoming WS connections. Since this is exactly what is done in bee (there is no separate port listener for WS connections), we must include this option when the WS transport is enabled.
