### PR TITLE
fix(api): bytes head entity headers

### DIFF
--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -255,12 +255,17 @@ paths:
             $ref: "SwarmCommon.yaml#/components/schemas/SwarmAddress"
           required: true
           description: Swarm address of chunk
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmCache"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyStrategyParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyFallbackModeParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyLevelParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmChunkRetrievalTimeoutParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActTimestamp"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActPublisher"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActHistoryAddress"
       responses:
         "200":
-          description: The chunk exists.
+          description: Headers for the content at the reference.
           headers:
             Content-Type:
               description: The MIME type of the resource (e.g., application/octet-stream).
@@ -489,12 +494,17 @@ paths:
             $ref: "SwarmCommon.yaml#/components/schemas/SwarmAddress"
           required: true
           description: Swarm address of chunk
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmCache"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyStrategyParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyFallbackModeParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmRedundancyLevelParameter"
+        - $ref: "SwarmCommon.yaml#/components/parameters/SwarmChunkRetrievalTimeoutParameter"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActTimestamp"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActPublisher"
         - $ref: "SwarmCommon.yaml#/components/parameters/SwarmActHistoryAddress"
       responses:
         "200":
-          description: Chunk exists
+          description: Headers for the content at the reference.
           headers:
             Content-Type:
               description: The MIME type of the resource.

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -246,6 +246,9 @@ paths:
           description: Default response
     head:
       summary: Retrieve headers containing the content type and length for the reference
+      description: >
+        Identical to GET on the same reference except that no content is sent,
+        so Range and conditional request headers are honored the same way.
       tags:
         - Bytes
       parameters:
@@ -286,15 +289,44 @@ paths:
               description: The reference, as an entity tag.
               schema:
                 type: string
+            Last-Modified:
+              description: The time the response was generated.
+              schema:
+                type: string
             Access-Control-Expose-Headers:
               description: Headers exposed for CORS.
               schema:
                 type: string
-                example: Content-Disposition, Accept-Ranges
+                example: Content-Disposition
+        "206":
+          description: Headers for the range requested via the Range header.
+          headers:
+            Content-Range:
+              description: The range covered, and the total size of the content.
+              schema:
+                type: string
+                example: bytes 0-1023/4096
+            Content-Length:
+              description: The size of the requested range in bytes.
+              schema:
+                type: integer
+                example: 1024
+        "304":
+          description: The entity tag in If-None-Match matches the reference.
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
+        "412":
+          description: A conditional request header was not satisfied.
+        "416":
+          description: The requested range cannot be satisfied.
+          headers:
+            Content-Range:
+              description: The total size of the content.
+              schema:
+                type: string
+                example: bytes */4096
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
@@ -485,6 +517,9 @@ paths:
           description: Default response
     head:
       summary: Retrieve headers with content type and length for the reference
+      description: >
+        Identical to GET on the same reference except that no content is sent,
+        so Range and conditional request headers are honored the same way.
       tags:
         - BZZ
       parameters:
@@ -525,15 +560,44 @@ paths:
               description: The reference, as an entity tag.
               schema:
                 type: string
+            Last-Modified:
+              description: The time the response was generated.
+              schema:
+                type: string
             Access-Control-Expose-Headers:
               description: Headers exposed for CORS.
               schema:
                 type: string
-                example: Content-Disposition, Accept-Ranges
+                example: Content-Disposition
+        "206":
+          description: Headers for the range requested via the Range header.
+          headers:
+            Content-Range:
+              description: The range covered, and the total size of the content.
+              schema:
+                type: string
+                example: bytes 0-1023/4096
+            Content-Length:
+              description: The size of the requested range in bytes.
+              schema:
+                type: integer
+                example: 1024
+        "304":
+          description: The entity tag in If-None-Match matches the reference.
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
+        "412":
+          description: A conditional request header was not satisfied.
+        "416":
+          description: The requested range cannot be satisfied.
+          headers:
+            Content-Range:
+              description: The total size of the content.
+              schema:
+                type: string
+                example: bytes */4096
         "500":
           $ref: "SwarmCommon.yaml#/components/responses/500"
         default:

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -268,19 +268,30 @@ paths:
                 type: string
                 example: application/octet-stream
             Content-Length:
-              description: The size of the chunk in bytes.
+              description: The size of the retrievable content in bytes.
               schema:
                 type: integer
                 example: 1024
+            Accept-Ranges:
+              description: Indicates that ranged requests are supported for the reference.
+              schema:
+                type: string
+                example: bytes
+            ETag:
+              description: The reference, as an entity tag.
+              schema:
+                type: string
             Access-Control-Expose-Headers:
               description: Headers exposed for CORS.
               schema:
                 type: string
-                example: Accept-Ranges, Content-Encoding
+                example: Content-Disposition, Accept-Ranges, Content-Encoding
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
           description: Default response
 
@@ -484,10 +495,37 @@ paths:
       responses:
         "200":
           description: Chunk exists
+          headers:
+            Content-Type:
+              description: The MIME type of the resource.
+              schema:
+                type: string
+                example: application/octet-stream
+            Content-Length:
+              description: The size of the retrievable content in bytes.
+              schema:
+                type: integer
+                example: 1024
+            Accept-Ranges:
+              description: Indicates that ranged requests are supported for the reference.
+              schema:
+                type: string
+                example: bytes
+            ETag:
+              description: The reference, as an entity tag.
+              schema:
+                type: string
+            Access-Control-Expose-Headers:
+              description: Headers exposed for CORS.
+              schema:
+                type: string
+                example: Content-Disposition, Accept-Ranges, Content-Encoding
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
           $ref: "SwarmCommon.yaml#/components/responses/404"
+        "500":
+          $ref: "SwarmCommon.yaml#/components/responses/500"
         default:
           description: Default response
 

--- a/openapi/Swarm.yaml
+++ b/openapi/Swarm.yaml
@@ -285,7 +285,7 @@ paths:
               description: Headers exposed for CORS.
               schema:
                 type: string
-                example: Content-Disposition, Accept-Ranges, Content-Encoding
+                example: Content-Disposition, Accept-Ranges
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":
@@ -519,7 +519,7 @@ paths:
               description: Headers exposed for CORS.
               schema:
                 type: string
-                example: Content-Disposition, Accept-Ranges, Content-Encoding
+                example: Content-Disposition, Accept-Ranges
         "400":
           $ref: "SwarmCommon.yaml#/components/responses/400"
         "404":

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -107,7 +107,6 @@ const (
 	ContentTypeHeader          = "Content-Type"
 	ContentDispositionHeader   = "Content-Disposition"
 	ContentLengthHeader        = "Content-Length"
-	ContentEncodingHeader      = "Content-Encoding"
 	AcceptRangesHeader         = "Accept-Ranges"
 	RangeHeader                = "Range"
 	OriginHeader               = "Origin"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -107,6 +107,7 @@ const (
 	ContentTypeHeader          = "Content-Type"
 	ContentDispositionHeader   = "Content-Disposition"
 	ContentLengthHeader        = "Content-Length"
+	ContentRangeHeader         = "Content-Range"
 	AcceptRangesHeader         = "Accept-Ranges"
 	RangeHeader                = "Range"
 	OriginHeader               = "Origin"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -107,6 +107,8 @@ const (
 	ContentTypeHeader          = "Content-Type"
 	ContentDispositionHeader   = "Content-Disposition"
 	ContentLengthHeader        = "Content-Length"
+	ContentEncodingHeader      = "Content-Encoding"
+	AcceptRangesHeader         = "Accept-Ranges"
 	RangeHeader                = "Range"
 	OriginHeader               = "Origin"
 	AccessControlExposeHeaders = "Access-Control-Expose-Headers"

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -210,8 +210,7 @@ func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
 		ContentTypeHeader: {"application/octet-stream"},
 	}
 
-	// share the download path with the GET handler so that the length is resolved
-	// by the joiner. It strips the redundancy level that may be encoded in the
-	// root chunk span, and splits an encrypted reference into address and key.
+	// share the GET path: the joiner strips the redundancy level encoded in the
+	// root chunk span and splits an encrypted reference into address and key.
 	s.downloadHandler(logger, w, r, address, additionalHeaders, true, true, nil)
 }

--- a/pkg/api/bytes.go
+++ b/pkg/api/bytes.go
@@ -5,15 +5,12 @@
 package api
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/ethersphere/bee/v2/pkg/accesscontrol"
-	"github.com/ethersphere/bee/v2/pkg/cac"
 	"github.com/ethersphere/bee/v2/pkg/file/redundancy"
 	"github.com/ethersphere/bee/v2/pkg/jsonhttp"
 	"github.com/ethersphere/bee/v2/pkg/postage"
@@ -209,24 +206,12 @@ func (s *Service) bytesHeadHandler(w http.ResponseWriter, r *http.Request) {
 		address = v
 	}
 
-	getter := s.storer.Download(true)
-	ch, err := getter.Get(r.Context(), address)
-	if err != nil {
-		logger.Debug("get root chunk failed", "chunk_address", address, "error", err)
-		logger.Error(nil, "get root chunk failed")
-		w.WriteHeader(http.StatusNotFound)
-		return
+	additionalHeaders := http.Header{
+		ContentTypeHeader: {"application/octet-stream"},
 	}
 
-	w.Header().Add(AccessControlExposeHeaders, "Accept-Ranges, Content-Encoding")
-	w.Header().Add(ContentTypeHeader, "application/octet-stream")
-	var span int64
-
-	if cac.Valid(ch) {
-		span = int64(binary.LittleEndian.Uint64(ch.Data()[:swarm.SpanSize]))
-	} else {
-		span = int64(len(ch.Data()))
-	}
-	w.Header().Set(ContentLengthHeader, strconv.FormatInt(span, 10))
-	w.WriteHeader(http.StatusOK) // HEAD requests do not write a body
+	// share the download path with the GET handler so that the length is resolved
+	// by the joiner. It strips the redundancy level that may be encoded in the
+	// root chunk span, and splits an encrypted reference into address and key.
+	s.downloadHandler(logger, w, r, address, additionalHeaders, true, true, nil)
 }

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -486,6 +486,17 @@ func TestBytesHead(t *testing.T) {
 						jsonhttptest.WithNonEmptyResponseHeader("Last-Modified"),
 					)
 				}
+
+				// The range is resolved against the length decoded from the root
+				// chunk span, so it has to hold for every redundancy level and for
+				// encrypted references, where that span is decrypted first.
+				for _, method := range []string{http.MethodHead, http.MethodGet} {
+					jsonhttptest.Request(t, client, method, resource, http.StatusPartialContent,
+						jsonhttptest.WithRequestHeader(api.RangeHeader, "bytes=0-10"),
+						jsonhttptest.WithExpectedContentLength(11),
+						jsonhttptest.WithExpectedResponseHeader(api.ContentRangeHeader, fmt.Sprintf("bytes 0-10/%d", len(content))),
+					)
+				}
 			})
 		}
 	}

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -441,3 +441,86 @@ func TestBytesRedundancyLevel(t *testing.T) {
 		})
 	}
 }
+
+// TestBytesHead tests that a HEAD request reports the same entity headers as a
+// GET, for every redundancy level and for encrypted references. The redundancy
+// level is encoded into the most significant byte of the root chunk span and has
+// to be stripped before the length is read out of it, and an encrypted reference
+// carries a decryption key that is not part of the root chunk address.
+func TestBytesHead(t *testing.T) {
+	t.Parallel()
+
+	g := mockbytes.New(0, mockbytes.MockTypeStandard).WithModulus(255)
+	content, err := g.SequentialBytes(swarm.ChunkSize * 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for level := redundancy.NONE; level <= redundancy.PARANOID; level++ {
+		for _, encrypt := range []bool{false, true} {
+			t.Run(fmt.Sprintf("level %d encrypt %v", level, encrypt), func(t *testing.T) {
+				t.Parallel()
+
+				client, _, _, _ := newTestServer(t, testServerOptions{
+					Storer: mockstorer.New(),
+					Post:   mockpost.New(mockpost.WithAcceptAll()),
+				})
+
+				var resp struct {
+					Reference swarm.Address `json:"reference"`
+				}
+				jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusCreated,
+					jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
+					jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
+					jsonhttptest.WithRequestHeader(api.SwarmRedundancyLevelHeader, strconv.Itoa(int(level))),
+					jsonhttptest.WithRequestHeader(api.SwarmEncryptHeader, strconv.FormatBool(encrypt)),
+					jsonhttptest.WithRequestBody(bytes.NewReader(content)),
+					jsonhttptest.WithUnmarshalJSONResponse(&resp),
+				)
+
+				resource := "/bytes/" + resp.Reference.String()
+
+				jsonhttptest.Request(t, client, http.MethodHead, resource, http.StatusOK,
+					jsonhttptest.WithExpectedContentLength(len(content)),
+					jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
+					jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
+				)
+				jsonhttptest.Request(t, client, http.MethodGet, resource, http.StatusOK,
+					jsonhttptest.WithExpectedContentLength(len(content)),
+					jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
+					jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
+				)
+			})
+		}
+	}
+}
+
+// TestBytesHeadErrorsMatchGet tests that HEAD reports the same status as GET for
+// references that cannot be served, so a client probing with HEAD is not told
+// something different from what the subsequent GET would do.
+func TestBytesHeadErrorsMatchGet(t *testing.T) {
+	t.Parallel()
+
+	client, _, _, _ := newTestServer(t, testServerOptions{
+		Storer: mockstorer.New(),
+		Post:   mockpost.New(mockpost.WithAcceptAll()),
+	})
+
+	tests := []struct {
+		name string
+		ref  string
+		want int
+	}{
+		{"unresolvable address", "abcd", http.StatusInternalServerError},
+		{"unknown address", "0000000000000000000000000000000000000000000000000000000000000001", http.StatusNotFound},
+		{"invalid address", "zzzz", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := "/bytes/" + tt.ref
+			jsonhttptest.Request(t, client, http.MethodHead, resource, tt.want)
+			jsonhttptest.Request(t, client, http.MethodGet, resource, tt.want)
+		})
+	}
+}

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -507,9 +507,9 @@ func TestBytesHeadErrorsMatchGet(t *testing.T) {
 		ref  string
 		want int
 	}{
-		{"unresolvable address", "abcd", http.StatusInternalServerError},
+		{"short address", "abcd", http.StatusInternalServerError},
 		{"unknown address", "0000000000000000000000000000000000000000000000000000000000000001", http.StatusNotFound},
-		{"invalid address", "zzzz", http.StatusBadRequest},
+		{"non-hex address", "zzzz", http.StatusBadRequest},
 	}
 
 	for _, tt := range tests {

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -477,18 +477,109 @@ func TestBytesHead(t *testing.T) {
 
 				resource := "/bytes/" + resp.Reference.String()
 
-				jsonhttptest.Request(t, client, http.MethodHead, resource, http.StatusOK,
-					jsonhttptest.WithExpectedContentLength(len(content)),
-					jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
-					jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
-				)
-				jsonhttptest.Request(t, client, http.MethodGet, resource, http.StatusOK,
-					jsonhttptest.WithExpectedContentLength(len(content)),
-					jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
-					jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
-				)
+				for _, method := range []string{http.MethodHead, http.MethodGet} {
+					jsonhttptest.Request(t, client, method, resource, http.StatusOK,
+						jsonhttptest.WithExpectedContentLength(len(content)),
+						jsonhttptest.WithExpectedResponseHeader(api.ContentTypeHeader, "application/octet-stream"),
+						jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
+						jsonhttptest.WithExpectedResponseHeader(api.ETagHeader, fmt.Sprintf("%q", resp.Reference)),
+						jsonhttptest.WithNonEmptyResponseHeader("Last-Modified"),
+					)
+				}
 			})
 		}
+	}
+}
+
+// TestBytesHeadRangeAndConditional tests that HEAD applies Range and precondition
+// headers exactly as GET does, since HEAD differs from GET only in sending no body.
+func TestBytesHeadRangeAndConditional(t *testing.T) {
+	t.Parallel()
+
+	g := mockbytes.New(0, mockbytes.MockTypeStandard).WithModulus(255)
+	content, err := g.SequentialBytes(swarm.ChunkSize * 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, _, _, _ := newTestServer(t, testServerOptions{
+		Storer: mockstorer.New(),
+		Post:   mockpost.New(mockpost.WithAcceptAll()),
+	})
+
+	var resp struct {
+		Reference swarm.Address `json:"reference"`
+	}
+	jsonhttptest.Request(t, client, http.MethodPost, "/bytes", http.StatusCreated,
+		jsonhttptest.WithRequestHeader(api.SwarmDeferredUploadHeader, "true"),
+		jsonhttptest.WithRequestHeader(api.SwarmPostageBatchIdHeader, batchOkStr),
+		jsonhttptest.WithRequestBody(bytes.NewReader(content)),
+		jsonhttptest.WithUnmarshalJSONResponse(&resp),
+	)
+
+	resource := "/bytes/" + resp.Reference.String()
+	etag := fmt.Sprintf("%q", resp.Reference)
+
+	tests := []struct {
+		name    string
+		header  [2]string
+		want    int
+		headers []jsonhttptest.Option
+	}{
+		{
+			name:   "satisfiable range",
+			header: [2]string{api.RangeHeader, "bytes=0-99"},
+			want:   http.StatusPartialContent,
+			headers: []jsonhttptest.Option{
+				jsonhttptest.WithExpectedContentLength(100),
+				jsonhttptest.WithExpectedResponseHeader(api.ContentRangeHeader, fmt.Sprintf("bytes 0-99/%d", len(content))),
+			},
+		},
+		{
+			name:   "unsatisfiable range",
+			header: [2]string{api.RangeHeader, "bytes=99999999-"},
+			want:   http.StatusRequestedRangeNotSatisfiable,
+			headers: []jsonhttptest.Option{
+				jsonhttptest.WithExpectedResponseHeader(api.ContentRangeHeader, fmt.Sprintf("bytes */%d", len(content))),
+			},
+		},
+		{
+			name:   "matching if-none-match",
+			header: [2]string{"If-None-Match", etag},
+			want:   http.StatusNotModified,
+			headers: []jsonhttptest.Option{
+				jsonhttptest.WithNoResponseBody(),
+			},
+		},
+		{
+			name:   "non-matching if-none-match",
+			header: [2]string{"If-None-Match", `"0000000000000000000000000000000000000000000000000000000000000001"`},
+			want:   http.StatusOK,
+			headers: []jsonhttptest.Option{
+				jsonhttptest.WithExpectedContentLength(len(content)),
+			},
+		},
+		{
+			// A body-less response must not inherit the full content length, or the
+			// server truncates the connection and the client sees an unexpected EOF.
+			name:   "non-matching if-match",
+			header: [2]string{"If-Match", `"0000000000000000000000000000000000000000000000000000000000000001"`},
+			want:   http.StatusPreconditionFailed,
+			headers: []jsonhttptest.Option{
+				jsonhttptest.WithNoResponseBody(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, method := range []string{http.MethodHead, http.MethodGet} {
+				opts := append([]jsonhttptest.Option{
+					jsonhttptest.WithRequestHeader(tt.header[0], tt.header[1]),
+				}, tt.headers...)
+				jsonhttptest.Request(t, client, method, resource, tt.want, opts...)
+			}
+		})
 	}
 }
 

--- a/pkg/api/bytes_test.go
+++ b/pkg/api/bytes_test.go
@@ -442,11 +442,8 @@ func TestBytesRedundancyLevel(t *testing.T) {
 	}
 }
 
-// TestBytesHead tests that a HEAD request reports the same entity headers as a
-// GET, for every redundancy level and for encrypted references. The redundancy
-// level is encoded into the most significant byte of the root chunk span and has
-// to be stripped before the length is read out of it, and an encrypted reference
-// carries a decryption key that is not part of the root chunk address.
+// TestBytesHead tests that HEAD reports the same entity headers as GET, for every
+// redundancy level and for encrypted references.
 func TestBytesHead(t *testing.T) {
 	t.Parallel()
 
@@ -496,8 +493,7 @@ func TestBytesHead(t *testing.T) {
 }
 
 // TestBytesHeadErrorsMatchGet tests that HEAD reports the same status as GET for
-// references that cannot be served, so a client probing with HEAD is not told
-// something different from what the subsequent GET would do.
+// references that cannot be served.
 func TestBytesHeadErrorsMatchGet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -794,7 +794,7 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
 	if headersOnly {
-		// http.ServeContent sets this on the GET path, but is not reached here.
+		// http.ServeContent would set this, but the GET path is not reached here.
 		// "bytes" is the range unit, not the endpoint.
 		w.Header().Set(AcceptRangesHeader, "bytes")
 		w.Header().Add(AccessControlExposeHeaders, AcceptRangesHeader)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -794,6 +794,12 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
 	if headersOnly {
+		// http.ServeContent, which advertises range support on the GET path, is
+		// never reached here, so the header has to be set explicitly to keep HEAD
+		// responses consistent with GET, as RFC 9110 section 9.3.2 requires.
+		w.Header().Set(AcceptRangesHeader, "bytes")
+		w.Header().Add(AccessControlExposeHeaders, AcceptRangesHeader)
+		w.Header().Add(AccessControlExposeHeaders, ContentEncodingHeader)
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -794,9 +794,8 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
 	if headersOnly {
-		// http.ServeContent, which advertises range support on the GET path, is
-		// never reached here, so the header has to be set explicitly to keep HEAD
-		// responses consistent with GET, as RFC 9110 section 9.3.2 requires.
+		// http.ServeContent sets these on the GET path, but is not reached here.
+		// "bytes" is the range unit, not the endpoint.
 		w.Header().Set(AcceptRangesHeader, "bytes")
 		w.Header().Add(AccessControlExposeHeaders, AcceptRangesHeader)
 		w.Header().Add(AccessControlExposeHeaders, ContentEncodingHeader)

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -790,15 +789,17 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 	if etag {
 		w.Header().Set(ETagHeader, fmt.Sprintf("%q", reference))
 	}
-	w.Header().Set(ContentLengthHeader, strconv.FormatInt(l, 10))
+	// Content-Length is left to http.ServeContent, which knows how many bytes the
+	// response actually carries. Setting it here would survive into the responses
+	// that carry no content, notably the 412 from a failed precondition.
 	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
+	// http.ServeContent writes no body for HEAD, so header-only responses take the
+	// same path as GET and inherit its preconditions, Range handling and headers.
+	// The reader is passed unbuffered: a response without a body has nothing to
+	// read ahead for.
 	if headersOnly {
-		// http.ServeContent would set this, but the GET path is not reached here.
-		// "bytes" is the range unit, not the endpoint.
-		w.Header().Set(AcceptRangesHeader, "bytes")
-		w.Header().Add(AccessControlExposeHeaders, AcceptRangesHeader)
-		w.WriteHeader(http.StatusOK)
+		http.ServeContent(w, r, "", time.Now(), reader)
 		return
 	}
 

--- a/pkg/api/bzz.go
+++ b/pkg/api/bzz.go
@@ -794,11 +794,10 @@ func (s *Service) downloadHandler(logger log.Logger, w http.ResponseWriter, r *h
 	w.Header().Add(AccessControlExposeHeaders, ContentDispositionHeader)
 
 	if headersOnly {
-		// http.ServeContent sets these on the GET path, but is not reached here.
+		// http.ServeContent sets this on the GET path, but is not reached here.
 		// "bytes" is the range unit, not the endpoint.
 		w.Header().Set(AcceptRangesHeader, "bytes")
 		w.Header().Add(AccessControlExposeHeaders, AcceptRangesHeader)
-		w.Header().Add(AccessControlExposeHeaders, ContentEncodingHeader)
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/pkg/api/bzz_test.go
+++ b/pkg/api/bzz_test.go
@@ -597,6 +597,7 @@ func TestBzzFiles(t *testing.T) {
 				jsonhttptest.WithRequestBody(bytes.NewReader(simpleData)),
 				jsonhttptest.WithRequestHeader(api.ContentTypeHeader, "text/html; charset=utf-8"),
 				jsonhttptest.WithExpectedContentLength(21),
+				jsonhttptest.WithExpectedResponseHeader(api.AcceptRangesHeader, "bytes"),
 			)
 		})
 	})


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

`HEAD /bytes/<ref>` did not return usable entity headers. Three separate defects:

1. **Invalid `Content-Length`.** The redundancy level is packed into the most significant byte of the root chunk span (`redundancy.EncodeLevel`), so reading the span as `int64` yielded a negative number for any upload with redundancy level >= 1 spanning more than one chunk. Bee sent `Content-Length: -9151314442816647872`; curl rejects that and aborts header parsing (exit 8), which is why the response looked like it had no headers at all.
2. **Encrypted references returned 404.** The handler looked up the full 64-byte reference (address + key) as if it were a chunk address.
3. **`Accept-Ranges` was never sent** on HEAD, for `/bytes` or `/bzz`, even though both serve ranged GETs.

`bytesHeadHandler` now delegates to `downloadHandler` with `headersOnly`, the same path `bzzHeadHandler` already uses. HEAD and GET therefore share one implementation and the length comes from the joiner, which strips the encoded redundancy level and splits an encrypted reference into address and key. `Accept-Ranges` is set on that shared header-only branch, so both endpoints are covered.

Behavior change worth noting: HEAD now reports the same status as GET for references that cannot be served, where it previously always returned 404. Pinned by `TestBytesHeadErrorsMatchGet`.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

Documented `Accept-Ranges`, `ETag` and the `500` response on `HEAD /bytes/{address}` and `HEAD /bzz/{address}`.

`info.version` left at 8.1.0. The added response headers are additive, but the HEAD status change above is arguably breaking — happy to bump if you would rather record it.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

Size-then-range is how generic HTTP clients read a large remote object: HEAD for the length, then ranged GETs. Bee's ranged GET support already works, so the missing HEAD headers were the only thing blocking that whole class of client (`nbdkit`, `rclone`, `aria2`, anything on libcurl's remote-file handling).

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

Closes #5545

### Screenshots (if appropriate):

### AI Disclosure
- [x] This PR contains code that has been generated by an LLM.
- [x] I have reviewed the AI generated code thoroughly.
- [x] I possess the technical expertise to responsibly review the code generated in this PR.
