### PR TITLE
fix(api): guard nil postage contract in /chainstate during startup

### DIFF
--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -458,12 +458,16 @@ func (s *Service) chainStateHandler(w http.ResponseWriter, r *http.Request) {
 		jsonhttp.InternalServerError(w, "block number unavailable")
 		return
 	}
-	minimumValidityBlocks, err := s.postageContract.MinimumValidityBlocks(r.Context())
-	if err != nil && !errors.Is(err, postagecontract.ErrChainDisabled) {
-		logger.Debug("get minimum validity blocks failed", "error", err)
-		logger.Error(nil, "get minimum validity blocks failed")
-		jsonhttp.InternalServerError(w, "minimum validity blocks unavailable")
-		return
+	// postageContract is wired in Configure; guard against early calls during startup.
+	var minimumValidityBlocks uint64
+	if s.postageContract != nil {
+		minimumValidityBlocks, err = s.postageContract.MinimumValidityBlocks(r.Context())
+		if err != nil && !errors.Is(err, postagecontract.ErrChainDisabled) {
+			logger.Debug("get minimum validity blocks failed", "error", err)
+			logger.Error(nil, "get minimum validity blocks failed")
+			jsonhttp.InternalServerError(w, "minimum validity blocks unavailable")
+			return
+		}
 	}
 	jsonhttp.OK(w, chainStateResponse{
 		ChainTip:              chainTip,

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -492,6 +492,36 @@ func TestChainState(t *testing.T) {
 			}),
 		)
 	})
+
+	t.Run("nil postage contract during startup omits minimumValidityBlocks", func(t *testing.T) {
+		t.Parallel()
+
+		// postageContract is wired in Configure, which runs after the API starts
+		// serving. /chainstate is reachable before that, so a nil contract must
+		// omit minimumValidityBlocks (omitempty) instead of panicking. Regression
+		// for the startup-window panic.
+		cs := &postage.ChainState{
+			Block:        123456,
+			TotalAmount:  big.NewInt(50),
+			CurrentPrice: big.NewInt(5),
+		}
+		ts, _, _, _ := newTestServer(t, testServerOptions{
+			BatchStore: mock.New(mock.WithChainState(cs)),
+			BackendOpts: []backendmock.Option{backendmock.WithBlockNumberFunc(func(ctx context.Context) (uint64, error) {
+				return 1, nil
+			})},
+			// PostageContract left nil to simulate the startup window before Configure.
+		})
+		jsonhttptest.Request(t, ts, http.MethodGet, "/chainstate", http.StatusOK,
+			jsonhttptest.WithExpectedJSONResponse(&api.ChainStateResponse{
+				ChainTip:     1,
+				Block:        123456,
+				TotalAmount:  bigint.Wrap(big.NewInt(50)),
+				CurrentPrice: bigint.Wrap(big.NewInt(5)),
+				// MinimumValidityBlocks omitted (0) because the contract is nil.
+			}),
+		)
+	})
 }
 
 func TestPostageTopUpStamp(t *testing.T) {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
`GET /chainstate` panics with a nil-pointer dereference when it's hit while the node is still starting up. The request connection is dropped (empty response / `HTTP 000`) and a full panic stack is logged. Once the  node finishes warming up, the endpoint works normally.

Fixing #5509 

### Fix
  Guard the contract call with a nil check. When the contract isn't wired yet, `minimumValidityBlocks` is left at zero and omitted from the response (the field is already `omitempty`), and the rest of the chain state is returned.

  ### Why it happens

  `/chainstate` is mounted in `mountTechnicalDebug()`, so it's reachable as soon as the API server starts — it is **not** behind the `checkRouteAvailability` ("Node is syncing") gate. #5465 added a call to
 `s.postageContract.MinimumValidityBlocks(...)` in `chainStateHandler`, but `s.postageContract` is only assigned in `Service.Configure()`, which runs later. Any request that arrives before `Configure()` calls a method on a nil interface and panics.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
