### PR TITLE
ci: disable golangci-lint cache to avoid stale-cache lint failures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,7 +71,10 @@ jobs:
     - name: GolangCI-Lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        skip-cache: false
+        # Disable the golangci-lint cache: a restored stale cache has produced
+        # phantom staticcheck findings in files unrelated to the PR diff. The
+        # full lint run is fast enough that correctness is worth the trade-off.
+        skip-cache: true
         version: v2.11.3
     - name: Whitespace check
       run: make check-whitespace


### PR DESCRIPTION
### Description

The CI **Lint** job intermittently fails with staticcheck errors (SA4023, SA5011) in files that are not part of the PR diff. These are phantom findings from a restored, stale `golangci-lint-action` cache (`skip-cache: false`, `cache-invalidation-interval: 7`).

This was reproduced and diagnosed on #5431: the Lint job failed with 8 staticcheck issues — in `cmd/bee/cmd/cmd.go` (the `createWindowsEventLogger` SA4023), `pkg/manifest/mantaray/marshal_test.go`, and
`pkg/p2p/libp2p/mock/mock_certmagic_test.go` — none of which were touched by that PR (its diff was limited to `start.go` + `resolve_node_mode_test.go`).

Diagnosis on #5431:
- Reproducing locally with the exact CI versions (golangci-lint v2.11.3, Go from `go.mod`, including Go 1.26.3) reported **0 issues**.
- The failing job log showed `Cache hit for: golangci-lint.cache-Linux-...`.
- After deleting the cache entries and re-running, **Lint passed on the same commit** with no code change.

This sets `skip-cache: true` so the linter always runs a fresh analysis and cannot resurrect stale results. The full lint run is fast enough that the correctness trade-off is worth it.
