### PR TITLE
feat(api): server-side manifest listing endpoint (read path for #5535)

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -536,6 +536,77 @@ paths:
         default:
           description: Default response
 
+  "/manifest/{address}/{prefix}":
+    get:
+      summary: "List the contents of a manifest (server-side trie walk)"
+      description: >
+        Enumerate the entries of a manifest without downloading and traversing
+        the Mantaray trie client-side. Semantics follow S3 ListObjectsV2:
+        optional path prefix, an optional delimiter for shallow
+        (pseudo-directory) listings, and lexicographic pagination via
+        `limit`/`after`. See ethersphere/bee#5535.
+      tags:
+        - BZZ
+      parameters:
+        - in: path
+          name: address
+          schema:
+            $ref: "SwarmCommon.yaml#/components/schemas/SwarmReference"
+          required: true
+          description: Swarm address of the manifest.
+        - in: path
+          name: prefix
+          schema:
+            type: string
+          required: false
+          description: Path prefix to list under (default is the manifest root).
+        - in: query
+          name: delimiter
+          schema:
+            type: string
+          required: false
+          description: >
+            If set (typically `/`), return a shallow listing: entries directly
+            under the prefix plus `commonPrefixes` for deeper paths. If unset,
+            the listing is recursive.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 1000
+          required: false
+          description: Maximum number of entries (plus common prefixes) per page. Node-enforced hard cap.
+        - in: query
+          name: after
+          schema:
+            type: string
+          required: false
+          description: Continuation token; return entries strictly after this path.
+        - in: query
+          name: sizes
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: >
+            If true, resolve each entry's byte length from its root-chunk span
+            (one extra chunk read per entry).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "SwarmCommon.yaml#/components/schemas/ManifestList"
+        "400":
+          $ref: "SwarmCommon.yaml#/components/responses/400"
+        "404":
+          $ref: "SwarmCommon.yaml#/components/responses/404"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
+        default:
+          description: Default response
+
   "/tags":
     get:
       summary: Get list of tags

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -574,8 +574,12 @@ paths:
           schema:
             type: integer
             default: 1000
+            maximum: 1000000
           required: false
-          description: Maximum number of entries (plus common prefixes) per page. Node-enforced hard cap.
+          description: >
+            Maximum number of entries (plus common prefixes) per page. A value
+            above the node's hard cap (1000000) is rejected with 400; a
+            non-positive value falls back to the default.
         - in: query
           name: after
           schema:

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -558,8 +558,8 @@ paths:
           name: prefix
           schema:
             type: string
-          required: false
-          description: Path prefix to list under (default is the manifest root).
+          required: true
+          description: Path prefix to list under; use an empty value to list the manifest root.
         - in: query
           name: delimiter
           schema:

--- a/openapi/SwarmCommon.yaml
+++ b/openapi/SwarmCommon.yaml
@@ -726,6 +726,40 @@ components:
         - $ref: "#/components/schemas/SwarmEncryptedReference"
         - $ref: "#/components/schemas/DomainName"
 
+    ManifestListEntry:
+      type: object
+      properties:
+        path:
+          type: string
+        reference:
+          $ref: "#/components/schemas/SwarmReference"
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        size:
+          type: integer
+          description: Present only when the request set sizes=true and the span could be read.
+
+    ManifestList:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestListEntry"
+        commonPrefixes:
+          type: array
+          description: Pseudo-directory prefixes; present only when a delimiter was supplied.
+          items:
+            type: string
+        truncated:
+          type: boolean
+          description: True when more entries remain beyond this page.
+        nextMarker:
+          type: string
+          description: Continuation token to pass as `after` for the next page.
+
     SwapCashoutResult:
       type: object
       properties:

--- a/pkg/api/manifest.go
+++ b/pkg/api/manifest.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -21,8 +22,15 @@ import (
 )
 
 const (
+	// manifestListDefaultLimit is the page size used when the client does not
+	// request one. Callers paginate the rest via after/nextMarker.
 	manifestListDefaultLimit = 1000
-	manifestListMaxLimit     = 10000
+	// manifestListMaxLimit bounds a single page. The whole page is buffered in
+	// memory before it is written, so this caps per-request allocation; it does
+	// not limit total enumeration, which is unbounded via after/nextMarker. An
+	// over-cap limit is rejected rather than silently clamped, so the client
+	// keeps an accurate view of its own page size.
+	manifestListMaxLimit = 1000000
 )
 
 // emptyManifestEntry is the reference bee's uploader stores for manifest-level
@@ -73,9 +81,15 @@ func (s *Service) manifestListHandler(w http.ResponseWriter, r *http.Request) {
 		response("invalid query params", logger, w)
 		return
 	}
-	// enforce the node-side hard cap; a non-positive limit falls back to it too.
-	if queries.Limit <= 0 || queries.Limit > manifestListMaxLimit {
-		queries.Limit = manifestListMaxLimit
+	// reject an over-cap limit explicitly rather than silently clamping it, so
+	// the client is not misled about its page size. a non-positive limit falls
+	// back to the default.
+	if queries.Limit > manifestListMaxLimit {
+		jsonhttp.BadRequest(w, fmt.Sprintf("limit exceeds maximum of %d", manifestListMaxLimit))
+		return
+	}
+	if queries.Limit <= 0 {
+		queries.Limit = manifestListDefaultLimit
 	}
 
 	address := paths.Address

--- a/pkg/api/manifest.go
+++ b/pkg/api/manifest.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
+	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
+	"github.com/ethersphere/bee/v2/pkg/manifest"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	"github.com/ethersphere/bee/v2/pkg/tracing"
+	"github.com/gorilla/mux"
+)
+
+const (
+	manifestListDefaultLimit = 1000
+	manifestListMaxLimit     = 10000
+)
+
+// emptyManifestEntry is the reference bee's uploader stores for manifest-level
+// metadata held at RootPath (e.g. website-index-document): 32 zero bytes. Note
+// this is NOT swarm.ZeroAddress (which has nil bytes), so Address.IsZero() does
+// not match it — mirror the convention used by mantarayManifest.IterateAddresses.
+var emptyManifestEntry = swarm.NewAddress([]byte{31: 0})
+
+type ManifestListEntry struct {
+	Path      string            `json:"path"`
+	Reference swarm.Address     `json:"reference"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Size      *int64            `json:"size,omitempty"`
+}
+
+type ManifestListResponse struct {
+	Entries        []ManifestListEntry `json:"entries"`
+	CommonPrefixes []string            `json:"commonPrefixes,omitempty"`
+	Truncated      bool                `json:"truncated"`
+	NextMarker     string              `json:"nextMarker,omitempty"`
+}
+
+// manifestListHandler serves a server-side listing of a manifest's contents,
+// walking the Mantaray trie on the node instead of forcing clients to fetch
+// and traverse it chunk by chunk. Semantics mirror S3 ListObjectsV2 (prefix,
+// delimiter, pagination) — see ethersphere/bee#5535.
+func (s *Service) manifestListHandler(w http.ResponseWriter, r *http.Request) {
+	logger := tracing.NewLoggerWithTraceID(r.Context(), s.logger.WithName("get_manifest").Build())
+
+	paths := struct {
+		Address swarm.Address `map:"address,resolve" validate:"required"`
+		Prefix  string        `map:"path"`
+	}{}
+	if response := s.mapStructure(mux.Vars(r), &paths); response != nil {
+		response("invalid path params", logger, w)
+		return
+	}
+
+	queries := struct {
+		Delimiter string `map:"delimiter"`
+		Limit     int    `map:"limit"`
+		After     string `map:"after"`
+		Sizes     bool   `map:"sizes"`
+	}{
+		Limit: manifestListDefaultLimit,
+	}
+	if response := s.mapStructure(r.URL.Query(), &queries); response != nil {
+		response("invalid query params", logger, w)
+		return
+	}
+	// enforce the node-side hard cap; a non-positive limit falls back to it too.
+	if queries.Limit <= 0 || queries.Limit > manifestListMaxLimit {
+		queries.Limit = manifestListMaxLimit
+	}
+
+	address := paths.Address
+	if v := getAddressFromContext(r.Context()); !v.IsZero() {
+		address = v
+	}
+
+	ctx := r.Context()
+	ls := loadsave.NewReadonly(s.storer.Download(true), s.storer.Cache(), redundancy.DefaultDownloadLevel)
+
+	m, err := manifest.NewDefaultManifestReference(address, ls)
+	if err != nil {
+		logger.Debug("manifest list: not a manifest", "address", address, "error", err)
+		logger.Error(nil, "manifest list: not a manifest")
+		jsonhttp.NotFound(w, nil)
+		return
+	}
+
+	walker, ok := m.(manifest.EntryWalker)
+	if !ok {
+		logger.Error(nil, "manifest list: manifest type does not support listing")
+		jsonhttp.InternalServerError(w, "manifest listing not supported")
+		return
+	}
+
+	prefix := paths.Prefix
+	resp := ManifestListResponse{Entries: []ManifestListEntry{}}
+	seenPrefix := make(map[string]struct{})
+	// marker tracks the last path fully consumed on this page; on truncation it
+	// becomes nextMarker so a resumed page starts strictly after it. It is only
+	// advanced for paths that are actually accounted for (emitted or folded into
+	// a common prefix), never for entries skipped by the `after` continuation.
+	var marker string
+
+	walkErr := walker.WalkEntry(ctx, prefix, func(p string, entry manifest.Entry) error {
+		// skip the synthetic root-metadata entry (empty reference); its
+		// manifest-level metadata (e.g. website-index-document) is not a file.
+		if entry.Reference().IsZero() || entry.Reference().Equal(emptyManifestEntry) {
+			return nil
+		}
+		// continuation token: only paths strictly after it are unseen.
+		if queries.After != "" && p <= queries.After {
+			return nil
+		}
+
+		if queries.Delimiter != "" {
+			rest := strings.TrimPrefix(p, prefix)
+			if idx := strings.Index(rest, queries.Delimiter); idx >= 0 {
+				cp := prefix + rest[:idx+len(queries.Delimiter)]
+				if _, dup := seenPrefix[cp]; dup {
+					// already an open common prefix — folding p in is free.
+					marker = p
+					return nil
+				}
+				if len(resp.Entries)+len(resp.CommonPrefixes) >= queries.Limit {
+					resp.Truncated = true
+					resp.NextMarker = marker
+					return manifest.ErrStopWalk
+				}
+				seenPrefix[cp] = struct{}{}
+				resp.CommonPrefixes = append(resp.CommonPrefixes, cp)
+				marker = p
+				return nil
+			}
+		}
+
+		if len(resp.Entries)+len(resp.CommonPrefixes) >= queries.Limit {
+			resp.Truncated = true
+			resp.NextMarker = marker
+			return manifest.ErrStopWalk
+		}
+
+		le := ManifestListEntry{
+			Path:      p,
+			Reference: entry.Reference(),
+			Metadata:  entry.Metadata(),
+		}
+		if queries.Sizes {
+			if size, err := s.manifestEntrySize(ctx, entry.Reference()); err == nil {
+				le.Size = &size
+			} else {
+				// size is best-effort: a legacy/unreachable entry still lists.
+				logger.Debug("manifest list: size resolution failed", "path", p, "error", err)
+			}
+		}
+		resp.Entries = append(resp.Entries, le)
+		marker = p
+		return nil
+	})
+	if walkErr != nil {
+		if errors.Is(walkErr, manifest.ErrNotFound) {
+			logger.Debug("manifest list: prefix not found", "address", address, "prefix", prefix)
+			jsonhttp.NotFound(w, "prefix not found")
+			return
+		}
+		// a partially-retrievable manifest is reported as an error rather than
+		// silently returning a truncated view (see #5535 error semantics).
+		logger.Debug("manifest list: walk failed", "address", address, "error", walkErr)
+		logger.Error(nil, "manifest list: walk failed")
+		jsonhttp.NotFound(w, "manifest incomplete or not retrievable")
+		return
+	}
+
+	jsonhttp.OK(w, resp)
+}
+
+// manifestEntrySize resolves a file entry's byte length by reading the 8-byte
+// span header from its root chunk. Opt-in (sizes=true): one extra chunk read
+// per entry.
+func (s *Service) manifestEntrySize(ctx context.Context, ref swarm.Address) (int64, error) {
+	ch, err := s.storer.Download(true).Get(ctx, ref)
+	if err != nil {
+		return 0, err
+	}
+	data := ch.Data()
+	if len(data) < swarm.SpanSize {
+		return 0, errors.New("chunk shorter than span")
+	}
+	return int64(binary.LittleEndian.Uint64(data[:swarm.SpanSize])), nil
+}

--- a/pkg/api/manifest_test.go
+++ b/pkg/api/manifest_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ethersphere/bee/v2/pkg/api"
+	"github.com/ethersphere/bee/v2/pkg/file/loadsave"
+	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
+	"github.com/ethersphere/bee/v2/pkg/jsonhttp/jsonhttptest"
+	"github.com/ethersphere/bee/v2/pkg/log"
+	"github.com/ethersphere/bee/v2/pkg/manifest"
+	mockstorer "github.com/ethersphere/bee/v2/pkg/storer/mock"
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+)
+
+// fakeRef derives a deterministic non-zero 32-byte reference from a path. The
+// listing endpoint returns entry references straight from the trie without
+// dereferencing them, so a synthetic address is sufficient for these tests.
+func fakeRef(path string) swarm.Address {
+	b := make([]byte, swarm.HashSize)
+	copy(b, path)
+	b[swarm.HashSize-1] = 0x01 // guarantee non-zero even for the empty path
+	return swarm.NewAddress(b)
+}
+
+// buildManifest writes a mantaray manifest containing the given paths to the
+// storer and returns its root reference.
+func buildManifest(t *testing.T, storer api.Storer, paths []string) swarm.Address {
+	t.Helper()
+	ctx := context.Background()
+
+	m, err := manifest.NewDefaultManifest(
+		loadsave.New(storer.ChunkStore(), storer.Cache(), pipelineFactory(storer.Cache(), false, 0), redundancy.DefaultDownloadLevel),
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// bee's uploader stores manifest-level metadata at RootPath with an empty
+	// (32-zero-byte) reference; the listing must not surface it as a file entry.
+	err = m.Add(ctx, manifest.RootPath, manifest.NewEntry(
+		swarm.NewAddress(make([]byte, swarm.HashSize)),
+		map[string]string{"website-index-document": "index.html"},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range paths {
+		err = m.Add(ctx, p, manifest.NewEntry(fakeRef(p), map[string]string{
+			manifest.EntryMetadataContentTypeKey: "application/octet-stream",
+			manifest.EntryMetadataFilenameKey:    p,
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	ref, err := m.Store(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref
+}
+
+func manifestPaths(resp api.ManifestListResponse) []string {
+	out := make([]string, len(resp.Entries))
+	for i, e := range resp.Entries {
+		out[i] = e.Path
+	}
+	return out
+}
+
+func TestManifestList(t *testing.T) {
+	t.Parallel()
+
+	storer := mockstorer.New()
+	client, _, _, _ := newTestServer(t, testServerOptions{
+		Storer: storer,
+		Logger: log.Noop,
+	})
+
+	files := []string{
+		"index.html",
+		"data/a.parquet",
+		"data/b.parquet",
+		"data/2025/x.parquet",
+		"docs/readme.md",
+	}
+	ref := buildManifest(t, storer, files)
+
+	list := func(t *testing.T, url string) api.ManifestListResponse {
+		t.Helper()
+		var resp api.ManifestListResponse
+		jsonhttptest.Request(t, client, http.MethodGet, url, http.StatusOK,
+			jsonhttptest.WithUnmarshalJSONResponse(&resp),
+		)
+		return resp
+	}
+
+	t.Run("recursive from root", func(t *testing.T) {
+		resp := list(t, fmt.Sprintf("/manifest/%s/", ref))
+		want := []string{
+			"data/2025/x.parquet",
+			"data/a.parquet",
+			"data/b.parquet",
+			"docs/readme.md",
+			"index.html",
+		}
+		got := manifestPaths(resp)
+		if !equalStrings(got, want) {
+			t.Fatalf("recursive listing mismatch:\n got %v\nwant %v", got, want)
+		}
+		if resp.Truncated {
+			t.Fatalf("did not expect truncation")
+		}
+		if len(resp.CommonPrefixes) != 0 {
+			t.Fatalf("did not expect common prefixes, got %v", resp.CommonPrefixes)
+		}
+		// metadata should round-trip
+		if ct := resp.Entries[0].Metadata[manifest.EntryMetadataContentTypeKey]; ct != "application/octet-stream" {
+			t.Fatalf("unexpected content-type metadata: %q", ct)
+		}
+	})
+
+	t.Run("delimiter shallow listing", func(t *testing.T) {
+		resp := list(t, fmt.Sprintf("/manifest/%s/?delimiter=/", ref))
+		if got := manifestPaths(resp); !equalStrings(got, []string{"index.html"}) {
+			t.Fatalf("shallow entries mismatch: got %v", got)
+		}
+		if got := resp.CommonPrefixes; !equalStrings(got, []string{"data/", "docs/"}) {
+			t.Fatalf("common prefixes mismatch: got %v", got)
+		}
+	})
+
+	t.Run("prefix", func(t *testing.T) {
+		resp := list(t, fmt.Sprintf("/manifest/%s/data/", ref))
+		want := []string{"data/2025/x.parquet", "data/a.parquet", "data/b.parquet"}
+		if got := manifestPaths(resp); !equalStrings(got, want) {
+			t.Fatalf("prefix listing mismatch:\n got %v\nwant %v", got, want)
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		var all []string
+		url := fmt.Sprintf("/manifest/%s/?limit=2", ref)
+		for {
+			resp := list(t, url)
+			all = append(all, manifestPaths(resp)...)
+			if !resp.Truncated {
+				break
+			}
+			if resp.NextMarker == "" {
+				t.Fatal("truncated page without a nextMarker")
+			}
+			url = fmt.Sprintf("/manifest/%s/?limit=2&after=%s", ref, resp.NextMarker)
+		}
+		want := []string{
+			"data/2025/x.parquet",
+			"data/a.parquet",
+			"data/b.parquet",
+			"docs/readme.md",
+			"index.html",
+		}
+		if !equalStrings(all, want) {
+			t.Fatalf("paginated listing mismatch:\n got %v\nwant %v", all, want)
+		}
+	})
+
+	t.Run("missing prefix is 404", func(t *testing.T) {
+		jsonhttptest.Request(t, client, http.MethodGet,
+			fmt.Sprintf("/manifest/%s/nope/", ref), http.StatusNotFound)
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/api/manifest_test.go
+++ b/pkg/api/manifest_test.go
@@ -176,6 +176,11 @@ func TestManifestList(t *testing.T) {
 		jsonhttptest.Request(t, client, http.MethodGet,
 			fmt.Sprintf("/manifest/%s/nope/", ref), http.StatusNotFound)
 	})
+
+	t.Run("limit above cap is 400", func(t *testing.T) {
+		jsonhttptest.Request(t, client, http.MethodGet,
+			fmt.Sprintf("/manifest/%s/?limit=1000001", ref), http.StatusBadRequest)
+	})
 }
 
 func equalStrings(a, b []string) bool {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -359,6 +359,20 @@ func (s *Service) mountAPI() {
 		),
 	})
 
+	handle("/manifest/{address}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := r.URL
+		u.Path += "/"
+		http.Redirect(w, r, u.String(), http.StatusPermanentRedirect)
+	}))
+
+	handle("/manifest/{address}/{path:.*}", jsonhttp.MethodHandler{
+		"GET": web.ChainHandlers(
+			s.newTracingHandler("manifest-list"),
+			s.actDecryptionHandler(),
+			web.FinalHandlerFunc(s.manifestListHandler),
+		),
+	})
+
 	handle("/pss/send/{topic}/{targets}", jsonhttp.MethodHandler{
 		"POST": web.ChainHandlers(
 			jsonhttp.NewMaxBodyBytesHandler(swarm.ChunkSize),

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -35,6 +35,10 @@ var (
 	// ErrMissingReference is returned when the reference for the manifest file
 	// is missing.
 	ErrMissingReference = errors.New("manifest: missing reference")
+
+	// ErrStopWalk can be returned by a WalkEntryFunc to terminate an entry
+	// walk early without the walk itself reporting an error.
+	ErrStopWalk = errors.New("manifest: stop walk")
 )
 
 // StoreSizeFunc is a callback on every content size that will be stored by
@@ -66,6 +70,23 @@ type Entry interface {
 	Reference() swarm.Address
 	// Metadata returns the metadata of the file.
 	Metadata() map[string]string
+}
+
+// WalkEntryFunc is the type of the function called for each manifest entry
+// visited by an EntryWalker. Entries are visited in deterministic
+// (lexicographic) path order. Returning ErrStopWalk terminates the walk
+// cleanly; any other error aborts the walk and is propagated.
+type WalkEntryFunc func(path string, entry Entry) error
+
+// EntryWalker is an optional interface implemented by manifests that can
+// enumerate their entries server-side. It powers manifest listing without
+// forcing every Interface implementation to support traversal, and without
+// exposing the underlying trie representation to callers.
+type EntryWalker interface {
+	// WalkEntry visits every value entry whose path is at or below prefix,
+	// in lexicographic order, calling fn for each. A prefix of "" (or
+	// RootPath) walks the whole manifest.
+	WalkEntry(ctx context.Context, prefix string, fn WalkEntryFunc) error
 }
 
 // NewDefaultManifest creates a new manifest with default type.

--- a/pkg/manifest/mantaray.go
+++ b/pkg/manifest/mantaray.go
@@ -131,6 +131,32 @@ func (m *mantarayManifest) Store(ctx context.Context, storeSizeFn ...StoreSizeFu
 	return address, nil
 }
 
+func (m *mantarayManifest) WalkEntry(ctx context.Context, prefix string, fn WalkEntryFunc) error {
+	walker := func(path []byte, node *mantaray.Node, err error) error {
+		if err != nil {
+			return err
+		}
+		if node == nil || !node.IsValueType() {
+			return nil
+		}
+		entry := NewEntry(swarm.NewAddress(node.Entry()), node.Metadata())
+		return fn(string(path), entry)
+	}
+
+	err := m.trie.WalkNode(ctx, []byte(prefix), m.ls, walker)
+	if err != nil {
+		if errors.Is(err, ErrStopWalk) {
+			return nil
+		}
+		if errors.Is(err, mantaray.ErrNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	return nil
+}
+
 func (m *mantarayManifest) IterateAddresses(ctx context.Context, fn swarm.AddressIterFunc) error {
 	reference := swarm.NewAddress(m.trie.Reference())
 


### PR DESCRIPTION
## Summary

Adds a read-only, server-side manifest **listing** endpoint, implementing the read half of #5535.

```
GET /manifest/{address}/{prefix}
```

Bee currently has no way to enumerate a manifest's contents over HTTP — clients must download and walk the Mantaray trie themselves, chunk by chunk via `/bytes` (one round trip per node). This endpoint walks the trie **on the node** and returns entries as JSON, turning O(trie nodes) round trips into O(pages). Semantics mirror S3 `ListObjectsV2`:

| Param | Default | Meaning |
|---|---|---|
| `delimiter` | none | `/` → shallow listing: direct entries + `commonPrefixes`. Unset → recursive. |
| `limit` | 1000 | Max entries+prefixes per page. Bounds per-request buffered memory, not total enumeration (unbounded via `after`/`nextMarker`). Hard cap 1000000; a higher value is rejected with 400 rather than silently clamped, and a non-positive value falls back to the default. |
| `after` | none | Continuation token — return entries strictly after this path. |
| `sizes` | `false` | Resolve each entry's byte length from its root-chunk span (one extra chunk read per entry). |

Response: `{ entries[], commonPrefixes[], truncated, nextMarker }`.

This is deliberately **listing only**. The companion server-side *mutation* endpoint sketched in #5535 is a separate follow-up.

## Implementation

Everything needed already existed in the tree:

- **`pkg/manifest`** — a small optional `EntryWalker` interface (+ `ErrStopWalk`), implemented as `WalkEntry` on the mantaray manifest over the existing sorted `WalkNode`. This keeps the core `manifest.Interface` and `simple.go` untouched and doesn't expose the trie representation to callers.
- **`pkg/api/manifest.go`** — `manifestListHandler`, mirroring the `/bzz` download path's manifest resolution (`loadsave.NewReadonly` → `NewDefaultManifestReference`) and reusing the ACT decryption chain, so encrypted/ACT manifests resolve unchanged. Pagination uses a last-consumed-path marker that is correct for both recursive and delimiter modes.
- **`openapi/`** — path + `ManifestList`/`ManifestListEntry` schemas.

No new storage, protocol, or incentive-layer behavior — purely a local read amplification of data the node already serves.

## Testing

- **Unit** (`pkg/api/manifest_test.go`): recursive, `delimiter=/`, prefix, multi-page pagination round-trip, missing-prefix 404, and over-cap-limit 400, over a real mantaray fixture (incl. the empty root-metadata entry). `go test ./pkg/api/ ./pkg/manifest/...` green; `go vet` and `gofmt` clean.
- **Live**: verified end-to-end against a funded Bee 2.8.1 light node on mainnet, listing a manifest built by Bee's own `POST /bzz` uploader. All cases correct, and `sizes=true` returned exact byte lengths from real chunk spans. The live run caught one bug the synthetic test missed — the `RootPath` metadata entry carries a 32-zero-byte reference (not `swarm.ZeroAddress`, which has nil bytes), so it leaked as a `/` entry until the skip was aligned with the `IterateAddresses` convention.

## Known limitations / scope (draft — feedback welcome on the API shape)

Opening as a **draft** to agree the API before polishing. Deliberately out of scope here, happy to address based on review:

1. **Delimiter mode still descends full subtrees.** `WalkNode` has no pruning hook, so `delimiter=/` walks a subtree fully to emit one `commonPrefixes` entry — output is correct but not yet the cheap shallow listing it should be. The clean fix is a pruning-aware walk in the mantaray layer.
2. **Each page re-walks from the start** (`after` is a post-filter), so paginating N pages is ~O(N × subtree) node loads. A trie-seek to `after` would fix it.
3. **`prefix` is directory-boundary-only**, not an arbitrary S3 byte-prefix (e.g. `prefix=da` 404s; `data/` works). Documented as such; could add `HasPrefix`-style handling.
4. **No per-request node-load budget** yet (the DoS mitigation noted in #5535); `sizes=true` on encrypted refs is silently unsupported. The `limit` hard cap bounds buffered response memory but not the number of trie nodes walked to build a page.
5. Root-level manifest metadata (e.g. `website-index-document`) is currently dropped from the listing; #5535 proposes surfacing it as a top-level `manifestMetadata` — easy to add if wanted.

Refs #5535.
