### PR TITLE
fix(addressbook): validate address entrie to prevent nil dereference

### DIFF
--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -83,6 +83,7 @@ func (s *store) Get(overlay swarm.Address) (*bzz.Address, bool, error) {
 		return nil, false, err
 	}
 	if v.Address == nil {
+		_ = s.store.Delete(key)
 		return nil, false, ErrNotFound
 	}
 	return v.Address, v.Verified, nil

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -82,6 +82,9 @@ func (s *store) Get(overlay swarm.Address) (*bzz.Address, bool, error) {
 		}
 		return nil, false, err
 	}
+	if v.Address == nil {
+		return nil, false, ErrNotFound
+	}
 	return v.Address, v.Verified, nil
 }
 

--- a/pkg/addressbook/addressbook_test.go
+++ b/pkg/addressbook/addressbook_test.go
@@ -5,6 +5,7 @@
 package addressbook_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/ethersphere/bee/v2/pkg/bzz"
 	"github.com/ethersphere/bee/v2/pkg/crypto"
 	"github.com/ethersphere/bee/v2/pkg/statestore/mock"
+	"github.com/ethersphere/bee/v2/pkg/storage"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -94,5 +96,46 @@ func run(t *testing.T, f bookFunc) {
 
 	if len(addresses) != 1 {
 		t.Fatalf("expected addresses len %v, got %v", 1, len(addresses))
+	}
+}
+
+type mockCorruptedStore struct{}
+
+func (m *mockCorruptedStore) Get(key string, i any) error {
+	corruptedJSON := []byte(`{"address": null}`)
+	return json.Unmarshal(corruptedJSON, i)
+}
+
+func (m *mockCorruptedStore) Put(key string, i any) error {
+	return nil
+}
+
+func (m *mockCorruptedStore) Delete(key string) error {
+	return nil
+}
+
+func (m *mockCorruptedStore) Iterate(prefix string, fn storage.StateIterFunc) error {
+	return nil
+}
+
+func (m *mockCorruptedStore) Close() error {
+	return nil
+}
+
+func TestGetCorruptedNilAddress(t *testing.T) {
+	t.Parallel()
+
+	corruptedStore := &mockCorruptedStore{}
+	book := addressbook.New(corruptedStore)
+
+	addr := swarm.NewAddress([]byte{0, 1, 2, 3})
+
+	v, _, err := book.Get(addr)
+	if !errors.Is(err, addressbook.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for corrupted entry, got %v", err)
+	}
+
+	if v != nil {
+		t.Fatalf("expected nil address, got %s", v)
 	}
 }


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Nodes crash with panic error when connecting to peers if the addressbook contains corrupted entries with nil Address fields.
Added `nil` check for `address` before returning it

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
