### PR TITLE
feat(openapi): document utilization; add utilizedPercentage to postag…

### DIFF
--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -535,10 +535,10 @@ components:
             the fullest bucket caps at `2^(depth - bucketDepth)` chunks, so
             the fractional usage of the batch is
             `utilization / 2^(depth - bucketDepth)` (also exposed directly as
-            `utilizedPercentage`). When the value reaches
+            `utilizationRatio`). When the value reaches
             `2^(depth - bucketDepth)` the batch is effectively full and any
             further write to the fullest bucket would overflow it.
-        utilizedPercentage:
+        utilizationRatio:
           type: number
           format: double
           minimum: 0

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -527,6 +527,27 @@ components:
           $ref: "#/components/schemas/BatchID"
         utilization:
           type: integer
+          description: >
+            Raw batch fullness indicator: the highest write count among the
+            `2^bucketDepth` collision buckets of the batch. This is **not** a
+            percentage; one unit corresponds to one chunk written into the
+            fullest bucket. Total batch capacity is `2^depth` chunks, while
+            the fullest bucket caps at `2^(depth - bucketDepth)` chunks, so
+            the fractional usage of the batch is
+            `utilization / 2^(depth - bucketDepth)` (also exposed directly as
+            `utilizedPercentage`). When the value reaches
+            `2^(depth - bucketDepth)` the batch is effectively full and any
+            further write to the fullest bucket would overflow it.
+        utilizedPercentage:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Fractional batch fullness in the range `[0, 1]`, computed as
+            `utilization / 2^(depth - bucketDepth)`. A value of `1` means the
+            fullest bucket has reached its capacity and the batch can no
+            longer accept writes that would land in that bucket.
         usable:
           description: Indicates whether the batch was discovered by the Bee node and has received sufficient on-chain confirmations
           type: boolean

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -139,17 +139,18 @@ func (s *Service) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type postageStampResponse struct {
-	BatchID       hexByte        `json:"batchID"`
-	Utilization   uint32         `json:"utilization"`
-	Usable        bool           `json:"usable"`
-	Label         string         `json:"label"`
-	Depth         uint8          `json:"depth"`
-	Amount        *bigint.BigInt `json:"amount"`
-	BucketDepth   uint8          `json:"bucketDepth"`
-	BlockNumber   uint64         `json:"blockNumber"`
-	ImmutableFlag bool           `json:"immutableFlag"`
-	Exists        bool           `json:"exists"`
-	BatchTTL      int64          `json:"batchTTL"`
+	BatchID            hexByte        `json:"batchID"`
+	Utilization        uint32         `json:"utilization"`
+	UtilizedPercentage float64        `json:"utilizedPercentage"`
+	Usable             bool           `json:"usable"`
+	Label              string         `json:"label"`
+	Depth              uint8          `json:"depth"`
+	Amount             *bigint.BigInt `json:"amount"`
+	BucketDepth        uint8          `json:"bucketDepth"`
+	BlockNumber        uint64         `json:"blockNumber"`
+	ImmutableFlag      bool           `json:"immutableFlag"`
+	Exists             bool           `json:"exists"`
+	BatchTTL           int64          `json:"batchTTL"`
 }
 
 type postageStampsResponse struct {
@@ -205,17 +206,18 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 		}
 
 		resp.Stamps = append(resp.Stamps, postageStampResponse{
-			BatchID:       v.ID(),
-			Utilization:   v.Utilization(),
-			Usable:        s.post.IssuerUsable(v),
-			Label:         v.Label(),
-			Depth:         v.Depth(),
-			Amount:        bigint.Wrap(v.Amount()),
-			BucketDepth:   v.BucketDepth(),
-			BlockNumber:   v.BlockNumber(),
-			ImmutableFlag: v.ImmutableFlag(),
-			Exists:        true,
-			BatchTTL:      batchTTL,
+			BatchID:            v.ID(),
+			Utilization:        v.Utilization(),
+			UtilizedPercentage: v.UtilizationPercentage(),
+			Usable:             s.post.IssuerUsable(v),
+			Label:              v.Label(),
+			Depth:              v.Depth(),
+			Amount:             bigint.Wrap(v.Amount()),
+			BucketDepth:        v.BucketDepth(),
+			BlockNumber:        v.BlockNumber(),
+			ImmutableFlag:      v.ImmutableFlag(),
+			Exists:             true,
+			BatchTTL:           batchTTL,
 		})
 	}
 
@@ -395,17 +397,18 @@ func (s *Service) postageGetStampHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	jsonhttp.OK(w, &postageStampResponse{
-		BatchID:       paths.BatchID,
-		Depth:         issuer.Depth(),
-		BucketDepth:   issuer.BucketDepth(),
-		ImmutableFlag: issuer.ImmutableFlag(),
-		Exists:        true,
-		BatchTTL:      batchTTL,
-		Utilization:   issuer.Utilization(),
-		Usable:        s.post.IssuerUsable(issuer),
-		Label:         issuer.Label(),
-		Amount:        bigint.Wrap(issuer.Amount()),
-		BlockNumber:   issuer.BlockNumber(),
+		BatchID:            paths.BatchID,
+		Depth:              issuer.Depth(),
+		BucketDepth:        issuer.BucketDepth(),
+		ImmutableFlag:      issuer.ImmutableFlag(),
+		Exists:             true,
+		BatchTTL:           batchTTL,
+		Utilization:        issuer.Utilization(),
+		UtilizedPercentage: issuer.UtilizationPercentage(),
+		Usable:             s.post.IssuerUsable(issuer),
+		Label:              issuer.Label(),
+		Amount:             bigint.Wrap(issuer.Amount()),
+		BlockNumber:        issuer.BlockNumber(),
 	})
 }
 

--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -139,18 +139,18 @@ func (s *Service) postageCreateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type postageStampResponse struct {
-	BatchID            hexByte        `json:"batchID"`
-	Utilization        uint32         `json:"utilization"`
-	UtilizedPercentage float64        `json:"utilizedPercentage"`
-	Usable             bool           `json:"usable"`
-	Label              string         `json:"label"`
-	Depth              uint8          `json:"depth"`
-	Amount             *bigint.BigInt `json:"amount"`
-	BucketDepth        uint8          `json:"bucketDepth"`
-	BlockNumber        uint64         `json:"blockNumber"`
-	ImmutableFlag      bool           `json:"immutableFlag"`
-	Exists             bool           `json:"exists"`
-	BatchTTL           int64          `json:"batchTTL"`
+	BatchID          hexByte        `json:"batchID"`
+	Utilization      uint32         `json:"utilization"`
+	UtilizationRatio float64        `json:"utilizationRatio"`
+	Usable           bool           `json:"usable"`
+	Label            string         `json:"label"`
+	Depth            uint8          `json:"depth"`
+	Amount           *bigint.BigInt `json:"amount"`
+	BucketDepth      uint8          `json:"bucketDepth"`
+	BlockNumber      uint64         `json:"blockNumber"`
+	ImmutableFlag    bool           `json:"immutableFlag"`
+	Exists           bool           `json:"exists"`
+	BatchTTL         int64          `json:"batchTTL"`
 }
 
 type postageStampsResponse struct {
@@ -206,18 +206,18 @@ func (s *Service) postageGetStampsHandler(w http.ResponseWriter, r *http.Request
 		}
 
 		resp.Stamps = append(resp.Stamps, postageStampResponse{
-			BatchID:            v.ID(),
-			Utilization:        v.Utilization(),
-			UtilizedPercentage: v.UtilizationPercentage(),
-			Usable:             s.post.IssuerUsable(v),
-			Label:              v.Label(),
-			Depth:              v.Depth(),
-			Amount:             bigint.Wrap(v.Amount()),
-			BucketDepth:        v.BucketDepth(),
-			BlockNumber:        v.BlockNumber(),
-			ImmutableFlag:      v.ImmutableFlag(),
-			Exists:             true,
-			BatchTTL:           batchTTL,
+			BatchID:          v.ID(),
+			Utilization:      v.Utilization(),
+			UtilizationRatio: v.UtilizationRatio(),
+			Usable:           s.post.IssuerUsable(v),
+			Label:            v.Label(),
+			Depth:            v.Depth(),
+			Amount:           bigint.Wrap(v.Amount()),
+			BucketDepth:      v.BucketDepth(),
+			BlockNumber:      v.BlockNumber(),
+			ImmutableFlag:    v.ImmutableFlag(),
+			Exists:           true,
+			BatchTTL:         batchTTL,
 		})
 	}
 
@@ -397,18 +397,18 @@ func (s *Service) postageGetStampHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	jsonhttp.OK(w, &postageStampResponse{
-		BatchID:            paths.BatchID,
-		Depth:              issuer.Depth(),
-		BucketDepth:        issuer.BucketDepth(),
-		ImmutableFlag:      issuer.ImmutableFlag(),
-		Exists:             true,
-		BatchTTL:           batchTTL,
-		Utilization:        issuer.Utilization(),
-		UtilizedPercentage: issuer.UtilizationPercentage(),
-		Usable:             s.post.IssuerUsable(issuer),
-		Label:              issuer.Label(),
-		Amount:             bigint.Wrap(issuer.Amount()),
-		BlockNumber:        issuer.BlockNumber(),
+		BatchID:          paths.BatchID,
+		Depth:            issuer.Depth(),
+		BucketDepth:      issuer.BucketDepth(),
+		ImmutableFlag:    issuer.ImmutableFlag(),
+		Exists:           true,
+		BatchTTL:         batchTTL,
+		Utilization:      issuer.Utilization(),
+		UtilizationRatio: issuer.UtilizationRatio(),
+		Usable:           s.post.IssuerUsable(issuer),
+		Label:            issuer.Label(),
+		Amount:           bigint.Wrap(issuer.Amount()),
+		BlockNumber:      issuer.BlockNumber(),
 	})
 }
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -222,18 +222,18 @@ func TestPostageGetStamps(t *testing.T) {
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{
 				Stamps: []api.PostageStampResponse{
 					{
-						BatchID:            b.ID,
-						Utilization:        si.Utilization(),
-						UtilizedPercentage: si.UtilizationPercentage(),
-						Usable:             true,
-						Label:              si.Label(),
-						Depth:              si.Depth(),
-						Amount:             bigint.Wrap(si.Amount()),
-						BucketDepth:        si.BucketDepth(),
-						BlockNumber:        si.BlockNumber(),
-						ImmutableFlag:      si.ImmutableFlag(),
-						Exists:             true,
-						BatchTTL:           15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
+						BatchID:          b.ID,
+						Utilization:      si.Utilization(),
+						UtilizationRatio: si.UtilizationRatio(),
+						Usable:           true,
+						Label:            si.Label(),
+						Depth:            si.Depth(),
+						Amount:           bigint.Wrap(si.Amount()),
+						BucketDepth:      si.BucketDepth(),
+						BlockNumber:      si.BlockNumber(),
+						ImmutableFlag:    si.ImmutableFlag(),
+						Exists:           true,
+						BatchTTL:         15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
 					},
 				},
 			}),
@@ -374,18 +374,18 @@ func TestPostageGetStamp(t *testing.T) {
 
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps/"+hex.EncodeToString(b.ID), http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampResponse{
-				BatchID:            b.ID,
-				Utilization:        si.Utilization(),
-				UtilizedPercentage: si.UtilizationPercentage(),
-				Usable:             true,
-				Label:              si.Label(),
-				Depth:              si.Depth(),
-				Amount:             bigint.Wrap(si.Amount()),
-				BucketDepth:        si.BucketDepth(),
-				BlockNumber:        si.BlockNumber(),
-				ImmutableFlag:      si.ImmutableFlag(),
-				Exists:             true,
-				BatchTTL:           15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
+				BatchID:          b.ID,
+				Utilization:      si.Utilization(),
+				UtilizationRatio: si.UtilizationRatio(),
+				Usable:           true,
+				Label:            si.Label(),
+				Depth:            si.Depth(),
+				Amount:           bigint.Wrap(si.Amount()),
+				BucketDepth:      si.BucketDepth(),
+				BlockNumber:      si.BlockNumber(),
+				ImmutableFlag:    si.ImmutableFlag(),
+				Exists:           true,
+				BatchTTL:         15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
 			}),
 		)
 	})

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -222,17 +222,18 @@ func TestPostageGetStamps(t *testing.T) {
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampsResponse{
 				Stamps: []api.PostageStampResponse{
 					{
-						BatchID:       b.ID,
-						Utilization:   si.Utilization(),
-						Usable:        true,
-						Label:         si.Label(),
-						Depth:         si.Depth(),
-						Amount:        bigint.Wrap(si.Amount()),
-						BucketDepth:   si.BucketDepth(),
-						BlockNumber:   si.BlockNumber(),
-						ImmutableFlag: si.ImmutableFlag(),
-						Exists:        true,
-						BatchTTL:      15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
+						BatchID:            b.ID,
+						Utilization:        si.Utilization(),
+						UtilizedPercentage: si.UtilizationPercentage(),
+						Usable:             true,
+						Label:              si.Label(),
+						Depth:              si.Depth(),
+						Amount:             bigint.Wrap(si.Amount()),
+						BucketDepth:        si.BucketDepth(),
+						BlockNumber:        si.BlockNumber(),
+						ImmutableFlag:      si.ImmutableFlag(),
+						Exists:             true,
+						BatchTTL:           15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
 					},
 				},
 			}),
@@ -373,17 +374,18 @@ func TestPostageGetStamp(t *testing.T) {
 
 		jsonhttptest.Request(t, ts, http.MethodGet, "/stamps/"+hex.EncodeToString(b.ID), http.StatusOK,
 			jsonhttptest.WithExpectedJSONResponse(&api.PostageStampResponse{
-				BatchID:       b.ID,
-				Utilization:   si.Utilization(),
-				Usable:        true,
-				Label:         si.Label(),
-				Depth:         si.Depth(),
-				Amount:        bigint.Wrap(si.Amount()),
-				BucketDepth:   si.BucketDepth(),
-				BlockNumber:   si.BlockNumber(),
-				ImmutableFlag: si.ImmutableFlag(),
-				Exists:        true,
-				BatchTTL:      15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
+				BatchID:            b.ID,
+				Utilization:        si.Utilization(),
+				UtilizedPercentage: si.UtilizationPercentage(),
+				Usable:             true,
+				Label:              si.Label(),
+				Depth:              si.Depth(),
+				Amount:             bigint.Wrap(si.Amount()),
+				BucketDepth:        si.BucketDepth(),
+				BlockNumber:        si.BlockNumber(),
+				ImmutableFlag:      si.ImmutableFlag(),
+				Exists:             true,
+				BatchTTL:           15, // ((value-totalAmount)/pricePerBlock)*blockTime=((20-5)/2)*2.
 			}),
 		)
 	})

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -222,6 +222,14 @@ func (si *StampIssuer) Utilization() uint32 {
 	return si.data.MaxBucketCount
 }
 
+// UtilizationPercentage returns the batch fullness as a fraction in the
+// range [0, 1], computed as Utilization / 2^(BatchDepth - BucketDepth).
+// A value of 1 means the most-filled bucket is full and any further write
+// to that bucket would overflow the batch.
+func (si *StampIssuer) UtilizationPercentage() float64 {
+	return float64(si.data.MaxBucketCount) / float64(uint64(1)<<(si.data.BatchDepth-si.data.BucketDepth))
+}
+
 // ID returns the BatchID for this batch.
 func (si *StampIssuer) ID() []byte {
 	id := make([]byte, len(si.data.BatchID))

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -227,6 +227,11 @@ func (si *StampIssuer) Utilization() uint32 {
 // A value of 1 means the most-filled bucket is full and any further write
 // to that bucket would overflow the batch.
 func (si *StampIssuer) UtilizationRatio() float64 {
+	// A valid batch always has BatchDepth >= BucketDepth; return 0 for any
+	// other combination so the ratio stays well-defined in [0, 1].
+	if si.data.BatchDepth < si.data.BucketDepth {
+		return 0
+	}
 	return float64(si.data.MaxBucketCount) / float64(uint64(1)<<(si.data.BatchDepth-si.data.BucketDepth))
 }
 

--- a/pkg/postage/stampissuer.go
+++ b/pkg/postage/stampissuer.go
@@ -222,11 +222,11 @@ func (si *StampIssuer) Utilization() uint32 {
 	return si.data.MaxBucketCount
 }
 
-// UtilizationPercentage returns the batch fullness as a fraction in the
+// UtilizationRatio returns the batch fullness as a fraction in the
 // range [0, 1], computed as Utilization / 2^(BatchDepth - BucketDepth).
 // A value of 1 means the most-filled bucket is full and any further write
 // to that bucket would overflow the batch.
-func (si *StampIssuer) UtilizationPercentage() float64 {
+func (si *StampIssuer) UtilizationRatio() float64 {
 	return float64(si.data.MaxBucketCount) / float64(uint64(1)<<(si.data.BatchDepth-si.data.BucketDepth))
 }
 

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -251,6 +251,39 @@ func TestUtilization(t *testing.T) {
 	}
 }
 
+func TestUtilizationPercentage(t *testing.T) {
+	t.Parallel()
+
+	// depth=17, bucketDepth=16 => fullest bucket caps at 2^(17-16)=2 chunks.
+	const depth, bucketDepth uint8 = 17, 16
+
+	sti := postage.NewStampIssuer("label", "keyID", make([]byte, 32), big.NewInt(3), depth, bucketDepth, 0, true)
+
+	if got := sti.UtilizationPercentage(); got != 0 {
+		t.Fatalf("empty issuer: want 0, got %v", got)
+	}
+
+	// Fill the issuer until the fullest bucket is full, then check the value
+	// matches the formula utilization / 2^(depth - bucketDepth).
+	for {
+		_, _, err := sti.Increment(swarm.RandAddress(t))
+		if errors.Is(err, postage.ErrBucketFull) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want := float64(sti.Utilization()) / math.Pow(2, float64(depth-bucketDepth))
+	if got := sti.UtilizationPercentage(); got != want {
+		t.Fatalf("filled issuer: want %v, got %v", want, got)
+	}
+	if got := sti.UtilizationPercentage(); got != 1 {
+		t.Fatalf("filled issuer should report 1, got %v", got)
+	}
+}
+
 func bytesToIndex(buf []byte) (bucket, index uint32) {
 	index64 := binary.BigEndian.Uint64(buf)
 	bucket = uint32(index64 >> 32)

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -251,7 +251,7 @@ func TestUtilization(t *testing.T) {
 	}
 }
 
-func TestUtilizationPercentage(t *testing.T) {
+func TestUtilizationRatio(t *testing.T) {
 	t.Parallel()
 
 	// depth=17, bucketDepth=16 => fullest bucket caps at 2^(17-16)=2 chunks.
@@ -259,7 +259,7 @@ func TestUtilizationPercentage(t *testing.T) {
 
 	sti := postage.NewStampIssuer("label", "keyID", make([]byte, 32), big.NewInt(3), depth, bucketDepth, 0, true)
 
-	if got := sti.UtilizationPercentage(); got != 0 {
+	if got := sti.UtilizationRatio(); got != 0 {
 		t.Fatalf("empty issuer: want 0, got %v", got)
 	}
 
@@ -276,10 +276,10 @@ func TestUtilizationPercentage(t *testing.T) {
 	}
 
 	want := float64(sti.Utilization()) / math.Pow(2, float64(depth-bucketDepth))
-	if got := sti.UtilizationPercentage(); got != want {
+	if got := sti.UtilizationRatio(); got != want {
 		t.Fatalf("filled issuer: want %v, got %v", want, got)
 	}
-	if got := sti.UtilizationPercentage(); got != 1 {
+	if got := sti.UtilizationRatio(); got != 1 {
 		t.Fatalf("filled issuer should report 1, got %v", got)
 	}
 }

--- a/pkg/postage/stampissuer_test.go
+++ b/pkg/postage/stampissuer_test.go
@@ -284,6 +284,17 @@ func TestUtilizationRatio(t *testing.T) {
 	}
 }
 
+func TestUtilizationRatioInvalidDepth(t *testing.T) {
+	t.Parallel()
+
+	// batchDepth < bucketDepth is an invalid combination; the ratio should
+	// stay well-defined and report 0.
+	sti := postage.NewStampIssuer("label", "keyID", make([]byte, 32), big.NewInt(3), 8, 16, 0, true)
+	if got := sti.UtilizationRatio(); got != 0 {
+		t.Fatalf("invalid depth: want 0, got %v", got)
+	}
+}
+
 func bytesToIndex(buf []byte) (bucket, index uint32) {
 	index64 := binary.BigEndian.Uint64(buf)
 	bucket = uint32(index64 >> 32)


### PR DESCRIPTION

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Closes #5226

  Adds a description to the existing PostageBatch.utilization property in
  the OpenAPI spec, clarifying that it is a raw bucket-count value (not a
  usage percentage) and giving the formula for fractional usage.

  Adds a new utilizedPercentage field to the /stamps and
  /stamps/{batchID} responses, exposing utilization / 2^(depth -
  bucketDepth) as a float in [0, 1] so API consumers don't have to derive
  it themselves and can't accidentally treat the raw utilization as a
  percentage.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
