### PR TITLE
fix(puller): prevent massive log lines from joined errors

### DIFF
--- a/pkg/puller/error_summary_test.go
+++ b/pkg/puller/error_summary_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Swarm Authors. All rights reserved.
+// Copyright 2026 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -382,11 +382,7 @@ func (p *Puller) syncPeerBin(parentCtx context.Context, peer *syncPeer, bin uint
 					return
 				}
 				errCount := countErrors(err)
-				if errCount > 1 {
-					p.logger.Debug("syncWorker interval failed", "error_count", errCount, "example_error", errors.Unwrap(err), "peer_address", address, "bin", bin, "cursor", cursor, "start", start, "topmost", top)
-				} else {
-					p.logger.Debug("syncWorker interval failed", "error", err, "peer_address", address, "bin", bin, "cursor", cursor, "start", start, "topmost", top)
-				}
+				p.logger.Debug("syncWorker interval failed", "error_count", errCount, "example_error", errors.Unwrap(err), "peer_address", address, "bin", bin, "cursor", cursor, "start", start, "topmost", top)
 			}
 
 			_ = p.limiter.WaitN(ctx, count)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Previously, when many errors were joined together during sync
operations, all errors were logged in a single line, creating
log entries up to 30KB (e.g., 245 identical "batch not found" 
errors).

This commit adds countErrors() to count total errors and logs
only the count plus one example error, keeping entries concise
while maintaining diagnostic value.

Changes:
- Add countErrors() helper to count errors in joined error chains
- Update syncWorker logging to show error_count and example_error
- Add test coverage for error counting

Example output:
- Before: "error"="batch not found\nbatch not found\n..." (30KB)
- After: "error_count"=245 "example_error"="batch not found"

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
