### PR TITLE
fix(manifest): infer refBytesSize at marshal time when never set

### DIFF
--- a/pkg/manifest/mantaray/marshal.go
+++ b/pkg/manifest/mantaray/marshal.go
@@ -105,6 +105,24 @@ func (n *Node) MarshalBinary() (bytes []byte, err error) {
 		return nil, ErrInvalidInput
 	}
 
+	// Infer refBytesSize when Add() never set it (directory-only adds): use
+	// our own entry width if present, else the first child ref's width.
+	// Without this, the header reports refBytesSize=0 while the body still
+	// carries full-width data, and the v0.2 reader at line 280 silently drops
+	// every fork.
+	if n.refBytesSize == 0 {
+		if len(n.entry) > 0 {
+			n.refBytesSize = len(n.entry)
+		} else {
+			for _, f := range n.forks {
+				if len(f.ref) > 0 {
+					n.refBytesSize = len(f.ref)
+					break
+				}
+			}
+		}
+	}
+
 	// header
 
 	headerBytes := make([]byte, nodeHeaderSize)

--- a/pkg/manifest/mantaray/persist_test.go
+++ b/pkg/manifest/mantaray/persist_test.go
@@ -174,6 +174,46 @@ func TestPersistRemove(t *testing.T) {
 	}
 }
 
+// TestPersistDirectoryOnlyAdds covers the case where every Add() to a node
+// carries an empty entry (only forks/metadata), so the lazy-init in Add()
+// never sets refBytesSize. Without the marshal-time inference, the header
+// would report refBytesSize=0 even though the children have full-width refs,
+// and the v0.2 reader would silently drop every fork.
+func TestPersistDirectoryOnlyAdds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ls := mantaray.LoadSaver(newMockLoadSaver())
+
+	n := mantaray.New()
+	n.SetObfuscationKey(mantaray.ZeroObfuscationKey)
+
+	paths := [][]byte{[]byte("foo"), []byte("bar"), []byte("baz")}
+	for _, p := range paths {
+		// empty entry; only metadata. Mirrors bee/pkg/api/bzz.go:266 which
+		// adds the root path with swarm.ZeroAddress (a nil []byte).
+		if err := n.Add(ctx, p, nil, map[string]string{"k": "v"}, ls); err != nil {
+			t.Fatalf("add %q: %v", p, err)
+		}
+	}
+
+	if err := n.Save(ctx, ls); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	ref := n.Reference()
+
+	nn := mantaray.NewNodeRef(ref)
+	for _, p := range paths {
+		ln, err := nn.LookupNode(ctx, p, ls)
+		if err != nil {
+			t.Fatalf("lookup %q: %v", p, err)
+		}
+		if v := ln.Metadata()["k"]; v != "v" {
+			t.Fatalf("lookup %q: expected metadata k=v, got %q", p, v)
+		}
+	}
+}
+
 type (
 	addr          [32]byte
 	mockLoadSaver struct {


### PR DESCRIPTION
Fixes #5483.

`Add()` defers setting `n.refBytesSize` until the first non-empty entry is added. Bee calls `Add` with an empty entry at `pkg/api/bzz.go:266` for root metadata; if that node accumulates forks, `MarshalBinary` writes `refBytesSize = 0` while the fork bodies still carry full-width refs, and the v0.2 reader at `marshal.go:280` silently drops them on reload.

This patch infers `refBytesSize` at the top of `MarshalBinary` — from the node's own entry width if present, else the first child fork's saved ref width. The existing v0.2 read-side guard is left in place as backward-compat for already-persisted manifests.

`TestPersistDirectoryOnlyAdds` covers the directory-only-adds path; it fails on master with `entry on 'foo' ('666f6f'): not found` (silent fork loss) and passes here.

### Checklist
- [x] `make build` clean
- [x] `go test ./pkg/manifest/...` passes
- [x] `golangci-lint run ./pkg/manifest/mantaray/...` clean
- [x] `gofumpt` clean on touched lines

### AI Disclosure
- [x] This PR contains suggestions and code generated by an LLM.
- [x] I have reviewed the AI generated content thoroughly.
- [x] I possess the technical expertise to responsibly review the AI generated content mentioned in this PR.