### PR TITLE
fix: include bootnodes in /status and /status/peers

### DIFF
--- a/pkg/api/status.go
+++ b/pkg/api/status.go
@@ -146,7 +146,7 @@ func (s *Service) statusGetPeersHandler(w http.ResponseWriter, r *http.Request) 
 
 	err := s.topologyDriver.EachConnectedPeer(
 		peerFunc,
-		topology.Select{},
+		topology.Select{IncludeBootnodes: true},
 	)
 	if err != nil {
 		logger.Debug("status snapshot", "error", err)

--- a/pkg/api/status_test.go
+++ b/pkg/api/status_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/status"
 	"github.com/ethersphere/bee/v2/pkg/storer"
 	"github.com/ethersphere/bee/v2/pkg/topology"
+	topologymock "github.com/ethersphere/bee/v2/pkg/topology/mock"
 )
 
 func TestGetStatus(t *testing.T) {
@@ -74,6 +75,35 @@ func TestGetStatus(t *testing.T) {
 		)
 	})
 
+}
+
+// TestGetStatusPeersIncludesBootnodes is a regression test for
+// https://github.com/ethersphere/bee/issues/5111: the /status/peers handler
+// must pass topology.Select{IncludeBootnodes: true} to the topology iterator
+// so that bootnodes appear alongside other peers (matching /peers).
+func TestGetStatusPeersIncludesBootnodes(t *testing.T) {
+	t.Parallel()
+
+	var captured topology.Select
+	topoOpts := []topologymock.Option{
+		// No WithPeers: the iterator captures the Select arg before yielding
+		// any peers, so we don't need to plumb a streamer for PeerSnapshot.
+		topologymock.WithSelectRecorder(&captured),
+	}
+
+	statusSvc := status.NewService(log.Noop, nil, new(topologyPeersIterNoopMock), api.FullMode.String(), nil, nil, nil)
+
+	client, _, _, _ := newTestServer(t, testServerOptions{
+		BeeMode:      api.FullMode,
+		NodeStatus:   statusSvc,
+		TopologyOpts: topoOpts,
+	})
+
+	jsonhttptest.Request(t, client, http.MethodGet, "/status/peers", http.StatusOK)
+
+	if !captured.IncludeBootnodes {
+		t.Fatalf("/status/peers must pass topology.Select{IncludeBootnodes: true}, got %#v", captured)
+	}
 }
 
 // topologyPeersIterNoopMock is noop topology.PeerIterator.

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -125,7 +125,7 @@ func (s *Service) LocalSnapshot() (*Snapshot, error) {
 			}
 			return false, false, nil
 		},
-		topology.Select{},
+		topology.Select{IncludeBootnodes: true},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("iterate connected peers: %w", err)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -7,6 +7,7 @@ package status_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ethersphere/bee/v2/pkg/api"
@@ -240,6 +241,70 @@ func (m *topologyPeersIterNoopMock) EachConnectedPeerRev(_ topology.EachPeerFunc
 
 func (m *topologyPeersIterNoopMock) IsReachable() bool {
 	return true
+}
+
+// recordingPeerIterMock captures the topology.Select passed to its iterator
+// methods and yields a configurable set of peers, so callers can verify that
+// LocalSnapshot opts in to bootnode inclusion.
+type recordingPeerIterMock struct {
+	peers           []swarm.Address
+	gotSelect       topology.Select
+	eachConnCalls   int
+	eachConnRevCall int
+}
+
+func (m *recordingPeerIterMock) EachConnectedPeer(f topology.EachPeerFunc, s topology.Select) error {
+	m.gotSelect = s
+	m.eachConnCalls++
+	for _, p := range m.peers {
+		if _, _, err := f(p, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *recordingPeerIterMock) EachConnectedPeerRev(_ topology.EachPeerFunc, s topology.Select) error {
+	m.gotSelect = s
+	m.eachConnRevCall++
+	return nil
+}
+
+func (m *recordingPeerIterMock) IsReachable() bool { return true }
+
+// TestLocalSnapshotIncludesBootnodes is a regression test for
+// https://github.com/ethersphere/bee/issues/5111: LocalSnapshot must ask the
+// topology iterator to include bootnodes so that the connectedPeers count
+// reported by /status matches the peer set returned by /peers.
+func TestLocalSnapshotIncludesBootnodes(t *testing.T) {
+	t.Parallel()
+
+	peers := []swarm.Address{
+		swarm.MustParseHexAddress("11" + strings.Repeat("00", 31)),
+		swarm.MustParseHexAddress("22" + strings.Repeat("00", 31)),
+		swarm.MustParseHexAddress("33" + strings.Repeat("00", 31)),
+	}
+
+	iter := &recordingPeerIterMock{peers: peers}
+	sssMock := &statusSnapshotMock{&pb.Snapshot{BatchCommitment: 1, LastSyncedBlock: 1}}
+
+	svc := status.NewService(log.Noop, nil, iter, api.FullMode.String(), sssMock, sssMock, nil)
+	svc.SetSync(sssMock)
+
+	snap, err := svc.LocalSnapshot()
+	if err != nil {
+		t.Fatalf("LocalSnapshot: %v", err)
+	}
+
+	if !iter.gotSelect.IncludeBootnodes {
+		t.Fatalf("LocalSnapshot must pass topology.Select{IncludeBootnodes: true} to EachConnectedPeer, got %#v", iter.gotSelect)
+	}
+	if iter.eachConnCalls != 1 {
+		t.Fatalf("expected EachConnectedPeer to be called exactly once, got %d", iter.eachConnCalls)
+	}
+	if got, want := snap.ConnectedPeers, uint64(len(peers)); got != want {
+		t.Fatalf("ConnectedPeers: got %d, want %d (every iterated peer must be counted, including bootnodes)", got, want)
+	}
 }
 
 // statusSnapshotMock satisfies the following interfaces:

--- a/pkg/topology/kademlia/export_test.go
+++ b/pkg/topology/kademlia/export_test.go
@@ -7,6 +7,7 @@ package kademlia
 import (
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/ethersphere/bee/v2/pkg/topology"
+	im "github.com/ethersphere/bee/v2/pkg/topology/kademlia/internal/metrics"
 	"github.com/ethersphere/bee/v2/pkg/topology/pslice"
 )
 
@@ -99,4 +100,11 @@ func closestPeer(peers *pslice.PSlice, addr swarm.Address) (swarm.Address, error
 
 func (k *Kad) Trigger() {
 	k.manageC <- struct{}{}
+}
+
+// MarkAsBootnode marks the given address as a bootnode in the metrics
+// collector, mirroring what the production connectBootNodes path does. Used by
+// tests to assert iterator filtering behavior.
+func (k *Kad) MarkAsBootnode(addr swarm.Address) {
+	k.collector.Record(addr, im.IsBootnode(true))
 }

--- a/pkg/topology/kademlia/kademlia.go
+++ b/pkg/topology/kademlia/kademlia.go
@@ -1408,8 +1408,10 @@ func (k *Kad) SubscribeTopologyChange() (c <-chan struct{}, unsubscribe func()) 
 
 func excludeFromIterator(filter topology.Select) []im.ExcludeOp {
 	ops := make([]im.ExcludeOp, 0, 3)
-	ops = append(ops, im.Bootnode())
 
+	if !filter.IncludeBootnodes {
+		ops = append(ops, im.Bootnode())
+	}
 	if filter.Reachable {
 		ops = append(ops, im.Reachability(false))
 	}

--- a/pkg/topology/kademlia/kademlia_test.go
+++ b/pkg/topology/kademlia/kademlia_test.go
@@ -1878,6 +1878,106 @@ func TestIteratorOpts(t *testing.T) {
 	})
 }
 
+// TestIteratorBootnodes is a regression test for
+// https://github.com/ethersphere/bee/issues/5111: EachConnectedPeer must
+// exclude bootnodes by default (so protocol callers don't gossip to or query
+// them), but include them when the IncludeBootnodes Select flag is set (so
+// operator-facing /status and /status/peers agree with /peers).
+func TestIteratorBootnodes(t *testing.T) {
+	t.Parallel()
+
+	var (
+		conns                    int32
+		base, kad, ab, _, signer = newTestKademlia(t, &conns, nil, kademlia.Options{})
+	)
+
+	if err := kad.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	testutil.CleanupCloser(t, kad)
+
+	// Connect a handful of peers and mark every other one as a bootnode.
+	const peerCount = 6
+	all := make([]swarm.Address, 0, peerCount)
+	bootnodes := make(map[string]struct{})
+	for i := range peerCount {
+		addr := swarm.RandAddressAt(t, base, i%4)
+		connectOne(t, signer, kad, ab, addr, nil)
+		all = append(all, addr)
+		if i%2 == 0 {
+			kad.MarkAsBootnode(addr)
+			bootnodes[addr.ByteString()] = struct{}{}
+		}
+	}
+
+	collect := func(filter topology.Select) []swarm.Address {
+		var got []swarm.Address
+		if err := kad.EachConnectedPeer(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			got = append(got, addr)
+			return false, false, nil
+		}, filter); err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	t.Run("default Select excludes bootnodes", func(t *testing.T) {
+		got := collect(topology.Select{})
+		for _, addr := range got {
+			if _, ok := bootnodes[addr.ByteString()]; ok {
+				t.Fatalf("default iterator returned bootnode %s", addr)
+			}
+		}
+		if want, have := peerCount-len(bootnodes), len(got); want != have {
+			t.Fatalf("default iterator: want %d non-bootnode peers, got %d", want, have)
+		}
+	})
+
+	t.Run("IncludeBootnodes returns the full set", func(t *testing.T) {
+		got := collect(topology.Select{IncludeBootnodes: true})
+		if want, have := len(all), len(got); want != have {
+			t.Fatalf("IncludeBootnodes iterator: want %d peers, got %d", want, have)
+		}
+		seen := make(map[string]struct{}, len(got))
+		for _, addr := range got {
+			seen[addr.ByteString()] = struct{}{}
+		}
+		for _, addr := range all {
+			if _, ok := seen[addr.ByteString()]; !ok {
+				t.Fatalf("IncludeBootnodes iterator missing peer %s", addr)
+			}
+		}
+	})
+
+	t.Run("EachConnectedPeerRev honors IncludeBootnodes", func(t *testing.T) {
+		var got []swarm.Address
+		if err := kad.EachConnectedPeerRev(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			got = append(got, addr)
+			return false, false, nil
+		}, topology.Select{IncludeBootnodes: true}); err != nil {
+			t.Fatal(err)
+		}
+		if want, have := len(all), len(got); want != have {
+			t.Fatalf("Rev IncludeBootnodes iterator: want %d peers, got %d", want, have)
+		}
+	})
+
+	t.Run("EachConnectedPeerRev default excludes bootnodes", func(t *testing.T) {
+		var got []swarm.Address
+		if err := kad.EachConnectedPeerRev(func(addr swarm.Address, _ uint8) (bool, bool, error) {
+			got = append(got, addr)
+			return false, false, nil
+		}, topology.Select{}); err != nil {
+			t.Fatal(err)
+		}
+		for _, addr := range got {
+			if _, ok := bootnodes[addr.ByteString()]; ok {
+				t.Fatalf("Rev default iterator returned bootnode %s", addr)
+			}
+		}
+	})
+}
+
 type boolgen struct {
 	cache     int64
 	remaining int

--- a/pkg/topology/mock/mock.go
+++ b/pkg/topology/mock/mock.go
@@ -26,6 +26,8 @@ type mock struct {
 	marshalJSONFunc func() ([]byte, error)
 	mtx             sync.Mutex
 	health          map[string]bool
+	lastSelect      topology.Select
+	selectRecorder  *topology.Select
 }
 
 var _ topology.Driver = (*mock)(nil)
@@ -69,6 +71,15 @@ func WithMarshalJSONFunc(f func() ([]byte, error)) Option {
 func WithIsWithinFunc(f func(swarm.Address) bool) Option {
 	return optionFunc(func(d *mock) {
 		d.isWithinFunc = f
+	})
+}
+
+// WithSelectRecorder records the topology.Select most recently passed to
+// EachConnectedPeer or EachConnectedPeerRev into out. Tests use this to assert
+// callers opt in to filtering flags (e.g. IncludeBootnodes).
+func WithSelectRecorder(out *topology.Select) Option {
+	return optionFunc(func(d *mock) {
+		d.selectRecorder = out
 	})
 }
 
@@ -191,9 +202,14 @@ func (m *mock) NeighborhoodDepth() uint8 {
 func (m *mock) SetStorageRadius(uint8) {}
 
 // EachConnectedPeer implements topology.PeerIterator interface.
-func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Select) (err error) {
+func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, s topology.Select) (err error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
+
+	d.lastSelect = s
+	if d.selectRecorder != nil {
+		*d.selectRecorder = s
+	}
 
 	if d.peersErr != nil {
 		return d.peersErr
@@ -210,9 +226,14 @@ func (d *mock) EachConnectedPeer(f topology.EachPeerFunc, _ topology.Select) (er
 }
 
 // EachConnectedPeerRev implements topology.PeerIterator interface.
-func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Select) (err error) {
+func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, s topology.Select) (err error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
+
+	d.lastSelect = s
+	if d.selectRecorder != nil {
+		*d.selectRecorder = s
+	}
 
 	for i := len(d.peers) - 1; i >= 0; i-- {
 		_, _, err = f(d.peers[i], uint8(i))
@@ -222,6 +243,15 @@ func (d *mock) EachConnectedPeerRev(f topology.EachPeerFunc, _ topology.Select) 
 	}
 
 	return nil
+}
+
+// LastSelect returns the topology.Select most recently passed to
+// EachConnectedPeer or EachConnectedPeerRev. Intended for tests that assert
+// callers opt in to filtering flags (e.g. IncludeBootnodes).
+func (d *mock) LastSelect() topology.Select {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	return d.lastSelect
 }
 
 func (d *mock) Snapshot() *topology.KadParams {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -63,6 +63,10 @@ type PeerIterator interface {
 type Select struct {
 	Reachable bool
 	Healthy   bool
+	// IncludeBootnodes disables the default bootnode exclusion. Protocol callers
+	// should leave this false; operator-facing status views set it to true so
+	// bootnode peers show up alongside non-bootnode peers.
+	IncludeBootnodes bool
 }
 
 // EachPeerFunc is a callback that is called with a peer and its PO


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
  Fixes #5111. The peer counts reported by `/peers`, `/status`, and
  `/status/peers` disagree on any node connected to a bootnode.

  PR #4909 ("fix: exclude bootnode from protocol requests") made
  kademlia's `EachConnectedPeer` / `EachConnectedPeerRev` always filter
  bootnodes out via `excludeFromIterator`. That is the correct policy
  for protocol traffic (pushsync, retrieval, puller, salud, kad's own
  random-peer selection), but it also silently dropped bootnodes from
  the two operator-facing status views, which iterate via the same
  method. Meanwhile `/peers` reads `p2p.Peers()` directly and never
  went through the kademlia filter — so it kept showing bootnodes.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
