### PR TITLE
feat: mic moc

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -846,6 +846,48 @@ paths:
         default:
           description: Default response
 
+  "/moc/subscribe/{id}":
+    get:
+      summary: Subscribe to MOC payloads
+      description: "Subscribe to Single Owner Chunks by their identifier, regardless of owner (Mined Owner Chunk)."
+      tags:
+        - MOC
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/HexString"
+          required: true
+          description: "Single Owner Chunk identifier (32 bytes, hex encoded)"
+      responses:
+        "200":
+          description: Establishes a WebSocket subscription for incoming messages on the Single Owner Chunk identifier
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
+
+  "/mic/subscribe/{owner}":
+    get:
+      summary: Subscribe to MIC payloads
+      description: "Subscribe to Single Owner Chunks by their owner ethereum address, regardless of identifier (Mined ID Chunk)."
+      tags:
+        - MIC
+      parameters:
+        - in: path
+          name: owner
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/EthereumAddress"
+          required: true
+          description: "Single Owner Chunk owner ethereum address (20 bytes, hex encoded)"
+      responses:
+        "200":
+          description: Establishes a WebSocket subscription for incoming messages on the Single Owner Chunk owner
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
+
   "/soc/{owner}/{id}":
     post:
       summary: Upload a Single Owner Chunk

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 8.1.0
+  version: 8.2.0
   title: Bee API
   description: "API endpoints for interacting with the Swarm network, supporting file operations, messaging, and node management"
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,6 +35,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/gsoc"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	"github.com/ethersphere/bee/v2/pkg/moc"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/pingpong"
 	"github.com/ethersphere/bee/v2/pkg/postage"
@@ -153,6 +155,8 @@ type Service struct {
 	resolver        resolver.Interface
 	pss             pss.Interface
 	gsoc            gsoc.Listener
+	moc             moc.Listener
+	mic             mic.Listener
 	steward         steward.Interface
 	logger          log.Logger
 	loggerV1        log.Logger
@@ -259,6 +263,8 @@ type ExtraOptions struct {
 	Resolver        resolver.Interface
 	Pss             pss.Interface
 	Gsoc            gsoc.Listener
+	Moc             moc.Listener
+	Mic             mic.Listener
 	FeedFactory     feeds.Factory
 	Post            postage.Service
 	AccessControl   accesscontrol.Controller
@@ -340,6 +346,8 @@ func (s *Service) Configure(signer crypto.Signer, tracer *tracing.Tracer, o Opti
 	s.resolver = e.Resolver
 	s.pss = e.Pss
 	s.gsoc = e.Gsoc
+	s.moc = e.Moc
+	s.mic = e.Mic
 	s.feedFactory = e.FeedFactory
 	s.post = e.Post
 	s.accesscontrol = e.AccessControl

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/gsoc"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
 	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	"github.com/ethersphere/bee/v2/pkg/moc"
 	p2pmock "github.com/ethersphere/bee/v2/pkg/p2p/mock"
 	"github.com/ethersphere/bee/v2/pkg/pingpong"
 	"github.com/ethersphere/bee/v2/pkg/postage"
@@ -94,6 +96,8 @@ type testServerOptions struct {
 	Resolver           resolver.Interface
 	Pss                pss.Interface
 	Gsoc               gsoc.Listener
+	Moc                moc.Listener
+	Mic                mic.Listener
 	WsPath             string
 	WsPingPeriod       time.Duration
 	Logger             log.Logger
@@ -201,6 +205,8 @@ func newTestServer(t *testing.T, o testServerOptions) (*http.Client, *websocket.
 		Resolver:        o.Resolver,
 		Pss:             o.Pss,
 		Gsoc:            o.Gsoc,
+		Moc:             o.Moc,
+		Mic:             o.Mic,
 		FeedFactory:     o.Feeds,
 		Post:            o.Post,
 		AccessControl:   o.AccessControl,

--- a/pkg/api/mic.go
+++ b/pkg/api/mic.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	"github.com/gorilla/mux"
+)
+
+func (s *Service) micWsHandler(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.WithName("mic_subscribe").Build()
+
+	paths := struct {
+		Owner []byte `map:"owner" validate:"required"`
+	}{}
+
+	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
+		response("invalid path params", logger, w)
+		return
+	}
+
+	conn, ok := s.wsUpgrade(w, r, logger)
+	if !ok {
+		return
+	}
+
+	s.wsWg.Add(1)
+	go s.socSubscribeWs("mic", conn, func(handler func([]byte)) func() {
+		return s.mic.Subscribe(paths.Owner, mic.Handler(handler))
+	})
+}

--- a/pkg/api/mic_test.go
+++ b/pkg/api/mic_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/cac"
+	"github.com/ethersphere/bee/v2/pkg/crypto"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	mockbatchstore "github.com/ethersphere/bee/v2/pkg/postage/batchstore/mock"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/ethersphere/bee/v2/pkg/util/testutil"
+	"github.com/gorilla/websocket"
+)
+
+// TestMicWebsocketSingleHandler subscribes on a SOC owner and receives a message.
+func TestMicWebsocketSingleHandler(t *testing.T) {
+	t.Parallel()
+
+	var (
+		id            = make([]byte, 32)
+		m, cl, signer = newMicTest(t, 0)
+		respC         = make(chan error, 1)
+		payload       = []byte("hello there!")
+	)
+
+	err := cl.SetReadDeadline(time.Now().Add(longTimeout))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl.SetReadLimit(swarm.ChunkSize)
+
+	ch, _ := cac.New(payload)
+	socCh := soc.New(id, ch)
+	ch, _ = socCh.Sign(signer)
+	socCh, _ = soc.FromChunk(ch)
+	m.Handle(socCh)
+
+	go expectMessage(t, cl, respC, payload)
+	if err := <-respC; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newMicTest(t *testing.T, pingPeriod time.Duration) (mic.Listener, *websocket.Conn, crypto.Signer) {
+	t.Helper()
+	if pingPeriod == 0 {
+		pingPeriod = 10 * time.Second
+	}
+	var (
+		batchStore = mockbatchstore.New()
+		storer     = mockstorer.New()
+	)
+
+	privKey, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.NewDefaultSigner(privKey)
+	owner, err := signer.EthereumAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	micService := mic.New(log.NewLogger("test"))
+	testutil.CleanupCloser(t, micService)
+
+	_, cl, _, _ := newTestServer(t, testServerOptions{
+		Mic:          micService,
+		WsPath:       fmt.Sprintf("/mic/subscribe/%s", hex.EncodeToString(owner.Bytes())),
+		Storer:       storer,
+		BatchStore:   batchStore,
+		Logger:       log.Noop,
+		WsPingPeriod: pingPeriod,
+	})
+
+	return micService, cl, signer
+}

--- a/pkg/api/moc.go
+++ b/pkg/api/moc.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/ethersphere/bee/v2/pkg/moc"
+	"github.com/gorilla/mux"
+)
+
+func (s *Service) mocWsHandler(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.WithName("moc_subscribe").Build()
+
+	paths := struct {
+		ID []byte `map:"id" validate:"required"`
+	}{}
+
+	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
+		response("invalid path params", logger, w)
+		return
+	}
+
+	conn, ok := s.wsUpgrade(w, r, logger)
+	if !ok {
+		return
+	}
+
+	s.wsWg.Add(1)
+	go s.socSubscribeWs("moc", conn, func(handler func([]byte)) func() {
+		return s.moc.Subscribe(paths.ID, moc.Handler(handler))
+	})
+}

--- a/pkg/api/moc_test.go
+++ b/pkg/api/moc_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/cac"
+	"github.com/ethersphere/bee/v2/pkg/crypto"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/moc"
+	mockbatchstore "github.com/ethersphere/bee/v2/pkg/postage/batchstore/mock"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/ethersphere/bee/v2/pkg/util/testutil"
+	"github.com/gorilla/websocket"
+)
+
+// TestMocWebsocketSingleHandler subscribes on a SOC id and receives a message.
+func TestMocWebsocketSingleHandler(t *testing.T) {
+	t.Parallel()
+
+	var (
+		id            = make([]byte, 32)
+		m, cl, signer = newMocTest(t, id, 0)
+		respC         = make(chan error, 1)
+		payload       = []byte("hello there!")
+	)
+
+	err := cl.SetReadDeadline(time.Now().Add(longTimeout))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl.SetReadLimit(swarm.ChunkSize)
+
+	ch, _ := cac.New(payload)
+	socCh := soc.New(id, ch)
+	ch, _ = socCh.Sign(signer)
+	socCh, _ = soc.FromChunk(ch)
+	m.Handle(socCh)
+
+	go expectMessage(t, cl, respC, payload)
+	if err := <-respC; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newMocTest(t *testing.T, socId []byte, pingPeriod time.Duration) (moc.Listener, *websocket.Conn, crypto.Signer) {
+	t.Helper()
+	if pingPeriod == 0 {
+		pingPeriod = 10 * time.Second
+	}
+	var (
+		batchStore = mockbatchstore.New()
+		storer     = mockstorer.New()
+	)
+
+	privKey, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.NewDefaultSigner(privKey)
+
+	mocService := moc.New(log.NewLogger("test"))
+	testutil.CleanupCloser(t, mocService)
+
+	_, cl, _, _ := newTestServer(t, testServerOptions{
+		Moc:          mocService,
+		WsPath:       fmt.Sprintf("/moc/subscribe/%s", hex.EncodeToString(socId)),
+		Storer:       storer,
+		BatchStore:   batchStore,
+		Logger:       log.Noop,
+		WsPingPeriod: pingPeriod,
+	})
+
+	return mocService, cl, signer
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -376,6 +376,18 @@ func (s *Service) mountAPI() {
 		),
 	})
 
+	handle("/moc/subscribe/{id}", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			web.FinalHandlerFunc(s.mocWsHandler),
+		),
+	})
+
+	handle("/mic/subscribe/{owner}", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			web.FinalHandlerFunc(s.micWsHandler),
+		),
+	})
+
 	handle("/tags", jsonhttp.MethodHandler{
 		"GET": http.HandlerFunc(s.listTagsHandler),
 		"POST": web.ChainHandlers(

--- a/pkg/api/socsubscribe.go
+++ b/pkg/api/socsubscribe.go
@@ -1,0 +1,115 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/gorilla/websocket"
+)
+
+// wsUpgrade upgrades an HTTP request to a websocket connection using the
+// standard chunk-sized buffers and origin check. On failure it writes the
+// error response and returns ok=false.
+func (s *Service) wsUpgrade(w http.ResponseWriter, r *http.Request, logger log.Logger) (*websocket.Conn, bool) {
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  swarm.ChunkSize,
+		WriteBufferSize: swarm.ChunkSize,
+		CheckOrigin:     s.checkOrigin,
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logger.Debug("upgrade failed", "error", err)
+		logger.Error(nil, "upgrade failed")
+		jsonhttp.InternalServerError(w, "upgrade failed")
+		return nil, false
+	}
+
+	return conn, true
+}
+
+// socSubscribeWs pumps payloads from a single-owner-chunk subscription to the
+// websocket connection until the client disconnects or the node shuts down.
+// subscribe registers the supplied message handler with the relevant listener
+// and returns its cleanup func. name is used for logging only.
+func (s *Service) socSubscribeWs(name string, conn *websocket.Conn, subscribe func(handler func([]byte)) (cleanup func())) {
+	defer s.wsWg.Done()
+
+	var (
+		dataC  = make(chan []byte)
+		gone   = make(chan struct{})
+		ticker = time.NewTicker(s.WsPingPeriod)
+		err    error
+	)
+	defer func() {
+		ticker.Stop()
+		_ = conn.Close()
+	}()
+
+	cleanup := subscribe(func(m []byte) {
+		select {
+		case dataC <- m:
+		case <-gone:
+			return
+		case <-s.quit:
+			return
+		}
+	})
+	defer cleanup()
+
+	conn.SetCloseHandler(func(code int, text string) error {
+		s.logger.Debug("soc subscribe ws: client gone", "name", name, "code", code, "message", text)
+		close(gone)
+		return nil
+	})
+
+	for {
+		select {
+		case b := <-dataC:
+			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+			if err != nil {
+				s.logger.Debug("soc subscribe ws: set write deadline failed", "name", name, "error", err)
+				return
+			}
+
+			err = conn.WriteMessage(websocket.BinaryMessage, b)
+			if err != nil {
+				s.logger.Debug("soc subscribe ws: write message failed", "name", name, "error", err)
+				return
+			}
+
+		case <-s.quit:
+			// shutdown
+			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+			if err != nil {
+				s.logger.Debug("soc subscribe ws: set write deadline failed", "name", name, "error", err)
+				return
+			}
+			err = conn.WriteMessage(websocket.CloseMessage, []byte{})
+			if err != nil {
+				s.logger.Debug("soc subscribe ws: write close message failed", "name", name, "error", err)
+			}
+			return
+		case <-gone:
+			// client gone
+			return
+		case <-ticker.C:
+			err = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+			if err != nil {
+				s.logger.Debug("soc subscribe ws: set write deadline failed", "name", name, "error", err)
+				return
+			}
+			if err = conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				// error encountered while pinging client. client probably gone
+				return
+			}
+		}
+	}
+}

--- a/pkg/gsoc/gsoc.go
+++ b/pkg/gsoc/gsoc.go
@@ -6,6 +6,7 @@ package gsoc
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/soc"
@@ -24,7 +25,8 @@ type Listener interface {
 
 type listener struct {
 	handlers   map[string][]*Handler
-	handlersMu sync.Mutex
+	handlersMu sync.RWMutex
+	subCount   atomic.Int32
 	quit       chan struct{}
 	logger     log.Logger
 }
@@ -44,6 +46,7 @@ func (l *listener) Subscribe(address swarm.Address, handler Handler) (cleanup fu
 	defer l.handlersMu.Unlock()
 
 	l.handlers[address.ByteString()] = append(l.handlers[address.ByteString()], &handler)
+	l.subCount.Add(1)
 
 	return func() {
 		l.handlersMu.Lock()
@@ -53,6 +56,7 @@ func (l *listener) Subscribe(address swarm.Address, handler Handler) (cleanup fu
 		for i := range h {
 			if h[i] == &handler {
 				l.handlers[address.ByteString()] = append(h[:i], h[i+1:]...)
+				l.subCount.Add(-1)
 				return
 			}
 		}
@@ -61,11 +65,24 @@ func (l *listener) Subscribe(address swarm.Address, handler Handler) (cleanup fu
 
 // Handle is called by push/pull sync and passes the chunk its registered handler
 func (l *listener) Handle(c *soc.SOC) {
+	if l.subCount.Load() == 0 {
+		return // no subscriptions, skip lock
+	}
+
 	addr, err := c.Address()
 	if err != nil {
 		return // no handler
 	}
-	h := l.getHandlers(addr)
+	payload := c.WrappedChunk().Data()[swarm.SpanSize:]
+
+	// The read lock is held for the whole iteration so that a concurrent
+	// Subscribe cleanup (write lock) cannot mutate the handlers slice while it
+	// is being ranged over. Each handler is dereferenced and dispatched to its
+	// own goroutine, so the lock is never held while a handler runs.
+	l.handlersMu.RLock()
+	defer l.handlersMu.RUnlock()
+
+	h := l.handlers[addr.ByteString()]
 	if h == nil {
 		return // no handler
 	}
@@ -73,16 +90,9 @@ func (l *listener) Handle(c *soc.SOC) {
 
 	for _, hh := range h {
 		go func(hh Handler) {
-			hh(c.WrappedChunk().Data()[swarm.SpanSize:])
+			hh(payload)
 		}(*hh)
 	}
-}
-
-func (p *listener) getHandlers(address swarm.Address) []*Handler {
-	p.handlersMu.Lock()
-	defer p.handlersMu.Unlock()
-
-	return p.handlers[address.ByteString()]
 }
 
 func (l *listener) Close() error {

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -75,7 +75,16 @@ func (l *listener) Handle(c *soc.SOC) {
 		return // no subscriptions, skip lock
 	}
 
-	h := l.getHandlers(c.OwnerAddress())
+	payload := c.WrappedChunk().Data()[swarm.SpanSize:]
+
+	// The read lock is held for the whole iteration so that a concurrent
+	// Subscribe cleanup (write lock) cannot mutate the handlers slice while it
+	// is being ranged over. Each handler is dereferenced and dispatched to its
+	// own goroutine, so the lock is never held while a handler runs.
+	l.handlersMu.RLock()
+	defer l.handlersMu.RUnlock()
+
+	h := l.handlers[string(c.OwnerAddress())]
 	if h == nil {
 		return // no handler
 	}
@@ -83,16 +92,9 @@ func (l *listener) Handle(c *soc.SOC) {
 
 	for _, hh := range h {
 		go func(hh Handler) {
-			hh(c.WrappedChunk().Data()[swarm.SpanSize:])
+			hh(payload)
 		}(*hh)
 	}
-}
-
-func (l *listener) getHandlers(owner []byte) []*Handler {
-	l.handlersMu.RLock()
-	defer l.handlersMu.RUnlock()
-
-	return l.handlers[string(owner)]
 }
 
 func (l *listener) Close() error {

--- a/pkg/mic/mic.go
+++ b/pkg/mic/mic.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package mic provides subscriptions to single-owner chunks by their owner
+// ethereum address. A MIC (Mined ID Chunk) subscription is matched against the
+// owner of every incoming single-owner chunk, regardless of its id.
+package mic
+
+import (
+	"encoding/hex"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+)
+
+// Handler defines code to be executed upon reception of a MIC message.
+// It is used as a parameter definition.
+type Handler func([]byte)
+
+type Listener interface {
+	Subscribe(owner []byte, handler Handler) (cleanup func())
+	Handle(c *soc.SOC)
+	Close() error
+}
+
+type listener struct {
+	handlers   map[string][]*Handler
+	handlersMu sync.RWMutex
+	subCount   atomic.Int32
+	quit       chan struct{}
+	logger     log.Logger
+}
+
+// New returns a new MIC listener service.
+func New(logger log.Logger) Listener {
+	return &listener{
+		logger:   logger,
+		handlers: make(map[string][]*Handler),
+		quit:     make(chan struct{}),
+	}
+}
+
+// Subscribe allows the definition of a Handler func on a specific SOC owner.
+func (l *listener) Subscribe(owner []byte, handler Handler) (cleanup func()) {
+	l.handlersMu.Lock()
+	defer l.handlersMu.Unlock()
+
+	key := string(owner)
+	l.handlers[key] = append(l.handlers[key], &handler)
+	l.subCount.Add(1)
+
+	return func() {
+		l.handlersMu.Lock()
+		defer l.handlersMu.Unlock()
+
+		h := l.handlers[key]
+		for i := range h {
+			if h[i] == &handler {
+				l.handlers[key] = append(h[:i], h[i+1:]...)
+				l.subCount.Add(-1)
+				return
+			}
+		}
+	}
+}
+
+// Handle is called by push/pull sync and passes the chunk to the handlers
+// registered on its owner.
+func (l *listener) Handle(c *soc.SOC) {
+	if l.subCount.Load() == 0 {
+		return // no subscriptions, skip lock
+	}
+
+	h := l.getHandlers(c.OwnerAddress())
+	if h == nil {
+		return // no handler
+	}
+	l.logger.Debug("new incoming MIC message", "soc owner", hex.EncodeToString(c.OwnerAddress()), "wrapped chunk address", c.WrappedChunk().Address())
+
+	for _, hh := range h {
+		go func(hh Handler) {
+			hh(c.WrappedChunk().Data()[swarm.SpanSize:])
+		}(*hh)
+	}
+}
+
+func (l *listener) getHandlers(owner []byte) []*Handler {
+	l.handlersMu.RLock()
+	defer l.handlersMu.RUnlock()
+
+	return l.handlers[string(owner)]
+}
+
+func (l *listener) Close() error {
+	close(l.quit)
+	l.handlersMu.Lock()
+	defer l.handlersMu.Unlock()
+
+	l.handlers = make(map[string][]*Handler) // unset handlers on shutdown
+
+	return nil
+}

--- a/pkg/mic/mic_test.go
+++ b/pkg/mic/mic_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mic_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/cac"
+	"github.com/ethersphere/bee/v2/pkg/crypto"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	"github.com/ethersphere/bee/v2/pkg/util/testutil"
+)
+
+// TestRegister verifies that handler funcs are registered and matched by SOC owner,
+// independently of the SOC id.
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	var (
+		g       = mic.New(log.Noop)
+		h1Calls = 0
+		h2Calls = 0
+		h3Calls = 0
+		msgChan = make(chan struct{})
+
+		payload1 = []byte("Hello there!")
+		payload2 = []byte("General Kenobi. You are a bold one. Kill him!")
+
+		privKey1, _ = crypto.GenerateSecp256k1Key()
+		signer1     = crypto.NewDefaultSigner(privKey1)
+		owner1, _   = signer1.EthereumAddress()
+		privKey2, _ = crypto.GenerateSecp256k1Key()
+		signer2     = crypto.NewDefaultSigner(privKey2)
+		owner2, _   = signer2.EthereumAddress()
+
+		socId1 = testutil.RandBytes(t, 32)
+		socId2 = append([]byte{socId1[0] + 1}, socId1[1:]...)
+
+		h1 = func(m []byte) {
+			h1Calls++
+			msgChan <- struct{}{}
+		}
+
+		h2 = func(m []byte) {
+			h2Calls++
+			msgChan <- struct{}{}
+		}
+
+		h3 = func(m []byte) {
+			h3Calls++
+			msgChan <- struct{}{}
+		}
+	)
+	_ = g.Subscribe(owner1.Bytes(), h1)
+	_ = g.Subscribe(owner2.Bytes(), h2)
+
+	// soc with socId1 signed by signer1 (owner1)
+	ch1, _ := cac.New(payload1)
+	socCh1 := soc.New(socId1, ch1)
+	ch1, _ = socCh1.Sign(signer1)
+	socCh1, _ = soc.FromChunk(ch1)
+
+	// soc with socId1 signed by signer2 (owner2)
+	ch2, _ := cac.New(payload2)
+	socCh2 := soc.New(socId1, ch2)
+	ch2, _ = socCh2.Sign(signer2)
+	socCh2, _ = soc.FromChunk(ch2)
+
+	// soc with a different id (socId2) but same owner1: must still match h1
+	ch3, _ := cac.New(payload1)
+	socCh3 := soc.New(socId2, ch3)
+	ch3, _ = socCh3.Sign(signer1)
+	socCh3, _ = soc.FromChunk(ch3)
+
+	// trigger soc from owner1, check that only h1 is called
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 1)
+	ensureCalls(t, &h2Calls, 0)
+
+	// register another handler on owner1
+	cleanup := g.Subscribe(owner1.Bytes(), h3)
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 2)
+	ensureCalls(t, &h1Calls, 2)
+	ensureCalls(t, &h2Calls, 0)
+	ensureCalls(t, &h3Calls, 1)
+
+	cleanup() // remove the last handler
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 3)
+	ensureCalls(t, &h2Calls, 0)
+	ensureCalls(t, &h3Calls, 1)
+
+	// different owner only triggers its own handler
+	g.Handle(socCh2)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 3)
+	ensureCalls(t, &h2Calls, 1)
+	ensureCalls(t, &h3Calls, 1)
+
+	// same owner, different id still matches the owner handler
+	g.Handle(socCh3)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 4)
+	ensureCalls(t, &h2Calls, 1)
+	ensureCalls(t, &h3Calls, 1)
+}
+
+func ensureCalls(t *testing.T, calls *int, exp int) {
+	t.Helper()
+
+	if exp != *calls {
+		t.Fatalf("expected %d calls, found %d", exp, *calls)
+	}
+}
+
+func waitHandlerCallback(t *testing.T, msgChan *chan struct{}, count int) {
+	t.Helper()
+
+	for range count {
+		select {
+		case <-*msgChan:
+		case <-time.After(1 * time.Second):
+			t.Fatal("reached timeout while waiting for handler message")
+		}
+	}
+}

--- a/pkg/moc/moc.go
+++ b/pkg/moc/moc.go
@@ -75,7 +75,16 @@ func (l *listener) Handle(c *soc.SOC) {
 		return // no subscriptions, skip lock
 	}
 
-	h := l.getHandlers(c.ID())
+	payload := c.WrappedChunk().Data()[swarm.SpanSize:]
+
+	// The read lock is held for the whole iteration so that a concurrent
+	// Subscribe cleanup (write lock) cannot mutate the handlers slice while it
+	// is being ranged over. Each handler is dereferenced and dispatched to its
+	// own goroutine, so the lock is never held while a handler runs.
+	l.handlersMu.RLock()
+	defer l.handlersMu.RUnlock()
+
+	h := l.handlers[string(c.ID())]
 	if h == nil {
 		return // no handler
 	}
@@ -83,16 +92,9 @@ func (l *listener) Handle(c *soc.SOC) {
 
 	for _, hh := range h {
 		go func(hh Handler) {
-			hh(c.WrappedChunk().Data()[swarm.SpanSize:])
+			hh(payload)
 		}(*hh)
 	}
-}
-
-func (l *listener) getHandlers(id []byte) []*Handler {
-	l.handlersMu.RLock()
-	defer l.handlersMu.RUnlock()
-
-	return l.handlers[string(id)]
 }
 
 func (l *listener) Close() error {

--- a/pkg/moc/moc.go
+++ b/pkg/moc/moc.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package moc provides subscriptions to single-owner chunks by their
+// identifier (id). A MOC (Mined Owner Chunk) subscription is matched against
+// the id of every incoming single-owner chunk, regardless of its owner.
+package moc
+
+import (
+	"encoding/hex"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+)
+
+// Handler defines code to be executed upon reception of a MOC message.
+// It is used as a parameter definition.
+type Handler func([]byte)
+
+type Listener interface {
+	Subscribe(id []byte, handler Handler) (cleanup func())
+	Handle(c *soc.SOC)
+	Close() error
+}
+
+type listener struct {
+	handlers   map[string][]*Handler
+	handlersMu sync.RWMutex
+	subCount   atomic.Int32
+	quit       chan struct{}
+	logger     log.Logger
+}
+
+// New returns a new MOC listener service.
+func New(logger log.Logger) Listener {
+	return &listener{
+		logger:   logger,
+		handlers: make(map[string][]*Handler),
+		quit:     make(chan struct{}),
+	}
+}
+
+// Subscribe allows the definition of a Handler func on a specific SOC id.
+func (l *listener) Subscribe(id []byte, handler Handler) (cleanup func()) {
+	l.handlersMu.Lock()
+	defer l.handlersMu.Unlock()
+
+	key := string(id)
+	l.handlers[key] = append(l.handlers[key], &handler)
+	l.subCount.Add(1)
+
+	return func() {
+		l.handlersMu.Lock()
+		defer l.handlersMu.Unlock()
+
+		h := l.handlers[key]
+		for i := range h {
+			if h[i] == &handler {
+				l.handlers[key] = append(h[:i], h[i+1:]...)
+				l.subCount.Add(-1)
+				return
+			}
+		}
+	}
+}
+
+// Handle is called by push/pull sync and passes the chunk to the handlers
+// registered on its id.
+func (l *listener) Handle(c *soc.SOC) {
+	if l.subCount.Load() == 0 {
+		return // no subscriptions, skip lock
+	}
+
+	h := l.getHandlers(c.ID())
+	if h == nil {
+		return // no handler
+	}
+	l.logger.Debug("new incoming MOC message", "soc id", hex.EncodeToString(c.ID()), "wrapped chunk address", c.WrappedChunk().Address())
+
+	for _, hh := range h {
+		go func(hh Handler) {
+			hh(c.WrappedChunk().Data()[swarm.SpanSize:])
+		}(*hh)
+	}
+}
+
+func (l *listener) getHandlers(id []byte) []*Handler {
+	l.handlersMu.RLock()
+	defer l.handlersMu.RUnlock()
+
+	return l.handlers[string(id)]
+}
+
+func (l *listener) Close() error {
+	close(l.quit)
+	l.handlersMu.Lock()
+	defer l.handlersMu.Unlock()
+
+	l.handlers = make(map[string][]*Handler) // unset handlers on shutdown
+
+	return nil
+}

--- a/pkg/moc/moc_test.go
+++ b/pkg/moc/moc_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package moc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/cac"
+	"github.com/ethersphere/bee/v2/pkg/crypto"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/moc"
+	"github.com/ethersphere/bee/v2/pkg/soc"
+	"github.com/ethersphere/bee/v2/pkg/util/testutil"
+)
+
+// TestRegister verifies that handler funcs are registered and matched by SOC id,
+// independently of the SOC owner.
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	var (
+		g       = moc.New(log.Noop)
+		h1Calls = 0
+		h2Calls = 0
+		h3Calls = 0
+		msgChan = make(chan struct{})
+
+		payload1 = []byte("What did it cost?")
+		payload2 = []byte("Everything.")
+		socId1   = testutil.RandBytes(t, 32)
+		socId2   = append([]byte{socId1[0] + 1}, socId1[1:]...)
+
+		privKey1, _ = crypto.GenerateSecp256k1Key()
+		signer1     = crypto.NewDefaultSigner(privKey1)
+		privKey2, _ = crypto.GenerateSecp256k1Key()
+		signer2     = crypto.NewDefaultSigner(privKey2)
+
+		h1 = func(m []byte) {
+			h1Calls++
+			msgChan <- struct{}{}
+		}
+
+		h2 = func(m []byte) {
+			h2Calls++
+			msgChan <- struct{}{}
+		}
+
+		h3 = func(m []byte) {
+			h3Calls++
+			msgChan <- struct{}{}
+		}
+	)
+	_ = g.Subscribe(socId1, h1)
+	_ = g.Subscribe(socId2, h2)
+
+	// soc with socId1 signed by signer1
+	ch1, _ := cac.New(payload1)
+	socCh1 := soc.New(socId1, ch1)
+	ch1, _ = socCh1.Sign(signer1)
+	socCh1, _ = soc.FromChunk(ch1)
+
+	// soc with socId2 signed by signer1
+	ch2, _ := cac.New(payload2)
+	socCh2 := soc.New(socId2, ch2)
+	ch2, _ = socCh2.Sign(signer1)
+	socCh2, _ = soc.FromChunk(ch2)
+
+	// soc with socId1 but a different owner (signer2): must still match h1
+	ch3, _ := cac.New(payload1)
+	socCh3 := soc.New(socId1, ch3)
+	ch3, _ = socCh3.Sign(signer2)
+	socCh3, _ = soc.FromChunk(ch3)
+
+	// trigger soc on socId1, check that only h1 is called
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 1)
+	ensureCalls(t, &h2Calls, 0)
+
+	// register another handler on the first id
+	cleanup := g.Subscribe(socId1, h3)
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 2)
+	ensureCalls(t, &h1Calls, 2)
+	ensureCalls(t, &h2Calls, 0)
+	ensureCalls(t, &h3Calls, 1)
+
+	cleanup() // remove the last handler
+	g.Handle(socCh1)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 3)
+	ensureCalls(t, &h2Calls, 0)
+	ensureCalls(t, &h3Calls, 1)
+
+	// different id only triggers its own handler
+	g.Handle(socCh2)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 3)
+	ensureCalls(t, &h2Calls, 1)
+	ensureCalls(t, &h3Calls, 1)
+
+	// same id, different owner still matches the id handler
+	g.Handle(socCh3)
+	waitHandlerCallback(t, &msgChan, 1)
+	ensureCalls(t, &h1Calls, 4)
+	ensureCalls(t, &h2Calls, 1)
+	ensureCalls(t, &h3Calls, 1)
+}
+
+func ensureCalls(t *testing.T, calls *int, exp int) {
+	t.Helper()
+
+	if exp != *calls {
+		t.Fatalf("expected %d calls, found %d", exp, *calls)
+	}
+}
+
+func waitHandlerCallback(t *testing.T, msgChan *chan struct{}, count int) {
+	t.Helper()
+
+	for range count {
+		select {
+		case <-*msgChan:
+		case <-time.After(1 * time.Second):
+			t.Fatal("reached timeout while waiting for handler message")
+		}
+	}
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -37,6 +37,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/hive"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/metrics"
+	"github.com/ethersphere/bee/v2/pkg/mic"
+	"github.com/ethersphere/bee/v2/pkg/moc"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/p2p/libp2p"
 	"github.com/ethersphere/bee/v2/pkg/pingpong"
@@ -60,6 +62,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/settlement/swap/chequebook"
 	"github.com/ethersphere/bee/v2/pkg/settlement/swap/erc20"
 	"github.com/ethersphere/bee/v2/pkg/settlement/swap/priceoracle"
+	"github.com/ethersphere/bee/v2/pkg/soc"
 	"github.com/ethersphere/bee/v2/pkg/stabilization"
 	"github.com/ethersphere/bee/v2/pkg/status"
 	"github.com/ethersphere/bee/v2/pkg/steward"
@@ -110,6 +113,8 @@ type Bee struct {
 	pullSyncCloser           io.Closer
 	pssCloser                io.Closer
 	gsocCloser               io.Closer
+	mocCloser                io.Closer
+	micCloser                io.Closer
 	transactionMonitorCloser io.Closer
 	transactionCloser        io.Closer
 	listenerCloser           io.Closer
@@ -1086,8 +1091,21 @@ func NewBee(
 
 	pssService := pss.New(pssPrivateKey, logger)
 	gsocService := gsoc.New(logger)
+	mocService := moc.New(logger)
+	micService := mic.New(logger)
 	b.pssCloser = pssService
 	b.gsocCloser = gsocService
+	b.mocCloser = mocService
+	b.micCloser = micService
+
+	// socHandler dispatches an incoming single-owner chunk to every
+	// subscription service: by chunk address (gsoc), by id (moc) and by
+	// owner (mic).
+	socHandler := func(c *soc.SOC) {
+		gsocService.Handle(c)
+		mocService.Handle(c)
+		micService.Handle(c)
+	}
 
 	validStamp := postage.ValidStamp(batchStore)
 
@@ -1149,7 +1167,7 @@ func NewBee(
 		}
 	}
 
-	pushSyncProtocol := pushsync.New(swarmAddress, networkID, nonce, p2ps, localStore, waitNetworkRFunc, kad, o.FullNodeMode && !o.BootnodeMode, pssService.TryUnwrap, gsocService.Handle, validStamp, logger, acc, pricer, signer, tracer, detector, uint8(shallowReceiptTolerance))
+	pushSyncProtocol := pushsync.New(swarmAddress, networkID, nonce, p2ps, localStore, waitNetworkRFunc, kad, o.FullNodeMode && !o.BootnodeMode, pssService.TryUnwrap, socHandler, validStamp, logger, acc, pricer, signer, tracer, detector, uint8(shallowReceiptTolerance))
 	b.pushSyncCloser = pushSyncProtocol
 
 	// set the pushSyncer in the PSS
@@ -1165,7 +1183,7 @@ func NewBee(
 
 	pusherService.AddFeed(localStore.PusherFeed())
 
-	pullSyncProtocol := pullsync.New(p2ps, localStore, pssService.TryUnwrap, gsocService.Handle, validStamp, logger, pullsync.DefaultMaxPage)
+	pullSyncProtocol := pullsync.New(p2ps, localStore, pssService.TryUnwrap, socHandler, validStamp, logger, pullsync.DefaultMaxPage)
 	b.pullSyncCloser = pullSyncProtocol
 
 	retrieveProtocolSpec := retrieval.Protocol()
@@ -1360,6 +1378,8 @@ func NewBee(
 		Resolver:        multiResolver,
 		Pss:             pssService,
 		Gsoc:            gsocService,
+		Moc:             mocService,
+		Mic:             micService,
 		FeedFactory:     feedFactory,
 		Post:            post,
 		AccessControl:   accesscontrol,
@@ -1515,6 +1535,8 @@ func (b *Bee) Shutdown() error {
 	closers := []namedCloser{
 		{b.pssCloser, "pss"},
 		{b.gsocCloser, "gsoc"},
+		{b.mocCloser, "moc"},
+		{b.micCloser, "mic"},
 		{b.pusherCloser, "pusher"},
 		{b.pullerCloser, "puller"},
 		{b.accountingCloser, "accounting"},


### PR DESCRIPTION
### Description

Adds WebSocket subscription endpoints for receiving real-time Single Owner Chunk (SOC) payloads filtered by owner address (MIC) or identifier (MOC):

- **MIC (Mined ID Chunk)**: Subscribe to all SOCs from a specific owner Ethereum address via `/mic/subscribe/{owner}`
- **MOC (Mined Owner Chunk)**: Subscribe to all SOCs with a specific identifier regardless of owner via `/moc/subscribe/{id}`

Both listeners integrate with push/pull sync to dispatch matching SOC payloads to WebSocket subscribers.

Includes optimized SOC listener implementation using `RWMutex` with atomic fast-path to minimize lock contention on the hot sync path. The same optimization is applied to the existing GSOC listener for consistency.

### Open API Spec Version Changes (if applicable)

8.1.0 → 8.2.0 (new endpoints are additive features per SemVer)

#### Motivation and Context (Optional)

Enables real-time notifications for specific SOC patterns without polling.

### Related Issue (Optional)

[MIC/MOC SWIP](https://github.com/ethersphere/SWIPs/pull/80)

### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.

<!-- last-described-at: 0d9275d9 -->