### PR TITLE
fix(postage): prevent nil pointer panic in TopUpBatch on transaction …

### DIFF
--- a/pkg/postage/postagecontract/contract.go
+++ b/pkg/postage/postagecontract/contract.go
@@ -390,7 +390,7 @@ func (c *postageContract) CreateBatch(ctx context.Context, initialBalance *big.I
 	if err != nil {
 		return
 	}
-	txHash = receipt.TxHash
+
 	for _, ev := range receipt.Logs {
 		if ev.Address == c.postageStampContractAddress && len(ev.Topics) > 0 && ev.Topics[0] == c.batchCreatedTopic {
 			var createdEvent batchCreatedEvent
@@ -415,6 +415,7 @@ func (c *postageContract) CreateBatch(ctx context.Context, initialBalance *big.I
 			if err != nil {
 				return
 			}
+			txHash = receipt.TxHash
 			return
 		}
 	}
@@ -482,9 +483,10 @@ func (c *postageContract) DiluteBatch(ctx context.Context, batchID []byte, newDe
 	if err != nil {
 		return
 	}
-	txHash = receipt.TxHash
+
 	for _, ev := range receipt.Logs {
 		if ev.Address == c.postageStampContractAddress && len(ev.Topics) > 0 && ev.Topics[0] == c.batchDepthIncreaseTopic {
+			txHash = receipt.TxHash
 			return
 		}
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Before when running this command you will get panic error, now with the fix:
`curl -s -X PATCH "http://localhost:1640/stamps/topup/{BATCH_ID}/2" \
  -H "Gas-Price: 10"`
  ```
  {"code":500,"message":"cannot topup batch"}
  ```
Config:
```
minimum-gas-tip-cap: 2
full-node: false
swap-enable: false
```
Logs:
```
"time"="2026-01-29 13:39:34.554380" "level"="debug" "logger"="node/transaction" "msg"="estimate gas failed" "sender_address"="0xb25D7c21Fd221719826028D371bEabf74eB061EE" "error"="Transaction execution fails"
"time"="2026-01-29 13:39:34.923401" "level"="debug" "logger"="node/api/patch_stamp_topup" "msg"="topup batch: topup failed" "batch_id"="fe5db63cc90c61509744f952c6fae608c7488ce194227d8d31ca9d7fe502b371" "amount"="10" "error"="topup batch: amount 10: Invalid, intrinsic gas too low"
"time"="2026-01-29 13:39:34.923453" "level"="error" "logger"="node/api/patch_stamp_topup" "msg"="topup batch: topup failed"
```

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
