### PR TITLE
feat(workflows): configure Docker for k3d local registry in beekeeper…

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -116,6 +116,14 @@ jobs:
           mkdir ~/.beekeeper && mv local.yaml ~/.beekeeper/local.yaml
           mv bee-1 bee
           sudo mv beekeeper /usr/local/bin/beekeeper
+      - name: Configure Docker for k3d local registry
+        run: |
+            sudo mkdir -p /etc/docker
+            echo '{
+              "features": {"containerd-snapshotter": false},
+              "insecure-registries": ["k3d-registry.localhost:5000", "127.0.0.1:5000"]
+            }' | sudo tee /etc/docker/daemon.json
+            sudo systemctl restart docker
       - name: Prepare local cluster
         run: |
           timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet' ACTION=prepare


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
GitHub recently upgraded runners to Docker 29, which started using containerd for image storage and stopped using insecure-registries, so pushes to the local HTTP registry failed until I disabled the containerd image store and restarted Docker. 

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
