### PR TITLE
fix(handshake): reuse session-stable signed BzzAddress

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/addresscache.go
+++ b/pkg/p2p/libp2p/internal/handshake/addresscache.go
@@ -5,55 +5,37 @@
 package handshake
 
 import (
-	"container/list"
 	"sync"
 
 	"github.com/ethersphere/bee/v2/pkg/bzz"
 )
 
-// addressCache stores the session-stable signed BzzAddress per cache key,
-// evicting the least recently used entry when capacity is exceeded.
+// addressCache stores the most recently minted session-stable signed
+// BzzAddress and the key (chequebook + underlay set) it was minted for. A key
+// change makes the previous record obsolete, so only the latest one is kept.
 //
-// The cache owns the mutex and runs mint inside it, which guarantees two
-// invariants no per-method locking could:
+// Minting runs inside the mutex, which guarantees:
 //
-//   - single flight: concurrent lookups for the same key produce exactly
-//     one signed record;
-//   - monotonic timestamps: every minted record carries a strictly greater
-//     timestamp than the previous one, across all keys, even when the wall
-//     clock repeats a second or steps backwards.
+//   - single flight: concurrent lookups for the same key mint exactly once;
+//   - monotonic timestamps: each mint is strictly newer than the last, even
+//     when the wall clock repeats a second or steps back. Peers reject
+//     records older than the one they hold (see bzz.CheckTimestamp).
 type addressCache struct {
-	mu      sync.Mutex
-	cap     int
-	entries map[string]*list.Element
-	lru     *list.List // *cacheEntry elements, most recently used in front
-	lastTS  int64      // timestamp of the most recently minted address
+	mu     sync.Mutex
+	key    string
+	addr   *bzz.Address
+	lastTS int64 // timestamp of the most recently minted address
 }
 
-// cacheEntry pairs the cache key with the signed address minted for it.
-type cacheEntry struct {
-	key  string
-	addr *bzz.Address
-}
-
-func newAddressCache(capacity int) *addressCache {
-	return &addressCache{
-		cap:     capacity,
-		entries: make(map[string]*list.Element),
-		lru:     list.New(),
-	}
-}
-
-// getOrMint returns the cached address for key, or calls mint exactly once
-// with the next monotonic timestamp, max(now, last+1), and caches the result.
-// A failed mint does not consume the timestamp.
+// getOrMint returns the cached address on a key match, otherwise mints with
+// the next monotonic timestamp, max(now, last+1), and caches the result. A
+// failed mint does not consume the timestamp.
 func (c *addressCache) getOrMint(key string, now int64, mint func(timestamp int64) (*bzz.Address, error)) (*bzz.Address, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if el, ok := c.entries[key]; ok {
-		c.lru.MoveToFront(el)
-		return el.Value.(*cacheEntry).addr, nil
+	if c.addr != nil && c.key == key {
+		return c.addr, nil
 	}
 
 	timestamp := max(now, c.lastTS+1)
@@ -63,30 +45,15 @@ func (c *addressCache) getOrMint(key string, now int64, mint func(timestamp int6
 		return nil, err
 	}
 	c.lastTS = timestamp
-
-	c.entries[key] = c.lru.PushFront(&cacheEntry{key: key, addr: addr})
-	if c.lru.Len() > c.cap {
-		oldest := c.lru.Back()
-		c.lru.Remove(oldest)
-		delete(c.entries, oldest.Value.(*cacheEntry).key)
-	}
+	c.key, c.addr = key, addr
 
 	return addr, nil
 }
 
-// purge drops all cached addresses; the next getOrMint per key re-signs.
+// purge drops the cached address; the next getOrMint re-signs.
 func (c *addressCache) purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	clear(c.entries)
-	c.lru.Init()
-}
-
-// size returns the number of cached addresses.
-func (c *addressCache) size() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.lru.Len()
+	c.key, c.addr = "", nil
 }

--- a/pkg/p2p/libp2p/internal/handshake/addresscache.go
+++ b/pkg/p2p/libp2p/internal/handshake/addresscache.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package handshake
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/ethersphere/bee/v2/pkg/bzz"
+)
+
+// addressCache stores the session-stable signed BzzAddress per cache key,
+// evicting the least recently used entry when capacity is exceeded.
+//
+// The cache owns the mutex and runs mint inside it, which guarantees two
+// invariants no per-method locking could:
+//
+//   - single flight: concurrent lookups for the same key produce exactly
+//     one signed record;
+//   - monotonic timestamps: every minted record carries a strictly greater
+//     timestamp than the previous one, across all keys, even when the wall
+//     clock repeats a second or steps backwards.
+type addressCache struct {
+	mu      sync.Mutex
+	cap     int
+	entries map[string]*list.Element
+	lru     *list.List // *cacheEntry elements, most recently used in front
+	lastTS  int64      // timestamp of the most recently minted address
+}
+
+// cacheEntry pairs the cache key with the signed address minted for it.
+type cacheEntry struct {
+	key  string
+	addr *bzz.Address
+}
+
+func newAddressCache(capacity int) *addressCache {
+	return &addressCache{
+		cap:     capacity,
+		entries: make(map[string]*list.Element),
+		lru:     list.New(),
+	}
+}
+
+// getOrMint returns the cached address for key, or calls mint exactly once
+// with the next monotonic timestamp, max(now, last+1), and caches the result.
+// A failed mint does not consume the timestamp.
+func (c *addressCache) getOrMint(key string, now int64, mint func(timestamp int64) (*bzz.Address, error)) (*bzz.Address, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if el, ok := c.entries[key]; ok {
+		c.lru.MoveToFront(el)
+		return el.Value.(*cacheEntry).addr, nil
+	}
+
+	timestamp := max(now, c.lastTS+1)
+
+	addr, err := mint(timestamp)
+	if err != nil {
+		return nil, err
+	}
+	c.lastTS = timestamp
+
+	c.entries[key] = c.lru.PushFront(&cacheEntry{key: key, addr: addr})
+	if c.lru.Len() > c.cap {
+		oldest := c.lru.Back()
+		c.lru.Remove(oldest)
+		delete(c.entries, oldest.Value.(*cacheEntry).key)
+	}
+
+	return addr, nil
+}
+
+// purge drops all cached addresses; the next getOrMint per key re-signs.
+func (c *addressCache) purge() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	clear(c.entries)
+	c.lru.Init()
+}
+
+// size returns the number of cached addresses.
+func (c *addressCache) size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.lru.Len()
+}

--- a/pkg/p2p/libp2p/internal/handshake/addresscache.go
+++ b/pkg/p2p/libp2p/internal/handshake/addresscache.go
@@ -49,11 +49,3 @@ func (c *addressCache) getOrMint(key string, now int64, mint func(timestamp int6
 
 	return addr, nil
 }
-
-// purge drops the cached address; the next getOrMint re-signs.
-func (c *addressCache) purge() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.key, c.addr = "", nil
-}

--- a/pkg/p2p/libp2p/internal/handshake/export_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/export_test.go
@@ -13,8 +13,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-const MaxCachedAddresses = maxCachedAddresses
-
 func (s *Service) SetTime(f func() time.Time) {
 	s.now = f
 }
@@ -25,8 +23,4 @@ func (s *Service) ParseCheckAck(ctx context.Context, ack *pb.Ack) (*bzz.Address,
 
 func (s *Service) SignedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) {
 	return s.signedAddress(underlays)
-}
-
-func (s *Service) AddressCacheLen() int {
-	return s.addrCache.size()
 }

--- a/pkg/p2p/libp2p/internal/handshake/export_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/export_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/ethersphere/bee/v2/pkg/bzz"
 	"github.com/ethersphere/bee/v2/pkg/p2p/libp2p/internal/handshake/pb"
+	ma "github.com/multiformats/go-multiaddr"
 )
+
+const MaxCachedAddresses = maxCachedAddresses
 
 func (s *Service) SetTime(f func() time.Time) {
 	s.now = f
@@ -18,4 +21,14 @@ func (s *Service) SetTime(f func() time.Time) {
 
 func (s *Service) ParseCheckAck(ctx context.Context, ack *pb.Ack) (*bzz.Address, error) {
 	return s.parseCheckAck(ctx, ack)
+}
+
+func (s *Service) SignedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) {
+	return s.signedAddress(underlays)
+}
+
+func (s *Service) AddressCacheLen() int {
+	s.addrCacheMu.Lock()
+	defer s.addrCacheMu.Unlock()
+	return s.addrCacheLRU.Len()
 }

--- a/pkg/p2p/libp2p/internal/handshake/export_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/export_test.go
@@ -28,7 +28,5 @@ func (s *Service) SignedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) 
 }
 
 func (s *Service) AddressCacheLen() int {
-	s.addrCacheMu.Lock()
-	defer s.addrCacheMu.Unlock()
-	return s.addrCacheLRU.Len()
+	return s.addrCache.size()
 }

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -102,8 +102,7 @@ type Service struct {
 	mu                    sync.RWMutex
 	hostAddresser         Addresser
 	now                   func() time.Time
-
-	addrCache addressCache // session-stable signed address, keyed by chequebook + underlays
+	addrCache             addressCache // session-stable signed address, keyed by chequebook + underlays
 }
 
 // Info contains the information received from the handshake.
@@ -149,19 +148,15 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 }
 
 // SetChequebookAddress sets the local chequebook address included in
-// subsequent signed BzzAddress payloads; the zero value clears it. The cached
-// signed address is purged so the next handshake re-signs. A mint in flight
-// during this call may land after the purge, but is keyed under the old
-// chequebook and simply gets overwritten by the next handshake.
+// subsequent signed BzzAddress payloads; the zero value clears it. The
+// chequebook is part of the signed-address cache key, so the next handshake
+// misses the cache and re-signs with the new chequebook.
 func (s *Service) SetChequebookAddress(addr common.Address) {
 	if (addr == common.Address{}) {
 		s.chequebookAddr.Store(nil)
 	} else {
-		cp := addr
-		s.chequebookAddr.Store(&cp)
+		s.chequebookAddr.Store(&addr)
 	}
-
-	s.addrCache.purge()
 }
 
 func (s *Service) chequebookAddress() common.Address {

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -41,10 +41,6 @@ const (
 	// MaxWelcomeMessageLength is maximum number of characters allowed in the welcome message.
 	MaxWelcomeMessageLength = 140
 	handshakeTimeout        = 15 * time.Second
-	// maxCachedAddresses bounds the signed-address cache so that peers
-	// reporting fabricated observed underlays cannot force unbounded growth
-	// or evict the legitimate entries fast enough to defeat record reuse.
-	maxCachedAddresses = 16
 )
 
 var (
@@ -107,7 +103,7 @@ type Service struct {
 	hostAddresser         Addresser
 	now                   func() time.Time
 
-	addrCache *addressCache // session-stable signed addresses, keyed by chequebook + underlays
+	addrCache addressCache // session-stable signed address, keyed by chequebook + underlays
 }
 
 // Info contains the information received from the handshake.
@@ -146,7 +142,6 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 		addressbook:           addrbook,
 		chequebookVerifier:    chequebookVerifier,
 		now:                   time.Now,
-		addrCache:             newAddressCache(maxCachedAddresses),
 	}
 	svc.welcomeMessage.Store(welcomeMessage)
 
@@ -154,11 +149,10 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 }
 
 // SetChequebookAddress sets the local chequebook address included in
-// subsequent signed BzzAddress payloads. The zero value clears it. Cached
-// signed addresses are invalidated so the next handshake re-signs with the
-// new chequebook. An entry minted by a handshake in flight during this call
-// may survive the purge, but is keyed under the old chequebook and can no
-// longer be looked up; it ages out of the cache unused.
+// subsequent signed BzzAddress payloads; the zero value clears it. The cached
+// signed address is purged so the next handshake re-signs. A mint in flight
+// during this call may land after the purge, but is keyed under the old
+// chequebook and simply gets overwritten by the next handshake.
 func (s *Service) SetChequebookAddress(addr common.Address) {
 	if (addr == common.Address{}) {
 		s.chequebookAddr.Store(nil)
@@ -178,11 +172,10 @@ func (s *Service) chequebookAddress() common.Address {
 }
 
 // signedAddress returns the session-stable signed BzzAddress advertising the
-// given canonical underlay set, minting and caching one on first use. Reusing
-// the timestamp and signature keeps the record byte-stable across handshakes,
-// so receiving peers see it as unchanged and skip redundant addressbook
-// writes and gossip updates. A new address is minted only when the underlay
-// set or the local chequebook changes.
+// given canonical underlay set. The record is minted on first use and reused
+// byte-stable (same timestamp and signature) across handshakes, so receiving
+// peers see it as unchanged and skip redundant addressbook writes and gossip
+// updates. It is re-minted when the underlay set or the chequebook changes.
 func (s *Service) signedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) {
 	underlaysBinary, err := bzz.SerializeUnderlays(underlays)
 	if err != nil {

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -193,7 +193,12 @@ func (s *Service) signedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) 
 	key := string(chequebook.Bytes()) + string(underlaysBinary)
 
 	return s.addrCache.getOrMint(key, s.now().Unix(), func(timestamp int64) (*bzz.Address, error) {
-		return bzz.NewAddress(s.signer, underlays, s.overlay, s.networkID, s.nonce, timestamp, chequebook)
+		addr, err := bzz.NewAddress(s.signer, underlays, s.overlay, s.networkID, s.nonce, timestamp, chequebook)
+		if err != nil {
+			return nil, err
+		}
+		s.metrics.AddressMinted.Inc()
+		return addr, nil
 	})
 }
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -6,6 +6,7 @@ package handshake
 
 import (
 	"cmp"
+	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -41,6 +42,10 @@ const (
 	// MaxWelcomeMessageLength is maximum number of characters allowed in the welcome message.
 	MaxWelcomeMessageLength = 140
 	handshakeTimeout        = 15 * time.Second
+	// maxCachedAddresses bounds the signed-address cache so that peers
+	// reporting fabricated observed underlays cannot force unbounded growth
+	// or evict the legitimate entries fast enough to defeat record reuse.
+	maxCachedAddresses = 16
 )
 
 var (
@@ -102,6 +107,18 @@ type Service struct {
 	mu                    sync.RWMutex
 	hostAddresser         Addresser
 	now                   func() time.Time
+
+	addrCacheMu   sync.Mutex
+	addrCache     map[string]*list.Element // key: chequebook bytes + serialized underlays
+	addrCacheLRU  *list.List               // *cachedAddress elements, most recently used in front
+	lastTimestamp int64                    // timestamp of the most recently minted address
+}
+
+// cachedAddress is an addrCache entry pairing the cache key with the
+// session-stable signed address minted for it.
+type cachedAddress struct {
+	key  string
+	addr *bzz.Address
 }
 
 // Info contains the information received from the handshake.
@@ -140,6 +157,8 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 		addressbook:           addrbook,
 		chequebookVerifier:    chequebookVerifier,
 		now:                   time.Now,
+		addrCache:             make(map[string]*list.Element),
+		addrCacheLRU:          list.New(),
 	}
 	svc.welcomeMessage.Store(welcomeMessage)
 
@@ -147,14 +166,22 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 }
 
 // SetChequebookAddress sets the local chequebook address included in
-// subsequent signed BzzAddress payloads. The zero value clears it.
+// subsequent signed BzzAddress payloads. The zero value clears it. Cached
+// signed addresses are invalidated so the next handshake re-signs with the
+// new chequebook.
 func (s *Service) SetChequebookAddress(addr common.Address) {
+	s.addrCacheMu.Lock()
+	defer s.addrCacheMu.Unlock()
+
 	if (addr == common.Address{}) {
 		s.chequebookAddr.Store(nil)
-		return
+	} else {
+		cp := addr
+		s.chequebookAddr.Store(&cp)
 	}
-	cp := addr
-	s.chequebookAddr.Store(&cp)
+
+	clear(s.addrCache)
+	s.addrCacheLRU.Init()
 }
 
 func (s *Service) chequebookAddress() common.Address {
@@ -162,6 +189,48 @@ func (s *Service) chequebookAddress() common.Address {
 		return *v
 	}
 	return common.Address{}
+}
+
+// signedAddress returns the session-stable signed BzzAddress advertising the
+// given canonical underlay set, minting and caching one on first use. Reusing
+// the timestamp and signature keeps the record byte-stable across handshakes,
+// so receiving peers see it as unchanged and skip redundant addressbook
+// writes and gossip updates. A new address is minted only when the underlay
+// set or the local chequebook changes, with a monotonically increasing
+// timestamp so distinct records are never issued with equal timestamps.
+func (s *Service) signedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) {
+	underlaysBinary, err := bzz.SerializeUnderlays(underlays)
+	if err != nil {
+		return nil, fmt.Errorf("serialize underlays: %w", err)
+	}
+
+	s.addrCacheMu.Lock()
+	defer s.addrCacheMu.Unlock()
+
+	chequebook := s.chequebookAddress()
+	key := string(chequebook.Bytes()) + string(underlaysBinary)
+
+	if el, ok := s.addrCache[key]; ok {
+		s.addrCacheLRU.MoveToFront(el)
+		return el.Value.(*cachedAddress).addr, nil
+	}
+
+	timestamp := max(s.now().Unix(), s.lastTimestamp+1)
+
+	addr, err := bzz.NewAddress(s.signer, underlays, s.overlay, s.networkID, s.nonce, timestamp, chequebook)
+	if err != nil {
+		return nil, err
+	}
+	s.lastTimestamp = timestamp
+
+	s.addrCache[key] = s.addrCacheLRU.PushFront(&cachedAddress{key: key, addr: addr})
+	if s.addrCacheLRU.Len() > maxCachedAddresses {
+		oldest := s.addrCacheLRU.Back()
+		s.addrCacheLRU.Remove(oldest)
+		delete(s.addrCache, oldest.Value.(*cachedAddress).key)
+	}
+
+	return addr, nil
 }
 
 func (s *Service) SetPicker(n p2p.Picker) {
@@ -268,7 +337,7 @@ func (s *Service) Handshake(ctx context.Context, stream p2p.Stream, peerMultiadd
 		s.metrics.AdvertisableUnderlaysTruncated.Inc()
 	}
 
-	bzzAddress, err := bzz.NewAddress(s.signer, advertisableUnderlays, s.overlay, s.networkID, s.nonce, s.now().Unix(), s.chequebookAddress())
+	bzzAddress, err := s.signedAddress(advertisableUnderlays)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +450,7 @@ func (s *Service) Handle(ctx context.Context, stream p2p.Stream, peerMultiaddrs 
 		s.metrics.AdvertisableUnderlaysTruncated.Inc()
 	}
 
-	bzzAddress, err := bzz.NewAddress(s.signer, advertisableUnderlays, s.overlay, s.networkID, s.nonce, s.now().Unix(), s.chequebookAddress())
+	bzzAddress, err := s.signedAddress(advertisableUnderlays)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/p2p/libp2p/internal/handshake/handshake.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake.go
@@ -6,7 +6,6 @@ package handshake
 
 import (
 	"cmp"
-	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -108,17 +107,7 @@ type Service struct {
 	hostAddresser         Addresser
 	now                   func() time.Time
 
-	addrCacheMu   sync.Mutex
-	addrCache     map[string]*list.Element // key: chequebook bytes + serialized underlays
-	addrCacheLRU  *list.List               // *cachedAddress elements, most recently used in front
-	lastTimestamp int64                    // timestamp of the most recently minted address
-}
-
-// cachedAddress is an addrCache entry pairing the cache key with the
-// session-stable signed address minted for it.
-type cachedAddress struct {
-	key  string
-	addr *bzz.Address
+	addrCache *addressCache // session-stable signed addresses, keyed by chequebook + underlays
 }
 
 // Info contains the information received from the handshake.
@@ -157,8 +146,7 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 		addressbook:           addrbook,
 		chequebookVerifier:    chequebookVerifier,
 		now:                   time.Now,
-		addrCache:             make(map[string]*list.Element),
-		addrCacheLRU:          list.New(),
+		addrCache:             newAddressCache(maxCachedAddresses),
 	}
 	svc.welcomeMessage.Store(welcomeMessage)
 
@@ -168,11 +156,10 @@ func New(signer crypto.Signer, advertisableAddresser AdvertisableAddressResolver
 // SetChequebookAddress sets the local chequebook address included in
 // subsequent signed BzzAddress payloads. The zero value clears it. Cached
 // signed addresses are invalidated so the next handshake re-signs with the
-// new chequebook.
+// new chequebook. An entry minted by a handshake in flight during this call
+// may survive the purge, but is keyed under the old chequebook and can no
+// longer be looked up; it ages out of the cache unused.
 func (s *Service) SetChequebookAddress(addr common.Address) {
-	s.addrCacheMu.Lock()
-	defer s.addrCacheMu.Unlock()
-
 	if (addr == common.Address{}) {
 		s.chequebookAddr.Store(nil)
 	} else {
@@ -180,8 +167,7 @@ func (s *Service) SetChequebookAddress(addr common.Address) {
 		s.chequebookAddr.Store(&cp)
 	}
 
-	clear(s.addrCache)
-	s.addrCacheLRU.Init()
+	s.addrCache.purge()
 }
 
 func (s *Service) chequebookAddress() common.Address {
@@ -196,41 +182,19 @@ func (s *Service) chequebookAddress() common.Address {
 // the timestamp and signature keeps the record byte-stable across handshakes,
 // so receiving peers see it as unchanged and skip redundant addressbook
 // writes and gossip updates. A new address is minted only when the underlay
-// set or the local chequebook changes, with a monotonically increasing
-// timestamp so distinct records are never issued with equal timestamps.
+// set or the local chequebook changes.
 func (s *Service) signedAddress(underlays []ma.Multiaddr) (*bzz.Address, error) {
 	underlaysBinary, err := bzz.SerializeUnderlays(underlays)
 	if err != nil {
 		return nil, fmt.Errorf("serialize underlays: %w", err)
 	}
 
-	s.addrCacheMu.Lock()
-	defer s.addrCacheMu.Unlock()
-
 	chequebook := s.chequebookAddress()
 	key := string(chequebook.Bytes()) + string(underlaysBinary)
 
-	if el, ok := s.addrCache[key]; ok {
-		s.addrCacheLRU.MoveToFront(el)
-		return el.Value.(*cachedAddress).addr, nil
-	}
-
-	timestamp := max(s.now().Unix(), s.lastTimestamp+1)
-
-	addr, err := bzz.NewAddress(s.signer, underlays, s.overlay, s.networkID, s.nonce, timestamp, chequebook)
-	if err != nil {
-		return nil, err
-	}
-	s.lastTimestamp = timestamp
-
-	s.addrCache[key] = s.addrCacheLRU.PushFront(&cachedAddress{key: key, addr: addr})
-	if s.addrCacheLRU.Len() > maxCachedAddresses {
-		oldest := s.addrCacheLRU.Back()
-		s.addrCacheLRU.Remove(oldest)
-		delete(s.addrCache, oldest.Value.(*cachedAddress).key)
-	}
-
-	return addr, nil
+	return s.addrCache.getOrMint(key, s.now().Unix(), func(timestamp int64) (*bzz.Address, error) {
+		return bzz.NewAddress(s.signer, underlays, s.overlay, s.networkID, s.nonce, timestamp, chequebook)
+	})
 }
 
 func (s *Service) SetPicker(n p2p.Picker) {

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -1041,3 +1041,202 @@ func TestParseCheckAck_TimestampRejections(t *testing.T) {
 		}
 	})
 }
+
+// testUnderlays returns a single-multiaddr underlay set on the given port so
+// tests can produce distinct canonical underlay sets cheaply.
+func testUnderlays(t *testing.T, port int) []ma.Multiaddr {
+	t.Helper()
+
+	m, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/16Uiu2HAkx8ULY8cTXhdVAcMmLcH9AsTKz6uBQ7DPLKRjMLgBVYkA", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []ma.Multiaddr{m}
+}
+
+// TestSignedAddress_StableAcrossCalls verifies that the signed address is
+// minted once per underlay set and reused verbatim on subsequent calls, even
+// when the clock advances (issue #23).
+func TestSignedAddress_StableAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	networkID := uint64(3)
+	now := time.Unix(1700000000, 0)
+	svc := newTimestampTestService(t, networkID, now)
+
+	underlays := testUnderlays(t, 1634)
+
+	first, err := svc.SignedAddress(underlays)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Timestamp != now.Unix() {
+		t.Fatalf("first timestamp: got %d, want %d", first.Timestamp, now.Unix())
+	}
+
+	svc.SetTime(func() time.Time { return now.Add(time.Hour) })
+
+	second, err := svc.SignedAddress(underlays)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if second.Timestamp != first.Timestamp {
+		t.Fatalf("timestamp changed across calls: got %d, want %d", second.Timestamp, first.Timestamp)
+	}
+	if !bytes.Equal(second.Signature, first.Signature) {
+		t.Fatal("signature changed across calls for the same underlay set")
+	}
+}
+
+// TestSignedAddress_ReSignsOnChange verifies that changing the underlay set or
+// the local chequebook mints a new record with a strictly newer timestamp,
+// even within the same clock second.
+func TestSignedAddress_ReSignsOnChange(t *testing.T) {
+	t.Parallel()
+
+	networkID := uint64(3)
+	now := time.Unix(1700000000, 0)
+	svc := newTimestampTestService(t, networkID, now)
+
+	first, err := svc.SignedAddress(testUnderlays(t, 1634))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := svc.SignedAddress(testUnderlays(t, 1635))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Timestamp != first.Timestamp+1 {
+		t.Fatalf("expected monotonic bump on underlay change: got %d, want %d", second.Timestamp, first.Timestamp+1)
+	}
+
+	chequebook := common.HexToAddress("0xab4f3b3c1d2e000000000000000000000000cafe")
+	svc.SetChequebookAddress(chequebook)
+
+	third, err := svc.SignedAddress(testUnderlays(t, 1634))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Timestamp <= second.Timestamp {
+		t.Fatalf("expected newer timestamp after chequebook change: got %d, existing %d", third.Timestamp, second.Timestamp)
+	}
+	if third.ChequebookAddress != chequebook {
+		t.Fatalf("chequebook: got %s, want %s", third.ChequebookAddress, chequebook)
+	}
+}
+
+// TestSignedAddress_CacheEviction verifies the LRU semantics of the signed
+// address cache: recently used entries survive an overflow, the least
+// recently used entry is evicted and re-minted on next use.
+func TestSignedAddress_CacheEviction(t *testing.T) {
+	t.Parallel()
+
+	networkID := uint64(3)
+	now := time.Unix(1700000000, 0)
+	svc := newTimestampTestService(t, networkID, now)
+
+	sets := make([][]ma.Multiaddr, handshake.MaxCachedAddresses+1)
+	timestamps := make([]int64, len(sets))
+	for i := range sets {
+		sets[i] = testUnderlays(t, 2000+i)
+	}
+
+	for i := range handshake.MaxCachedAddresses {
+		addr, err := svc.SignedAddress(sets[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		timestamps[i] = addr.Timestamp
+	}
+
+	// Touch the oldest entry so the upcoming eviction targets sets[1].
+	if _, err := svc.SignedAddress(sets[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := svc.SignedAddress(sets[handshake.MaxCachedAddresses]); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := svc.AddressCacheLen(); got != handshake.MaxCachedAddresses {
+		t.Fatalf("cache length: got %d, want %d", got, handshake.MaxCachedAddresses)
+	}
+
+	survived, err := svc.SignedAddress(sets[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if survived.Timestamp != timestamps[0] {
+		t.Fatalf("touched entry re-minted: got %d, want cached %d", survived.Timestamp, timestamps[0])
+	}
+
+	evicted, err := svc.SignedAddress(sets[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evicted.Timestamp <= timestamps[1] {
+		t.Fatalf("evicted entry not re-minted: got %d, cached was %d", evicted.Timestamp, timestamps[1])
+	}
+}
+
+// TestHandle_SignedAddressStableAcrossHandshakes verifies end to end that two
+// inbound handshakes advertise a byte-identical BzzAddress record (timestamp
+// and signature) even when the clock advances between them.
+func TestHandle_SignedAddressStableAcrossHandshakes(t *testing.T) {
+	t.Parallel()
+
+	networkID := uint64(3)
+	now := time.Unix(1700000000, 0)
+	svc := newTimestampTestService(t, networkID, now)
+
+	observed := testUnderlays(t, 1634)
+	observedBinary, err := bzz.SerializeUnderlays(observed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(clock time.Time) *pb.SynAck {
+		t.Helper()
+
+		svc.SetTime(func() time.Time { return clock })
+
+		var buffer1 bytes.Buffer
+		var buffer2 bytes.Buffer
+		stream1 := mock.NewStream(&buffer1, &buffer2)
+		stream2 := mock.NewStream(&buffer2, &buffer1)
+
+		w := protobuf.NewWriter(stream2)
+		if err := w.WriteMsg(&pb.Syn{ObservedUnderlay: observedBinary}); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.WriteMsg(signProtoAck(t, networkID, clock.Unix())); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := svc.Handle(context.Background(), stream1, observed); err != nil {
+			t.Fatal(err)
+		}
+
+		_, r := protobuf.NewWriterAndReader(stream2)
+		var got pb.SynAck
+		if err := r.ReadMsg(&got); err != nil {
+			t.Fatal(err)
+		}
+		return &got
+	}
+
+	first := run(now)
+	second := run(now.Add(time.Hour))
+
+	if second.Ack.Address.Timestamp != first.Ack.Address.Timestamp {
+		t.Fatalf("advertised timestamp changed across handshakes: got %d, want %d", second.Ack.Address.Timestamp, first.Ack.Address.Timestamp)
+	}
+	if !bytes.Equal(second.Ack.Address.Signature, first.Ack.Address.Signature) {
+		t.Fatal("advertised signature changed across handshakes")
+	}
+	if !bytes.Equal(second.Ack.Address.Underlay, first.Ack.Address.Underlay) {
+		t.Fatal("advertised underlays changed across handshakes")
+	}
+}

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -1055,8 +1055,8 @@ func testUnderlays(t *testing.T, port int) []ma.Multiaddr {
 }
 
 // TestSignedAddress_StableAcrossCalls verifies that the signed address is
-// minted once per underlay set and reused verbatim on subsequent calls, even
-// when the clock advances (issue #23).
+// minted once and reused verbatim on subsequent calls, even when the clock
+// advances.
 func TestSignedAddress_StableAcrossCalls(t *testing.T) {
 	t.Parallel()
 
@@ -1152,57 +1152,39 @@ func TestSignedAddress_ClockRegression(t *testing.T) {
 	}
 }
 
-// TestSignedAddress_CacheEviction verifies the LRU semantics of the signed
-// address cache: recently used entries survive an overflow, the least
-// recently used entry is evicted and re-minted on next use.
-func TestSignedAddress_CacheEviction(t *testing.T) {
+// TestSignedAddress_LatestEntryOnly verifies the cache keeps only the most
+// recently minted address: returning to a previously used underlay set
+// re-mints with a strictly newer timestamp instead of reviving the old record.
+func TestSignedAddress_LatestEntryOnly(t *testing.T) {
 	t.Parallel()
 
 	networkID := uint64(3)
 	now := time.Unix(1700000000, 0)
 	svc := newTimestampTestService(t, networkID, now)
 
-	sets := make([][]ma.Multiaddr, handshake.MaxCachedAddresses+1)
-	timestamps := make([]int64, len(sets))
-	for i := range sets {
-		sets[i] = testUnderlays(t, 2000+i)
-	}
-
-	for i := range handshake.MaxCachedAddresses {
-		addr, err := svc.SignedAddress(sets[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-		timestamps[i] = addr.Timestamp
-	}
-
-	// Touch the oldest entry so the upcoming eviction targets sets[1].
-	if _, err := svc.SignedAddress(sets[0]); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := svc.SignedAddress(sets[handshake.MaxCachedAddresses]); err != nil {
-		t.Fatal(err)
-	}
-
-	if got := svc.AddressCacheLen(); got != handshake.MaxCachedAddresses {
-		t.Fatalf("cache length: got %d, want %d", got, handshake.MaxCachedAddresses)
-	}
-
-	survived, err := svc.SignedAddress(sets[0])
+	first, err := svc.SignedAddress(testUnderlays(t, 2000))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if survived.Timestamp != timestamps[0] {
-		t.Fatalf("touched entry re-minted: got %d, want cached %d", survived.Timestamp, timestamps[0])
+
+	if _, err := svc.SignedAddress(testUnderlays(t, 2001)); err != nil {
+		t.Fatal(err)
 	}
 
-	evicted, err := svc.SignedAddress(sets[1])
+	reminted, err := svc.SignedAddress(testUnderlays(t, 2000))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if evicted.Timestamp <= timestamps[1] {
-		t.Fatalf("evicted entry not re-minted: got %d, cached was %d", evicted.Timestamp, timestamps[1])
+	if reminted.Timestamp != first.Timestamp+2 {
+		t.Fatalf("expected re-mint with newer timestamp: got %d, want %d", reminted.Timestamp, first.Timestamp+2)
+	}
+
+	cached, err := svc.SignedAddress(testUnderlays(t, 2000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached.Timestamp != reminted.Timestamp || !bytes.Equal(cached.Signature, reminted.Signature) {
+		t.Fatal("latest entry not reused verbatim")
 	}
 }
 

--- a/pkg/p2p/libp2p/internal/handshake/handshake_test.go
+++ b/pkg/p2p/libp2p/internal/handshake/handshake_test.go
@@ -1127,6 +1127,31 @@ func TestSignedAddress_ReSignsOnChange(t *testing.T) {
 	}
 }
 
+// TestSignedAddress_ClockRegression verifies a record minted after the wall
+// clock steps back still carries a strictly newer timestamp.
+func TestSignedAddress_ClockRegression(t *testing.T) {
+	t.Parallel()
+
+	networkID := uint64(3)
+	now := time.Unix(1700000000, 0)
+	svc := newTimestampTestService(t, networkID, now)
+
+	first, err := svc.SignedAddress(testUnderlays(t, 1634))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc.SetTime(func() time.Time { return now.Add(-time.Hour) })
+
+	second, err := svc.SignedAddress(testUnderlays(t, 1635))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Timestamp != first.Timestamp+1 {
+		t.Fatalf("timestamp after clock regression: got %d, want %d", second.Timestamp, first.Timestamp+1)
+	}
+}
+
 // TestSignedAddress_CacheEviction verifies the LRU semantics of the signed
 // address cache: recently used entries survive an overflow, the least
 // recently used entry is evicted and re-minted on next use.

--- a/pkg/p2p/libp2p/internal/handshake/metrics.go
+++ b/pkg/p2p/libp2p/internal/handshake/metrics.go
@@ -81,7 +81,7 @@ func newMetrics() metrics {
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "address_minted_total",
-			Help:      "Number of session-stable signed addresses minted (signed-address cache misses). Should plateau at a small number per session; linear growth with handshakes indicates advertised-underlay churn.",
+			Help:      "Number of session-stable signed addresses minted. Plateaus per session; linear growth indicates advertised-underlay churn.",
 		}),
 		TimestampRejected: prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/p2p/libp2p/internal/handshake/metrics.go
+++ b/pkg/p2p/libp2p/internal/handshake/metrics.go
@@ -19,6 +19,7 @@ type metrics struct {
 	AckRxFailed                    prometheus.Counter
 	AdvertisableUnderlaysTruncated prometheus.Counter
 	ObservedUnderlaysTruncated     prometheus.Counter
+	AddressMinted                  prometheus.Counter
 	TimestampRejected              *prometheus.CounterVec
 	ChequebookVerification         *prometheus.CounterVec
 }
@@ -75,6 +76,12 @@ func newMetrics() metrics {
 			Subsystem: subsystem,
 			Name:      "observed_underlays_truncated",
 			Help:      "Number of times observed peer underlays were truncated before sending.",
+		}),
+		AddressMinted: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "address_minted_total",
+			Help:      "Number of session-stable signed addresses minted (signed-address cache misses). Should plateau at a small number per session; linear growth with handshakes indicates advertised-underlay churn.",
 		}),
 		TimestampRejected: prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -773,11 +773,10 @@ func (s *Service) handleIncoming(stream network.Stream) {
 	s.logger.Debug("stream handler: successfully connected to peer (inbound)", "address", i.BzzAddress.Overlay, "light", i.LightString(), "user_agent", peerUserAgent)
 }
 
-// putHandshakeAddress persists a peer's BzzAddress from the handshake.
-// Timestamp and chequebook validation have already run in the handshake; here
-// we only need to perform the atomic registry-plus-addressbook write. The
-// addressbook write is skipped when the stored record is identical and
-// already verified, so steady-state reconnects cost no disk write.
+// putHandshakeAddress persists a peer's BzzAddress, already validated by the
+// handshake, as an atomic registry-plus-addressbook write. The addressbook
+// write is skipped when the stored record is identical and verified, so
+// steady-state reconnects cost no disk write.
 func (s *Service) putHandshakeAddress(addr *bzz.Address) error {
 	existing, verified, err := s.addressbook.Get(addr.Overlay)
 	if err != nil && !errors.Is(err, addressbook.ErrNotFound) {

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -775,15 +775,27 @@ func (s *Service) handleIncoming(stream network.Stream) {
 
 // putHandshakeAddress persists a peer's BzzAddress from the handshake.
 // Timestamp and chequebook validation have already run in the handshake; here
-// we only need to perform the atomic registry-plus-addressbook write.
+// we only need to perform the atomic registry-plus-addressbook write. The
+// addressbook write is skipped when the stored record is identical and
+// already verified, so steady-state reconnects cost no disk write.
 func (s *Service) putHandshakeAddress(addr *bzz.Address) error {
+	existing, verified, err := s.addressbook.Get(addr.Overlay)
+	if err != nil && !errors.Is(err, addressbook.ErrNotFound) {
+		return fmt.Errorf("addressbook get: %w", err)
+	}
+	unchanged := err == nil && verified && existing.Equal(addr)
+
 	if s.chequebookStorer != nil {
 		// The addressbook write is passed as a callback so it runs under the
 		// registry's mutex, keeping the in-memory registry and on-disk addressbook
 		// in sync if gossip and a direct handshake race for the same peer.
+		var writeAddressbook func() error
+		if !unchanged {
+			writeAddressbook = func() error { return s.addressbook.Put(addr.Overlay, *addr, true) }
+		}
 		if err := s.chequebookStorer.Put(
 			addr.Overlay, addr.ChequebookAddress, addr.Timestamp, bzz.TimestampSourceHandshake,
-			func() error { return s.addressbook.Put(addr.Overlay, *addr, true) },
+			writeAddressbook,
 		); err != nil {
 			// Concurrent ingestion (e.g. gossip) may have advanced the
 			// stored record between the handshake's stale check and this
@@ -797,6 +809,11 @@ func (s *Service) putHandshakeAddress(addr *bzz.Address) error {
 		}
 		return nil
 	}
+
+	if unchanged {
+		return nil
+	}
+
 	return s.addressbook.Put(addr.Overlay, *addr, true)
 }
 

--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -338,3 +338,161 @@ func TestPutHandshakeAddress_NoStorer_FallbackVerifiedTrue(t *testing.T) {
 		t.Fatalf("addressbook cb: got %s, want %s", got.ChequebookAddress.Hex(), cb.Hex())
 	}
 }
+
+// countingBook wraps an addressbook and counts writes going through Put.
+type countingBook struct {
+	addressbook.GetPutter
+	puts int
+}
+
+func (b *countingBook) Put(overlay swarm.Address, addr bzz.Address, verified bool) error {
+	b.puts++
+	return b.GetPutter.Put(overlay, addr, verified)
+}
+
+// testAddrPair builds two properly-signed bzz.Addresses for the same peer
+// identity, the second with a newer timestamp, mirroring a peer whose record
+// genuinely changed between two handshakes.
+func testAddrPair(t *testing.T, cb common.Address) (*bzz.Address, *bzz.Address) {
+	t.Helper()
+
+	pk, err := crypto.GenerateSecp256k1Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.NewDefaultSigner(pk)
+	nonce := common.HexToHash("0x1").Bytes()
+
+	overlay, err := crypto.NewOverlayAddress(pk.PublicKey, 1, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	underlay, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/1634")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := time.Now().Unix()
+	first, err := bzz.NewAddress(signer, []multiaddr.Multiaddr{underlay}, overlay, 1, nonce, ts, cb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := bzz.NewAddress(signer, []multiaddr.Multiaddr{underlay}, overlay, 1, nonce, ts+1, cb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return first, second
+}
+
+// TestPutHandshakeAddress_UnchangedRecord_SkipsAddressbookWrite covers the
+// reconnect path with the storer wired: a byte-identical, already-verified
+// record skips the addressbook write, while the storer still runs so the
+// chequebook-overlay mapping dropped on disconnect is re-registered.
+func TestPutHandshakeAddress_UnchangedRecord_SkipsAddressbookWrite(t *testing.T) {
+	t.Parallel()
+
+	book := addressbook.New(mock.NewStateStore())
+	storer := &fakeStorer{}
+	svc := libp2p.NewPutHandshakeAddressTestService(log.Noop, book, storer)
+
+	addr := testAddr(t, common.HexToAddress("0x5555555555555555555555555555555555555555"))
+
+	if err := svc.PutHandshakeAddress(addr); err != nil {
+		t.Fatalf("PutHandshakeAddress: %v", err)
+	}
+	if err := svc.PutHandshakeAddress(addr); err != nil {
+		t.Fatalf("PutHandshakeAddress (reconnect): %v", err)
+	}
+
+	if storer.puts != 2 {
+		t.Fatalf("storer.Put calls: got %d, want 2 (mapping must re-register on reconnect)", storer.puts)
+	}
+	if storer.cbCallbacks != 1 {
+		t.Fatalf("writeAddressbook callbacks: got %d, want 1 (unchanged record must skip the write)", storer.cbCallbacks)
+	}
+}
+
+// TestPutHandshakeAddress_NoStorer_UnchangedRecord_SkipsWrite covers the
+// reconnect path with the chequebook subsystem disabled: the second put of an
+// identical record performs no addressbook write.
+func TestPutHandshakeAddress_NoStorer_UnchangedRecord_SkipsWrite(t *testing.T) {
+	t.Parallel()
+
+	book := &countingBook{GetPutter: addressbook.New(mock.NewStateStore())}
+	svc := libp2p.NewPutHandshakeAddressTestService(log.Noop, book, nil)
+
+	addr := testAddr(t, common.HexToAddress("0x6666666666666666666666666666666666666666"))
+
+	if err := svc.PutHandshakeAddress(addr); err != nil {
+		t.Fatalf("PutHandshakeAddress: %v", err)
+	}
+	if err := svc.PutHandshakeAddress(addr); err != nil {
+		t.Fatalf("PutHandshakeAddress (reconnect): %v", err)
+	}
+
+	if book.puts != 1 {
+		t.Fatalf("addressbook writes: got %d, want 1 (unchanged record must skip the write)", book.puts)
+	}
+}
+
+// TestPutHandshakeAddress_IdenticalButUnverified_Writes guards the verified
+// upgrade: a record identical to the stored one but persisted with
+// Verified=false (e.g. by gossip) must still be re-written with Verified=true.
+func TestPutHandshakeAddress_IdenticalButUnverified_Writes(t *testing.T) {
+	t.Parallel()
+
+	inner := addressbook.New(mock.NewStateStore())
+	book := &countingBook{GetPutter: inner}
+	svc := libp2p.NewPutHandshakeAddressTestService(log.Noop, book, nil)
+
+	addr := testAddr(t, common.HexToAddress("0x7777777777777777777777777777777777777777"))
+
+	if err := inner.Put(addr.Overlay, *addr, false); err != nil {
+		t.Fatalf("seed addressbook: %v", err)
+	}
+
+	if err := svc.PutHandshakeAddress(addr); err != nil {
+		t.Fatalf("PutHandshakeAddress: %v", err)
+	}
+
+	if book.puts != 1 {
+		t.Fatalf("addressbook writes: got %d, want 1 (unverified record must be upgraded)", book.puts)
+	}
+	_, verified, err := inner.Get(addr.Overlay)
+	if err != nil {
+		t.Fatalf("addressbook.Get: %v", err)
+	}
+	if !verified {
+		t.Fatal("addressbook entry must be upgraded to Verified=true by the handshake")
+	}
+}
+
+// TestPutHandshakeAddress_ChangedRecord_Writes verifies a genuinely updated
+// record for a known overlay is still written.
+func TestPutHandshakeAddress_ChangedRecord_Writes(t *testing.T) {
+	t.Parallel()
+
+	book := &countingBook{GetPutter: addressbook.New(mock.NewStateStore())}
+	svc := libp2p.NewPutHandshakeAddressTestService(log.Noop, book, nil)
+
+	first, second := testAddrPair(t, common.HexToAddress("0x8888888888888888888888888888888888888888"))
+
+	if err := svc.PutHandshakeAddress(first); err != nil {
+		t.Fatalf("PutHandshakeAddress: %v", err)
+	}
+	if err := svc.PutHandshakeAddress(second); err != nil {
+		t.Fatalf("PutHandshakeAddress (updated record): %v", err)
+	}
+
+	if book.puts != 2 {
+		t.Fatalf("addressbook writes: got %d, want 2 (changed record must be written)", book.puts)
+	}
+	got, _, err := book.Get(first.Overlay)
+	if err != nil {
+		t.Fatalf("addressbook.Get: %v", err)
+	}
+	if got.Timestamp != second.Timestamp {
+		t.Fatalf("stored timestamp: got %d, want %d", got.Timestamp, second.Timestamp)
+	}
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Every handshake created and signed a new BzzAddress with a fresh timestamp, so each record the node advertised differed from the previous one even when nothing changed.
Receiving nodes therefore treated every record as an update: each reconnect caused an addressbook write on the peer, and re-gossiped records with advancing timestamps caused periodic addressbook writes across the whole network.

- The handshake service now mints the signed BzzAddress once and reuses it while the advertised underlay set and the local chequebook stay unchanged, so reconnects and re-gossip present a byte-identical record that peers skip without writing.
- A new record is minted only when the advertised underlays or the local chequebook actually change, with a monotonically increasing timestamp that stays valid across same-second mints and wall-clock regressions.
- The cache keeps only the most recently minted record: since peers reject handshake records older than the one they hold (`bzz.CheckTimestamp`), only the latest record is ever valid to present, so a single entry is sufficient — and bounded by design, regardless of what observed underlays peers report.
- `putHandshakeAddress` now skips the addressbook write when the stored record is identical and already verified, so a reconnecting peer costs one cached read and zero disk writes; the chequebook registry mapping is still re-registered and unverified records are still upgraded.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
Closes https://github.com/ethersphere/bee-private/issues/23

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.