### PR TITLE
fix(p2p/libp2p): redirect p2p-forge zap logger output to stdout

### DIFF
--- a/pkg/p2p/libp2p/p2pforge.go
+++ b/pkg/p2p/libp2p/p2pforge.go
@@ -98,8 +98,8 @@ func newZapLogger(beeLogger log.Logger) (*zap.Logger, error) {
 		Level:            zap.NewAtomicLevelAt(beeVerbosityToZapLevel(beeLogger.Verbosity())),
 		Development:      false,
 		Encoding:         "json",
-		OutputPaths:      []string{"stderr"},
-		ErrorOutputPaths: []string{"stderr"},
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stdout"},
 		Sampling: &zap.SamplingConfig{
 			Initial:    100,
 			Thereafter: 100,


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The zap logger created for the p2p-forge certificate manager was configured to write to `stderr` (`OutputPaths: ["stderr"]`, `ErrorOutputPaths: ["stderr"]`). However, bee's own logger is instantiated with `cmd.OutOrStdout()` as its sink, which defaults to `os.Stdout`. This caused p2p-forge/certmagic logs to be emitted to a different stream than all other bee logs.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
