### PR TITLE
fix: read exactly M values from channel

### DIFF
--- a/pkg/file/redundancy/getter/getter.go
+++ b/pkg/file/redundancy/getter/getter.go
@@ -248,7 +248,8 @@ func (g *decoder) runStrategy(s Strategy) error {
 		}(i)
 	}
 
-	for range c {
+	for range len(m) {
+		<-c
 		if g.fetchedCnt.Load() >= int32(g.shardCnt) {
 			return nil
 		}
@@ -257,7 +258,7 @@ func (g *decoder) runStrategy(s Strategy) error {
 		}
 	}
 
-	return nil
+	return errStrategyFailed
 }
 
 // recover wraps the stages of data shard recovery:


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Read exactly M values from channel instead of reading "forever", which leads to deadlock in really seldom cases, which happen in mostly in CI

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
`runStrategy` assumes that while consuming results from `c`, one of the two exit conditions will always become true before reads are exhausted. Because of that assumption, the previous loop used `for range c` (which only terminates when c is closed).

**Why this can deadlock**
In the DATA -> RACE fallback path, some DATA-owned shard fetches may still be finishing while RACE starts.
RACE can include data shard indices whose waits[i] is not closed yet; for those indices, fetch takes the fly=false path and waits on waits[i].
For a successful DATA fetch, the operation order is:

```
close(g.waits[i])       // 1) unblocks waiting fly=false RACE goroutine
g.fetchedCnt.Add(1)     // 2) increments success counter
```
There is a small window between (1) and (2):
- the waiting RACE goroutine can unblock and push its result into `c`,
- `runStrategy` can consume that last value from `c`,
- but `fetchedCnt` may still be stale for that check.

If this happens on the **last** available message in `c`, neither exit condition may trigger in that iteration, and the next read blocks forever (no more writers, channel not closed).

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
