### PR TITLE
ci: move Linux Go tests to self-hosted runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,14 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+  test-linux:
+    name: Test (Linux)
+    runs-on: [self-hosted, linux, bee]
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -33,19 +34,32 @@ jobs:
       with:
         cache: true
         go-version-file: go.mod
-    - name: Increase UDP buffer sizes (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo sysctl -w net.core.rmem_max=7500000
-        sudo sysctl -w net.core.wmem_max=7500000
+    - name: Build
+      run: make build
+    - name: Test with race detector
+      run: make test-ci-race
+  test-other:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        cache: true
+        go-version-file: go.mod
     - name: Increase UDP buffer sizes (macOS)
       if: matrix.os == 'macos-latest'
       run: |
         sudo sysctl -w kern.ipc.maxsockbuf=6291456
     - name: Build
       run: make build
-    - name: Test with race detector (Ubuntu and MacOS)
-      if: matrix.os != 'windows-latest'
+    - name: Test with race detector (macOS)
+      if: matrix.os == 'macos-latest'
       run: make test-ci-race
     - name: Test without race detector (Windows)
       if: matrix.os == 'windows-latest'
@@ -107,7 +121,7 @@ jobs:
   trigger-beekeeper:
     name: Trigger Beekeeper
     runs-on: ubuntu-latest
-    needs: [test, lint, coverage]
+    needs: [test-linux, test-other, lint, coverage]
     if: github.ref == 'refs/heads/master'
     steps:
     - name: Checkout


### PR DESCRIPTION
## Summary

- Splits `jobs.test` into `test-linux` (self-hosted) and `test-other` (macOS/Windows on GHA).
- Linux test job now runs on `[self-hosted, linux, bee]` — the new `bee-runners` org group on `sf-nbg1perf1` / `sf-nbg1perf2`.
- Drops the obsolete `sudo sysctl` step on Linux (host pre-sets `net.core.rmem_max` / `wmem_max` via `/etc/sysctl.d/`).
- Adds a concurrency group so superseded PR runs are cancelled (saves minutes).
- `trigger-beekeeper.needs[]` updated for the new job names.
- `lint` and `coverage` unchanged (still on `ubuntu-latest`).

Tracking: ethersphere/infra_tasks#49

## Risks

- **Walltime**: perf hosts are 4×AMD EPYC ~2 GHz with CPUQuota=75% (~3 cores). May be slightly slower than GHA's 4×Xeon ~3 GHz.
- **Memory**: 5 GB hard cap (cgroup). If \`make test-ci-race\` exceeds this, the runner OOMs and the job fails. Monitor first runs.
- **Co-tenancy**: hosts also run \`named\` (GeoDNS) and a \`bee\` perftest node. Resource caps protect them, but a wedged runner could still degrade DNS latency. First-run monitoring suggested.

## Test plan

- [ ] CI runs on this PR and goes green on both self-hosted Linux job and GHA macOS/Windows.
- [ ] Compare walltime to a recent \`master\` run.
- [ ] Check sf-nbg1perf{1,2} memory + load during the run; confirm bee + named unaffected.