### PR TITLE
feat(p2p): expose peer protocol version for backward compatibilities

### DIFF
--- a/pkg/p2p/libp2p/internal/handshake/mock/stream.go
+++ b/pkg/p2p/libp2p/internal/handshake/mock/stream.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"bytes"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 )
 
@@ -71,4 +72,8 @@ func (s *Stream) FullClose() error {
 
 func (s *Stream) Reset() error {
 	return nil
+}
+
+func (s *Stream) Version() (*semver.Version, error) {
+	return nil, nil
 }

--- a/pkg/p2p/libp2p/stream.go
+++ b/pkg/p2p/libp2p/stream.go
@@ -7,8 +7,10 @@ package libp2p
 import (
 	"errors"
 	"io"
+	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/libp2p/go-libp2p/core/network"
 )
@@ -36,6 +38,15 @@ func (s *stream) Headers() p2p.Headers {
 
 func (s *stream) ResponseHeaders() p2p.Headers {
 	return s.responseHeaders
+}
+
+func (s *stream) Version() (*semver.Version, error) {
+	parts := strings.Split(string(s.Stream.Protocol()), "/")
+	partsLen := len(parts)
+	if partsLen < 2 {
+		return nil, errors.New("invalid protocol version")
+	}
+	return semver.NewVersion(parts[partsLen-2])
 }
 
 func (s *stream) Reset() error {

--- a/pkg/p2p/libp2p/stream.go
+++ b/pkg/p2p/libp2p/stream.go
@@ -41,7 +41,7 @@ func (s *stream) ResponseHeaders() p2p.Headers {
 }
 
 func (s *stream) Version() (*semver.Version, error) {
-	parts := strings.Split(string(s.Stream.Protocol()), "/")
+	parts := strings.Split(string(s.Protocol()), "/")
 	partsLen := len(parts)
 	if partsLen < 2 {
 		return nil, errors.New("invalid protocol version")

--- a/pkg/p2p/libp2p/stream_test.go
+++ b/pkg/p2p/libp2p/stream_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package libp2p_test
+
+import (
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/ethersphere/bee/v2/pkg/p2p/libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+type mockNetStream struct {
+	network.Stream
+	protocol protocol.ID
+}
+
+func (m *mockNetStream) Protocol() protocol.ID {
+	return m.protocol
+}
+
+func TestStreamVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		protocolID protocol.ID
+		wantMajor  int64
+		wantMinor  int64
+		wantPatch  int64
+		wantErr    bool
+	}{
+		{
+			name:       "valid standard version",
+			protocolID: "/swarm/pingpong/1.2.3/ping",
+			wantMajor:  1,
+			wantMinor:  2,
+			wantPatch:  3,
+		},
+		{
+			name:       "valid rc version",
+			protocolID: "/swarm/pingpong/2.0.0-rc1/ping",
+			wantMajor:  2,
+			wantMinor:  0,
+			wantPatch:  0,
+		},
+		{
+			name:       "invalid version format",
+			protocolID: "/swarm/pingpong/abc/ping",
+			wantErr:    true,
+		},
+		{
+			name:       "too short protocol ID",
+			protocolID: "/ping",
+			wantErr:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &mockNetStream{protocol: tc.protocolID}
+			srv := &libp2p.Service{}
+			wrapped := srv.WrapStream(s)
+
+			v, err := wrapped.Version()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if v == nil {
+				t.Fatal("expected version to be non-nil")
+			}
+
+			expected := semver.Version{Major: tc.wantMajor, Minor: tc.wantMinor}
+			if v.Major != expected.Major || v.Minor != expected.Minor {
+				t.Errorf("got version %v, want %v", v, expected)
+			}
+		})
+	}
+}

--- a/pkg/p2p/p2p.go
+++ b/pkg/p2p/p2p.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/bzz"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -166,6 +167,7 @@ type Stream interface {
 	Headers() Headers
 	FullClose() error
 	Reset() error
+	Version() (*semver.Version, error)
 }
 
 // ProtocolSpec defines a collection of Stream specifications with handlers.

--- a/pkg/p2p/protobuf/protobuf_test.go
+++ b/pkg/p2p/protobuf/protobuf_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/p2p/protobuf"
 	"github.com/ethersphere/bee/v2/pkg/p2p/protobuf/internal/pb"
@@ -347,6 +348,10 @@ func (noopWriteCloser) ResponseHeaders() p2p.Headers {
 	return nil
 }
 
+func (noopWriteCloser) Version() (*semver.Version, error) {
+	return nil, nil
+}
+
 func (noopWriteCloser) Close() error {
 	return nil
 }
@@ -377,6 +382,10 @@ func (noopReadCloser) Headers() p2p.Headers {
 
 func (noopReadCloser) ResponseHeaders() p2p.Headers {
 	return nil
+}
+
+func (noopReadCloser) Version() (*semver.Version, error) {
+	return nil, nil
 }
 
 func (noopReadCloser) Close() error {

--- a/pkg/p2p/streamtest/streamtest.go
+++ b/pkg/p2p/streamtest/streamtest.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/spinlock"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -122,10 +123,12 @@ func (r *Recorder) NewStream(ctx context.Context, addr swarm.Address, h p2p.Head
 		}
 	}
 
+	version, versionErr := semver.NewVersion(protocolVersion)
+
 	recordIn := newRecord(r.messageLatency)
 	recordOut := newRecord(r.messageLatency)
-	streamOut := newStream(recordIn, recordOut)
-	streamIn := newStream(recordOut, recordIn)
+	streamOut := newStream(recordIn, recordOut, version, versionErr)
+	streamIn := newStream(recordOut, recordIn, version, versionErr)
 
 	var handler p2p.HandlerFunc
 	var headler p2p.HeadlerFunc
@@ -260,10 +263,12 @@ type stream struct {
 	responseHeaders p2p.Headers
 	closed          bool
 	lock            sync.Mutex
+	version         *semver.Version
+	versionErr      error
 }
 
-func newStream(in, out *record) *stream {
-	return &stream{in: in, out: out}
+func newStream(in, out *record, version *semver.Version, versionErr error) *stream {
+	return &stream{in: in, out: out, version: version, versionErr: versionErr}
 }
 
 func (s *stream) Read(p []byte) (int, error) {
@@ -288,6 +293,10 @@ func (s *stream) Headers() p2p.Headers {
 
 func (s *stream) ResponseHeaders() p2p.Headers {
 	return s.responseHeaders
+}
+
+func (s *stream) Version() (*semver.Version, error) {
+	return s.version, s.versionErr
 }
 
 func (s *stream) Close() error {

--- a/pkg/p2p/streamtest/streamtest_test.go
+++ b/pkg/p2p/streamtest/streamtest_test.go
@@ -15,6 +15,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/ethersphere/bee/v2/pkg/p2p"
 	"github.com/ethersphere/bee/v2/pkg/p2p/streamtest"
 	"github.com/ethersphere/bee/v2/pkg/swarm"
@@ -876,5 +877,47 @@ func testRecords(t *testing.T, records []*streamtest.Record, want [][2]string, w
 		if gotOut != w[1] {
 			t.Errorf("got stream out %q, want %q", gotOut, w[1])
 		}
+	}
+}
+
+func TestStreamVersion(t *testing.T) {
+	t.Parallel()
+
+	recorder := streamtest.New(
+		streamtest.WithProtocols(
+			newTestProtocol(func(_ context.Context, peer p2p.Peer, stream p2p.Stream) error {
+				v, err := stream.Version()
+				if err != nil {
+					t.Errorf("handler: unexpected error: %v", err)
+				}
+				if v == nil || v.String() != "1.0.1" {
+					t.Errorf("handler: got version %v, want 1.0.1", v)
+				}
+				return nil
+			}),
+		),
+	)
+
+	stream, err := recorder.NewStream(context.Background(), swarm.ZeroAddress, nil, testProtocolName, testProtocolVersion, testStreamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	v, err := stream.Version()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if v == nil {
+		t.Fatal("nil version")
+	}
+
+	if v.String() != "1.0.1" {
+		t.Fatalf("got string version %v, want 1.0.1", v)
+	}
+
+	if !v.Equal(semver.Version{Major: 1, Minor: 0, Patch: 1}) {
+		t.Fatalf("got semver version %v, want 1.0.1", v)
 	}
 }


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR adds a new method to p2p.Stream: Version() that exposes the protocol version of the peer as already parsed semver.Version for easier validations. It can be used in p2p Handlers for backward compatibility checks. Since libp2p is configured to follow semver in a semantic way, not only formal, it is possilbe to have the backward compatibility with only increasing Minor or Patch numbers in the version string.

It looked to me that exposing the more granular versioning on protocols can provide greater isolation on compatibility checks compared to the bee version check. And libp2p is validating the protocol version making it more reliable compared to the version of the bee in the user-agent. Since every protocol has its version, and the validation is scoped to the p2p layer, protocol versions are covering the same scope as p2p connection user-agent string.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
