### PR TITLE
ci: add radius-decrease liveness check for puller manage() recovery

### DIFF
--- a/.github/patches/radius_decrease_reserve.patch
+++ b/.github/patches/radius_decrease_reserve.patch
@@ -1,0 +1,4 @@
+45c45
+< func threshold(capacity int) int { return capacity * 5 / 10 }
+---
+> func threshold(capacity int) int { return capacity }

--- a/.github/patches/radius_decrease_storer.patch
+++ b/.github/patches/radius_decrease_storer.patch
@@ -1,0 +1,8 @@
+251c251
+< 	DefaultReserveCapacity        = 1 << 22 // 4194304 chunks
+---
+> 	DefaultReserveCapacity        = 200
+411c411
+< 		ReserveWakeUpDuration:     time.Minute * 30,
+---
+> 		ReserveWakeUpDuration:     time.Second * 10,

--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -19,7 +19,7 @@ env:
   SETUP_CONTRACT_IMAGE: "ethersphere/bee-localchain"
   SETUP_CONTRACT_IMAGE_TAG: "0.9.4"
   BEELOCAL_BRANCH: "main"
-  BEEKEEPER_BRANCH: "master"
+  BEEKEEPER_BRANCH: "ci/radius-decrease-check"
   BEEKEEPER_METRICS_ENABLED: false
   REACHABILITY_OVERRIDE_PUBLIC: true
   BATCHFACTOR_OVERRIDE_PUBLIC: 2
@@ -77,6 +77,14 @@ jobs:
           patch pkg/retrieval/retrieval.go .github/patches/retrieval.patch
           make binary
           mv dist/bee bee-1
+      - name: Apply patches and build - 2 (radius-decrease liveness test)
+        run: |
+          git checkout pkg/api/postage.go pkg/retrieval/retrieval.go
+          patch pkg/storer/storer.go .github/patches/radius_decrease_storer.patch
+          patch pkg/storer/reserve.go .github/patches/radius_decrease_reserve.patch
+          make binary
+          mv dist/bee bee-2
+          git checkout pkg/storer/storer.go pkg/storer/reserve.go
       - name: Install beekeeper
         run: |
           export PATH=$(pwd):$PATH
@@ -225,6 +233,60 @@ jobs:
         with:
           name: debug-dump
           path: dump/
+  radius-decrease:
+    name: Radius-decrease liveness test
+    runs-on: ubuntu-latest
+    needs: [init]
+    steps:
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/k3s-${{ env.K3S_VERSION }}
+          key: k3s-${{ env.K3S_VERSION }}
+      - name: "Download Artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: temp-artifacts
+      - name: Unpack artifacts
+        run: |
+          chmod +x bee-2 beekeeper .github/bin/beekeeper_artifacts.sh
+          mv .beekeeper.yaml ~/.beekeeper.yaml
+          mkdir ~/.beekeeper && mv local.yaml ~/.beekeeper/local.yaml
+          mv bee-2 bee
+          sudo mv beekeeper /usr/local/bin/beekeeper
+      - name: Prepare local cluster
+        run: |
+          timeout ${TIMEOUT} make beelocal OPTS='ci skip-vet' ACTION=prepare
+      - name: Set kube config
+        run: |
+          mkdir -p ~/.kube
+          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+      - name: Set local cluster
+        run: |
+          timeout ${TIMEOUT} make deploylocal BEEKEEPER_CLUSTER=local-dns
+      - name: Test pingpong (smoke)
+        run: timeout ${TIMEOUT} bash -c 'until beekeeper check --cluster-name local-dns --checks ci-pingpong; do echo "waiting for pingpong..."; sleep .3; done'
+      - name: Test radius-decrease liveness
+        id: radius-decrease
+        run: timeout ${TIMEOUT} beekeeper check --cluster-name local-dns --checks ci-radius-decrease
+      - name: Collect debug artifacts
+        if: failure()
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          TUNSHELL_KEY: ${{ secrets.TUNSHELL_KEY }}
+        run: |
+          bash .github/bin/beekeeper_artifacts.sh local-dns
+          export FAILED='no-test'
+          if ${{ steps.radius-decrease.outcome=='failure' }}; then FAILED=radius-decrease; fi
+          curl -sSf -X POST -H "Content-Type: application/json" -d "{\"text\": \"**${RUN_TYPE}** Radius-Decrease Test Error\nBranch: \`${HEAD_REF}\`\nUser: @${PR_USER}\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\nStep failed: \`${FAILED}\`\"}" https://beehive.ethswarm.org/hooks/$TUNSHELL_KEY
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: debug-dump-radius-decrease
+          path: dump/
+
   retag:
     name: Retag and Trigger ArgoCD
     env:


### PR DESCRIPTION
## Summary

- Adds a new `radius-decrease` CI job (parallel with `beekeeper`) that validates puller `manage()` goroutine recovery after a storage-radius decrease
- Adds three patch files to shrink the reserve (capacity 200, wakeup 10s, threshold 100%) so the scenario triggers within CI time
- Builds a separate `bee-2` binary from those patches and uses it exclusively in the radius-decrease job

## Test plan

- [ ] `beekeeper` integration test job passes (unchanged)
- [ ] `radius-decrease` job passes: overflow → cascade → recovery all complete within 30 min
- [ ] On buggy builds, `radius-decrease` job times out at the recovery phase and logs the blocked goroutine message

Note: `BEEKEEPER_BRANCH` temporarily points to `ci/radius-decrease-check` (ethersphere/beekeeper#581) until that PR merges.