### PR TITLE
fix(kademlia): update misleading debug log message for bootnode connection failure

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -827,11 +827,10 @@ func (k *Kad) connectBootNodes(ctx context.Context) {
 
 			if err != nil {
 				if !errors.Is(err, p2p.ErrAlreadyConnected) {
-					k.logger.Debug("connect to bootnode failed", "bootnode_address", addr, "error", err)
-					k.logger.Warning("connect to bootnode failed", "bootnode_address", addr)
+					k.logger.Error(err, "connect to bootnode failed", "bootnode_address", addr)
 					return false, err
 				}
-				k.logger.Debug("bootnode already connected", "bootnode_address", addr, "error", err)
+				k.logger.Debug("bootnode already connected", "bootnode_address", addr)
 				return false, nil
 			}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fix misleading log message, before when the error is `p2p.ErrAlreadyConnected` it said `connect to bootnode failed`but now with the fix i enhanced the log message.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
