### PR TITLE
fix: stamper store was dirty

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -470,7 +470,7 @@ func NewBee(
 		}
 	}(probe)
 
-	stamperStore, wasClean, err := InitStamperStore(logger, o.DataDir, stateStore)
+	stamperStore, wasDirty, err := InitStamperStore(logger, o.DataDir, stateStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize stamper store: %w", err)
 	}
@@ -730,7 +730,7 @@ func NewBee(
 	// construction, so no conditional is needed here.
 	p2ps.SetChequebookAddress(chequebookService.Address())
 
-	post, err := postage.NewService(logger, stamperStore, batchStore, chainID, wasClean)
+	post, err := postage.NewService(logger, stamperStore, batchStore, chainID, wasDirty)
 	if err != nil {
 		return nil, fmt.Errorf("postage service: %w", err)
 	}

--- a/pkg/postage/service.go
+++ b/pkg/postage/service.go
@@ -66,9 +66,9 @@ type service struct {
 	done chan struct{}
 }
 
-// NewService constructs a new Service. wasClean indicates whether the previous
-// shutdown was graceful; if false, bucket counts are recovered from the stamp store.
-func NewService(logger log.Logger, store storage.Store, postageStore Storer, chainID int64, wasClean bool) (Service, error) {
+// NewService constructs a new Service. wasDirty indicates whether the previous
+// shutdown was unclean; if true, bucket counts are recovered from the stamp store.
+func NewService(logger log.Logger, store storage.Store, postageStore Storer, chainID int64, wasDirty bool) (Service, error) {
 	s := &service{
 		logger:       logger.WithName(loggerName).Register(),
 		store:        store,
@@ -92,7 +92,7 @@ func NewService(logger log.Logger, store storage.Store, postageStore Storer, cha
 		return nil, err
 	}
 
-	if !wasClean {
+	if wasDirty {
 		s.logger.Info("recovering bucket counts from stamper store")
 		if err := s.recoverBuckets(); err != nil {
 			s.logger.Error(err, "postage stamper store recovery failed")

--- a/pkg/postage/service_test.go
+++ b/pkg/postage/service_test.go
@@ -32,7 +32,7 @@ func TestSaveLoad(t *testing.T) {
 	defer store.Close()
 	pstore := pstoremock.New()
 	saved := func(id int64) postage.Service {
-		ps, err := postage.NewService(log.Noop, store, pstore, id, true)
+		ps, err := postage.NewService(log.Noop, store, pstore, id, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -48,7 +48,7 @@ func TestSaveLoad(t *testing.T) {
 		return ps
 	}
 	loaded := func(id int64) postage.Service {
-		ps, err := postage.NewService(log.Noop, store, pstore, id, true)
+		ps, err := postage.NewService(log.Noop, store, pstore, id, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -88,7 +88,7 @@ func TestGetStampIssuer(t *testing.T) {
 	}
 	validBlockNumber := testChainState.Block - uint64(postage.BlockThreshold+1)
 	pstore := pstoremock.New(pstoremock.WithChainState(testChainState))
-	ps, err := postage.NewService(log.Noop, store, pstore, chainID, true)
+	ps, err := postage.NewService(log.Noop, store, pstore, chainID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestSetExpired(t *testing.T) {
 		return bytes.Equal(b, batch), nil
 	}))
 
-	ps, err := postage.NewService(log.Noop, store, pstore, 1, true)
+	ps, err := postage.NewService(log.Noop, store, pstore, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestSetExpired(t *testing.T) {
 }
 
 // TestCrashRecovery verifies that bucket counts are restored from stamp items
-// when the service starts after an unclean shutdown (wasClean=false).
+// when the service starts after an unclean shutdown (wasDirty=true).
 func TestCrashRecovery(t *testing.T) {
 	t.Parallel()
 
@@ -335,7 +335,7 @@ func TestCrashRecovery(t *testing.T) {
 	}
 
 	// Save the issuer with zero bucket counts to the store.
-	ps, err := postage.NewService(log.Noop, store, pstore, 1, true)
+	ps, err := postage.NewService(log.Noop, store, pstore, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,8 +347,8 @@ func TestCrashRecovery(t *testing.T) {
 	}
 
 	// Verify that the issuer on disk still has zero bucket counts (i.e., recovery
-	// has not happened yet). Open with wasClean=true to skip recovery.
-	psCheck, err := postage.NewService(log.Noop, store, pstore, 1, true)
+	// has not happened yet). Open with wasDirty=false to skip recovery.
+	psCheck, err := postage.NewService(log.Noop, store, pstore, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,8 +367,8 @@ func TestCrashRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Restart with wasClean=false — should trigger bucket recovery.
-	ps2, err := postage.NewService(log.Noop, store, pstore, 1, false)
+	// Restart with wasDirty=true — should trigger bucket recovery.
+	ps2, err := postage.NewService(log.Noop, store, pstore, 1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,9 +391,9 @@ func TestCrashRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Restart with wasClean=true — recovery is skipped, but counts must still
+	// Restart with wasDirty=false — recovery is skipped, but counts must still
 	// be correct because ps2.Close() persisted the recovered state.
-	ps3, err := postage.NewService(log.Noop, store, pstore, 1, true)
+	ps3, err := postage.NewService(log.Noop, store, pstore, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestUpdateIssuerLabel(t *testing.T) {
 	defer store.Close()
 	pstore := pstoremock.New()
 
-	ps, err := postage.NewService(log.Noop, store, pstore, 1, true)
+	ps, err := postage.NewService(log.Noop, store, pstore, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Related to https://github.com/ethersphere/bee/pull/5392
leveldbstore and InitStamperStore return dirty (true = unclean shutdown), but in node.go it was named wasClean and passed to NewService as if it meant a clean shutdown. As a result, recovery did not run after a crash and could run unnecessarily after a normal restart.

Fix: use consistent wasDirty semantics across the whole chain, with if wasDirty and no inversions.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
