### PR TITLE
fix: make stamps removal sync and data race in push chunk tests

### DIFF
--- a/pkg/api/gsoc_test.go
+++ b/pkg/api/gsoc_test.go
@@ -35,7 +35,7 @@ func TestGsocWebsocketSingleHandler(t *testing.T) {
 		payload          = []byte("hello there!")
 	)
 
-	err := cl.SetReadDeadline(time.Now().Add(2 * time.Second))
+	err := cl.SetReadDeadline(time.Now().Add(longTimeout))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestGsocWebsocketMultiHandler(t *testing.T) {
 	}
 	testutil.CleanupCloser(t, cl2)
 
-	err = cl.SetReadDeadline(time.Now().Add(2 * time.Second))
+	err = cl.SetReadDeadline(time.Now().Add(longTimeout))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -401,7 +401,11 @@ func (r *record) close() {
 }
 
 func (r *record) bytes() []byte {
-	return r.b
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	cp := make([]byte, len(r.b))
+	copy(cp, r.b)
+	return cp
 }
 
 func (r *record) bytesSize() int {

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -290,37 +290,33 @@ func (ps *service) HandleStampExpiry(ctx context.Context, id []byte) error {
 	return nil
 }
 
-// removeStampItems
+// removeStampItems removes all stamp items belonging to the given batch.
 func (ps *service) removeStampItems(ctx context.Context, batchID []byte) error {
 	ps.logger.Debug("removing expired stamp items", "batchID", hex.EncodeToString(batchID))
 
-	deleteItemC := make(chan *StampItem)
-	go func() {
-		for item := range deleteItemC {
-			_ = ps.store.Delete(item)
-		}
-	}()
+	var toDelete []*StampItem
 
-	count := 0
-
-	defer func() {
-		close(deleteItemC)
-		ps.logger.Debug("removed expired stamps", "batchID", hex.EncodeToString(batchID), "count", count)
-	}()
-
-	return ps.store.Iterate(
+	err := ps.store.Iterate(
 		storage.Query{
 			Factory: func() storage.Item { return new(StampItem) },
 			Prefix:  string(batchID),
 		}, func(result storage.Result) (bool, error) {
-			select {
-			case deleteItemC <- result.Entry.(*StampItem):
-			case <-ctx.Done():
-				return false, ctx.Err()
+			if err := ctx.Err(); err != nil {
+				return false, err
 			}
-			count++
+			toDelete = append(toDelete, result.Entry.(*StampItem))
 			return false, nil
 		})
+	if err != nil {
+		return err
+	}
+
+	for _, item := range toDelete {
+		_ = ps.store.Delete(item)
+	}
+
+	ps.logger.Debug("removed expired stamps", "batchID", hex.EncodeToString(batchID), "count", len(toDelete))
+	return nil
 }
 
 // SetExpired removes all expired batches from the stamp issuers.

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -311,8 +311,14 @@ func (ps *service) removeStampItems(ctx context.Context, batchID []byte) error {
 		return err
 	}
 
+	var firstErr error
 	for _, item := range toDelete {
-		_ = ps.store.Delete(item)
+		if err := ps.store.Delete(item); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove expired stamp items batch %s: %w", hex.EncodeToString(batchID), err)
+		}
+	}
+	if firstErr != nil {
+		return firstErr
 	}
 
 	ps.logger.Debug("removed expired stamps", "batchID", hex.EncodeToString(batchID), "count", len(toDelete))

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -296,7 +296,7 @@ func TestSetExpired(t *testing.T) {
 
 	err = store.Get(itemNotExists)
 	if err == nil {
-		t.Fatal(err)
+		t.Fatal("expected error getting expired stamp item, got nil")
 	}
 
 	testutil.CleanupCloser(t, ps)

--- a/pkg/storer/internal/events/subscribe_test.go
+++ b/pkg/storer/internal/events/subscribe_test.go
@@ -45,8 +45,9 @@ func TestSubscriber(t *testing.T) {
 
 		bin1, unsub1 := s.Subscribe("1")
 		go s.Trigger("1")
-		go s.Trigger("1")
 		<-bin1
+
+		go s.Trigger("1")
 		<-bin1
 
 		unsub1()


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
1. Collect all matching *StampItem in a slice during the iteration, then Delete only after the iterator returns.

2. Separate problem: fix data race in TestPushChunkToNextClosest, TestMultiplePushesAsForwarder TestPushChunkToClosestErrorAttemptRetry tests. 

The record.bytes() method in streamtest returned a direct reference to the internal slice without holding the mutex, causing a data race when tests read stream records while background goroutines were still writing to them. Fixed by acquiring the lock and returning a copy of the slice.

3. Fix gsoc test timeout (2s too small for CI) and fix TestSubscribe 
### Open API Spec Version Changes (if applicable)

<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
**Context:**
`removeStampItems` deletes all `StampItem` rows for a given batch by prefix-iterating the stamper store and calling store.Delete for each entry. For a time this used a helper goroutine and an **unbuffered** channel: the iterator sent each `*StampItem` to the goroutine, which called Delete outside the callback.

That pattern was carried over from an earlier fire-and-forget SetExpired implementation (node startup) where the goal was not to block; it was not a good fit for the later synchronous API, `HandleStampExpiry`, where callers and tests expect all matching rows to be gone when the function returns.

**Bonus problem:**
Previous implementation may lead to deadlock. 

Many stores protect `Iterate` and `Delete` with a lock, often an RWMutex. 
With the goroutine + unbuffered channel pattern and more than one StampItem for the same batch prefix we may have scenario:

- The iterator’s callback does the first send on the channel. The consumer receives and calls Delete. Delete blocks: it must wait for the write lock, but the iterator still holds the read lock for the walk.
- The callback returns; the walk continues to the next key. The second send blocks: the unbuffered channel is empty but the consumer is stuck inside the first Delete (not reading the next value).
- The walk cannot complete while the callback is blocked on send. The read lock is not released until the walk finishes, so the first Delete never acquires the write lock.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
