### PR TITLE
fix(api): reject empty label on PATCH /stamps/{batch_id}

### DIFF
--- a/pkg/api/postage.go
+++ b/pkg/api/postage.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/bigint"
@@ -529,6 +530,14 @@ func (s *Service) postageUpdateLabelHandler(w http.ResponseWriter, r *http.Reque
 		logger.Debug("patch stamp: decode body failed", "batch_id", hexBatchID, "error", err)
 		logger.Error(nil, "patch stamp: decode body failed")
 		jsonhttp.BadRequest(w, "invalid request body")
+		return
+	}
+
+	// label is required by the OpenAPI spec; reject empty/missing rather than
+	// silently blanking the issuer label.
+	if strings.TrimSpace(body.Label) == "" {
+		logger.Debug("patch stamp: empty label", "batch_id", hexBatchID)
+		jsonhttp.BadRequest(w, "label is required")
 		return
 	}
 

--- a/pkg/api/postage_test.go
+++ b/pkg/api/postage_test.go
@@ -1261,6 +1261,26 @@ func TestPostageUpdateLabelStamp(t *testing.T) {
 			jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{Code: http.StatusBadRequest, Message: "invalid request body"}),
 		)
 	})
+
+	t.Run("empty-label", func(t *testing.T) {
+		t.Parallel()
+
+		// label is required by the spec; an empty/missing/whitespace-only label
+		// must be rejected rather than silently blanking the issuer label.
+		si := postage.NewStampIssuer("original", "test identity", batchID, big.NewInt(3), 24, 6, 1000, false)
+		mp := mockpost.New(mockpost.WithIssuer(si))
+		ts, _, _, _ := newTestServer(t, testServerOptions{
+			Post: mp,
+		})
+
+		for _, body := range []string{`{}`, `{"label":""}`, `{"label":"   "}`} {
+			jsonhttptest.Request(t, ts, http.MethodPatch, updatePath, http.StatusBadRequest,
+				jsonhttptest.WithRequestHeader("Content-Type", "application/json"),
+				jsonhttptest.WithRequestBody(bytes.NewBufferString(body)),
+				jsonhttptest.WithExpectedJSONResponse(jsonhttp.StatusResponse{Code: http.StatusBadRequest, Message: "label is required"}),
+			)
+		}
+	})
 }
 
 //nolint:tparallel


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
`PATCH /stamps/{batch_id}` accepts an empty or missing `label` and returns `200`, silently blanking the issuer's label — even though the OpenAPI spec marks `label` as **required**.

Fixing #5510 

  ### Fix

  Reject an empty/whitespace-only label with `400 "label is required"`. This makes the handler match the spec (which already requires `label`), so no OpenAPI change is needed. The happy path (`{"label":"name"}`) is unchanged.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
