### PR TITLE
ci: auto-assign PR author when none is set

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,30 @@
+name: Auto-assign PR author
+
+# When a PR is opened without an assignee, assign its author, so no PR is left
+# unassigned (visibility in boards/filters/reports). This only sets the assignee
+# field — it is not a review-accountability mechanism (that's CODEOWNERS).
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    # Only internal-branch PRs (fork PRs get a read-only token and their author
+    # isn't a collaborator, so assignment can't apply), and only when the author
+    # left it unassigned.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.assignees[0] == null
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
## What
Adds a small workflow that assigns the PR **author** as the assignee when a PR is opened without one, so no PR is left unassigned (helps board/filter/report visibility).

## How
- Uses the official `actions/github-script` — no third-party/marketplace action, no external dependency.
- Triggers only on `pull_request: opened`.
- Skips if an assignee is already set (no duplicate, doesn't override an author-chosen assignee).
- Skips fork PRs (their token is read-only and the author isn't a collaborator, so assignment can't apply).
- Minimal permission: the built-in `GITHUB_TOKEN` with `pull-requests: write`, scoped to the run — no PAT, no GitHub App.

## Note
This only populates the assignee field for tracking visibility — it is intentionally **not** a review-accountability mechanism. That would be CODEOWNERS, which is deferred until path → owner boundaries are defined.
