### PR TITLE
feat: use larger block page size when syncing from snapshot

### DIFF
--- a/pkg/node/snapshot.go
+++ b/pkg/node/snapshot.go
@@ -49,6 +49,10 @@ func NewSnapshotLogFilterer(logger log.Logger, getter SnapshotGetter) *SnapshotL
 	}
 }
 
+func (f *SnapshotLogFilterer) GetBatchSnapshot() []byte {
+	return f.getter.GetBatchSnapshot()
+}
+
 // loadSnapshot is responsible for loading and processing the snapshot data.
 // It is intended to be called exactly once by initOnce.Do.
 func (f *SnapshotLogFilterer) loadSnapshot() error {

--- a/pkg/postage/listener/export_test.go
+++ b/pkg/postage/listener/export_test.go
@@ -5,6 +5,8 @@
 package listener
 
 var (
-	TailSize    = tailSize
-	BatchFactor = defaultBatchFactor
+	TailSize          = tailSize
+	BatchFactor       = defaultBatchFactor
+	BlockPage         = uint64(blockPage)
+	BlockPageSnapshot = uint64(blockPageSnapshot)
 )

--- a/pkg/postage/listener/listener.go
+++ b/pkg/postage/listener/listener.go
@@ -29,6 +29,7 @@ const loggerName = "listener"
 
 const (
 	blockPage          = 5000      // how many blocks to sync every time we page
+	blockPageSnapshot  = 50000     // how many blocks to sync every time from snapshot
 	tailSize           = 4         // how many blocks to tail from the tip of the chain
 	defaultBatchFactor = uint64(5) // minimal number of blocks to sync at once
 )
@@ -232,6 +233,15 @@ func (l *listener) Listen(ctx context.Context, from uint64, updater postage.Even
 
 	l.logger.Debug("batch factor", "value", batchFactor)
 
+	// Type assertion to detect if backend is SnapshotLogFilterer
+	pageSize := uint64(blockPage)
+	if _, isSnapshot := l.ev.(interface{ GetBatchSnapshot() []byte }); isSnapshot {
+		pageSize = blockPageSnapshot
+		l.logger.Debug("using snapshot page size", "page_size", pageSize)
+	} else {
+		l.logger.Debug("using standard page size", "page_size", pageSize)
+	}
+
 	synced := make(chan error)
 	closeOnce := new(sync.Once)
 	paged := true
@@ -312,9 +322,9 @@ func (l *listener) Listen(ctx context.Context, from uint64, updater postage.Even
 			}
 
 			// do some paging (sub-optimal)
-			if to-from >= blockPage {
+			if to-from >= pageSize {
 				paged = true
-				to = from + blockPage - 1
+				to = from + pageSize - 1
 			} else {
 				closeOnce.Do(func() { synced <- nil })
 			}

--- a/pkg/postage/listener/listener_test.go
+++ b/pkg/postage/listener/listener_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -416,6 +417,99 @@ func TestListener(t *testing.T) {
 		}
 	})
 }
+
+// TestListenerPageSize verifies that the block paging window is selected based
+// on the backend: a plain backend pages by blockPage, while a backend that also
+// exposes GetBatchSnapshot (the snapshot filterer) pages by blockPageSnapshot.
+func TestListenerPageSize(t *testing.T) {
+	t.Parallel()
+
+	// well above both page sizes so the first iteration is always capped by paging
+	const blockNumber = uint64(200000)
+
+	firstPageTo := func(t *testing.T, mkFilterer func(*pageCaptureFilterer) listener.BlockHeightContractFilterer) uint64 {
+		t.Helper()
+
+		base := &pageCaptureFilterer{
+			blockNumber: blockNumber,
+			firstTo:     make(chan uint64, 1),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := listener.New(
+			nil,
+			log.Noop,
+			mkFilterer(base),
+			postageStampContractAddress,
+			postageStampContractABI,
+			1,
+			stallingTimeout,
+			backoffTime,
+		)
+		testutil.CleanupCloser(t, l)
+
+		go l.Listen(ctx, 0, newEventUpdaterMock())
+
+		select {
+		case to := <-base.firstTo:
+			cancel() // unblock FilterLogs and let the listener shut down cleanly
+			return to
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for first FilterLogs call")
+			return 0
+		}
+	}
+
+	t.Run("standard backend uses block page", func(t *testing.T) {
+		to := firstPageTo(t, func(f *pageCaptureFilterer) listener.BlockHeightContractFilterer {
+			return f
+		})
+		if want := listener.BlockPage - 1; to != want {
+			t.Fatalf("first page ToBlock mismatch: got %d want %d", to, want)
+		}
+	})
+
+	t.Run("snapshot backend uses snapshot page", func(t *testing.T) {
+		to := firstPageTo(t, func(f *pageCaptureFilterer) listener.BlockHeightContractFilterer {
+			return snapshotPageCaptureFilterer{f}
+		})
+		if want := listener.BlockPageSnapshot - 1; to != want {
+			t.Fatalf("first page ToBlock mismatch: got %d want %d", to, want)
+		}
+	})
+}
+
+// pageCaptureFilterer records the ToBlock of the first FilterLogs call so the
+// chosen paging window can be asserted.
+type pageCaptureFilterer struct {
+	blockNumber uint64
+	firstTo     chan uint64
+	once        sync.Once
+}
+
+func (f *pageCaptureFilterer) BlockNumber(context.Context) (uint64, error) {
+	return f.blockNumber, nil
+}
+
+func (f *pageCaptureFilterer) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	f.once.Do(func() {
+		f.firstTo <- q.ToBlock.Uint64()
+	})
+	// block until shutdown so only the first page is observed and the listener
+	// exits via the context-canceled path without paging to completion
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// snapshotPageCaptureFilterer additionally exposes GetBatchSnapshot, matching the
+// interface the listener type-asserts against to detect a snapshot backend.
+type snapshotPageCaptureFilterer struct {
+	*pageCaptureFilterer
+}
+
+func (snapshotPageCaptureFilterer) GetBatchSnapshot() []byte { return nil }
 
 func newEventUpdaterMock() *updater {
 	return &updater{


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Re-introduces the snapshot block page-size increase from #5343, **without** the chainstate caching mechanism that caused that PR to be reverted in #5482.

  When syncing postage events from a snapshot, the listener now pages by `blockPageSnapshot = 50000` blocks instead of the standard `blockPage = 5000`, reducing the number of backend calls during snapshot-based sync. The standard page size is unchanged for live RPC backends.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
