### PR TITLE
fix: fail fast when postage block is ahead of chain tip

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -867,6 +867,31 @@ func NewBee(
 			return nil, errors.New("postage contract is paused")
 		}
 
+		// Refuse to start if the last-synced postage block sits ahead of the
+		// chain tip reported by the backend. The persisted state was advanced
+		// from earlier RPC responses, so the gap means the configured
+		// blockchain-rpc-endpoint is now returning data for a different chain
+		// than it was previously (a misrouted public RPC, a changed endpoint,
+		// or a load-balancer serving the wrong backend). Without this guard
+		// the postage listener loop spins until the 10-minute stalling
+		// timeout fires, surfacing as /stamps returning 503 "syncing in
+		// progress" the whole time (issue #4941).
+		if cs := batchStore.GetChainState(); cs.Block > 0 {
+			blockNumber, blockErr := chainBackend.BlockNumber(ctx)
+			switch {
+			case blockErr != nil:
+				logger.Warning("could not verify chain tip against stored chainstate", "error", blockErr)
+			case cs.Block > blockNumber:
+				return nil, fmt.Errorf(
+					"blockchain-rpc-endpoint reports block %d, but the local batch store has already synced past it to block %d. "+
+						"This means the RPC endpoint is now serving a different chain than it was on a previous run. "+
+						"Confirm that blockchain-rpc-endpoint points to the correct network (compare its eth_chainId and current block height against a second, trusted endpoint). "+
+						"Once the RPC is correct, restart with --resync to rebuild the batch store from the right chain",
+					blockNumber, cs.Block,
+				)
+			}
+		}
+
 		if o.FullNodeMode {
 			err = batchSvc.Start(ctx, postageSyncStart)
 			syncStatus.Store(true)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -202,6 +202,8 @@ const (
 	basePrice                     = 10_000                    // minimal price for retrieval and pushsync requests of maximum proximity
 	postageSyncingStallingTimeout = 10 * time.Minute          //
 	postageSyncingBackoffTimeout  = 5 * time.Second           //
+	startupBlockHeightChecks      = 3                         // number of probes at startup before declaring stored chainstate ahead of backend
+	startupBlockHeightBackoff     = 5 * time.Second           // wait between startup block-height probes
 	minPaymentThreshold           = 2 * refreshRate           // minimal accepted payment threshold of full nodes
 	maxPaymentThreshold           = 24 * refreshRate          // maximal accepted payment threshold of full nodes
 	mainnetNetworkID              = uint64(1)                 //
@@ -868,26 +870,42 @@ func NewBee(
 		}
 
 		// Refuse to start if the last-synced postage block sits ahead of the
-		// chain tip reported by the backend. The persisted state was advanced
-		// from earlier RPC responses, so the gap means the configured
-		// blockchain-rpc-endpoint is now returning data for a different chain
-		// than it was previously (a misrouted public RPC, a changed endpoint,
-		// or a load-balancer serving the wrong backend). Without this guard
-		// the postage listener loop spins until the 10-minute stalling
-		// timeout fires, surfacing as /stamps returning 503 "syncing in
-		// progress" the whole time (issue #4941).
+		// block number reported by the backend. The persisted state was
+		// advanced from earlier RPC responses, so a persistent gap means the
+		// configured blockchain-rpc-endpoint is now returning data for a
+		// different chain than it was previously (a misrouted public RPC, a
+		// changed endpoint, or a load-balancer serving the wrong backend).
+		// Probe a few times with a short backoff so a single bad response
+		// (transient RPC blip, brief failover) does not lock the node out.
+		// Without this guard the postage listener loop would spin until the
+		// 10-minute stalling timeout fires, surfacing as /stamps returning
+		// 503 "syncing in progress" the whole time (issue #4941).
 		if cs := batchStore.GetChainState(); cs.Block > 0 {
-			blockNumber, blockErr := chainBackend.BlockNumber(ctx)
+			var (
+				blockHeight uint64
+				blockErr    error
+			)
+			for i := 0; i < startupBlockHeightChecks; i++ {
+				blockHeight, blockErr = chainBackend.BlockNumber(ctx)
+				if blockErr != nil || blockHeight >= cs.Block {
+					break
+				}
+				select {
+				case <-time.After(startupBlockHeightBackoff):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
 			switch {
 			case blockErr != nil:
-				logger.Warning("could not verify chain tip against stored chainstate", "error", blockErr)
-			case cs.Block > blockNumber:
+				logger.Warning("could not verify block height against stored chainstate", "error", blockErr)
+			case cs.Block > blockHeight:
 				return nil, fmt.Errorf(
-					"blockchain-rpc-endpoint reports block %d, but the local batch store has already synced past it to block %d. "+
+					"blockchain-rpc-endpoint reports block %d after %d checks, but the local batch store has already synced past it to block %d. "+
 						"This means the RPC endpoint is now serving a different chain than it was on a previous run. "+
 						"Confirm that blockchain-rpc-endpoint points to the correct network (compare its eth_chainId and current block height against a second, trusted endpoint). "+
 						"Once the RPC is correct, restart with --resync to rebuild the batch store from the right chain",
-					blockNumber, cs.Block,
+					blockHeight, startupBlockHeightChecks, cs.Block,
 				)
 			}
 		}


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
 - Refuses to start when the persisted `chainstate.Block` is ahead of
    the block number reported by `blockchain-rpc-endpoint`, with a
    clear error pointing at the RPC misconfiguration.
  - Replaces a 10-minute "syncing in progress" stall plus
    lightnode-shutdown / fullnode-init-failure with an immediate, actionable
    failure.

  ## Why
  The reporter on #4941 observed `/stamps` returning `503 syncing in
  progress` indefinitely, with `/chainstate` showing `block` ~1.18M blocks
  ahead of `chainTip`. The two symptoms are one bug: once
  `chainstate.Block > chainTip`, the postage listener loop in
  `pkg/postage/listener/listener.go` evaluates `to < from` and `continue`s
  `pkg/postage/listener/listener.go` evaluates `to < from` and `continue`s
  `syncStatusFn` never returns `done=true` and `/stamps` stays in 503.
  After `postageSyncingStallingTimeout` (10 min) the loop exits with
  `ErrPostageSyncingStalled`; for lightnodes this triggers
  `b.syncingStopped.Signal()` and the node shuts down, for fullnodes
  init fails.

  `chainstate.Block` is only ever advanced by `UpdateBlockNumber`
  from events the listener received from the RPC. So a stored block
  ahead of the current chain tip means the configured RPC is now
  serving a different chain than it was on a previous run — a
  misrouted public endpoint, a changed `blockchain-rpc-endpoint`, a
  load-balancer pointing to the wrong backend. The chain-ID check at
  startup (`pkg/node/chain.go:109`) does not catch this if the wrong
  backend happens to report the configured chain ID. This is an RPC /
  operational problem, not local DB corruption, and not something Bee
  should auto-heal — silent rebuild would mask the misconfiguration and
  trigger long resyncs on every restart.

  ## Change
  Before `batchSvc.Start` runs, query `chainBackend.BlockNumber(ctx)`
  once. If the stored `chainstate.Block` is strictly greater, return an
  error naming both block numbers and explaining the likely cause and
  the recovery path (verify the RPC, then `--resync`). If the
  `BlockNumber` call itself fails, log a warning and continue — we don't
  want to block startup on a transient RPC hiccup.

  No tolerance is applied: the listener always writes
  `cs.Block <= blockNumber - tailSize`, so under normal operation `cs.Block` is
  strictly below the live tip. The only way the check can trip is the
  corruption scenario above.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
