### PR TITLE
fix(storer): unstick radius decrement on live networks

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -205,7 +205,7 @@ const (
 	minPaymentThreshold           = 2 * refreshRate           // minimal accepted payment threshold of full nodes
 	maxPaymentThreshold           = 24 * refreshRate          // maximal accepted payment threshold of full nodes
 	mainnetNetworkID              = uint64(1)                 //
-	reserveWakeUpDuration         = 15 * time.Minute          // time to wait before waking up reserveWorker
+	reserveWakeUpDuration         = 5 * time.Minute           // time to wait before waking up reserveWorker
 	reserveMinEvictCount          = 1_000
 	cacheMinEvictCount            = 10_000
 	maxAllowedDoubling            = 1

--- a/pkg/storer/reserve.go
+++ b/pkg/storer/reserve.go
@@ -167,20 +167,43 @@ func (db *DB) reserveWorker(ctx context.Context, ready chan<- struct{}) {
 		case <-thresholdTicker.C:
 
 			radius := db.reserve.Radius()
+			if radius <= db.reserveOptions.minimumRadius {
+				continue
+			}
 			count, err := db.countWithinRadius(ctx)
 			if err != nil {
 				db.logger.Warning("reserve worker count within radius", "error", err)
 				continue
 			}
 
-			if count < threshold(db.reserve.Capacity()) && db.syncer.SyncRate() == 0 && radius > db.reserveOptions.minimumRadius {
-				radius--
-				if err := db.reserve.SetRadius(radius); err != nil {
-					db.logger.Error(err, "reserve set radius")
-				}
-				db.metrics.StorageRadius.Set(float64(radius))
-				db.logger.Info("reserve radius decrease", "radius", radius)
+			t := threshold(db.reserve.Capacity())
+			if count >= t {
+				continue
 			}
+
+			// Decrement the storage radius. The decrement is gated only on
+			// the reserve fill state (count < threshold) and the operator's
+			// minimum-radius floor. There is no sync-rate gate here, which
+			// mirrors the unreserve path that raises radius without
+			// consulting sync activity. A previous SyncRate() == 0 gate
+			// proved structurally unreachable on live networks: peer churn
+			// kept historical sync above zero, and the resetIntervals call
+			// in puller.onChange (triggered by this very radius change)
+			// retriggered historical sync, locking the gate closed (issues
+			// #5396, #5428). When count is well below threshold, jump by
+			// two steps to keep adjustments bounded but recover faster from
+			// large gaps; under uniform CAC bin distribution each step
+			// roughly doubles count-within-radius.
+			steps := uint8(1)
+			if count*4 <= t && radius-1 > db.reserveOptions.minimumRadius {
+				steps = 2
+			}
+			radius -= steps
+			if err := db.reserve.SetRadius(radius); err != nil {
+				db.logger.Error(err, "reserve set radius")
+			}
+			db.metrics.StorageRadius.Set(float64(radius))
+			db.logger.Info("reserve radius decrease", "radius", radius, "steps", steps, "count_within_radius", count, "threshold", t)
 		}
 	}
 }

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -536,6 +536,35 @@ func TestRadiusManager(t *testing.T) {
 		}
 		waitForRadius(t, storer.Reserve(), 0)
 	})
+
+	t.Run("radius stops at minimum_radius", func(t *testing.T) {
+		t.Parallel()
+		opts := dbTestOps(baseAddr, 10, nil, nil, time.Millisecond*500)
+		opts.MinimumStorageRadius = 2
+		storer, err := diskStorer(t, opts)()
+		if err != nil {
+			t.Fatal(err)
+		}
+		readyC := make(chan struct{})
+		// An empty reserve at network radius 3 would normally let the worker
+		// decrement all the way to 0. With MinimumStorageRadius=2 the floor
+		// must hold: the two-step branch has to downgrade to a single step
+		// (because radius-1 == minimumRadius), and once radius reaches the
+		// floor the top-level guard must block any further decrement.
+		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(0), networkRadiusFunc(3), readyC)
+		select {
+		case <-readyC:
+		case <-t.Context().Done():
+			t.Fatal("start reserve worker timeout")
+		}
+		waitForRadius(t, storer.Reserve(), 2)
+
+		// Hold across several wake-up cycles to confirm the floor sticks.
+		time.Sleep(time.Millisecond * 500 * 3)
+		if got := storer.Reserve().Radius(); got != 2 {
+			t.Fatalf("radius dropped below minimum: want %d, got %d", 2, got)
+		}
+	})
 }
 
 func TestSubscribeBin(t *testing.T) {

--- a/pkg/storer/reserve_test.go
+++ b/pkg/storer/reserve_test.go
@@ -516,20 +516,25 @@ func TestRadiusManager(t *testing.T) {
 		waitForRadius(t, storer.Reserve(), 0)
 	})
 
-	t.Run("radius doesn't change due to non-zero pull rate", func(t *testing.T) {
+	t.Run("radius decreases even with non-zero pull rate", func(t *testing.T) {
 		t.Parallel()
 		storer, err := diskStorer(t, dbTestOps(baseAddr, 10, nil, nil, time.Millisecond*500))()
 		if err != nil {
 			t.Fatal(err)
 		}
 		readyC := make(chan struct{})
+		// Reserve is empty, so countWithinRadius == 0 < threshold; the worker
+		// should decrement radius regardless of the syncer's reported rate.
+		// The old behavior (gated on SyncRate() == 0) made this scenario
+		// permanently stuck on live networks where peer churn keeps the rate
+		// above zero — see issues #5396 and #5428.
 		storer.StartReserveWorker(context.Background(), pullerMock.NewMockRateReporter(1), networkRadiusFunc(3), readyC)
 		select {
 		case <-readyC:
 		case <-t.Context().Done():
 			t.Fatal("start reserve worker timeout")
 		}
-		waitForRadius(t, storer.Reserve(), 3)
+		waitForRadius(t, storer.Reserve(), 0)
 	})
 }
 


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
  Nodes whose local `storageRadius` drifts above the neighborhood consensus stay stuck there indefinitely. Salud (`pkg/salud/salud.go:243`) compares `CommittedDepth = capacityDoubling + Radius` against the network mode with zero tolerance, flips the node unhealthy on any mismatch, and redistribution stops playing rounds. The reporter of #5428 observed this on bee 2.7.1-rc2 after an RPC instability event; the reporter of #5396 reproduced the same condition with code-level analysis.
  
  The reserve worker's radius-decrement gate `db.syncer.SyncRate() == 0` is structurally unreachable on a live mainnet. SyncRate() measures historical sync only, but historical sync never goes quiet for the 15-minute rate window because (1) peer churn keeps starting new cursor-based historical workers and (2) every successful decrement calls puller.onChange → resetIntervals(prevRadius) which discards non-neighbor sync history and forces re-historical-sync, bumping SyncRate above zero for the next ~15-30 min. The gate locks closed permanently. Nodes whose local Radius drifts above the neighborhood consensus stay there indefinitely — salud (zero-tolerance comparison of CommittedDepth = capacityDoubling + Radius) flips the node unhealthy and redistribution stops playing rounds. Restart doesn't help because waitNetworkRFunc re-loads the wrong local value.

  Capacity-doubled nodes are structurally worse off: they pull more data, their SyncRate floor is higher, and the +1 from doubling amplifies any Radius mismatch into CommittedDepth mismatch.

  Three changes, applied together:

  1. Remove the SyncRate gate. The threshold check (count < threshold(capacity)) is already a correctness signal — if less than half of capacity sits within radius, the radius is wrong, regardless of sync activity. The unreserve path raises radius without consulting SyncRate; the asymmetry was unjustified.

  2. Allow a two-step decrement when count is far below threshold (count*4 <= threshold). Under approximately uniform CAC bin distribution, each step doubles count-within-radius, so two steps land at or below threshold rather than overshooting. Capped at two to keep behavior bounded; each radius change triggers one resetIntervals so multi-step in one tick is strictly cheaper than the equivalent single-step ticks 5 minutes apart.

  3. Reduce reserveWakeUpDuration from 15 to 5 minutes. With the gate gone, faster ticks bound worst-case recovery; tick cost is one countWithinRadius iteration.

  The existing test "radius doesn't change due to non-zero pull rate encoded the buggy behavior as an invariant. Renamed and inverted to assert the new contract: with an empty reserve, the worker decrements toward minimumRadius regardless of the syncer's reported rate.

  No protocol, storage layout, persistence format, or interface changes. The Syncer.SyncRate() interface stays — it's still used for "fully synced" determination at startup and for the status protocol's pullsyncRate field, both correct uses.

  Fixes #5396
  Fixes #5428

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.

