### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -146,8 +147,8 @@ func (r *Recorder) NewStream(ctx context.Context, addr swarm.Address, h p2p.Head
 	if handler == nil {
 		return nil, ErrStreamNotSupported
 	}
-	for i := len(r.middlewares) - 1; i >= 0; i-- {
-		handler = r.middlewares[i](handler)
+	for _, v := range slices.Backward(r.middlewares) {
+		handler = v(handler)
 	}
 	if headler != nil {
 		streamOut.headers = headler(h, addr)

--- a/pkg/storage/inmemstore/inmemstore.go
+++ b/pkg/storage/inmemstore/inmemstore.go
@@ -7,6 +7,7 @@ package inmemstore
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -209,12 +210,12 @@ func (s *Store) Iterate(q storage.Query, fn storage.IterateFn) error {
 		if retErr != nil {
 			break
 		}
-		for i := len(results) - 1; i >= 0; i-- {
+		for _, v := range slices.Backward(results) {
 			if q.SkipFirst && !firstSkipped {
 				firstSkipped = true
 				continue
 			}
-			stop, err := fn(results[i])
+			stop, err := fn(v)
 			if err != nil {
 				return fmt.Errorf("failed in iterate function: %w", err)
 			}

--- a/pkg/storer/internal/cache/cache_test.go
+++ b/pkg/storer/internal/cache/cache_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -191,21 +192,21 @@ func TestCache(t *testing.T) {
 		// at the end
 		t.Run("get reverse order", func(t *testing.T) {
 			var newOrder []swarm.Chunk
-			for idx := len(chunks) - 1; idx >= 0; idx-- {
-				readChunk, err := c.Getter(st).Get(context.TODO(), chunks[idx].Address())
+			for idx, v := range slices.Backward(chunks) {
+				readChunk, err := c.Getter(st).Get(context.TODO(), v.Address())
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !readChunk.Equal(chunks[idx]) {
-					t.Fatalf("incorrect chunk: %s", chunks[idx].Address())
+				if !readChunk.Equal(v) {
+					t.Fatalf("incorrect chunk: %s", v.Address())
 				}
 				if idx == 0 {
 					// once we access the first entry, the top will change
-					verifyCacheState(t, st.IndexStore(), c, chunks[9].Address(), chunks[idx].Address(), 10)
+					verifyCacheState(t, st.IndexStore(), c, chunks[9].Address(), v.Address(), 10)
 				} else {
-					verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), chunks[idx].Address(), 10)
+					verifyCacheState(t, st.IndexStore(), c, chunks[0].Address(), v.Address(), 10)
 				}
-				newOrder = append(newOrder, chunks[idx])
+				newOrder = append(newOrder, v)
 			}
 			verifyCacheOrder(t, c, st.IndexStore(), newOrder...)
 		})

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"context"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -214,8 +215,8 @@ func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Select) 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	for i := len(d.peers) - 1; i >= 0; i-- {
-		_, _, err = f(d.peers[i], uint8(i))
+	for i, v := range slices.Backward(d.peers) {
+		_, _, err = f(v, uint8(i))
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
