### PR TITLE
fix: draining strategy fetch

### DIFF
--- a/pkg/file/redundancy/getter/getter.go
+++ b/pkg/file/redundancy/getter/getter.go
@@ -19,6 +19,7 @@ import (
 var (
 	errStrategyNotAllowed = errors.New("strategy not allowed")
 	errStrategyFailed     = errors.New("strategy failed")
+	errShouldNeverHappen  = errors.New("should never happen")
 )
 
 // decoder is a private implementation of storage.Getter
@@ -266,7 +267,7 @@ func (g *decoder) runStrategy(s Strategy) error {
 		}
 	}
 
-	return errStrategyFailed
+	return errShouldNeverHappen
 }
 
 // recover wraps the stages of data shard recovery:

--- a/pkg/file/redundancy/getter/getter.go
+++ b/pkg/file/redundancy/getter/getter.go
@@ -240,7 +240,14 @@ func (g *decoder) runStrategy(s Strategy) error {
 	c := make(chan error, len(m))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	completed := 0
+	defer func() {
+		cancel()
+		remaining := len(m) - completed
+		for i := 0; i < remaining; i++ {
+			<-c
+		}
+	}()
 
 	for _, i := range m {
 		go func(i int) {
@@ -248,8 +255,9 @@ func (g *decoder) runStrategy(s Strategy) error {
 		}(i)
 	}
 
-	for range len(m) {
+	for completed < len(m) {
 		<-c
+		completed++
 		if g.fetchedCnt.Load() >= int32(g.shardCnt) {
 			return nil
 		}


### PR DESCRIPTION
fixes: #5448

`runStrategy` uses `defer cancel()` with a `for range c` loop to drive chunk fetches. When the loop exits early (enough chunks fetched or too many failed), `cancel()` fires but goroutines already inside `g.fetcher.Get` continue running. These ghost goroutines from a failed DATA strategy mutate shared atomic counters `g.failedCnt` and `g.fetchedCnt` concurrently with the subsequent RACE strategy, corrupting its accounting and causing it to terminate prematurely with `errStrategyFailed` even when enough parity chunks are available. Additionally, `for range c` never terminates on its own since `c` is never closed — the function can only exit via early returns.

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
