### PR TITLE
feat(api): add GET /batches/{batch_id} endpoint

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 8.0.0
+  version: 8.1.0
   title: Bee API
   description: "API endpoints for interacting with the Swarm network, supporting file operations, messaging, and node management"
 
@@ -2153,6 +2153,32 @@ paths:
               schema:
                 $ref: "SwarmCommon.yaml#/components/schemas/DebugPostageAllBatchesResponse"
 
+        default:
+          description: Default response
+
+  "/batches/{batch_id}":
+    parameters:
+      - in: path
+        name: batch_id
+        schema:
+          $ref: "SwarmCommon.yaml#/components/schemas/BatchID"
+        required: true
+        description: ID of the postage batch
+    get:
+      summary: Get a single globally available postage batch by ID
+      tags:
+        - Postage Stamps
+      responses:
+        "200":
+          description: The postage batch state
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/PostageBatchShort"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
         default:
           description: Default response
 

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -260,6 +260,50 @@ func (s *Service) postageGetAllBatchesHandler(w http.ResponseWriter, _ *http.Req
 	jsonhttp.OK(w, batchesRes)
 }
 
+func (s *Service) postageGetBatchHandler(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.WithName("get_batch").Build()
+
+	paths := struct {
+		BatchID []byte `map:"batch_id" validate:"required,len=32"`
+	}{}
+	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
+		response("invalid path params", logger, w)
+		return
+	}
+	hexBatchID := hex.EncodeToString(paths.BatchID)
+
+	batch, err := s.batchStore.Get(paths.BatchID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			jsonhttp.NotFound(w, "batch not found")
+			return
+		}
+		logger.Debug("get batch failed", "batch_id", hexBatchID, "error", err)
+		logger.Error(nil, "get batch failed")
+		jsonhttp.InternalServerError(w, "unable to get batch")
+		return
+	}
+
+	batchTTL, err := s.estimateBatchTTL(batch)
+	if err != nil {
+		logger.Debug("estimate batch expiration failed", "batch_id", hexBatchID, "error", err)
+		logger.Error(nil, "estimate batch expiration failed")
+		jsonhttp.InternalServerError(w, "unable to estimate batch expiration")
+		return
+	}
+
+	jsonhttp.OK(w, postageBatchResponse{
+		BatchID:     batch.ID,
+		Value:       bigint.Wrap(batch.Value),
+		Start:       batch.Start,
+		Owner:       batch.Owner,
+		Depth:       batch.Depth,
+		BucketDepth: batch.BucketDepth,
+		Immutable:   batch.Immutable,
+		BatchTTL:    batchTTL,
+	})
+}
+
 func (s *Service) postageGetStampBucketsHandler(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithName("get_stamp_bucket").Build()
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -302,6 +302,61 @@ func TestGetAllBatches(t *testing.T) {
 	})
 }
 
+// TestGetBatch tests that the endpoint that returns a single globally available
+// postage batch by ID functions correctly.
+func TestGetBatch(t *testing.T) {
+	t.Parallel()
+
+	b := postagetesting.MustNewBatch()
+	b.Value = big.NewInt(20)
+	cs := &postage.ChainState{Block: 10, TotalAmount: big.NewInt(5), CurrentPrice: big.NewInt(2)}
+	bs := mock.New(mock.WithChainState(cs), mock.WithBatch(b))
+	ts, _, _, _ := newTestServer(t, testServerOptions{BatchStore: bs, BlockTime: 2 * time.Second})
+
+	want := api.PostageBatchResponse{
+		BatchID:     b.ID,
+		Value:       bigint.Wrap(b.Value),
+		Start:       b.Start,
+		Owner:       b.Owner,
+		Depth:       b.Depth,
+		BucketDepth: b.BucketDepth,
+		Immutable:   b.Immutable,
+		BatchTTL:    15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		jsonhttptest.Request(t, ts, http.MethodGet, "/batches/"+hex.EncodeToString(b.ID), http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(want),
+		)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		missing := make([]byte, 32)
+		jsonhttptest.Request(t, ts, http.MethodGet, "/batches/"+hex.EncodeToString(missing), http.StatusNotFound,
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Code:    http.StatusNotFound,
+				Message: "batch not found",
+			}),
+		)
+	})
+
+	t.Run("invalid batch id length", func(t *testing.T) {
+		t.Parallel()
+
+		jsonhttptest.Request(t, ts, http.MethodGet, "/batches/abcdef", http.StatusBadRequest,
+			jsonhttptest.WithExpectedJSONResponse(&jsonhttp.StatusResponse{
+				Code:    http.StatusBadRequest,
+				Message: "invalid path params",
+				Reasons: []jsonhttp.Reason{{Field: "batch_id", Error: "want len:32"}},
+			}),
+		)
+	})
+}
+
 func TestPostageGetStamp(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -639,6 +639,10 @@ func (s *Service) mountBusinessDebug() {
 		"GET": http.HandlerFunc(s.postageGetAllBatchesHandler),
 	})
 
+	handle("/batches/{batch_id}", jsonhttp.MethodHandler{
+		"GET": http.HandlerFunc(s.postageGetBatchHandler),
+	})
+
 	handle("/accounting", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.accountingInfoHandler),
 	})


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Closes #5458.

  Adds the singular companion to GET /batches so callers can fetch a
  single globally-visible postage batch by ID in O(1) instead of pulling
  the entire batch set client-side. Mirrors the existing
  /stamps/{batch_id} pattern: 32-byte ID path param, batchStore.Get
  lookup, 404 on ErrNotFound, 200 with PostageBatchShort otherwise.

  OpenAPI spec bumped 8.0.0 -> 8.1.0 (backwards-compatible new endpoint).

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
