### PR TITLE
feat(node): use postage snapshot on --resync unless skipped

### DIFF
--- a/pkg/node/export_test.go
+++ b/pkg/node/export_test.go
@@ -4,4 +4,7 @@
 
 package node
 
-var ValidatePublicAddress = validatePublicAddress
+var (
+	ValidatePublicAddress = validatePublicAddress
+	UseEmbeddedSnapshot   = useEmbeddedSnapshot
+)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -881,13 +881,10 @@ func NewBee(
 		}
 	)
 
-	// When the postage snapshot applies, hand it to the batch service so it
-	// rebuilds the store from the snapshot during construction; otherwise the
-	// store is reset only when --resync is requested. Either way the store is
-	// reset in a single place (batchservice.New), which avoids a second reset
-	// wiping the snapshot that was just loaded (see #5495).
+	// When it applies, hand the snapshot to the batch service to rebuild the
+	// store during construction (see useEmbeddedSnapshot).
 	var batchSnapshot *batchservice.Snapshot
-	if !o.SkipPostageSnapshot && !batchStoreExists && (networkID == mainnetNetworkID) && beeNodeMode != api.UltraLightMode {
+	if useEmbeddedSnapshot(o.SkipPostageSnapshot, batchStoreExists, o.Resync, networkID, beeNodeMode) {
 		batchSnapshot, err = snapshot.New(ctx, logger, archive.Getter{}, b.syncingStopped, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout, postageSyncStart)
 		if err != nil {
 			// A corrupt snapshot is not fatal: rebuild from the chain instead.
@@ -1635,4 +1632,12 @@ func batchStoreExists(s storage.StateStorer) (bool, error) {
 	})
 
 	return hasOne, err
+}
+
+// useEmbeddedSnapshot reports whether to rebuild the batch store from the
+// embedded snapshot: mainnet, full or light node, and the store will be built
+// from scratch (no store yet, or a resync wipes it), unless explicitly skipped.
+func useEmbeddedSnapshot(skip, batchStoreExists, resync bool, networkID uint64, mode api.BeeNodeMode) bool {
+	storeWillRebuild := !batchStoreExists || resync
+	return !skip && storeWillRebuild && networkID == mainnetNetworkID && mode != api.UltraLightMode
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -881,8 +881,6 @@ func NewBee(
 		}
 	)
 
-	// When it applies, hand the snapshot to the batch service to rebuild the
-	// store during construction (see useEmbeddedSnapshot).
 	var batchSnapshot *batchservice.Snapshot
 	if useEmbeddedSnapshot(o.SkipPostageSnapshot, batchStoreExists, o.Resync, networkID, beeNodeMode) {
 		batchSnapshot, err = snapshot.New(ctx, logger, archive.Getter{}, b.syncingStopped, postageStampContractAddress, postageStampContractABI, o.BlockTime, postageSyncingStallingTimeout, postageSyncingBackoffTimeout, postageSyncStart)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -7,6 +7,7 @@ package node_test
 import (
 	"testing"
 
+	"github.com/ethersphere/bee/v2/pkg/api"
 	"github.com/ethersphere/bee/v2/pkg/node"
 )
 
@@ -103,6 +104,46 @@ func TestValidatePublicAddress(t *testing.T) {
 			}
 			if !tc.expErr && err != nil {
 				t.Fatalf("expected no error, but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestUseEmbeddedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mainnet = uint64(1)
+		testnet = uint64(10)
+	)
+
+	testCases := []struct {
+		name             string
+		skip             bool
+		batchStoreExists bool
+		resync           bool
+		networkID        uint64
+		mode             api.BeeNodeMode
+		want             bool
+	}{
+		{name: "first boot on mainnet", networkID: mainnet, mode: api.FullMode, want: true},
+		{name: "existing store, no resync", batchStoreExists: true, networkID: mainnet, mode: api.FullMode, want: false},
+		{name: "resync on a fresh store", resync: true, networkID: mainnet, mode: api.FullMode, want: true},
+		// New behavior: resync rebuilds from the snapshot even with a store present.
+		{name: "resync on an existing store uses the snapshot", batchStoreExists: true, resync: true, networkID: mainnet, mode: api.FullMode, want: true},
+		{name: "resync with skip syncs from the chain", batchStoreExists: true, resync: true, skip: true, networkID: mainnet, mode: api.FullMode, want: false},
+		{name: "skip on first boot", skip: true, networkID: mainnet, mode: api.FullMode, want: false},
+		{name: "light node uses the snapshot", networkID: mainnet, mode: api.LightMode, want: true},
+		{name: "ultra-light never uses the snapshot", resync: true, networkID: mainnet, mode: api.UltraLightMode, want: false},
+		{name: "non-mainnet never uses the snapshot", resync: true, networkID: testnet, mode: api.FullMode, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := node.UseEmbeddedSnapshot(tc.skip, tc.batchStoreExists, tc.resync, tc.networkID, tc.mode)
+			if got != tc.want {
+				t.Fatalf("UseEmbeddedSnapshot = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

`--resync` on an existing batch store rescanned the whole postage contract from the chain, because the snapshot only loaded when no store existed. Since a resync wipes the store anyway, treat it as "no store" and rebuild from the embedded snapshot on `--resync` too, unless `--skip-postage-snapshot` is set.

Decision extracted into `useEmbeddedSnapshot` with a table test.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
