### PR TITLE
fix: nested config priority

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -373,12 +373,14 @@ func (c *command) initLogger(cmd *cobra.Command) error {
 // nested (blockchain-rpc.endpoint) YAML forms, with nested taking precedence.
 func (c *command) bindBlockchainRpcConfig(cmd *cobra.Command) {
 	for _, p := range blockchainRpcConfigPairs {
-		// Check before registering the alias; afterwards the flat value is unreachable.
-		if c.config.InConfig(p.flat) && c.config.InConfig(p.dotted) {
-			c.logger.Warning("config key conflict: nested form takes precedence", "ignored", p.flat, "used", p.dotted)
-		}
+		nested := c.config.Get(p.dotted)
+		conflict := c.config.InConfig(p.flat) && c.config.IsSet(p.dotted)
 		_ = c.config.BindPFlag(p.dotted, cmd.Flags().Lookup(p.flat))
 		c.config.RegisterAlias(p.flat, p.dotted)
+		if conflict {
+			c.logger.Warning("config key conflict: nested form takes precedence", "ignored", p.flat, "used", p.dotted)
+			c.config.Set(p.dotted, nested)
+		}
 	}
 }
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fix conflict handling between flat and nested blockchain RPC config keys in YAML.

When both blockchain-rpc-endpoint and blockchain-rpc.endpoint were set in the same file, the node used the flat value instead of the nested one, and no warning was logged. Viper does not report nested keys via InConfig, and RegisterAlias caused the flat value to overwrite the nested one after the keys were linked.

Related to PR https://github.com/ethersphere/bee/pull/5420

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
