### PR TITLE
fix(pseudosettle): bound the first refreshment of a connection

### DIFF
--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -60,8 +60,9 @@ type Service struct {
 }
 
 type pseudoSettlePeer struct {
-	lock     sync.Mutex // lock to be held during receiving a payment from this peer
-	fullNode bool
+	lock        sync.Mutex // lock to be held during receiving a payment from this peer
+	fullNode    bool
+	connectedAt int64 // unix time the peer connected; anchors the first-contact allowance
 }
 
 type lastPayment struct {
@@ -108,7 +109,7 @@ func (s *Service) init(ctx context.Context, p p2p.Peer) error {
 
 	_, ok := s.peers[p.Address.String()]
 	if !ok {
-		peerData := &pseudoSettlePeer{fullNode: p.FullNode}
+		peerData := &pseudoSettlePeer{fullNode: p.FullNode, connectedAt: s.timeNow().Unix()}
 		s.peers[p.Address.String()] = peerData
 	}
 
@@ -142,14 +143,18 @@ func totalKeyPeer(key []byte, prefix string) (peer swarm.Address, err error) {
 
 // peerAllowance computes the maximum incoming payment value we accept
 // this is the time based allowance or the peers actual debt, whichever is less
-func (s *Service) peerAllowance(peer swarm.Address, fullNode bool) (limit *big.Int, stamp int64, err error) {
+func (s *Service) peerAllowance(peer swarm.Address, fullNode bool, connectedAt int64) (limit *big.Int, stamp int64, err error) {
 	var lastTime lastPayment
 	err = s.store.Get(totalKey(peer, SettlementReceivedPrefix), &lastTime)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound) {
 			return nil, 0, err
 		}
-		lastTime.Timestamp = int64(0)
+		// First contact with this peer: anchor the time-based allowance to the
+		// connection time rather than the zero epoch. Anchoring at zero would
+		// scale the entire Unix epoch by the refresh rate and let the initial
+		// refreshment forgive an effectively unbounded debt.
+		lastTime.Timestamp = connectedAt
 	}
 
 	currentTime := s.timeNow().Unix()
@@ -210,7 +215,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	pseudoSettlePeer.lock.Lock()
 	defer pseudoSettlePeer.lock.Unlock()
 
-	allowance, timestamp, err := s.peerAllowance(p.Address, pseudoSettlePeer.fullNode)
+	allowance, timestamp, err := s.peerAllowance(p.Address, pseudoSettlePeer.fullNode, pseudoSettlePeer.connectedAt)
 	if err != nil {
 		return err
 	}

--- a/pkg/settlement/pseudosettle/pseudosettle.go
+++ b/pkg/settlement/pseudosettle/pseudosettle.go
@@ -60,9 +60,10 @@ type Service struct {
 }
 
 type pseudoSettlePeer struct {
-	lock        sync.Mutex // lock to be held during receiving a payment from this peer
-	fullNode    bool
-	connectedAt int64 // unix time the peer connected; anchors the first-contact allowance
+	lock     sync.Mutex // lock to be held during receiving a payment from this peer
+	fullNode bool
+	received bool // a refreshment was received on this connection, guarded by peersMu
+	sent     bool // a refreshment was sent on this connection, guarded by peersMu
 }
 
 type lastPayment struct {
@@ -109,7 +110,7 @@ func (s *Service) init(ctx context.Context, p p2p.Peer) error {
 
 	_, ok := s.peers[p.Address.String()]
 	if !ok {
-		peerData := &pseudoSettlePeer{fullNode: p.FullNode, connectedAt: s.timeNow().Unix()}
+		peerData := &pseudoSettlePeer{fullNode: p.FullNode}
 		s.peers[p.Address.String()] = peerData
 	}
 
@@ -143,18 +144,14 @@ func totalKeyPeer(key []byte, prefix string) (peer swarm.Address, err error) {
 
 // peerAllowance computes the maximum incoming payment value we accept
 // this is the time based allowance or the peers actual debt, whichever is less
-func (s *Service) peerAllowance(peer swarm.Address, fullNode bool, connectedAt int64) (limit *big.Int, stamp int64, err error) {
+func (s *Service) peerAllowance(peer swarm.Address, fullNode, settled bool) (limit *big.Int, stamp int64, err error) {
 	var lastTime lastPayment
 	err = s.store.Get(totalKey(peer, SettlementReceivedPrefix), &lastTime)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound) {
 			return nil, 0, err
 		}
-		// First contact with this peer: anchor the time-based allowance to the
-		// connection time rather than the zero epoch. Anchoring at zero would
-		// scale the entire Unix epoch by the refresh rate and let the initial
-		// refreshment forgive an effectively unbounded debt.
-		lastTime.Timestamp = connectedAt
+		lastTime.Timestamp = int64(0)
 	}
 
 	currentTime := s.timeNow().Unix()
@@ -170,7 +167,15 @@ func (s *Service) peerAllowance(peer swarm.Address, fullNode bool, connectedAt i
 		refreshRateUsed = s.lightRefreshRate
 	}
 
-	maxAllowance := new(big.Int).Mul(big.NewInt(currentTime-lastTime.Timestamp), refreshRateUsed)
+	// the stored timestamp only bounds refreshments made within one connection. before
+	// the first refreshment of a connection it is absent or predates the connection, so
+	// allow a single refresh interval instead of the time since it was written.
+	interval := int64(1)
+	if settled {
+		interval = currentTime - lastTime.Timestamp
+	}
+
+	maxAllowance := new(big.Int).Mul(big.NewInt(interval), refreshRateUsed)
 
 	peerDebt, err := s.accounting.PeerDebt(peer)
 	if err != nil {
@@ -207,6 +212,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 
 	s.peersMu.Lock()
 	pseudoSettlePeer, ok := s.peers[p.Address.String()]
+	settled := ok && pseudoSettlePeer.received
 	s.peersMu.Unlock()
 	if !ok {
 		return ErrNoPseudoSettlePeer
@@ -215,7 +221,7 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 	pseudoSettlePeer.lock.Lock()
 	defer pseudoSettlePeer.lock.Unlock()
 
-	allowance, timestamp, err := s.peerAllowance(p.Address, pseudoSettlePeer.fullNode, pseudoSettlePeer.connectedAt)
+	allowance, timestamp, err := s.peerAllowance(p.Address, pseudoSettlePeer.fullNode, settled)
 	if err != nil {
 		return err
 	}
@@ -254,6 +260,10 @@ func (s *Service) handler(ctx context.Context, p p2p.Peer, stream p2p.Stream) (e
 		return err
 	}
 
+	s.peersMu.Lock()
+	pseudoSettlePeer.received = true
+	s.peersMu.Unlock()
+
 	receivedPaymentF64, _ := big.NewFloat(0).SetInt(paymentAmount).Float64()
 	s.metrics.TotalReceivedPseudoSettlements.Add(receivedPaymentF64)
 	s.metrics.ReceivedPseudoSettlements.Inc()
@@ -284,6 +294,11 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int) 
 		lastTime.Total = big.NewInt(0)
 		lastTime.Timestamp = 0
 	}
+
+	s.peersMu.Lock()
+	peerData, known := s.peers[peer.String()]
+	settled := known && peerData.sent
+	s.peersMu.Unlock()
 
 	stream, err := s.streamer.NewStream(ctx, peer, nil, protocolName, protocolVersion, streamName)
 	if err != nil {
@@ -325,6 +340,13 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int) 
 		return
 	}
 
+	// mirror peerAllowance: before the first refreshment of a connection the stored
+	// timestamps are absent or predate it, so expect a single refresh interval.
+	if !settled {
+		lastTime.Timestamp = paymentAck.Timestamp - 1
+		lastTime.CheckTimestamp = checkTime/1000 - 1
+	}
+
 	experiencedInterval := checkTime/1000 - lastTime.CheckTimestamp
 	allegedInterval := paymentAck.Timestamp - lastTime.Timestamp
 
@@ -354,6 +376,12 @@ func (s *Service) Pay(ctx context.Context, peer swarm.Address, amount *big.Int) 
 	if err != nil {
 		s.accounting.NotifyRefreshmentSent(peer, nil, nil, 0, 0, err)
 		return
+	}
+
+	if known {
+		s.peersMu.Lock()
+		peerData.sent = true
+		s.peersMu.Unlock()
 	}
 
 	amountFloat, _ := new(big.Float).SetInt(acceptedAmount).Float64()

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -277,6 +277,9 @@ func TestPayment(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
+	// Establish a connection time before init so the first-contact allowance is
+	// anchored to it rather than to the Unix epoch.
+	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -295,6 +298,50 @@ func TestPayment(t *testing.T) {
 	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 30, 30, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
 }
 
+// TestFirstContactAllowanceBounded verifies that the time-based allowance granted
+// on first contact is bounded by the time elapsed since the peer connected, not by
+// the Unix epoch. A peer connected one second ago may only settle a single refresh
+// interval of debt, no matter how large its outstanding debt is. Anchoring at the
+// epoch would let the first refreshment forgive an effectively unbounded amount.
+func TestFirstContactAllowanceBounded(t *testing.T) {
+	t.Parallel()
+
+	logger := log.Noop
+
+	storeRecipient := newStateStore(t)
+
+	peerID := swarm.MustParseHexAddress("9ee7add7")
+	peer := p2p.Peer{Address: peerID, FullNode: true}
+
+	// Debt far larger than a single refresh interval's worth of allowance.
+	debt := int64(1000) * testRefreshRate
+
+	payerObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
+	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
+	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
+	recipient.SetAccounting(receiverObserver)
+	// The peer connects at t=1000000.
+	recipient.SetTime(1000000)
+	err := recipient.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := streamtest.New(
+		streamtest.WithProtocols(recipient.Protocol()),
+		streamtest.WithBaseAddr(peerID),
+	)
+
+	storePayer := newStateStore(t)
+
+	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
+	payer.SetAccounting(payerObserver)
+
+	// One second after connecting the peer attempts to settle its entire debt.
+	// Only one refresh interval (testRefreshRate) may be accepted, not the full debt.
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 1000001, 1000001, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRate), big.NewInt(testRefreshRate))
+}
+
 func TestTimeLimitedPayment(t *testing.T) {
 	t.Parallel()
 
@@ -311,6 +358,9 @@ func TestTimeLimitedPayment(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
+	// Establish a connection time before init so the first-contact allowance is
+	// anchored to it rather than to the Unix epoch.
+	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -365,6 +415,9 @@ func TestTimeLimitedPaymentLight(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
+	// Establish a connection time before init so the first-contact allowance is
+	// anchored to it rather than to the Unix epoch.
+	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/settlement/pseudosettle/pseudosettle_test.go
+++ b/pkg/settlement/pseudosettle/pseudosettle_test.go
@@ -158,7 +158,7 @@ func testCaseNotAccepted(t *testing.T, recorder *streamtest.Recorder, payerObser
 	}
 }
 
-func testCaseAccepted(t *testing.T, recorder *streamtest.Recorder, payerObserver, receiverObserver *testObserver, payer, recipient *pseudosettle.Service, peerID swarm.Address, payerTime, recipientTime int64, recordsLength, msgLength, recMsgLength int, debtAmount, amount, accepted, totalAmount *big.Int) {
+func testCaseAccepted(t *testing.T, recorder *streamtest.Recorder, payerObserver, receiverObserver *testObserver, payer, recipient *pseudosettle.Service, peerID swarm.Address, payerTime, recipientTime, interval int64, recordsLength, msgLength, recMsgLength int, debtAmount, amount, accepted, totalAmount *big.Int) {
 	t.Helper()
 
 	payer.SetTime(payerTime)
@@ -173,6 +173,11 @@ func testCaseAccepted(t *testing.T, recorder *streamtest.Recorder, payerObserver
 	case sent := <-payerObserver.refreshSentCalled:
 		if sent.err != nil {
 			t.Fatal(sent.err)
+		}
+		// the interval the payer bases its allowance expectation on must match the
+		// one the recipient granted against, otherwise the payer blocklists it
+		if sent.interval != interval {
+			t.Fatalf("got alleged interval %d, want %d", sent.interval, interval)
 		}
 		acceptedAmount.Set(sent.amount)
 	case <-time.After(1 * time.Second):
@@ -277,9 +282,6 @@ func TestPayment(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
-	// Establish a connection time before init so the first-contact allowance is
-	// anchored to it rather than to the Unix epoch.
-	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -294,16 +296,20 @@ func TestPayment(t *testing.T) {
 
 	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	payer.SetAccounting(payerObserver)
+	err = payer.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// set time to non-zero, attempt payment based on debt, expect full amount to be accepted
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 30, 30, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 30, 30, 1, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
 }
 
-// TestFirstContactAllowanceBounded verifies that the time-based allowance granted
-// on first contact is bounded by the time elapsed since the peer connected, not by
-// the Unix epoch. A peer connected one second ago may only settle a single refresh
-// interval of debt, no matter how large its outstanding debt is. Anchoring at the
-// epoch would let the first refreshment forgive an effectively unbounded amount.
-func TestFirstContactAllowanceBounded(t *testing.T) {
+// TestFirstRefreshmentBounded verifies that the first refreshment of a connection is
+// bounded by a single refresh interval. Without a stored settlement the timestamp
+// defaults to the Unix epoch, which would scale the whole epoch by the refresh rate
+// and forgive the peer's entire outstanding debt in one go.
+func TestFirstRefreshmentBounded(t *testing.T) {
 	t.Parallel()
 
 	logger := log.Noop
@@ -313,15 +319,13 @@ func TestFirstContactAllowanceBounded(t *testing.T) {
 	peerID := swarm.MustParseHexAddress("9ee7add7")
 	peer := p2p.Peer{Address: peerID, FullNode: true}
 
-	// Debt far larger than a single refresh interval's worth of allowance.
+	// debt far larger than a single refresh interval's worth of allowance
 	debt := int64(1000) * testRefreshRate
 
 	payerObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
-	// The peer connects at t=1000000.
-	recipient.SetTime(1000000)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -336,10 +340,68 @@ func TestFirstContactAllowanceBounded(t *testing.T) {
 
 	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	payer.SetAccounting(payerObserver)
+	err = payer.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// One second after connecting the peer attempts to settle its entire debt.
-	// Only one refresh interval (testRefreshRate) may be accepted, not the full debt.
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 1000001, 1000001, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRate), big.NewInt(testRefreshRate))
+	// the peer attempts to settle its entire debt, only one refresh interval is accepted
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 1000000, 1000000, 1, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRate), big.NewInt(testRefreshRate))
+}
+
+// TestReconnectRefreshmentBounded verifies that allowance does not accrue while a peer
+// is disconnected. The stored settlement timestamp survives the disconnect, so on
+// reconnection the first refreshment is bounded by a single refresh interval rather
+// than by the time since the last settlement.
+func TestReconnectRefreshmentBounded(t *testing.T) {
+	t.Parallel()
+
+	logger := log.Noop
+
+	storeRecipient := newStateStore(t)
+
+	peerID := swarm.MustParseHexAddress("9ee7add7")
+	peer := p2p.Peer{Address: peerID, FullNode: true}
+
+	debt := int64(1000) * testRefreshRate
+
+	payerObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
+	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
+	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
+	recipient.SetAccounting(receiverObserver)
+	err := recipient.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := streamtest.New(
+		streamtest.WithProtocols(recipient.Protocol()),
+		streamtest.WithBaseAddr(peerID),
+	)
+
+	storePayer := newStateStore(t)
+
+	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
+	payer.SetAccounting(payerObserver)
+	err = payer.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10000, 10000, 1, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRate), big.NewInt(testRefreshRate))
+
+	for _, s := range []*pseudosettle.Service{payer, recipient} {
+		if err := s.Terminate(peer); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Init(context.Background(), peer); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// an hour of disconnected time must not be forgiven on reconnection
+	sentSum := big.NewInt(2 * testRefreshRate)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 13600, 13600, 1, 2, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRate), sentSum)
 }
 
 func TestTimeLimitedPayment(t *testing.T) {
@@ -358,9 +420,6 @@ func TestTimeLimitedPayment(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
-	// Establish a connection time before init so the first-contact allowance is
-	// anchored to it rather than to the Unix epoch.
-	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -375,28 +434,32 @@ func TestTimeLimitedPayment(t *testing.T) {
 
 	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	payer.SetAccounting(payerObserver)
+	err = payer.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Set time to 10000, attempt payment based on debt, expect full amount accepted
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10000, 10000, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10000, 10000, 1, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
 
 	// Set time 3 seconds later, attempt settlement below time based refreshment rate, expect full amount accepted
 	sentSum := big.NewInt(debt + testRefreshRate*3/2)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10003, 10003, 2, 1, 1, big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), sentSum)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10003, 10003, 3, 2, 1, 1, big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), sentSum)
 
 	// set time 1 seconds later, attempt settlement over the time-based allowed limit, expect partial amount accepted
 	sentSum = big.NewInt(debt + testRefreshRate*3/2 + testRefreshRate)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10004, 10004, 3, 1, 1, big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate), sentSum)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10004, 10004, 1, 3, 1, 1, big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate), sentSum)
 
 	// set time to same second as previous case on recipient, 1 second later on payer, attempt settlement, expect sent but failed
 	testCaseNotAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10005, 10004, 4, big.NewInt(2*testRefreshRate), big.NewInt(2*testRefreshRate), io.EOF)
 
 	// set time 6 seconds later, attempt with debt over time based allowance, expect partial accept
 	sentSum = big.NewInt(debt + testRefreshRate*3/2 + testRefreshRate + 6*testRefreshRate)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10010, 10010, 5, 1, 1, big.NewInt(9*testRefreshRate), big.NewInt(9*testRefreshRate), big.NewInt(6*testRefreshRate), sentSum)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10010, 10010, 6, 5, 1, 1, big.NewInt(9*testRefreshRate), big.NewInt(9*testRefreshRate), big.NewInt(6*testRefreshRate), sentSum)
 
 	// set time 10 seconds later, attempt with debt below time based allowance, expect full amount accepted
 	sentSum = big.NewInt(debt + testRefreshRate*3/2 + testRefreshRate + 6*testRefreshRate + 5*testRefreshRate)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10020, 10020, 6, 1, 1, big.NewInt(5*testRefreshRate), big.NewInt(5*testRefreshRate), big.NewInt(5*testRefreshRate), sentSum)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10020, 10020, 10, 6, 1, 1, big.NewInt(5*testRefreshRate), big.NewInt(5*testRefreshRate), big.NewInt(5*testRefreshRate), sentSum)
 }
 
 func TestTimeLimitedPaymentLight(t *testing.T) {
@@ -415,9 +478,6 @@ func TestTimeLimitedPaymentLight(t *testing.T) {
 	receiverObserver := newTestObserver(map[string]*big.Int{peerID.String(): big.NewInt(debt)}, map[string]*big.Int{})
 	recipient := pseudosettle.New(nil, logger, storeRecipient, receiverObserver, big.NewInt(testRefreshRate), big.NewInt(testRefreshRateLight), mockp2p.New())
 	recipient.SetAccounting(receiverObserver)
-	// Establish a connection time before init so the first-contact allowance is
-	// anchored to it rather than to the Unix epoch.
-	recipient.SetTime(1)
 	err := recipient.Init(context.Background(), peer)
 	if err != nil {
 		t.Fatal(err)
@@ -432,23 +492,27 @@ func TestTimeLimitedPaymentLight(t *testing.T) {
 
 	payer := pseudosettle.New(recorder, logger, storePayer, payerObserver, big.NewInt(testRefreshRateLight), big.NewInt(testRefreshRateLight), mockp2p.New())
 	payer.SetAccounting(payerObserver)
+	err = payer.Init(context.Background(), peer)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// Set time to 10000, attempt payment based on debt, expect full amount accepted
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10000, 10000, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(debt), big.NewInt(debt))
+	// Set time to 10000, attempt payment based on debt, expect one light refresh interval accepted
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10000, 10000, 1, 1, 1, 1, big.NewInt(debt), big.NewInt(debt), big.NewInt(testRefreshRateLight), big.NewInt(testRefreshRateLight))
 	// Set time 3 seconds later, attempt settlement below time based light refreshment rate, expect full amount accepted
-	sentSum := big.NewInt(debt + testRefreshRateLight*3)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10003, 10003, 2, 1, 1, big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRateLight*3), sentSum)
+	sentSum := big.NewInt(testRefreshRateLight + testRefreshRateLight*3)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10003, 10003, 3, 2, 1, 1, big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRate*3/2), big.NewInt(testRefreshRateLight*3), sentSum)
 	// set time 1 seconds later, attempt settlement over the time-based light allowed limit, expect partial amount accepted
-	sentSum = big.NewInt(debt + testRefreshRateLight*3 + testRefreshRateLight)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10004, 10004, 3, 1, 1, big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRateLight), sentSum)
+	sentSum = big.NewInt(testRefreshRateLight + testRefreshRateLight*3 + testRefreshRateLight)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10004, 10004, 1, 3, 1, 1, big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRate*3), big.NewInt(testRefreshRateLight), sentSum)
 	// set time to same second as previous case on recipient, 1 second later on payer, attempt settlement, expect sent but failed
 	testCaseNotAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10005, 10004, 4, big.NewInt(2*testRefreshRate), big.NewInt(2*testRefreshRate), io.EOF)
 	// set time 6 seconds later, attempt with debt over time based light allowance, expect partial accept
-	sentSum = big.NewInt(debt + testRefreshRateLight*3 + testRefreshRateLight + 6*testRefreshRateLight)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10010, 10010, 5, 1, 1, big.NewInt(9*testRefreshRate), big.NewInt(9*testRefreshRate), big.NewInt(6*testRefreshRateLight), sentSum)
+	sentSum = big.NewInt(testRefreshRateLight + testRefreshRateLight*3 + testRefreshRateLight + 6*testRefreshRateLight)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10010, 10010, 6, 5, 1, 1, big.NewInt(9*testRefreshRate), big.NewInt(9*testRefreshRate), big.NewInt(6*testRefreshRateLight), sentSum)
 	// set time 100 seconds later, attempt with debt below time based allowance, expect full amount accepted
-	sentSum = big.NewInt(debt + testRefreshRateLight*3 + testRefreshRateLight + 6*testRefreshRateLight + 50*testRefreshRateLight)
-	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10110, 10110, 6, 1, 1, big.NewInt(50*testRefreshRateLight), big.NewInt(50*testRefreshRateLight), big.NewInt(50*testRefreshRateLight), sentSum)
+	sentSum = big.NewInt(testRefreshRateLight + testRefreshRateLight*3 + testRefreshRateLight + 6*testRefreshRateLight + 50*testRefreshRateLight)
+	testCaseAccepted(t, recorder, payerObserver, receiverObserver, payer, recipient, peerID, 10110, 10110, 100, 6, 1, 1, big.NewInt(50*testRefreshRateLight), big.NewInt(50*testRefreshRateLight), big.NewInt(50*testRefreshRateLight), sentSum)
 }
 
 func newStateStore(t *testing.T) storage.StateStorer {


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

`peerAllowance` computes the acceptable incoming payment as `(now - lastSettlementTime) * refreshRate`. With no stored settlement record `lastSettlementTime` defaults to `0`, so the first refreshment from a peer is granted the whole Unix epoch scaled by the refresh rate and forgives its entire outstanding debt in one go. The same holds on reconnection: the stored record survives the disconnect, so a peer returning after an hour is granted an hour of allowance for a connection that is seconds old.

The bound cannot be applied to the recipient alone. `NotifyRefreshmentSent` recomputes the expectation as `min(allegedInterval * refreshRate, attemptedAmount)` and blocklists the peer when the accepted amount falls short, and `allegedInterval` is derived from the payer's own stored record, which defaults to `0` in exactly the same way. Both ends defaulting to the epoch is what makes them agree today, so tightening one side alone would make a patched recipient accept less than every peer expects and be blocklisted on the first refreshment.

This bounds the first refreshment of a connection to a single refresh interval, applied identically on the recipient and the payer. Refreshments after the first use the stored timestamps as before, and reconnection is treated as a first refreshment so allowance no longer accrues while a peer is disconnected.

Anchoring at the connection time was considered and dropped. The quantity being bounded is of the same order as the clock skew the protocol already tolerates, 2 seconds in `ErrTimeOutOfSyncRecent` against a default payment threshold of 3 seconds of refresh rate, so a bound derived from two independently measured clocks would be unreliable, and slack added to absorb the skew would be claimable on every refreshment. Treating an absent or pre-connection timestamp as one interval needs no clock comparison between peers and is identical on both ends by construction.

On rollout: an unpatched payer still expects the full attempted amount on first contact, so it will blocklist a patched recipient for roughly `(debt + paymentThreshold) / refreshRate` seconds on each new peer until the network has upgraded. The payer half is a pure relaxation and can never cause a blocklist, so it can be released on its own first with the recipient bound following later if you would rather not carry that. Happy to split it that way.

One correction to #5530: the allowance is capped by the peer's debt, which the recipient already caps at `disconnectLimit`, so the exposure is one payment threshold plus tolerance per new peer identity rather than an unbounded amount. Still worth closing off given identities are cheap, but the issue overstates the magnitude.

### Open API Spec Version Changes (if applicable)

None.

#### Motivation and Context (Optional)

See #5530.

### Related Issue (Optional)

Closes #5530.

### Screenshots (if appropriate):

N/A

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
