### PR TITLE
fix(salud): transient unhealthy state during capacity doubling

### DIFF
--- a/pkg/salud/salud.go
+++ b/pkg/salud/salud.go
@@ -242,9 +242,9 @@ func (s *service) salud(mode string, durPercentile float64, connsPercentile floa
 	}
 
 	selfHealth := true
-	if nHoodRadius == networkRadius && s.reserve.CommittedDepth() != networkRadius {
+	if nHoodRadius == networkRadius && s.reserve.StorageRadius() > networkRadius {
 		selfHealth = false
-		s.logger.Warning("node is unhealthy due to storage radius discrepancy", "self_radius", s.reserve.CommittedDepth(), "network_radius", networkRadius)
+		s.logger.Warning("node is unhealthy due to storage radius discrepancy", "self_storage_radius", s.reserve.StorageRadius(), "network_radius", networkRadius)
 	}
 
 	s.isSelfHealthy.Store(selfHealth)


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR addresses an issue where nodes configured with `ReserveCapacityDoubling` would incorrectly report themselves as "Unhealthy" during the transient period where the CommittedDepth exceeds the network radius, but the physical StorageRadius is still adjusting.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
