### PR TITLE
test: add stamp-expiry step to beekeeper CI workflow

### DIFF
--- a/.github/workflows/beekeeper.yml
+++ b/.github/workflows/beekeeper.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Test postage stamps
         id: postage-stamps
         run: timeout ${TIMEOUT} beekeeper check --cluster-name local-dns --checks ci-postage
+      - name: Test stamp expiry
+        id: stamp-expiry
+        run: timeout ${TIMEOUT} beekeeper check --cluster-name local-dns --checks ci-stamp-expiry
       - name: Test staking
         id: stake
         run: timeout ${TIMEOUT} beekeeper check --cluster-name local-dns --checks ci-stake
@@ -204,6 +207,7 @@ jobs:
           if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi
           if ${{ steps.manifest-v1.outcome=='failure' }}; then FAILED=manifest-v1; fi
           if ${{ steps.postage-stamps.outcome=='failure' }}; then FAILED=postage-stamps; fi
+          if ${{ steps.stamp-expiry.outcome=='failure' }}; then FAILED=stamp-expiry; fi
           if ${{ steps.stake.outcome=='failure' }}; then FAILED=stake; fi
           if ${{ steps.withdraw.outcome=='failure' }}; then FAILED=withdraw; fi
           if ${{ steps.redundancy.outcome=='failure' }}; then FAILED=redundancy; fi


### PR DESCRIPTION
wires the new stamp-expiry check into the beekeeper integration test pipeline, running after the postage stamps check

### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
