### PR TITLE
fix(cmd): resolve db command data-dir and verbosity from config

### DIFF
--- a/cmd/bee/cmd/db.go
+++ b/cmd/bee/cmd/db.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethersphere/bee/v2/pkg/log"
 	"github.com/ethersphere/bee/v2/pkg/node"
 	"github.com/ethersphere/bee/v2/pkg/postage"
 	"github.com/ethersphere/bee/v2/pkg/puller"
@@ -41,40 +42,58 @@ func (c *command) initDBCmd() {
 		Short: "Perform basic DB related operations",
 	}
 
-	dbExportCmd(cmd)
-	dbImportCmd(cmd)
-	dbNukeCmd(cmd)
-	dbInfoCmd(cmd)
-	dbCompactCmd(cmd)
-	dbValidateCmd(cmd)
-	dbValidatePinsCmd(cmd)
-	dbRepairReserve(cmd)
+	c.dbExportCmd(cmd)
+	c.dbImportCmd(cmd)
+	c.dbNukeCmd(cmd)
+	c.dbInfoCmd(cmd)
+	c.dbCompactCmd(cmd)
+	c.dbValidateCmd(cmd)
+	c.dbValidatePinsCmd(cmd)
+	c.dbRepairReserve(cmd)
 
 	c.root.AddCommand(cmd)
 }
 
-func dbInfoCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "info",
-		Short: "Prints the different indexes present in the Database",
+// newLoggerFromConfig builds a logger using the verbosity resolved from viper.
+func (c *command) newLoggerFromConfig(cmd *cobra.Command) (log.Logger, error) {
+	logger, err := newLogger(cmd, strings.ToLower(c.config.GetString(optionNameVerbosity)))
+	if err != nil {
+		return nil, fmt.Errorf("new logger: %w", err)
+	}
+	return logger, nil
+}
+
+// bindConfigFlags binds a db subcommand's flags to viper. Used as PreRunE so
+// values fall back to env and the config file when a flag is omitted.
+func (c *command) bindConfigFlags(cmd *cobra.Command, _ []string) error {
+	return c.config.BindPFlags(cmd.Flags())
+}
+
+// resolveDataDir returns the data dir from viper (flag, env, or config),
+// erroring when none is set.
+func (c *command) resolveDataDir() (string, error) {
+	dataDir := c.config.GetString(optionNameDataDir)
+	if dataDir == "" {
+		return "", errors.New("no data-dir provided")
+	}
+	return dataDir, nil
+}
+
+func (c *command) dbInfoCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "info",
+		Short:   "Prints the different indexes present in the Database",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			start := time.Now()
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Info("getting db indices with data-dir", "path", dataDir)
@@ -108,24 +127,20 @@ func dbInfoCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	parent.AddCommand(cmd)
 }
 
-func dbCompactCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "compact",
-		Short: "Compacts the localstore sharky store.",
+func (c *command) dbCompactCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "compact",
+		Short:   "Compacts the localstore sharky store.",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
 			d, err := cmd.Flags().GetDuration(optionNameSleepAfter)
@@ -139,12 +154,9 @@ func dbCompactCmd(cmd *cobra.Command) {
 				}
 			}()
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			validation, err := cmd.Flags().GetBool(optionNameValidation)
@@ -174,34 +186,27 @@ func dbCompactCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	c.Flags().Bool(optionNameValidation, false, "run chunk validation checks before and after the compaction")
-	c.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	cmd.Flags().Bool(optionNameValidation, false, "run chunk validation checks before and after the compaction")
+	cmd.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
+	parent.AddCommand(cmd)
 }
 
-func dbValidatePinsCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "validate-pin",
-		Short: "Validates pin collection chunks with sharky store.",
+func (c *command) dbValidatePinsCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "validate-pin",
+		Short:   "Validates pin collection chunks with sharky store.",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			providedPin, err := cmd.Flags().GetString(optionNameCollectionPin)
@@ -229,34 +234,27 @@ func dbValidatePinsCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	c.Flags().String(optionNameCollectionPin, "", "only validate given pin")
-	c.Flags().String(optionNameOutputLocation, "", "location and name of the output file")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	cmd.Flags().String(optionNameCollectionPin, "", "only validate given pin")
+	cmd.Flags().String(optionNameOutputLocation, "", "location and name of the output file")
+	parent.AddCommand(cmd)
 }
 
-func dbRepairReserve(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "repair-reserve",
-		Short: "Repairs the reserve by resetting the binIDs and removes dangling entries.",
+func (c *command) dbRepairReserve(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "repair-reserve",
+		Short:   "Repairs the reserve by resetting the binIDs and removes dangling entries.",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Warning("Repair will recreate the reserve entries based on the chunk availability in the chunkstore. The epoch time and bin IDs will be reset.")
@@ -306,33 +304,26 @@ func dbRepairReserve(cmd *cobra.Command) {
 			})
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	c.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	cmd.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
+	parent.AddCommand(cmd)
 }
 
-func dbValidateCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "validate",
-		Short: "Validates the localstore sharky store.",
+func (c *command) dbValidateCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "validate",
+		Short:   "Validates the localstore sharky store.",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Warning("Validation ensures that sharky returns a chunk that hashes to the expected reference.")
@@ -355,52 +346,45 @@ func dbValidateCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "info", "verbosity level")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "info", "verbosity level")
+	parent.AddCommand(cmd)
 }
 
-func dbExportCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
+func (c *command) dbExportCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Perform DB export to a file",
 	}
-	c.PersistentFlags().String(optionNameDataDir, "", "data directory")
-	c.PersistentFlags().String(optionNameVerbosity, "info", "verbosity level")
+	cmd.PersistentFlags().String(optionNameDataDir, "", "data directory")
+	cmd.PersistentFlags().String(optionNameVerbosity, "info", "verbosity level")
 
-	dbExportReserveCmd(c)
-	dbExportPinningCmd(c)
-	cmd.AddCommand(c)
+	c.dbExportReserveCmd(cmd)
+	c.dbExportPinningCmd(cmd)
+	parent.AddCommand(cmd)
 }
 
 type noopRadiusSetter struct{}
 
 func (noopRadiusSetter) SetStorageRadius(uint8) {}
 
-func dbExportReserveCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "reserve <filename>",
-		Short: "Export reserve DB to a file. Use \"-\" as filename in order to write to STDOUT",
+func (c *command) dbExportReserveCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "reserve <filename>",
+		Short:   "Export reserve DB to a file. Use \"-\" as filename in order to write to STDOUT",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if (len(args)) != 1 {
 				return cmd.Help()
 			}
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Info("starting export process with data-dir", "path", dataDir)
@@ -458,33 +442,26 @@ func dbExportReserveCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	cmd.AddCommand(c)
+	parent.AddCommand(cmd)
 }
 
-func dbExportPinningCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "pinning <filename>",
-		Short: "Export pinning DB to a file. Use \"-\" as filename in order to write to STDOUT",
+func (c *command) dbExportPinningCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "pinning <filename>",
+		Short:   "Export pinning DB to a file. Use \"-\" as filename in order to write to STDOUT",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if (len(args)) != 1 {
 				return cmd.Help()
 			}
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Info("starting export process with data-dir", "path", dataDir)
@@ -555,45 +532,38 @@ func dbExportPinningCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	cmd.AddCommand(c)
+	parent.AddCommand(cmd)
 }
 
-func dbImportCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
+func (c *command) dbImportCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "Perform DB import from a file",
 	}
-	c.PersistentFlags().String(optionNameDataDir, "", "data directory")
-	c.PersistentFlags().String(optionNameVerbosity, "info", "verbosity level")
+	cmd.PersistentFlags().String(optionNameDataDir, "", "data directory")
+	cmd.PersistentFlags().String(optionNameVerbosity, "info", "verbosity level")
 
-	dbImportReserveCmd(c)
-	dbImportPinningCmd(c)
-	cmd.AddCommand(c)
+	c.dbImportReserveCmd(cmd)
+	c.dbImportPinningCmd(cmd)
+	parent.AddCommand(cmd)
 }
 
-func dbImportReserveCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "reserve <filename>",
-		Short: "Import reserve DB from a file. Use \"-\" as filename in order to read from STDIN",
+func (c *command) dbImportReserveCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "reserve <filename>",
+		Short:   "Import reserve DB from a file. Use \"-\" as filename in order to read from STDIN",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if (len(args)) != 1 {
 				return cmd.Help()
 			}
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
+				return err
 			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
-			}
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
-			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			fmt.Printf("starting import process with data-dir at %s\n", dataDir)
@@ -652,32 +622,25 @@ func dbImportReserveCmd(cmd *cobra.Command) {
 		},
 	}
 
-	cmd.AddCommand(c)
+	parent.AddCommand(cmd)
 }
 
-func dbImportPinningCmd(cmd *cobra.Command) {
-	c := &cobra.Command{
-		Use:   "pinning <filename>",
-		Short: "Import pinning DB from a file. Use \"-\" as filename in order to read from STDIN",
+func (c *command) dbImportPinningCmd(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "pinning <filename>",
+		Short:   "Import pinning DB from a file. Use \"-\" as filename in order to read from STDIN",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if (len(args)) != 1 {
 				return cmd.Help()
 			}
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
+				return err
 			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
-			}
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
-			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			fmt.Printf("starting import process with data-dir at %s\n", dataDir)
@@ -760,10 +723,10 @@ func dbImportPinningCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	cmd.AddCommand(c)
+	parent.AddCommand(cmd)
 }
 
-func dbNukeCmd(cmd *cobra.Command) {
+func (c *command) dbNukeCmd(parent *cobra.Command) {
 	const (
 		optionNameForgetOverlay = "forget-overlay"
 		optionNameForgetStamps  = "forget-stamps"
@@ -774,18 +737,14 @@ func dbNukeCmd(cmd *cobra.Command) {
 		stamperstore = "stamperstore"
 	)
 
-	c := &cobra.Command{
-		Use:   "nuke",
-		Short: "Nuke the DB so that bee resyncs all data next time it boots up.",
+	cmd := &cobra.Command{
+		Use:     "nuke",
+		Short:   "Nuke the DB so that bee resyncs all data next time it boots up.",
+		PreRunE: c.bindConfigFlags,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			v, err := cmd.Flags().GetString(optionNameVerbosity)
+			logger, err := c.newLoggerFromConfig(cmd)
 			if err != nil {
-				return fmt.Errorf("get verbosity: %w", err)
-			}
-			v = strings.ToLower(v)
-			logger, err := newLogger(cmd, v)
-			if err != nil {
-				return fmt.Errorf("new logger: %w", err)
+				return err
 			}
 			d, err := cmd.Flags().GetDuration(optionNameSleepAfter)
 			if err != nil {
@@ -798,12 +757,9 @@ func dbNukeCmd(cmd *cobra.Command) {
 				}
 			}()
 
-			dataDir, err := cmd.Flags().GetString(optionNameDataDir)
+			dataDir, err := c.resolveDataDir()
 			if err != nil {
-				return fmt.Errorf("get data-dir: %w", err)
-			}
-			if dataDir == "" {
-				return errors.New("no data-dir provided")
+				return err
 			}
 
 			logger.Warning("starting to nuke the DB with data-dir", "path", dataDir)
@@ -869,12 +825,12 @@ func dbNukeCmd(cmd *cobra.Command) {
 			return nil
 		},
 	}
-	c.Flags().String(optionNameDataDir, "", "data directory")
-	c.Flags().String(optionNameVerbosity, "trace", "verbosity level")
-	c.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
-	c.Flags().Bool(optionNameForgetOverlay, false, "forget the overlay and deploy a new chequebook on next boot-up")
-	c.Flags().Bool(optionNameForgetStamps, false, "forget the existing stamps belonging to the node. even when forgotten, they will show up again after a chain resync")
-	cmd.AddCommand(c)
+	cmd.Flags().String(optionNameDataDir, "", "data directory")
+	cmd.Flags().String(optionNameVerbosity, "trace", "verbosity level")
+	cmd.Flags().Duration(optionNameSleepAfter, time.Duration(0), "time to sleep after the operation finished")
+	cmd.Flags().Bool(optionNameForgetOverlay, false, "forget the overlay and deploy a new chequebook on next boot-up")
+	cmd.Flags().Bool(optionNameForgetStamps, false, "forget the existing stamps belonging to the node. even when forgotten, they will show up again after a chain resync")
+	parent.AddCommand(cmd)
 }
 
 func removeContent(path string) error {

--- a/cmd/bee/cmd/db_test.go
+++ b/cmd/bee/cmd/db_test.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -267,6 +269,122 @@ func TestDBInfo(t *testing.T) {
 	if !strings.Contains(buf.String(), fmt.Sprintf("\"msg\"=\"reserve\" \"size_within_radius\"=%d \"total_size\"=%d \"capacity\"=%d", nChunks, nChunks, storer.DefaultReserveCapacity)) {
 		t.Fatal("reserve info not correct")
 	}
+}
+
+func TestDBDataDirFromConfig(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	ctx := context.Background()
+	db := newTestDB(t, ctx, &storer.Options{
+		Batchstore:      new(postage.NoOpBatchStore),
+		RadiusSetter:    kademlia.NewTopologyDriver(),
+		Logger:          testutil.NewLogger(t),
+		ReserveCapacity: storer.DefaultReserveCapacity,
+	}, dataDir)
+
+	nChunks := 10
+	for range nChunks {
+		ch := storagetest.GenerateTestRandomChunk()
+		if err := db.ReservePutter().Put(ctx, ch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "bee.yaml")
+	if err := os.WriteFile(cfgPath, []byte("data-dir: "+dataDir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wantSize := fmt.Sprintf("\"total_size\"=%d", nChunks)
+
+	t.Run("data-dir taken from config when flag omitted", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := newCommand(t, cmd.WithArgs("db", "info", "--config", cfgPath), cmd.WithOutput(&buf)).Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(buf.String(), wantSize) {
+			t.Fatalf("reserve info not read from config data-dir; got: %s", buf.String())
+		}
+	})
+
+	t.Run("explicit flag overrides config", func(t *testing.T) {
+		emptyCfg := filepath.Join(t.TempDir(), "bee.yaml")
+		if err := os.WriteFile(emptyCfg, []byte("data-dir: "+t.TempDir()+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		err := newCommand(t, cmd.WithArgs("db", "info", "--config", emptyCfg, "--data-dir", dataDir), cmd.WithOutput(&buf)).Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(buf.String(), wantSize) {
+			t.Fatalf("explicit --data-dir did not override config; got: %s", buf.String())
+		}
+	})
+
+	t.Run("errors when neither flag nor config provides data-dir", func(t *testing.T) {
+		err := newCommand(t, cmd.WithArgs("db", "info")).Execute()
+		if err == nil || !strings.Contains(err.Error(), "no data-dir provided") {
+			t.Fatalf("expected no data-dir error, got: %v", err)
+		}
+	})
+}
+
+func TestDBVerbosityFromConfig(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	ctx := context.Background()
+	db := newTestDB(t, ctx, &storer.Options{
+		Batchstore:      new(postage.NoOpBatchStore),
+		RadiusSetter:    kademlia.NewTopologyDriver(),
+		Logger:          testutil.NewLogger(t),
+		ReserveCapacity: storer.DefaultReserveCapacity,
+	}, dataDir)
+	for range 10 {
+		if err := db.ReservePutter().Put(ctx, storagetest.GenerateTestRandomChunk()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.Close()
+
+	writeConfig := func(t *testing.T, verbosity string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "bee.yaml")
+		body := fmt.Sprintf("data-dir: %s\nverbosity: %s\n", dataDir, verbosity)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// "reserve" is logged at info level by db info.
+	const infoMarker = "\"msg\"=\"reserve\""
+
+	t.Run("verbosity taken from config", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := newCommand(t, cmd.WithArgs("db", "info", "--config", writeConfig(t, "error")), cmd.WithOutput(&buf)).Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(buf.String(), infoMarker) {
+			t.Fatalf("expected info logs suppressed by config verbosity=error; got: %s", buf.String())
+		}
+	})
+
+	t.Run("explicit flag overrides config", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := newCommand(t, cmd.WithArgs("db", "info", "--config", writeConfig(t, "error"), "--verbosity", "info"), cmd.WithOutput(&buf)).Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(buf.String(), infoMarker) {
+			t.Fatalf("expected --verbosity to override config; got: %s", buf.String())
+		}
+	})
 }
 
 func TestMarshalChunk(t *testing.T) {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

`bee db <cmd> --config=...` failed with `no data-dir provided` because the db subcommands read flags directly and ignored the loaded config file.

- Bind each db subcommand's flags to viper in `PreRunE` (composing with the root's config load, like `start`/`init` do).
- Resolve `data-dir` and `verbosity` via `c.config`, so both follow the usual precedence: **flag → env → config file**.
- Factor the repeated logger/data-dir boilerplate into helpers.

Result:

```
bee db nuke --config=config.sepolia.yaml   # now reuses data-dir from config
```

An explicit `--data-dir`/`--verbosity` still wins; an empty `data-dir` is the only required-key check. Added tests for config fallback, flag-over-config precedence, and the required-key error.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)

The db maintenance commands should reuse the same config file as the node so operators don't have to re-pass `--data-dir` that already lives in their config.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
