### PR TITLE
ci(auto-assign-author): skip bot/agent PR authors

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -16,10 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     # Only internal-branch PRs (fork PRs get a read-only token and their author
     # isn't a collaborator, so assignment can't apply), and only when the author
-    # left it unassigned.
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.assignees[0] == null
+    # left it unassigned. Skip bot/agent authors: assigning an agent (e.g. a
+    # Copilot coding-agent PR) requires a user token, which GITHUB_TOKEN is not.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.assignees[0] == null
+      && github.event.pull_request.user.type != 'Bot'
     steps:
       - uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             await github.rest.issues.addAssignees({


### PR DESCRIPTION
## Problem
`auto-assign-author.yml` fails on PRs opened by an **agent/bot** (e.g. Copilot coding-agent PRs) with:
```
HttpError: Assigning agents is not supported with GitHub App installation tokens. Use a user token (personal access token or OAuth token) instead.
```
`addAssignees` can't assign an agent using `GITHUB_TOKEN` (a GitHub App installation token).

## Fix
The workflow only needs to assign **human** authors (board/report visibility), so:
- guard the job on `github.event.pull_request.user.type != 'Bot'` → skip bot/agent authors entirely
- add `continue-on-error: true` on the step so this cosmetic assignment can never fail CI again

No PAT/secret needed.