### PR TITLE
fix(workflows): add failure checks for gsoc, postage-stamps, stake, w…

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -192,11 +192,16 @@ jobs:
           if ${{ steps.settlements.outcome=='failure' }}; then FAILED=settlements; fi
           if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi
           if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi
+          if ${{ steps.gsoc.outcome=='failure' }}; then FAILED=gsoc; fi
           if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi
           if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi
           if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi
           if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi
           if ${{ steps.manifest-v1.outcome=='failure' }}; then FAILED=manifest-v1; fi
+          if ${{ steps.postage-stamps.outcome=='failure' }}; then FAILED=postage-stamps; fi
+          if ${{ steps.stake.outcome=='failure' }}; then FAILED=stake; fi
+          if ${{ steps.withdraw.outcome=='failure' }}; then FAILED=withdraw; fi
+          if ${{ steps.redundancy.outcome=='failure' }}; then FAILED=redundancy; fi
           if ${{ steps.feeds.outcome=='failure' }}; then FAILED=feeds; fi
           if ${{ steps.feeds-v1.outcome=='failure' }}; then FAILED=feeds-v1; fi
           if ${{ steps.act.outcome=='failure' }}; then FAILED=act; fi


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
- Added missing failure handling for Beekeeper checks that were not previously reported in the debug notification logic.
- Covered additional checks: `gsoc`, `postage-stamps`, `stake`, `withdraw`, and `redundancy`.

#### Why this is needed

The workflow already collects and reports the name of the failing Beekeeper check through the `FAILED` variable, but several checks were not included in this mapping.

When one of these checks failed, the workflow still produced artifacts, but the reported failed step was incomplete or misleading.

This change ensures that failures from all executed Beekeeper checks are correctly identified and reported, which improves the reliability of CI diagnostics and reduces investigation time.

#### Files changed

- `.github/workflows/beekeeper.yml`  

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
