### PR TITLE
chore(redundancy): increment fetchedCnt before closing wait channel

### DIFF
--- a/pkg/file/redundancy/getter/getter.go
+++ b/pkg/file/redundancy/getter/getter.go
@@ -151,8 +151,8 @@ func (g *decoder) fetch(ctx context.Context, i int, waitForRecovery bool) (err e
 		}
 
 		g.setData(i, ch.Data())
-		close(g.waits[i])
 		g.fetchedCnt.Add(1)
+		close(g.waits[i])
 		return nil
 	}
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Independent ordering-correctness change in decoder.fetch().
On the successful-retrieval path the per-shard wait channel was closed before fetchedCnt was incremented

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
