### PR TITLE
feat(puller): add pullsync rate metric

### DIFF
--- a/pkg/puller/metrics.go
+++ b/pkg/puller/metrics.go
@@ -15,9 +15,10 @@ type metrics struct {
 	SyncedCounter         *prometheus.CounterVec // number of synced chunks
 	SyncWorkerErrCounter  prometheus.Counter     // count number of errors
 	MaxUintErrCounter     prometheus.Counter     // how many times we got maxuint as topmost
+	PullsyncRate          prometheus.GaugeFunc   // rate of historical syncing
 }
 
-func newMetrics() metrics {
+func newMetrics(pullsyncRate func() float64) metrics {
 	subsystem := "puller"
 
 	return metrics{
@@ -51,6 +52,12 @@ func newMetrics() metrics {
 			Name:      "max_uint_errors",
 			Help:      "Total max uint errors.",
 		}),
+		PullsyncRate: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "pullsync_rate",
+			Help:      "Rate of historical syncing in chunks.",
+		}, pullsyncRate),
 	}
 }
 

--- a/pkg/puller/puller.go
+++ b/pkg/puller/puller.go
@@ -124,18 +124,19 @@ func New(
 	if o.Bins != 0 {
 		bins = o.Bins
 	}
+	histRate := rate.New(DefaultHistRateWindow)
 	p := &Puller{
 		base:        addr,
 		statestore:  stateStore,
 		topology:    topology,
 		radius:      reserveState,
 		syncer:      pullSync,
-		metrics:     newMetrics(),
+		metrics:     newMetrics(histRate.Rate),
 		logger:      logger.WithName(loggerName).Register(),
 		syncPeers:   make(map[string]*syncPeer),
 		bins:        bins,
 		blockLister: blockLister,
-		rate:        rate.New(DefaultHistRateWindow),
+		rate:        histRate,
 		cancel:      func() { /* Noop, since the context is initialized in the Start(). */ },
 		limiter:     ratelimit.NewLimiter(ratelimit.Every(time.Second/maxChunksPerSecond), maxChunksPerSecond),
 	}


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The bee node shrinks its storage radius only when historical syncing has fully stopped (SyncRate() == 0). Until now, we couldn't see that sync rate anywhere, so when the radius didn't decrease, we couldn't tell why, or how close it was to happening.

With this change, we expose that number as `bee_puller_pullsync_rate`.

Now we can put it on a dashboard and watch the story unfold: the rate is high while we catch up on history → it decays to 0 when syncing finishes → and the moment it hits 0, our radius is allowed to step down. With this metric, we make the previously invisible condition that controls radius decrease visible.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
