### PR TITLE
test: fix invalid chunk generation

### DIFF
--- a/pkg/storage/testing/chunk.go
+++ b/pkg/storage/testing/chunk.go
@@ -62,10 +62,16 @@ func GenerateTestRandomSoChunk(tb testing.TB, cac swarm.Chunk) swarm.Chunk {
 }
 
 // GenerateTestRandomInvalidChunk generates a random, however invalid, content
-// addressed chunk.
+// addressed chunk. The chunk is also guaranteed to be invalid as a SOC: with
+// purely random bytes, the embedded signature recovery byte falls inside
+// btcec's valid range often enough (~0.7%) that soc.FromChunk would succeed
+// and consumers expecting an "invalid" chunk see flaky behavior. Forcing the
+// recovery byte (data[swarm.HashSize+swarm.SocSignatureSize-1]) outside the
+// valid 27..34 range makes signature recovery deterministically fail.
 func GenerateTestRandomInvalidChunk() swarm.Chunk {
 	data := make([]byte, swarm.ChunkSize)
 	_, _ = rand.Read(data)
+	data[swarm.HashSize+swarm.SocSignatureSize-1] = 0xFF
 	key := make([]byte, swarm.SectionSize)
 	_, _ = rand.Read(key)
 	stamp := postagetesting.MustNewStamp()


### PR DESCRIPTION
### Description

The `GenerateTestRandomInvalidChunk` helper may occasionally generate a random `soc` chunk that recovers gracefully during a lax `soc.FromChunk` call.

This fixes the flaky test `TestIncoming_WantErrors`.

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.

### Script that reproduces the problem

```go
// Standalone reproducer for the TestIncoming_WantErrors flake.
//
// It uses the exact same helper (testingc.GenerateTestRandomInvalidChunk)
// the test uses, and the exact same validation sequence pullsync.go performs
// on a delivered chunk:
//
//	if cac.Valid(chunk) {
//	    // CAC path
//	} else if _, err := soc.FromChunk(chunk); err == nil {
//	    // gsoc path  -- this is the path that should NOT be reached for an
//	    //               "invalid" chunk, but sometimes is.
//	} else {
//	    // ErrInvalidChunk path  -- this is what the test expects.
//	}
//
// We loop until we hit a chunk that takes the gsoc path. When we do, we
// print the exact bytes so the result is reproducible/auditable.
package main

import (
	"encoding/hex"
	"fmt"
	"os"

	"github.com/ethersphere/bee/v2/pkg/cac"
	"github.com/ethersphere/bee/v2/pkg/soc"
	testingc "github.com/ethersphere/bee/v2/pkg/storage/testing"
)

func main() {
	const maxAttempts = 1_000_000

	cacValid := 0
	socOK := 0
	bothFail := 0

	for i := 1; i <= maxAttempts; i++ {
		ch := testingc.GenerateTestRandomInvalidChunk()

		isCAC := cac.Valid(ch)
		s, socErr := soc.FromChunk(ch)

		switch {
		case isCAC:
			cacValid++
		case socErr == nil:
			socOK++
			// First time we hit this case, dump everything and exit.
			if socOK == 1 {
				fmt.Printf("HIT after %d attempts\n", i)
				fmt.Printf("chunk address: %s\n", ch.Address())
				fmt.Printf("chunk data len: %d\n", len(ch.Data()))
				fmt.Printf("chunk data (hex): %s\n", hex.EncodeToString(ch.Data()))
				fmt.Printf("\nValidation results:\n")
				fmt.Printf("  cac.Valid(chunk):     %v\n", isCAC)
				fmt.Printf("  soc.FromChunk error:  %v  <-- nil means pullsync routes this to gsocHandler\n", socErr)
				fmt.Printf("\nRecovered SOC fields:\n")
				fmt.Printf("  id        (hex):  %s\n", hex.EncodeToString(s.ID()))
				fmt.Printf("  signature (hex):  %s\n", hex.EncodeToString(s.Signature()))
				fmt.Printf("  recovered owner:  %s\n", hex.EncodeToString(s.OwnerAddress()))
				socAddr, addrErr := s.Address()
				fmt.Printf("  SOC.Address():    %s  err=%v\n", socAddr, addrErr)
				fmt.Printf("  chunk.Address():  %s\n", ch.Address())
				fmt.Printf("  addresses match:  %v  (note: pullsync.go does NOT enforce this)\n",
					socAddr.Equal(ch.Address()))

				fmt.Printf("\nConclusion: pullsync's branch order means this chunk reaches the\n")
				fmt.Printf("`else if soc.FromChunk(...) == nil` branch, gets handed to gsocHandler,\n")
				fmt.Printf("appended to chunksToPut, and ErrInvalidChunk is NEVER added to chunkErr.\n")
				os.Exit(0)
			}
		default:
			bothFail++
		}

		if i%50_000 == 0 {
			fmt.Fprintf(os.Stderr, "after %d: cac=%d soc=%d both-fail=%d\n",
				i, cacValid, socOK, bothFail)
		}
	}

	fmt.Printf("no SOC-passing invalid chunk found in %d attempts\n", maxAttempts)
	fmt.Printf("  cac.Valid:        %d\n", cacValid)
	fmt.Printf("  soc.FromChunk OK: %d\n", socOK)
	fmt.Printf("  both fail:        %d\n", bothFail)
}
```