### PR TITLE
fix(p2p): synchronize handshake by moving FullClose into Handshake

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -242,6 +242,14 @@ func (s *Service) Handshake(ctx context.Context, stream p2p.Stream, peerMultiadd
 		return nil, fmt.Errorf("write ack message: %w", err)
 	}
 
+	// FullClose the stream to synchronize with the inbound side.
+	// This blocks until the remote either accepts the handshake
+	// (closes the stream gracefully) or rejects it (resets the
+	// stream, e.g. due to a picker rejection).
+	if err := stream.FullClose(); err != nil {
+		return nil, fmt.Errorf("full close: %w", err)
+	}
+
 	loggerV1.Debug("handshake finished for peer (outbound)", "peer_address", remoteBzzAddress.Overlay)
 	if len(resp.Ack.WelcomeMessage) > 0 {
 		s.logger.Debug("greeting message from peer", "peer_address", remoteBzzAddress.Overlay, "message", resp.Ack.WelcomeMessage)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The outbound Handshake returned immediately after writing the Ack,
before the inbound side decided whether to accept the peer. Outbound blocks until the
inbound has accepted or rejected.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
