### PR TITLE
feat(cmd): add --light-node-limit CLI and config option

### DIFF
--- a/cmd/bee/cmd/cmd.go
+++ b/cmd/bee/cmd/cmd.go
@@ -60,6 +60,7 @@ const (
 	optionNameChequebookVerification       = "chequebook-verification"
 	optionNameChequebookMinBalance         = "chequebook-min-balance"
 	optionNameFullNode                     = "full-node"
+	optionNameLightNodeLimit               = "light-node-limit"
 	optionNamePostageContractAddress       = "postage-stamp-address"
 	optionNamePostageContractStartBlock    = "postage-stamp-start-block"
 	optionNamePriceOracleAddress           = "price-oracle-address"
@@ -361,6 +362,7 @@ func (c *command) setAllFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(optionNameChequebookVerification, false, "reject full-node hive/handshake records that carry no chequebook address")
 	cmd.Flags().String(optionNameChequebookMinBalance, "110000000000000000", "minimum chequebook token balance required for verification, in token small units (default 11 BZZ)")
 	cmd.Flags().Bool(optionNameFullNode, false, "cause the node to start in full mode")
+	cmd.Flags().Int(optionNameLightNodeLimit, 100, "light node limit")
 	cmd.Flags().String(optionNamePostageContractAddress, "", "postage stamp contract address")
 	cmd.Flags().Uint64(optionNamePostageContractStartBlock, 0, "postage stamp contract start block number")
 	cmd.Flags().String(optionNamePriceOracleAddress, "", "price oracle contract address")

--- a/cmd/bee/cmd/start.go
+++ b/cmd/bee/cmd/start.go
@@ -325,6 +325,7 @@ func buildBeeNode(ctx context.Context, c *command, cmd *cobra.Command, logger lo
 		AutoTLSDomain:                 c.config.GetString(optionAutoTLSDomain),
 		AutoTLSRegistrationEndpoint:   c.config.GetString(optionAutoTLSRegistrationEndpoint),
 		FullNodeMode:                  fullNode,
+		LightNodeLimit:                c.config.GetInt(optionNameLightNodeLimit),
 		Logger:                        logger,
 		MinimumGasTipCap:              c.config.GetUint64(optionNameMinimumGasTipCap),
 		GasLimitFallback:              c.config.GetUint64(optionNameGasLimitFallback),

--- a/packaging/bee.yaml
+++ b/packaging/bee.yaml
@@ -151,3 +151,5 @@ password-file: "/var/lib/bee/password"
 # autotls-ca-endpoint: ""
 ## SIMD BMT hashing opt-in flag (only available on linux amd64)
 # use-simd-hashing: false
+## limit of possible connected light nodes (default: 100)
+# light-node-limit: 100

--- a/packaging/homebrew-amd64/bee.yaml
+++ b/packaging/homebrew-amd64/bee.yaml
@@ -151,3 +151,5 @@ password-file: "/usr/local/var/lib/swarm-bee/password"
 # autotls-ca-endpoint: ""
 ## SIMD BMT hashing opt-in flag (only available on linux amd64)
 # use-simd-hashing: false
+## limit of possible connected light nodes (default: 100)
+# light-node-limit: 100

--- a/packaging/homebrew-arm64/bee.yaml
+++ b/packaging/homebrew-arm64/bee.yaml
@@ -151,3 +151,5 @@ password-file: "/opt/homebrew/var/lib/swarm-bee/password"
 # autotls-ca-endpoint: ""
 ## SIMD BMT hashing opt-in flag (only available on linux amd64)
 # use-simd-hashing: false
+## limit of possible connected light nodes (default: 100)
+# light-node-limit: 100

--- a/packaging/scoop/bee.yaml
+++ b/packaging/scoop/bee.yaml
@@ -151,3 +151,5 @@ password-file: "./password"
 # autotls-ca-endpoint: ""
 ## SIMD BMT hashing opt-in flag (only available on linux amd64)
 # use-simd-hashing: false
+## limit of possible connected light nodes (default: 100)
+# light-node-limit: 100

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -165,6 +165,7 @@ type Options struct {
 	AutoTLSDomain                 string
 	AutoTLSRegistrationEndpoint   string
 	FullNodeMode                  bool
+	LightNodeLimit                int
 	GasLimitFallback              uint64
 	Logger                        log.Logger
 	MinimumGasTipCap              uint64
@@ -733,6 +734,7 @@ func NewBee(
 		AutoTLSCAEndpoint:           o.AutoTLSCAEndpoint,
 		WelcomeMessage:              o.WelcomeMessage,
 		FullNode:                    o.FullNodeMode,
+		LightNodeLimit:              o.LightNodeLimit,
 		Nonce:                       nonce,
 		AllowPrivateCIDRs:           o.AllowPrivateCIDRs,
 		Registry:                    registry,


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR exposes the Light Node connection limit via the `--light-node-limit` CLI flag and `light-node-limit` YAML configuration parameter.

Changes for #5556, evaluating performance under increased light node connection capacity requires the ability to configure `LightNodeLimit` dynamically. While `pkg/p2p/libp2p` already supported `LightNodeLimit` in its `Options` struct, the CLI flag and `node.Options` wiring were missing.

Resolves #5556

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
