### PR TITLE
feat: export ReserveSample duration breakdown metrics

### DIFF
--- a/pkg/storer/sample.go
+++ b/pkg/storer/sample.go
@@ -463,6 +463,9 @@ func (db *DB) recordReserveSampleMetrics(duration time.Duration, stats *SampleSt
 		"chunks_per_second":                    float64(stats.TotalIterated) / duration.Seconds(),
 		"stamp_validation_duration_seconds":    stats.ValidStampDuration.Seconds(),
 		"batches_below_value_duration_seconds": stats.BatchesBelowValueDuration.Seconds(),
+		"taddr_duration_seconds":               stats.TaddrDuration.Seconds(),
+		"chunk_load_duration_seconds":          stats.ChunkLoadDuration.Seconds(),
+		"iteration_duration_seconds":           stats.IterationDuration.Seconds(),
 	}
 
 	for metric, value := range summaryMetrics {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Export already-tracked TaddrDuration, ChunkLoadDuration, and IterationDuration to Prometheus to enable analysis in Grafana.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
