### PR TITLE
fix: prevent second batch store reset wiping postage snapshot on --resync

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -45,6 +45,8 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/postage/batchstore"
 	"github.com/ethersphere/bee/v2/pkg/postage/listener"
 	"github.com/ethersphere/bee/v2/pkg/postage/postagecontract"
+	"github.com/ethersphere/bee/v2/pkg/postage/snapshot"
+	"github.com/ethersphere/bee/v2/pkg/postage/snapshot/archive"
 	"github.com/ethersphere/bee/v2/pkg/pricer"
 	"github.com/ethersphere/bee/v2/pkg/pricing"
 	"github.com/ethersphere/bee/v2/pkg/pss"
@@ -892,21 +894,17 @@ func NewBee(
 	// store is reset only when --resync is requested. Either way the store is
 	// reset in a single place (batchservice.New), which avoids a second reset
 	// wiping the snapshot that was just loaded (see #5495).
-	var snapshot *batchservice.Snapshot
+	var batchSnapshot *batchservice.Snapshot
 	if !o.SkipPostageSnapshot && !batchStoreExists && (networkID == mainnetNetworkID) && beeNodeMode != api.UltraLightMode {
-		chainBackend := NewSnapshotLogFilterer(logger, archiveSnapshotGetter{})
-
-		snapshotEventListener := listener.New(b.syncingStopped, logger, chainBackend, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout)
-
-		snapshot = &batchservice.Snapshot{
-			Listener:   snapshotEventListener,
-			Backend:    chainBackend,
-			StartBlock: postageSyncStart,
+		batchSnapshot, err = snapshot.New(ctx, logger, archive.Getter{}, b.syncingStopped, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout, postageSyncStart)
+		if err != nil {
+			// A corrupt snapshot is not fatal: rebuild from the chain instead.
+			logger.Error(err, "postage snapshot unavailable, syncing from chain instead")
 		}
 	}
 
 	var snapshotLoaded bool
-	batchSvc, snapshotLoaded, err = batchservice.New(ctx, stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, snapshot, o.Resync)
+	batchSvc, snapshotLoaded, err = batchservice.New(ctx, stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, batchSnapshot, o.Resync)
 	if err != nil {
 		return nil, fmt.Errorf("init batch service: %w", err)
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -887,37 +887,33 @@ func NewBee(
 		}
 	)
 
-	snapshotLoaded := false
+	// When the postage snapshot applies, hand it to the batch service so it
+	// rebuilds the store from the snapshot during construction; otherwise the
+	// store is reset only when --resync is requested. Either way the store is
+	// reset in a single place (batchservice.New), which avoids a second reset
+	// wiping the snapshot that was just loaded (see #5495).
+	var snapshot *batchservice.Snapshot
 	if !o.SkipPostageSnapshot && !batchStoreExists && (networkID == mainnetNetworkID) && beeNodeMode != api.UltraLightMode {
 		chainBackend := NewSnapshotLogFilterer(logger, archiveSnapshotGetter{})
 
 		snapshotEventListener := listener.New(b.syncingStopped, logger, chainBackend, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout)
 
-		snapshotBatchSvc, err := batchservice.New(stateStore, batchStore, logger, snapshotEventListener, overlayEthAddress.Bytes(), post, sha3.New256, o.Resync)
-		if err != nil {
-			logger.Error(err, "failed to initialize batch service from snapshot, continuing outside snapshot block...")
-		} else {
-			err = snapshotBatchSvc.Start(ctx, postageSyncStart)
-			syncStatus.Store(true)
-			if err != nil {
-				syncErr.Store(err)
-				logger.Error(err, "failed to start batch service from snapshot, continuing outside snapshot block...")
-			} else {
-				postageSyncStart = chainBackend.maxBlockHeight
-				snapshotLoaded = true
-			}
+		snapshot = &batchservice.Snapshot{
+			Listener:   snapshotEventListener,
+			Backend:    chainBackend,
+			StartBlock: postageSyncStart,
 		}
-		if errClose := snapshotEventListener.Close(); errClose != nil {
-			logger.Error(errClose, "failed to close event listener (snapshot) failure")
-		}
-
 	}
 
-	// Don't resync the live batch service when the snapshot already rebuilt the
-	// store, otherwise it would be discarded and sync would fail (see #5495).
-	batchSvc, err = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, o.Resync && !snapshotLoaded)
+	var snapshotLoaded bool
+	batchSvc, snapshotLoaded, err = batchservice.New(ctx, stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, snapshot, o.Resync)
 	if err != nil {
 		return nil, fmt.Errorf("init batch service: %w", err)
+	}
+	if snapshotLoaded {
+		// The snapshot rebuilt the store up to its block height, so the node can
+		// already serve postage requests while the remaining gap syncs live.
+		syncStatus.Store(true)
 	}
 
 	if batchSvc != nil && chainEnabled {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -787,11 +787,6 @@ func NewBee(
 	eventListener = listener.New(b.syncingStopped, logger, chainBackend, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout)
 	b.listenerCloser = eventListener
 
-	batchSvc, err = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, o.Resync)
-	if err != nil {
-		return nil, fmt.Errorf("init batch service: %w", err)
-	}
-
 	// Construct protocols.
 	pingPong := pingpong.New(p2ps, logger, tracer)
 
@@ -892,6 +887,7 @@ func NewBee(
 		}
 	)
 
+	snapshotLoaded := false
 	if !o.SkipPostageSnapshot && !batchStoreExists && (networkID == mainnetNetworkID) && beeNodeMode != api.UltraLightMode {
 		chainBackend := NewSnapshotLogFilterer(logger, archiveSnapshotGetter{})
 
@@ -908,12 +904,20 @@ func NewBee(
 				logger.Error(err, "failed to start batch service from snapshot, continuing outside snapshot block...")
 			} else {
 				postageSyncStart = chainBackend.maxBlockHeight
+				snapshotLoaded = true
 			}
 		}
 		if errClose := snapshotEventListener.Close(); errClose != nil {
 			logger.Error(errClose, "failed to close event listener (snapshot) failure")
 		}
 
+	}
+
+	// Don't resync the live batch service when the snapshot already rebuilt the
+	// store, otherwise it would be discarded and sync would fail (see #5495).
+	batchSvc, err = batchservice.New(stateStore, batchStore, logger, eventListener, overlayEthAddress.Bytes(), post, sha3.New256, o.Resync && !snapshotLoaded)
+	if err != nil {
+		return nil, fmt.Errorf("init batch service: %w", err)
 	}
 
 	if batchSvc != nil && chainEnabled {

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -40,14 +40,48 @@ type batchService struct {
 
 	checksum hash.Hash // checksum hasher
 	resync   bool
+
+	// snapshotLoaded reports whether the store was rebuilt from a postage
+	// snapshot in New. When true, Start must not reset the store again,
+	// otherwise the freshly loaded snapshot would be discarded (see #5495).
+	snapshotLoaded bool
+	// snapshotResumeBlock is the chain block height the store was rebuilt to
+	// from a postage snapshot. When non-zero, live sync resumes from here.
+	snapshotResumeBlock uint64
 }
 
 type Interface interface {
 	postage.EventUpdater
 }
 
+// Snapshot carries the optional inputs needed to rebuild the batch store from a
+// postage snapshot. When passed to New (non-nil), the store is reset and
+// replayed from the snapshot before the service is returned, and live sync
+// later resumes from the snapshot's block height. New takes ownership of
+// Listener and closes it once the snapshot has been replayed.
+type Snapshot struct {
+	// Listener replays the snapshot's events into the batch store.
+	Listener postage.Listener
+	// Backend reports the block height the snapshot reached, from which live
+	// sync resumes.
+	Backend interface {
+		BlockNumber(context.Context) (uint64, error)
+	}
+	// StartBlock is the block height from which the snapshot is replayed (the
+	// postage contract start block).
+	StartBlock uint64
+}
+
 // New will create a new BatchService.
+//
+// When a snapshot is provided it is replayed before the service is returned
+// (resetting the store first if a resync was requested or a dirty shutdown was
+// detected), and snapshotLoaded reports whether that succeeded. When no snapshot
+// is loaded, a resync or dirty shutdown instead triggers a single reset in Start
+// so live sync rebuilds the store from the chain. The store is therefore reset
+// at most once across New and Start.
 func New(
+	ctx context.Context,
 	stateStore storage.StateStorer,
 	storer postage.Storer,
 	logger log.Logger,
@@ -55,8 +89,9 @@ func New(
 	owner []byte,
 	batchListener postage.BatchEventListener,
 	checksumFunc func() hash.Hash,
+	snapshot *Snapshot,
 	resync bool,
-) (Interface, error) {
+) (Interface, bool, error) {
 	if checksumFunc == nil {
 		checksumFunc = sha3.New256
 	}
@@ -65,37 +100,113 @@ func New(
 		sum = checksumFunc()
 	)
 
+	logger = logger.WithName(loggerName).Register()
+
 	dirty := false
-	err := stateStore.Get(dirtyDBKey, &dirty)
-	if err != nil && !errors.Is(err, storage.ErrNotFound) {
-		return nil, err
+	if err := stateStore.Get(dirtyDBKey, &dirty); err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return nil, false, err
 	}
 
 	if resync {
 		if err := stateStore.Delete(checksumDBKey); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	} else if !dirty {
 		if err := stateStore.Get(checksumDBKey, &b); err != nil {
 			if !errors.Is(err, storage.ErrNotFound) {
-				return nil, err
+				return nil, false, err
 			}
 		} else {
 			s, err := hex.DecodeString(b)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			n, err := sum.Write(s)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			if n != len(s) {
-				return nil, errors.New("batchstore checksum init")
+				return nil, false, errors.New("batchstore checksum init")
 			}
 		}
 	}
 
-	return &batchService{stateStore, storer, logger.WithName(loggerName).Register(), listener, owner, batchListener, sum, resync}, nil
+	bs := &batchService{
+		stateStore:    stateStore,
+		storer:        storer,
+		logger:        logger,
+		listener:      listener,
+		owner:         owner,
+		batchListener: batchListener,
+		checksum:      sum,
+		resync:        resync,
+	}
+
+	// When a snapshot is supplied the rebuild happens here: reset the store (only
+	// if a resync was requested or a dirty shutdown was detected, mirroring the
+	// pre-snapshot live path) and replay the snapshot onto it. A failed snapshot
+	// is not fatal; Start then rebuilds from the chain instead.
+	if snapshot != nil {
+		if dirty || resync {
+			if err := bs.reset(dirty); err != nil {
+				return nil, false, err
+			}
+		}
+		if err := bs.loadSnapshot(ctx, snapshot); err != nil {
+			logger.Error(err, "failed to start batch service from snapshot, continuing outside snapshot block...")
+		} else {
+			bs.snapshotLoaded = true
+		}
+	}
+
+	return bs, bs.snapshotLoaded, nil
+}
+
+// reset wipes the batch store so it can be rebuilt from scratch. It is called at
+// most once per startup, from New (snapshot rebuild) or Start (live rebuild).
+func (svc *batchService) reset(dirty bool) error {
+	if dirty {
+		svc.logger.Warning("batch service: dirty shutdown detected, resetting batch store")
+	} else {
+		svc.logger.Warning("batch service: resync requested, resetting batch store")
+	}
+
+	if err := svc.storer.Reset(); err != nil {
+		return err
+	}
+	if err := svc.stateStore.Delete(dirtyDBKey); err != nil {
+		return err
+	}
+	svc.logger.Warning("batch service: batch store has been reset. your node will now resync chain data. this might take a while...")
+
+	return nil
+}
+
+// loadSnapshot rebuilds the (already reset) store from a postage snapshot by
+// replaying its events and records the block height to resume live sync from.
+func (svc *batchService) loadSnapshot(ctx context.Context, snapshot *Snapshot) error {
+	defer func() {
+		if err := snapshot.Listener.Close(); err != nil {
+			svc.logger.Error(err, "failed to close event listener (snapshot) failure")
+		}
+	}()
+
+	startBlock := snapshot.StartBlock
+	if cs := svc.storer.GetChainState(); cs.Block > startBlock {
+		startBlock = cs.Block
+	}
+
+	if err := <-snapshot.Listener.Listen(ctx, startBlock+1, svc); err != nil {
+		return err
+	}
+
+	resumeBlock, err := snapshot.Backend.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("snapshot block height: %w", err)
+	}
+	svc.snapshotResumeBlock = resumeBlock
+
+	return nil
 }
 
 // Create will create a new batch with the given ID, owner value and depth and
@@ -248,26 +359,23 @@ func (svc *batchService) Start(ctx context.Context, startBlock uint64) (err erro
 		return err
 	}
 
-	if dirty || svc.resync {
-
-		if dirty {
-			svc.logger.Warning("batch service: dirty shutdown detected, resetting batch store")
-		} else {
-			svc.logger.Warning("batch service: resync requested, resetting batch store")
-		}
-
-		if err := svc.storer.Reset(); err != nil {
+	// Reset and rebuild from the live chain when a dirty shutdown is detected or
+	// a resync was requested. A snapshot that already rebuilt the store in New is
+	// left intact: resetting it here would discard the snapshot (see #5495).
+	if dirty || (svc.resync && !svc.snapshotLoaded) {
+		if err := svc.reset(dirty); err != nil {
 			return err
 		}
-		if err := svc.stateStore.Delete(dirtyDBKey); err != nil {
-			return err
-		}
-		svc.logger.Warning("batch service: batch store has been reset. your node will now resync chain data. this might take a while...")
 	}
 
 	cs := svc.storer.GetChainState()
 	if cs.Block > startBlock {
 		startBlock = cs.Block
+	}
+	// When the store was rebuilt from a snapshot, resume live sync from the
+	// snapshot's block height rather than the requested start block.
+	if svc.snapshotResumeBlock > startBlock {
+		startBlock = svc.snapshotResumeBlock
 	}
 
 	syncedChan := svc.listener.Listen(ctx, startBlock+1, svc)

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -46,7 +46,7 @@ type batchService struct {
 	// otherwise the freshly loaded snapshot would be discarded (see #5495).
 	snapshotLoaded bool
 	// snapshotResumeBlock is the chain block height the store was rebuilt to
-	// from a postage snapshot. When non-zero, live sync resumes from here.
+	// from a postage snapshot. When set, live sync resumes from here.
 	snapshotResumeBlock uint64
 }
 
@@ -62,14 +62,12 @@ type Interface interface {
 type Snapshot struct {
 	// Listener replays the snapshot's events into the batch store.
 	Listener postage.Listener
-	// Backend reports the block height the snapshot reached, from which live
-	// sync resumes.
-	Backend interface {
-		BlockNumber(context.Context) (uint64, error)
-	}
 	// StartBlock is the block height from which the snapshot is replayed (the
 	// postage contract start block).
 	StartBlock uint64
+	// ResumeBlock is the block height the snapshot reached, from which live sync
+	// resumes once the replay completes.
+	ResumeBlock uint64
 }
 
 // New will create a new BatchService.
@@ -147,12 +145,15 @@ func New(
 	// pre-snapshot live path) and replay the snapshot onto it. A failed snapshot
 	// is not fatal; Start then rebuilds from the chain instead.
 	if snapshot != nil {
-		if dirty || resync {
-			if dirty {
-				logger.Warning("batch service: dirty shutdown detected, resetting batch store")
-			} else {
-				logger.Warning("batch service: resync requested, resetting batch store")
-			}
+		var resetReason string
+		switch {
+		case dirty:
+			resetReason = "batch service: dirty shutdown detected, resetting batch store"
+		case resync:
+			resetReason = "batch service: resync requested, resetting batch store"
+		}
+		if resetReason != "" {
+			logger.Warning(resetReason)
 			if err := bs.reset(); err != nil {
 				return nil, false, err
 			}
@@ -201,11 +202,7 @@ func (svc *batchService) loadSnapshot(ctx context.Context, snapshot *Snapshot) e
 		return err
 	}
 
-	resumeBlock, err := snapshot.Backend.BlockNumber(ctx)
-	if err != nil {
-		return fmt.Errorf("snapshot block height: %w", err)
-	}
-	svc.snapshotResumeBlock = resumeBlock
+	svc.snapshotResumeBlock = snapshot.ResumeBlock
 
 	return nil
 }
@@ -363,12 +360,15 @@ func (svc *batchService) Start(ctx context.Context, startBlock uint64) (err erro
 	// Reset and rebuild from the live chain when a dirty shutdown is detected or
 	// a resync was requested. A snapshot that already rebuilt the store in New is
 	// left intact: resetting it here would discard the snapshot (see #5495).
-	if dirty || (svc.resync && !svc.snapshotLoaded) {
-		if dirty {
-			svc.logger.Warning("batch service: dirty shutdown detected, resetting batch store")
-		} else {
-			svc.logger.Warning("batch service: resync requested, resetting batch store")
-		}
+	var resetReason string
+	switch {
+	case dirty:
+		resetReason = "batch service: dirty shutdown detected, resetting batch store"
+	case svc.resync && !svc.snapshotLoaded:
+		resetReason = "batch service: resync requested, resetting batch store"
+	}
+	if resetReason != "" {
+		svc.logger.Warning(resetReason)
 		if err := svc.reset(); err != nil {
 			return err
 		}

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -148,7 +148,12 @@ func New(
 	// is not fatal; Start then rebuilds from the chain instead.
 	if snapshot != nil {
 		if dirty || resync {
-			if err := bs.reset(dirty); err != nil {
+			if dirty {
+				logger.Warning("batch service: dirty shutdown detected, resetting batch store")
+			} else {
+				logger.Warning("batch service: resync requested, resetting batch store")
+			}
+			if err := bs.reset(); err != nil {
 				return nil, false, err
 			}
 		}
@@ -164,13 +169,9 @@ func New(
 
 // reset wipes the batch store so it can be rebuilt from scratch. It is called at
 // most once per startup, from New (snapshot rebuild) or Start (live rebuild).
-func (svc *batchService) reset(dirty bool) error {
-	if dirty {
-		svc.logger.Warning("batch service: dirty shutdown detected, resetting batch store")
-	} else {
-		svc.logger.Warning("batch service: resync requested, resetting batch store")
-	}
-
+// The reason for the reset is logged by the caller at the point of detection, so
+// the intent is recorded even if the reset itself then fails.
+func (svc *batchService) reset() error {
 	if err := svc.storer.Reset(); err != nil {
 		return err
 	}
@@ -363,7 +364,12 @@ func (svc *batchService) Start(ctx context.Context, startBlock uint64) (err erro
 	// a resync was requested. A snapshot that already rebuilt the store in New is
 	// left intact: resetting it here would discard the snapshot (see #5495).
 	if dirty || (svc.resync && !svc.snapshotLoaded) {
-		if err := svc.reset(dirty); err != nil {
+		if dirty {
+			svc.logger.Warning("batch service: dirty shutdown detected, resetting batch store")
+		} else {
+			svc.logger.Warning("batch service: resync requested, resetting batch store")
+		}
+		if err := svc.reset(); err != nil {
 			return err
 		}
 	}

--- a/pkg/postage/batchservice/batchservice.go
+++ b/pkg/postage/batchservice/batchservice.go
@@ -39,12 +39,7 @@ type batchService struct {
 	batchListener postage.BatchEventListener
 
 	checksum hash.Hash // checksum hasher
-	resync   bool
 
-	// snapshotLoaded reports whether the store was rebuilt from a postage
-	// snapshot in New. When true, Start must not reset the store again,
-	// otherwise the freshly loaded snapshot would be discarded (see #5495).
-	snapshotLoaded bool
 	// snapshotResumeBlock is the chain block height the store was rebuilt to
 	// from a postage snapshot. When set, live sync resumes from here.
 	snapshotResumeBlock uint64
@@ -72,12 +67,11 @@ type Snapshot struct {
 
 // New will create a new BatchService.
 //
-// When a snapshot is provided it is replayed before the service is returned
-// (resetting the store first if a resync was requested or a dirty shutdown was
-// detected), and snapshotLoaded reports whether that succeeded. When no snapshot
-// is loaded, a resync or dirty shutdown instead triggers a single reset in Start
-// so live sync rebuilds the store from the chain. The store is therefore reset
-// at most once across New and Start.
+// The batch store is reset here, in the constructor, when a resync was requested
+// or a dirty shutdown was detected. A provided snapshot is then replayed onto the
+// (possibly reset) store; if that replay fails the store is reset again so live
+// sync can rebuild it from the chain. Start never resets the store. The returned
+// bool reports whether the snapshot was replayed successfully.
 func New(
 	ctx context.Context,
 	stateStore storage.StateStorer,
@@ -104,8 +98,12 @@ func New(
 	if err := stateStore.Get(dirtyDBKey, &dirty); err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return nil, false, err
 	}
+	if dirty {
+		logger.Warning("batch service: dirty shutdown detected, resetting batch store")
+	}
 
 	if resync {
+		logger.Warning("batch service: resync requested, resetting batch store")
 		if err := stateStore.Delete(checksumDBKey); err != nil {
 			return nil, false, err
 		}
@@ -137,41 +135,37 @@ func New(
 		owner:         owner,
 		batchListener: batchListener,
 		checksum:      sum,
-		resync:        resync,
 	}
 
-	// When a snapshot is supplied the rebuild happens here: reset the store (only
-	// if a resync was requested or a dirty shutdown was detected, mirroring the
-	// pre-snapshot live path) and replay the snapshot onto it. A failed snapshot
-	// is not fatal; Start then rebuilds from the chain instead.
-	if snapshot != nil {
-		var resetReason string
-		switch {
-		case dirty:
-			resetReason = "batch service: dirty shutdown detected, resetting batch store"
-		case resync:
-			resetReason = "batch service: resync requested, resetting batch store"
+	// Reset the store once, here, when a resync was requested or a dirty shutdown
+	// was detected (both already logged above). A snapshot is then replayed onto
+	// the store; Start does not reset, so this is the only unconditional reset.
+	if dirty || resync {
+		if err := bs.reset(); err != nil {
+			return nil, false, err
 		}
-		if resetReason != "" {
-			logger.Warning(resetReason)
+	}
+
+	snapshotLoaded := false
+	if snapshot != nil {
+		if err := bs.loadSnapshot(ctx, snapshot); err != nil {
+			logger.Error(err, "failed to start batch service from snapshot, continuing outside snapshot block...")
+			// A partial replay may have written to (and dirtied) the store, so
+			// reset it again to rebuild cleanly from the chain during live sync.
 			if err := bs.reset(); err != nil {
 				return nil, false, err
 			}
-		}
-		if err := bs.loadSnapshot(ctx, snapshot); err != nil {
-			logger.Error(err, "failed to start batch service from snapshot, continuing outside snapshot block...")
 		} else {
-			bs.snapshotLoaded = true
+			snapshotLoaded = true
 		}
 	}
 
-	return bs, bs.snapshotLoaded, nil
+	return bs, snapshotLoaded, nil
 }
 
-// reset wipes the batch store so it can be rebuilt from scratch. It is called at
-// most once per startup, from New (snapshot rebuild) or Start (live rebuild).
-// The reason for the reset is logged by the caller at the point of detection, so
-// the intent is recorded even if the reset itself then fails.
+// reset wipes the batch store so it can be rebuilt from scratch. It runs only
+// during New. The reason for the reset is logged by the caller at the point of
+// detection, so the intent is recorded even if the reset itself then fails.
 func (svc *batchService) reset() error {
 	if err := svc.storer.Reset(); err != nil {
 		return err
@@ -351,29 +345,7 @@ func (svc *batchService) TransactionEnd() error {
 var ErrInterruped = errors.New("postage sync interrupted")
 
 func (svc *batchService) Start(ctx context.Context, startBlock uint64) (err error) {
-	dirty := false
-	err = svc.stateStore.Get(dirtyDBKey, &dirty)
-	if err != nil && !errors.Is(err, storage.ErrNotFound) {
-		return err
-	}
-
-	// Reset and rebuild from the live chain when a dirty shutdown is detected or
-	// a resync was requested. A snapshot that already rebuilt the store in New is
-	// left intact: resetting it here would discard the snapshot (see #5495).
-	var resetReason string
-	switch {
-	case dirty:
-		resetReason = "batch service: dirty shutdown detected, resetting batch store"
-	case svc.resync && !svc.snapshotLoaded:
-		resetReason = "batch service: resync requested, resetting batch store"
-	}
-	if resetReason != "" {
-		svc.logger.Warning(resetReason)
-		if err := svc.reset(); err != nil {
-			return err
-		}
-	}
-
+	// The store reset already happened in New, so Start only drives live sync.
 	cs := svc.storer.GetChainState()
 	if cs.Block > startBlock {
 		startBlock = cs.Block

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -635,15 +635,6 @@ func (r *recordingListener) Close() error {
 	return r.closeErr
 }
 
-type mockSnapshotBackend struct {
-	block uint64
-	err   error
-}
-
-func (m mockSnapshotBackend) BlockNumber(context.Context) (uint64, error) {
-	return m.block, m.err
-}
-
 // TestSnapshotRebuild covers the snapshot rebuild path and the #5495 fix: live
 // sync resumes from the snapshot's block height, and the store is reset at most
 // once even when --resync is set alongside a snapshot (never twice, which would
@@ -654,9 +645,9 @@ func TestSnapshotRebuild(t *testing.T) {
 	newSnapshot := func() (*recordingListener, *batchservice.Snapshot) {
 		snapListener := &recordingListener{}
 		return snapListener, &batchservice.Snapshot{
-			Listener:   snapListener,
-			Backend:    mockSnapshotBackend{block: 4096},
-			StartBlock: 100,
+			Listener:    snapListener,
+			StartBlock:  100,
+			ResumeBlock: 4096,
 		}
 	}
 
@@ -687,11 +678,13 @@ func TestSnapshotRebuild(t *testing.T) {
 			t.Fatal("expected snapshot listener to be closed")
 		}
 
+		// Live sync resumes from the snapshot's block height, not the requested
+		// start block.
 		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
 			t.Fatal(err)
 		}
-		if liveListener.from != 4097 {
-			t.Fatalf("expect live sync from 4097 got %d", liveListener.from)
+		if liveListener.from != snapshot.ResumeBlock+1 {
+			t.Fatalf("expect live sync from %d got %d", snapshot.ResumeBlock+1, liveListener.from)
 		}
 		if c := store.ResetCalls(); c != 0 {
 			t.Fatalf("expect store never reset, got %d", c)
@@ -729,18 +722,18 @@ func TestSnapshotRebuild(t *testing.T) {
 }
 
 // TestSnapshotCornerCases pushes the snapshot rebuild path into its failure and
-// boundary scenarios: a failed replay, an unavailable snapshot block height, a
-// dirty shutdown coinciding with a snapshot, a chain state already ahead of the
-// snapshot, and a listener that errors on close.
+// boundary scenarios: a failed replay, a dirty shutdown coinciding with a
+// snapshot, a chain state already ahead of the snapshot, and a listener that
+// errors on close.
 func TestSnapshotCornerCases(t *testing.T) {
 	t.Parallel()
 
 	newSnapshot := func(listenErr error) (*recordingListener, *batchservice.Snapshot) {
 		snapListener := &recordingListener{listenErr: listenErr}
 		return snapListener, &batchservice.Snapshot{
-			Listener:   snapListener,
-			Backend:    mockSnapshotBackend{block: 4096},
-			StartBlock: 100,
+			Listener:    snapListener,
+			StartBlock:  100,
+			ResumeBlock: 4096,
 		}
 	}
 
@@ -803,30 +796,6 @@ func TestSnapshotCornerCases(t *testing.T) {
 		// from the chain. Two resets is correct here (matrix row 8).
 		if c := store.ResetCalls(); c != 2 {
 			t.Fatalf("expect %d reset calls after Start got %d", 2, c)
-		}
-	})
-
-	t.Run("backend block-height error fails the load", func(t *testing.T) {
-		t.Parallel()
-
-		s := mocks.NewStateStore()
-		store := mock.New()
-		snapListener := &recordingListener{}
-		snapshot := &batchservice.Snapshot{
-			Listener:   snapListener,
-			Backend:    mockSnapshotBackend{block: 4096, err: errTest},
-			StartBlock: 100,
-		}
-
-		_, loaded, err := batchservice.New(context.Background(), s, store, testLog, &recordingListener{}, nil, nil, nil, snapshot, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if loaded {
-			t.Fatal("expected load to fail when the snapshot block height is unavailable")
-		}
-		if !snapListener.listened {
-			t.Fatal("expected snapshot replay to have run before the block-height lookup")
 		}
 	})
 
@@ -908,7 +877,6 @@ func TestSnapshotCornerCases(t *testing.T) {
 		snapListener := &recordingListener{closeErr: errTest}
 		snapshot := &batchservice.Snapshot{
 			Listener:   snapListener,
-			Backend:    mockSnapshotBackend{block: 4096},
 			StartBlock: 100,
 		}
 

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -564,12 +564,12 @@ func TestTransactionError(t *testing.T) {
 }
 
 // TestResyncControlsReset checks that, with no snapshot, the resync flag passed
-// to New determines whether Start resets the store, and that the reset happens
-// in Start (after node.go's wrong-chain guard has inspected the chain state).
+// to New determines whether the store is reset, and that the reset happens in
+// New (the constructor), with Start never resetting.
 func TestResyncControlsReset(t *testing.T) {
 	t.Parallel()
 
-	t.Run("resync resets the store", func(t *testing.T) {
+	t.Run("resync resets the store in New", func(t *testing.T) {
 		t.Parallel()
 
 		s := mocks.NewStateStore()
@@ -579,16 +579,15 @@ func TestResyncControlsReset(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// The reset is deferred to Start, not New, so the store is untouched
-		// while node.go performs its wrong-chain block-height check.
-		if c := store.ResetCalls(); c != 0 {
-			t.Fatalf("expect %d reset calls before Start got %d", 0, c)
+		// The reset happens in the constructor.
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls after New got %d", 1, c)
 		}
 
+		// Start never resets.
 		if err := svc.Start(context.Background(), 10); err != nil {
 			t.Fatal(err)
 		}
-
 		if c := store.ResetCalls(); c != 1 {
 			t.Fatalf("expect %d reset calls got %d", 1, c)
 		}
@@ -755,22 +754,26 @@ func TestSnapshotCornerCases(t *testing.T) {
 		if !snapListener.closed {
 			t.Fatal("expected snapshot listener to be closed even on failure")
 		}
-		// resync=false and the store is empty: nothing to reset.
-		if c := store.ResetCalls(); c != 0 {
-			t.Fatalf("expect %d reset calls got %d", 0, c)
+		// A partial replay may have dirtied the store, so New resets it once to
+		// clean up for the live rebuild.
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls after New got %d", 1, c)
 		}
 
 		// Live sync still proceeds, from the requested start block, since no
-		// snapshot resume point was recorded.
+		// snapshot resume point was recorded; Start never resets.
 		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
 			t.Fatal(err)
 		}
 		if liveListener.from != snapshot.StartBlock+1 {
 			t.Fatalf("expect live sync from %d got %d", snapshot.StartBlock+1, liveListener.from)
 		}
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect store reset exactly once, got %d", c)
+		}
 	})
 
-	t.Run("replay failure with resync resets in New and again in Start", func(t *testing.T) {
+	t.Run("replay failure with resync resets once before and once after the replay", func(t *testing.T) {
 		t.Parallel()
 
 		s := mocks.NewStateStore()
@@ -785,15 +788,14 @@ func TestSnapshotCornerCases(t *testing.T) {
 		if loaded {
 			t.Fatal("expected snapshot not to be loaded on replay error")
 		}
-		// resync resets once during the (failed) snapshot rebuild...
-		if c := store.ResetCalls(); c != 1 {
-			t.Fatalf("expect %d reset calls after New got %d", 1, c)
+		// resync resets once up front, then the failed replay's cleanup resets
+		// again — both in New. Start never resets.
+		if c := store.ResetCalls(); c != 2 {
+			t.Fatalf("expect %d reset calls after New got %d", 2, c)
 		}
 		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
 			t.Fatal(err)
 		}
-		// ...and again in Start because no snapshot loaded, so the store is rebuilt
-		// from the chain. Two resets is correct here (matrix row 8).
 		if c := store.ResetCalls(); c != 2 {
 			t.Fatalf("expect %d reset calls after Start got %d", 2, c)
 		}

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -525,7 +525,7 @@ func TestTransactionOk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc2, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, false)
+	svc2, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +550,7 @@ func TestTransactionError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc2, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, false)
+	svc2, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -563,10 +563,9 @@ func TestTransactionError(t *testing.T) {
 	}
 }
 
-// TestResyncControlsReset checks that the resync flag passed to New determines
-// whether Start resets the store. node.go relies on this to fix #5495: the live
-// batch service is constructed with resync=false after a snapshot rebuilt the
-// store, so Start leaves it intact instead of discarding the snapshot.
+// TestResyncControlsReset checks that, with no snapshot, the resync flag passed
+// to New determines whether Start resets the store, and that the reset happens
+// in Start (after node.go's wrong-chain guard has inspected the chain state).
 func TestResyncControlsReset(t *testing.T) {
 	t.Parallel()
 
@@ -575,9 +574,15 @@ func TestResyncControlsReset(t *testing.T) {
 
 		s := mocks.NewStateStore()
 		store := mock.New()
-		svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, true)
+		svc, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, nil, nil, true)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		// The reset is deferred to Start, not New, so the store is untouched
+		// while node.go performs its wrong-chain block-height check.
+		if c := store.ResetCalls(); c != 0 {
+			t.Fatalf("expect %d reset calls before Start got %d", 0, c)
 		}
 
 		if err := svc.Start(context.Background(), 10); err != nil {
@@ -594,7 +599,7 @@ func TestResyncControlsReset(t *testing.T) {
 
 		s := mocks.NewStateStore()
 		store := mock.New()
-		svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, false)
+		svc, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, nil, nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -609,13 +614,324 @@ func TestResyncControlsReset(t *testing.T) {
 	})
 }
 
+type recordingListener struct {
+	from      uint64
+	listened  bool
+	closed    bool
+	listenErr error
+	closeErr  error
+}
+
+func (r *recordingListener) Listen(_ context.Context, from uint64, _ postage.EventUpdater) <-chan error {
+	r.listened = true
+	r.from = from
+	c := make(chan error, 1)
+	c <- r.listenErr
+	return c
+}
+
+func (r *recordingListener) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+type mockSnapshotBackend struct {
+	block uint64
+	err   error
+}
+
+func (m mockSnapshotBackend) BlockNumber(context.Context) (uint64, error) {
+	return m.block, m.err
+}
+
+// TestSnapshotRebuild covers the snapshot rebuild path and the #5495 fix: live
+// sync resumes from the snapshot's block height, and the store is reset at most
+// once even when --resync is set alongside a snapshot (never twice, which would
+// discard the freshly loaded snapshot).
+func TestSnapshotRebuild(t *testing.T) {
+	t.Parallel()
+
+	newSnapshot := func() (*recordingListener, *batchservice.Snapshot) {
+		snapListener := &recordingListener{}
+		return snapListener, &batchservice.Snapshot{
+			Listener:   snapListener,
+			Backend:    mockSnapshotBackend{block: 4096},
+			StartBlock: 100,
+		}
+	}
+
+	t.Run("snapshot replays and live sync resumes from its block", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		snapListener, snapshot := newSnapshot()
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !loaded {
+			t.Fatal("expected snapshot to be loaded")
+		}
+		// The store is empty when a snapshot applies (snapshot only runs when no
+		// batch store exists), so without --resync there is nothing to reset.
+		if c := store.ResetCalls(); c != 0 {
+			t.Fatalf("expect %d reset calls got %d", 0, c)
+		}
+		if snapListener.from != snapshot.StartBlock+1 {
+			t.Fatalf("expect snapshot replay from %d got %d", snapshot.StartBlock+1, snapListener.from)
+		}
+		if !snapListener.closed {
+			t.Fatal("expected snapshot listener to be closed")
+		}
+
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		if liveListener.from != 4097 {
+			t.Fatalf("expect live sync from 4097 got %d", liveListener.from)
+		}
+		if c := store.ResetCalls(); c != 0 {
+			t.Fatalf("expect store never reset, got %d", c)
+		}
+	})
+
+	t.Run("resync alongside a snapshot still resets only once", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		_, snapshot := newSnapshot()
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !loaded {
+			t.Fatal("expected snapshot to be loaded")
+		}
+		// --resync resets once during the snapshot rebuild in New.
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls after New got %d", 1, c)
+		}
+
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		// Start must not reset again: that second reset was the #5495 bug.
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect store reset exactly once with snapshot+resync, got %d", c)
+		}
+	})
+}
+
+// TestSnapshotCornerCases pushes the snapshot rebuild path into its failure and
+// boundary scenarios: a failed replay, an unavailable snapshot block height, a
+// dirty shutdown coinciding with a snapshot, a chain state already ahead of the
+// snapshot, and a listener that errors on close.
+func TestSnapshotCornerCases(t *testing.T) {
+	t.Parallel()
+
+	newSnapshot := func(listenErr error) (*recordingListener, *batchservice.Snapshot) {
+		snapListener := &recordingListener{listenErr: listenErr}
+		return snapListener, &batchservice.Snapshot{
+			Listener:   snapListener,
+			Backend:    mockSnapshotBackend{block: 4096},
+			StartBlock: 100,
+		}
+	}
+
+	t.Run("replay failure falls back to live sync without loading", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		snapListener, snapshot := newSnapshot(errTest)
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatalf("a failed replay must not be fatal: %v", err)
+		}
+		if loaded {
+			t.Fatal("expected snapshot not to be loaded on replay error")
+		}
+		if !snapListener.closed {
+			t.Fatal("expected snapshot listener to be closed even on failure")
+		}
+		// resync=false and the store is empty: nothing to reset.
+		if c := store.ResetCalls(); c != 0 {
+			t.Fatalf("expect %d reset calls got %d", 0, c)
+		}
+
+		// Live sync still proceeds, from the requested start block, since no
+		// snapshot resume point was recorded.
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		if liveListener.from != snapshot.StartBlock+1 {
+			t.Fatalf("expect live sync from %d got %d", snapshot.StartBlock+1, liveListener.from)
+		}
+	})
+
+	t.Run("replay failure with resync resets in New and again in Start", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		_, snapshot := newSnapshot(errTest)
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if loaded {
+			t.Fatal("expected snapshot not to be loaded on replay error")
+		}
+		// resync resets once during the (failed) snapshot rebuild...
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls after New got %d", 1, c)
+		}
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		// ...and again in Start because no snapshot loaded, so the store is rebuilt
+		// from the chain. Two resets is correct here (matrix row 8).
+		if c := store.ResetCalls(); c != 2 {
+			t.Fatalf("expect %d reset calls after Start got %d", 2, c)
+		}
+	})
+
+	t.Run("backend block-height error fails the load", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		snapListener := &recordingListener{}
+		snapshot := &batchservice.Snapshot{
+			Listener:   snapListener,
+			Backend:    mockSnapshotBackend{block: 4096, err: errTest},
+			StartBlock: 100,
+		}
+
+		_, loaded, err := batchservice.New(context.Background(), s, store, testLog, &recordingListener{}, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if loaded {
+			t.Fatal("expected load to fail when the snapshot block height is unavailable")
+		}
+		if !snapListener.listened {
+			t.Fatal("expected snapshot replay to have run before the block-height lookup")
+		}
+	})
+
+	t.Run("dirty shutdown with a snapshot resets exactly once", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+
+		// Simulate a dirty shutdown: a prior service started a transaction and
+		// never finished it, leaving the dirty marker set.
+		prior, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, nil, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := prior.TransactionStart(); err != nil {
+			t.Fatal(err)
+		}
+
+		snapListener, snapshot := newSnapshot(nil)
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !loaded {
+			t.Fatal("expected snapshot to be loaded")
+		}
+		if !snapListener.closed {
+			t.Fatal("expected snapshot listener to be closed")
+		}
+		// The dirty flag triggers one reset during the snapshot rebuild...
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls after New got %d", 1, c)
+		}
+		// ...and Start must not reset again and wipe the freshly loaded snapshot.
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect store reset exactly once, got %d", c)
+		}
+	})
+
+	t.Run("persisted chain state ahead of the snapshot block wins", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		_, snapshot := newSnapshot(nil) // snapshot block 4096
+		liveListener := &recordingListener{}
+
+		svc, loaded, err := batchservice.New(context.Background(), s, store, testLog, liveListener, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !loaded {
+			t.Fatal("expected snapshot to be loaded")
+		}
+
+		// A chain state further ahead than the snapshot must take precedence so
+		// live sync never rewinds and reprocesses events.
+		putChainState(t, store, &postage.ChainState{Block: 5000, TotalAmount: big.NewInt(0), CurrentPrice: big.NewInt(0)})
+
+		if err := svc.Start(context.Background(), snapshot.StartBlock); err != nil {
+			t.Fatal(err)
+		}
+		if liveListener.from != 5001 {
+			t.Fatalf("expect live sync from 5001 got %d", liveListener.from)
+		}
+	})
+
+	t.Run("snapshot listener close error is not fatal", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		snapListener := &recordingListener{closeErr: errTest}
+		snapshot := &batchservice.Snapshot{
+			Listener:   snapListener,
+			Backend:    mockSnapshotBackend{block: 4096},
+			StartBlock: 100,
+		}
+
+		_, loaded, err := batchservice.New(context.Background(), s, store, testLog, &recordingListener{}, nil, nil, nil, snapshot, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !loaded {
+			t.Fatal("expected snapshot to be loaded despite a listener close error")
+		}
+		if !snapListener.closed {
+			t.Fatal("expected snapshot listener close to be attempted")
+		}
+	})
+}
+
 func TestChecksum(t *testing.T) {
 	t.Parallel()
 
 	s := mocks.NewStateStore()
 	store := mock.New()
 	mockHash := &hs{}
-	svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash }, false)
+	svc, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash }, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +954,7 @@ func TestChecksumResync(t *testing.T) {
 	s := mocks.NewStateStore()
 	store := mock.New()
 	mockHash := &hs{}
-	svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash }, true)
+	svc, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash }, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -657,7 +973,7 @@ func TestChecksumResync(t *testing.T) {
 	// now start a new instance and check that the value gets read from statestore
 	store2 := mock.New()
 	mockHash2 := &hs{}
-	_, err = batchservice.New(s, store2, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash2 }, false)
+	_, _, err = batchservice.New(context.Background(), s, store2, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash2 }, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -669,7 +985,7 @@ func TestChecksumResync(t *testing.T) {
 	// when resyncing
 	store3 := mock.New()
 	mockHash3 := &hs{}
-	_, err = batchservice.New(s, store3, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash3 }, true)
+	_, _, err = batchservice.New(context.Background(), s, store3, testLog, newMockListener(), nil, nil, func() hash.Hash { return mockHash3 }, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +1003,7 @@ func newTestStoreAndServiceWithListener(
 	t.Helper()
 	s := mocks.NewStateStore()
 	store := mock.New(opts...)
-	svc, err := batchservice.New(s, store, testLog, newMockListener(), owner, batchListener, nil, false)
+	svc, _, err := batchservice.New(context.Background(), s, store, testLog, newMockListener(), owner, batchListener, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/postage/batchservice/batchservice_test.go
+++ b/pkg/postage/batchservice/batchservice_test.go
@@ -563,6 +563,52 @@ func TestTransactionError(t *testing.T) {
 	}
 }
 
+// TestResyncControlsReset checks that the resync flag passed to New determines
+// whether Start resets the store. node.go relies on this to fix #5495: the live
+// batch service is constructed with resync=false after a snapshot rebuilt the
+// store, so Start leaves it intact instead of discarding the snapshot.
+func TestResyncControlsReset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resync resets the store", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.Start(context.Background(), 10); err != nil {
+			t.Fatal(err)
+		}
+
+		if c := store.ResetCalls(); c != 1 {
+			t.Fatalf("expect %d reset calls got %d", 1, c)
+		}
+	})
+
+	t.Run("no resync leaves the store intact", func(t *testing.T) {
+		t.Parallel()
+
+		s := mocks.NewStateStore()
+		store := mock.New()
+		svc, err := batchservice.New(s, store, testLog, newMockListener(), nil, nil, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.Start(context.Background(), 10); err != nil {
+			t.Fatal(err)
+		}
+
+		if c := store.ResetCalls(); c != 0 {
+			t.Fatalf("expect %d reset calls got %d", 0, c)
+		}
+	})
+}
+
 func TestChecksum(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/postage/snapshot/archive/archive.go
+++ b/pkg/postage/snapshot/archive/archive.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Swarm Authors. All rights reserved.
+// Copyright 2026 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/postage/snapshot/archive/archive.go
+++ b/pkg/postage/snapshot/archive/archive.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package archive provides a snapshot.SnapshotGetter backed by the postage batch
+// snapshot blob embedded in the binary at build time. It is the single importer
+// of the (large) embedded archive, keeping that payload out of pkg/postage/snapshot
+// and its other consumers.
+package archive
+
+import (
+	batcharchive "github.com/ethersphere/batch-archive"
+	"github.com/ethersphere/bee/v2/pkg/postage/snapshot"
+)
+
+var _ snapshot.SnapshotGetter = Getter{}
+
+// Getter sources the postage batch snapshot from the embedded archive blob.
+type Getter struct{}
+
+func (Getter) GetBatchSnapshot() []byte {
+	return batcharchive.GetBatchSnapshot()
+}

--- a/pkg/postage/snapshot/factory.go
+++ b/pkg/postage/snapshot/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Swarm Authors. All rights reserved.
+// Copyright 2026 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/postage/snapshot/factory.go
+++ b/pkg/postage/snapshot/factory.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/postage/batchservice"
+	"github.com/ethersphere/bee/v2/pkg/postage/listener"
+	"github.com/ethersphere/bee/v2/pkg/util/syncutil"
+)
+
+// New assembles the postage-snapshot inputs the batch service needs to rebuild
+// the store from the embedded snapshot: a listener that replays the snapshot's
+// logs, the block the replay starts from, and the block height it reaches. The
+// snapshot is parsed eagerly to resolve that height, so a corrupt snapshot
+// surfaces here as an error and the caller can fall back to a full chain rebuild.
+func New(
+	ctx context.Context,
+	logger log.Logger,
+	getter SnapshotGetter,
+	syncingStopped *syncutil.Signaler,
+	contractAddress common.Address,
+	contractABI abi.ABI,
+	blockTime time.Duration,
+	stallingTimeout time.Duration,
+	backoffTimeout time.Duration,
+	startBlock uint64,
+) (*batchservice.Snapshot, error) {
+	filterer := NewSnapshotLogFilterer(logger, getter)
+
+	resumeBlock, err := filterer.BlockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read postage snapshot: %w", err)
+	}
+
+	eventListener := listener.New(syncingStopped, logger, filterer, contractAddress, contractABI, blockTime, stallingTimeout, backoffTimeout)
+
+	return &batchservice.Snapshot{
+		Listener:    eventListener,
+		StartBlock:  startBlock,
+		ResumeBlock: resumeBlock,
+	}, nil
+}

--- a/pkg/postage/snapshot/snapshot.go
+++ b/pkg/postage/snapshot/snapshot.go
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package node
+// Package snapshot provides a BlockHeightContractFilterer backed by a
+// pre-computed postage batch snapshot, used to rebuild the batch store from an
+// embedded snapshot instead of replaying the whole postage contract history.
+package snapshot
 
 import (
 	"bytes"
@@ -17,7 +20,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
-	archive "github.com/ethersphere/batch-archive"
 	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/postage/listener"
 )
@@ -26,12 +28,6 @@ var _ listener.BlockHeightContractFilterer = (*SnapshotLogFilterer)(nil)
 
 type SnapshotGetter interface {
 	GetBatchSnapshot() []byte
-}
-
-type archiveSnapshotGetter struct{}
-
-func (a archiveSnapshotGetter) GetBatchSnapshot() []byte {
-	return archive.GetBatchSnapshot()
 }
 
 type SnapshotLogFilterer struct {

--- a/pkg/postage/snapshot/snapshot_test.go
+++ b/pkg/postage/snapshot/snapshot_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package node_test
+package snapshot_test
 
 import (
 	"bytes"
@@ -11,13 +11,15 @@ import (
 	"encoding/json"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethersphere/bee/v2/pkg/log"
-	"github.com/ethersphere/bee/v2/pkg/node"
 	"github.com/ethersphere/bee/v2/pkg/postage/listener"
+	"github.com/ethersphere/bee/v2/pkg/postage/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +52,7 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 	t.Run("invalid gzip", func(t *testing.T) {
 		t.Parallel()
 		getter := newMockSnapshotGetter([]byte("not-gzip"))
-		filterer := node.NewSnapshotLogFilterer(log.Noop, getter)
+		filterer := snapshot.NewSnapshotLogFilterer(log.Noop, getter)
 		_, err := filterer.BlockNumber(context.Background())
 		assert.Error(t, err)
 	})
@@ -63,7 +65,7 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 		require.NoError(t, err)
 		gz.Close()
 		getter := newMockSnapshotGetter(buf.Bytes())
-		filterer := node.NewSnapshotLogFilterer(log.Noop, getter)
+		filterer := snapshot.NewSnapshotLogFilterer(log.Noop, getter)
 		_, err = filterer.BlockNumber(context.Background())
 		assert.ErrorIs(t, err, listener.ErrParseSnapshot)
 	})
@@ -76,7 +78,7 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 			{BlockNumber: 2, Topics: []common.Hash{}},
 		}
 		getter := newMockSnapshotGetter(makeSnapshotData(logs))
-		filterer := node.NewSnapshotLogFilterer(log.Noop, getter)
+		filterer := snapshot.NewSnapshotLogFilterer(log.Noop, getter)
 
 		_, err := filterer.BlockNumber(context.Background())
 		assert.ErrorIs(t, err, listener.ErrParseSnapshot)
@@ -91,7 +93,7 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 			{BlockNumber: 3, Topics: []common.Hash{}},
 		}
 		getter := newMockSnapshotGetter(makeSnapshotData(logs))
-		filterer := node.NewSnapshotLogFilterer(log.Noop, getter)
+		filterer := snapshot.NewSnapshotLogFilterer(log.Noop, getter)
 
 		blockNumber, err := filterer.BlockNumber(context.Background())
 		assert.NoError(t, err)
@@ -107,7 +109,7 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 			{BlockNumber: 5, Address: common.HexToAddress("0x4"), TxHash: common.HexToHash("0x4"), Topics: []common.Hash{common.HexToHash("0xa4"), common.HexToHash("0xa5")}},
 		}
 		getter := newMockSnapshotGetter(makeSnapshotData(logs))
-		filterer := node.NewSnapshotLogFilterer(log.Noop, getter)
+		filterer := snapshot.NewSnapshotLogFilterer(log.Noop, getter)
 
 		res, err := filterer.FilterLogs(context.Background(), ethereum.FilterQuery{
 			FromBlock: big.NewInt(2),
@@ -148,5 +150,30 @@ func TestNewSnapshotLogFilterer(t *testing.T) {
 		assert.Equal(t, 0, res[1].Topics[0].Cmp(common.HexToHash("0xa1")))
 		assert.Equal(t, 0, res[2].Topics[0].Cmp(common.HexToHash("0xa4")))
 		assert.Equal(t, 0, res[3].Topics[0].Cmp(common.HexToHash("0xa4")))
+	})
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	logs := []types.Log{
+		{BlockNumber: 1, Topics: []common.Hash{}},
+		{BlockNumber: 5, Topics: []common.Hash{}},
+	}
+	getter := newMockSnapshotGetter(makeSnapshotData(logs))
+
+	snap, err := snapshot.New(context.Background(), log.Noop, getter, nil,
+		common.Address{}, abi.ABI{}, time.Second, time.Second, time.Second, 100)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(100), snap.StartBlock)
+	assert.Equal(t, uint64(5), snap.ResumeBlock) // max block height in the snapshot
+	assert.NotNil(t, snap.Listener)
+
+	t.Run("corrupt snapshot returns an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := snapshot.New(context.Background(), log.Noop, newMockSnapshotGetter([]byte("not-gzip")), nil,
+			common.Address{}, abi.ABI{}, time.Second, time.Second, time.Second, 100)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Fixes #5495: a node started with `--resync` while the postage snapshot is active shuts down during sync with:

```
get: get batch <id>: storage: not found
```

#### Root cause

The batch store is reset **twice** on startup in this configuration:

1. `snapshotBatchSvc.Start()` resets the store (`resync`) and rebuilds it from the snapshot, then sets `postageSyncStart = maxBlockHeight`.
2. The live `batchSvc` was constructed with the same `o.Resync` flag, so its `Start()` reset the store **again**, discarding the snapshot that was just loaded.

Live sync then started from the snapshot block height against an **empty** store, so the first top-up/dilute event referencing a batch created before the snapshot height failed with `storage: not found`, and the node shut down.

This matches the report exactly: two `"resync requested, resetting batch store"` log lines, and the fact that `skip-postage-snapshot` works around it (only one reset, and sync replays from contract genesis where every create precedes its top-up).

Note: this is **independent of #5343/#5482**. The flow originates in #5094 and is still present on master; the reporter's build (`2.8.0-41d6efc6`) predates the #5343 revert, but reverting #5343 does not address this.

#### Fix

The two reset sites are not redundant — one rebuilds from the snapshot, the other is the fallback rebuild for the no-snapshot / snapshot-failed / non-mainnet cases — they were just both armed at once.

Construct the live batch service **after** the snapshot path has run and pass resync only when the snapshot did not rebuild the store:

```go
batchSvc, err = batchservice.New(..., o.Resync && !snapshotLoaded)
```

The reset logic stays in its single existing place (`batchservice.Start()`), exactly one service is armed to reset, and there is no runtime toggle. The store is still reset exactly once in every other case (snapshot skipped, failed, not applicable, or a non-resync start).

### Testing

- `TestResyncControlsReset` in `batchservice` asserts both directions of the contract `node.go` relies on:
  - `resync=true` ⇒ store reset once
  - `resync=false` ⇒ store **not** reset (the post-snapshot live-service case)
- `go test -race ./pkg/postage/batchservice/...` passes
- `go build ./pkg/node/...` passes; `go vet`, `gofumpt`, and `golangci-lint` clean

### Open API Spec Version Changes (if applicable)

None.

### Related Issue

Closes #5495

### AI Disclosure

- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
