### PR TITLE
fix(p2p): give each underlay address fresh 15s connection timeout

### DIFF
--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -1030,7 +1030,7 @@ func (s *Service) Connect(ctx context.Context, addrs []ma.Multiaddr) (address *b
 			return address, p2p.ErrAlreadyConnected
 		}
 
-		connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		connectCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		err = s.connectionBreaker.Execute(func() error { return s.host.Connect(connectCtx, *info) })
 		cancel()
 

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -42,7 +42,7 @@ const (
 
 	addPeerBatchSize = 500
 
-	// Each underlay address gets up to 10s for connection (in libp2p.Connect).
+	// Each underlay address gets up to 15s for connection (in libp2p.Connect).
 	// This budget allows multiple addresses to be tried sequentially per peer.
 	peerConnectionAttemptTimeout = 45 * time.Second // timeout for establishing a new connection with peer.
 )


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

- Give each underlay address a dedicated 15-second connection timeout
- Prevents later addresses from being starved of connection time
- Increase kademlia's total peer connection timeout from 15s to 45s to accommodate multiple address attempts
- Each bootnode connection attempt now gets the full 45s budget

Previously, when connecting to a peer with multiple underlay addresses, all addresses shared a single timeout context. This meant later addresses had little to no time remaining for connection attempts. Now each address receives its own fresh 15-second timeout, ensuring fair connection attempts to all underlay addresses.

In kademlia's bootnode connection logic, the global 15-second timeout has been removed and replaced with a per-connection 45-second timeout, allowing multiple addresses per peer to be tried sequentially with adequate time budget.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
