### PR TITLE
fix(kademlia): set reachability status metric value to 1 instead of 0

### DIFF
--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -279,7 +279,7 @@ func New(
 
 	k.bgBroadcastCtx, k.bgBroadcastCancel = context.WithCancel(context.Background())
 
-	k.metrics.ReachabilityStatus.WithLabelValues(p2p.ReachabilityStatusUnknown.String()).Set(0)
+	k.metrics.ReachabilityStatus.WithLabelValues(p2p.ReachabilityStatusUnknown.String()).Set(1)
 
 	return k, nil
 }
@@ -1363,7 +1363,8 @@ func (k *Kad) UpdateReachability(status p2p.ReachabilityStatus) {
 	}
 	k.logger.Debug("reachability updated", "reachability", status)
 	k.reachability = status
-	k.metrics.ReachabilityStatus.WithLabelValues(status.String()).Set(0)
+	k.metrics.ReachabilityStatus.Reset()
+	k.metrics.ReachabilityStatus.WithLabelValues(status.String()).Set(1)
 }
 
 // UpdateReachability updates node reachability status.


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The ReachabilityStatus gauge was always being set to 0 for all labels,
making the metric effectively useless. Reset all labels on status change
and set the current status to 1.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
