### PR TITLE
feat: add new metrics

### DIFF
--- a/pkg/bzz/transport.go
+++ b/pkg/bzz/transport.go
@@ -24,6 +24,10 @@ const (
 	TransportWS
 	// TransportWSS indicates WebSocket with TLS (secure).
 	TransportWSS
+	// TransportQUICV1 indicates QUIC (version 1) transport.
+	TransportQUICV1
+	// TransportQUIC indicates legacy QUIC transport.
+	TransportQUIC
 )
 
 // String returns a string representation of the transport type.
@@ -35,13 +39,17 @@ func (t TransportType) String() string {
 		return "ws"
 	case TransportWSS:
 		return "wss"
+	case TransportQUICV1:
+		return "quic-v1"
+	case TransportQUIC:
+		return "quic"
 	default:
 		return "unknown"
 	}
 }
 
 // Priority returns the sorting priority for the transport type.
-// Lower value = higher priority: TCP (0) > WS (1) > WSS (2) > Unknown (3)
+// Lower value = higher priority: TCP(0) > WS(1) > WSS(2) > QUIC/Unknown(3).
 func (t TransportType) Priority() int {
 	switch t {
 	case TransportTCP:
@@ -50,6 +58,10 @@ func (t TransportType) Priority() int {
 		return 1
 	case TransportWSS:
 		return 2
+	case TransportQUICV1, TransportQUIC:
+		// Treat QUIC like unknown for address sorting so existing selection
+		// behavior stays stable.
+		return 3
 	default:
 		return 3
 	}
@@ -70,12 +82,19 @@ func ClassifyTransport(addr ma.Multiaddr) TransportType {
 	hasWS := hasProtocol(ma.P_WS)
 	hasTLS := hasProtocol(ma.P_TLS)
 	hasTCP := hasProtocol(ma.P_TCP)
+	hasWSS := hasProtocol(ma.P_WSS) // deprecated component used by libp2p live conns
+	hasQUICV1 := hasProtocol(ma.P_QUIC_V1)
+	hasQUIC := hasProtocol(ma.P_QUIC)
 
 	switch {
-	case hasWS && hasTLS:
+	case hasWSS || hasWS && hasTLS:
 		return TransportWSS
 	case hasWS:
 		return TransportWS
+	case hasQUICV1:
+		return TransportQUICV1
+	case hasQUIC:
+		return TransportQUIC
 	case hasTCP:
 		return TransportTCP
 	default:

--- a/pkg/bzz/transport_test.go
+++ b/pkg/bzz/transport_test.go
@@ -284,6 +284,21 @@ func TestClassifyTransport(t *testing.T) {
 			expected: bzz.TransportWSS,
 		},
 		{
+			name:     "WSS address with deprecated /wss component",
+			addr:     mustMultiaddr("/ip4/104.28.194.73/tcp/443/wss/p2p/QmfSx1ujzboapD5h2CiqTJqUy46FeTDwXBszB3XUCfKEEj"),
+			expected: bzz.TransportWSS,
+		},
+		{
+			name:     "QUIC v1 address",
+			addr:     mustMultiaddr("/ip4/1.2.3.4/udp/1234/quic-v1"),
+			expected: bzz.TransportQUICV1,
+		},
+		{
+			name:     "legacy QUIC address",
+			addr:     mustMultiaddr("/ip4/1.2.3.4/udp/1234/quic"),
+			expected: bzz.TransportQUIC,
+		},
+		{
 			name:     "UDP address returns unknown",
 			addr:     mustMultiaddr("/ip4/127.0.0.1/udp/8080"),
 			expected: bzz.TransportUnknown,
@@ -315,6 +330,8 @@ func TestTransportTypePriority(t *testing.T) {
 		{bzz.TransportTCP, 0},
 		{bzz.TransportWS, 1},
 		{bzz.TransportWSS, 2},
+		{bzz.TransportQUICV1, 3},
+		{bzz.TransportQUIC, 3},
 		{bzz.TransportUnknown, 3},
 	}
 
@@ -326,15 +343,24 @@ func TestTransportTypePriority(t *testing.T) {
 		})
 	}
 
-	// Verify priority ordering: TCP < WS < WSS < Unknown
+	// Verify priority ordering: TCP < WS < WSS < QUIC/Unknown
 	if bzz.TransportTCP.Priority() >= bzz.TransportWS.Priority() {
 		t.Error("TCP priority should be lower (better) than WS")
 	}
 	if bzz.TransportWS.Priority() >= bzz.TransportWSS.Priority() {
 		t.Error("WS priority should be lower (better) than WSS")
 	}
-	if bzz.TransportWSS.Priority() >= bzz.TransportUnknown.Priority() {
-		t.Error("WSS priority should be lower (better) than Unknown")
+	if bzz.TransportWSS.Priority() >= bzz.TransportQUICV1.Priority() {
+		t.Error("WSS priority should be lower (better) than QUIC v1")
+	}
+	if bzz.TransportWSS.Priority() >= bzz.TransportQUIC.Priority() {
+		t.Error("WSS priority should be lower (better) than legacy QUIC")
+	}
+	if bzz.TransportQUICV1.Priority() != bzz.TransportUnknown.Priority() {
+		t.Error("QUIC v1 priority should match Unknown")
+	}
+	if bzz.TransportQUIC.Priority() != bzz.TransportUnknown.Priority() {
+		t.Error("legacy QUIC priority should match Unknown")
 	}
 }
 

--- a/pkg/p2p/libp2p/libp2p.go
+++ b/pkg/p2p/libp2p/libp2p.go
@@ -1214,7 +1214,7 @@ func (s *Service) Connect(ctx context.Context, addrs []ma.Multiaddr) (address *b
 		return nil, fmt.Errorf("libp2p connect: peer %s does not exist %w", overlay, p2p.ErrPeerNotFound)
 	}
 
-	s.metrics.CreatedConnectionCount.Inc()
+	s.metrics.incCreatedConnection(stream.Conn().RemoteMultiaddr())
 
 	if len(peerAddrs) > 0 {
 		s.notifyReacherConnected(overlay, peerAddrs)
@@ -1572,8 +1572,8 @@ type connectionNotifier struct {
 	network.Notifiee
 }
 
-func (c *connectionNotifier) Connected(_ network.Network, _ network.Conn) {
-	c.metrics.HandledConnectionCount.Inc()
+func (c *connectionNotifier) Connected(_ network.Network, conn network.Conn) {
+	c.metrics.observeHandledConnection(conn.RemoteMultiaddr())
 }
 
 // isNetworkOrHostUnreachableError determines based on the

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -5,16 +5,26 @@
 package libp2p
 
 import (
+	"github.com/ethersphere/bee/v2/pkg/bzz"
 	m "github.com/ethersphere/bee/v2/pkg/metrics"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	connectionTransportLabelName = "transport"
+	connectionTransportHelp      = "The 'transport' label is one of: tcp, ws, wss, quic-v1, quic, unknown."
 )
 
 type metrics struct {
 	// all metrics fields must be exported
 	// to be able to return them by Metrics()
 	// using reflection
-	CreatedConnectionCount     prometheus.Counter
-	HandledConnectionCount     prometheus.Counter
+	CreatedConnectionCount     *prometheus.CounterVec
+	HandledConnectionCount     *prometheus.CounterVec
+	PublicAddressConnections   *prometheus.CounterVec
+	PrivateAddressConnections  *prometheus.CounterVec
 	CreatedStreamCount         prometheus.Counter
 	ClosedStreamCount          prometheus.Counter
 	StreamResetCount           prometheus.Counter
@@ -33,18 +43,42 @@ func newMetrics() metrics {
 	subsystem := "libp2p"
 
 	return metrics{
-		CreatedConnectionCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "created_connection_count",
-			Help:      "Number of initiated outgoing libp2p connections.",
-		}),
-		HandledConnectionCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: m.Namespace,
-			Subsystem: subsystem,
-			Name:      "handled_connection_count",
-			Help:      "Number of handled incoming libp2p connections.",
-		}),
+		CreatedConnectionCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "created_connection_count",
+				Help:      "Number of initiated outgoing libp2p connections. " + connectionTransportHelp,
+			},
+			[]string{connectionTransportLabelName},
+		),
+		HandledConnectionCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "handled_connection_count",
+				Help:      "Number of handled incoming libp2p connections. " + connectionTransportHelp,
+			},
+			[]string{connectionTransportLabelName},
+		),
+		PublicAddressConnections: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "public_address_connections_total",
+				Help:      "Number of libp2p connections whose remote multiaddr is a public address. " + connectionTransportHelp,
+			},
+			[]string{connectionTransportLabelName},
+		),
+		PrivateAddressConnections: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: m.Namespace,
+				Subsystem: subsystem,
+				Name:      "private_address_connections_total",
+				Help:      "Number of libp2p connections whose remote multiaddr is a private address. " + connectionTransportHelp,
+			},
+			[]string{connectionTransportLabelName},
+		),
 		CreatedStreamCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
@@ -118,6 +152,42 @@ func newMetrics() metrics {
 			Help:      "The duration spent exchanging the headers.",
 		}),
 	}
+}
+
+func (m metrics) incCreatedConnection(addr ma.Multiaddr) {
+	m.CreatedConnectionCount.WithLabelValues(connectionTransportLabel(addr)).Inc()
+}
+
+func (m metrics) observeHandledConnection(addr ma.Multiaddr) {
+	transport := connectionTransportLabel(addr)
+	m.HandledConnectionCount.WithLabelValues(transport).Inc()
+	if manet.IsPublicAddr(addr) {
+		m.PublicAddressConnections.WithLabelValues(transport).Inc()
+		return
+	}
+	m.PrivateAddressConnections.WithLabelValues(transport).Inc()
+}
+
+// connectionTransportLabel returns the Prometheus transport label for a connection
+// multiaddr. Live WSS connections are often encoded with the deprecated /wss
+// component rather than the /tls/.../ws form used in advertised AutoTLS addresses.
+func connectionTransportLabel(addr ma.Multiaddr) string {
+	if addr == nil {
+		return bzz.TransportUnknown.String()
+	}
+	if _, err := addr.ValueForProtocol(ma.P_WSS); err == nil {
+		return bzz.TransportWSS.String()
+	}
+	if t := bzz.ClassifyTransport(addr); t != bzz.TransportUnknown {
+		return t.String()
+	}
+	if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
+		return "quic-v1"
+	}
+	if _, err := addr.ValueForProtocol(ma.P_QUIC); err == nil {
+		return "quic"
+	}
+	return bzz.TransportUnknown.String()
 }
 
 func (s *Service) Metrics() []prometheus.Collector {

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -20,12 +20,11 @@ const (
 )
 
 var (
+	// TCP/WS/WSS only: bee does not register QUIC today.
 	transportLabelValues = []string{
 		bzz.TransportTCP.String(),
 		bzz.TransportWS.String(),
 		bzz.TransportWSS.String(),
-		bzz.TransportQUICV1.String(),
-		bzz.TransportQUIC.String(),
 		bzz.TransportUnknown.String(),
 	}
 	publicLabelValues = []string{"true", "false"}
@@ -56,14 +55,16 @@ func newMetrics() metrics {
 	transportHelp := "The 'transport' label is one of: " + strings.Join(transportLabelValues, ", ")
 	publicHelp := "The 'public' label is one of: " + strings.Join(publicLabelValues, ", ") + " (true = public remote multiaddr)."
 
+	connectionLabels := []string{connectionTransportLabelName, connectionPublicLabelName}
+
 	createdConnectionCount := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
 			Name:      "created_connection_count",
-			Help:      "Number of initiated outgoing libp2p connections. " + transportHelp,
+			Help:      "Number of initiated outgoing libp2p connections. " + transportHelp + " " + publicHelp,
 		},
-		[]string{connectionTransportLabelName},
+		connectionLabels,
 	)
 
 	handledConnectionCount := prometheus.NewCounterVec(
@@ -73,14 +74,14 @@ func newMetrics() metrics {
 			Name:      "handled_connection_count",
 			Help:      "Number of handled incoming libp2p connections. " + transportHelp + " " + publicHelp,
 		},
-		[]string{connectionTransportLabelName, connectionPublicLabelName},
+		connectionLabels,
 	)
 
 	// Ensure all expected label value combinations exist as 0-valued series,
 	// so Grafana shows a flat line instead of "No Data".
 	for _, transport := range transportLabelValues {
-		createdConnectionCount.WithLabelValues(transport).Add(0)
 		for _, public := range publicLabelValues {
+			createdConnectionCount.WithLabelValues(transport, public).Add(0)
 			handledConnectionCount.WithLabelValues(transport, public).Add(0)
 		}
 	}
@@ -164,19 +165,22 @@ func newMetrics() metrics {
 }
 
 func (m metrics) incCreatedConnection(addr ma.Multiaddr) {
-	m.CreatedConnectionCount.WithLabelValues(connectionTransportLabel(addr)).Inc()
+	m.CreatedConnectionCount.WithLabelValues(connectionTransportLabel(addr), connectionPublicLabel(addr)).Inc()
 }
 
 func (m metrics) observeHandledConnection(addr ma.Multiaddr) {
-	public := "false"
-	if manet.IsPublicAddr(addr) {
-		public = "true"
-	}
-	m.HandledConnectionCount.WithLabelValues(connectionTransportLabel(addr), public).Inc()
+	m.HandledConnectionCount.WithLabelValues(connectionTransportLabel(addr), connectionPublicLabel(addr)).Inc()
 }
 
 func connectionTransportLabel(addr ma.Multiaddr) string {
 	return bzz.ClassifyTransport(addr).String()
+}
+
+func connectionPublicLabel(addr ma.Multiaddr) string {
+	if manet.IsPublicAddr(addr) {
+		return "true"
+	}
+	return "false"
 }
 
 func (s *Service) Metrics() []prometheus.Collector {

--- a/pkg/p2p/libp2p/metrics.go
+++ b/pkg/p2p/libp2p/metrics.go
@@ -5,6 +5,8 @@
 package libp2p
 
 import (
+	"strings"
+
 	"github.com/ethersphere/bee/v2/pkg/bzz"
 	m "github.com/ethersphere/bee/v2/pkg/metrics"
 	ma "github.com/multiformats/go-multiaddr"
@@ -14,7 +16,19 @@ import (
 
 const (
 	connectionTransportLabelName = "transport"
-	connectionTransportHelp      = "The 'transport' label is one of: tcp, ws, wss, quic-v1, quic, unknown."
+	connectionPublicLabelName    = "public"
+)
+
+var (
+	transportLabelValues = []string{
+		bzz.TransportTCP.String(),
+		bzz.TransportWS.String(),
+		bzz.TransportWSS.String(),
+		bzz.TransportQUICV1.String(),
+		bzz.TransportQUIC.String(),
+		bzz.TransportUnknown.String(),
+	}
+	publicLabelValues = []string{"true", "false"}
 )
 
 type metrics struct {
@@ -23,8 +37,6 @@ type metrics struct {
 	// using reflection
 	CreatedConnectionCount     *prometheus.CounterVec
 	HandledConnectionCount     *prometheus.CounterVec
-	PublicAddressConnections   *prometheus.CounterVec
-	PrivateAddressConnections  *prometheus.CounterVec
 	CreatedStreamCount         prometheus.Counter
 	ClosedStreamCount          prometheus.Counter
 	StreamResetCount           prometheus.Counter
@@ -41,44 +53,41 @@ type metrics struct {
 
 func newMetrics() metrics {
 	subsystem := "libp2p"
+	transportHelp := "The 'transport' label is one of: " + strings.Join(transportLabelValues, ", ")
+	publicHelp := "The 'public' label is one of: " + strings.Join(publicLabelValues, ", ") + " (true = public remote multiaddr)."
+
+	createdConnectionCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "created_connection_count",
+			Help:      "Number of initiated outgoing libp2p connections. " + transportHelp,
+		},
+		[]string{connectionTransportLabelName},
+	)
+
+	handledConnectionCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: m.Namespace,
+			Subsystem: subsystem,
+			Name:      "handled_connection_count",
+			Help:      "Number of handled incoming libp2p connections. " + transportHelp + " " + publicHelp,
+		},
+		[]string{connectionTransportLabelName, connectionPublicLabelName},
+	)
+
+	// Ensure all expected label value combinations exist as 0-valued series,
+	// so Grafana shows a flat line instead of "No Data".
+	for _, transport := range transportLabelValues {
+		createdConnectionCount.WithLabelValues(transport).Add(0)
+		for _, public := range publicLabelValues {
+			handledConnectionCount.WithLabelValues(transport, public).Add(0)
+		}
+	}
 
 	return metrics{
-		CreatedConnectionCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "created_connection_count",
-				Help:      "Number of initiated outgoing libp2p connections. " + connectionTransportHelp,
-			},
-			[]string{connectionTransportLabelName},
-		),
-		HandledConnectionCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "handled_connection_count",
-				Help:      "Number of handled incoming libp2p connections. " + connectionTransportHelp,
-			},
-			[]string{connectionTransportLabelName},
-		),
-		PublicAddressConnections: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "public_address_connections_total",
-				Help:      "Number of libp2p connections whose remote multiaddr is a public address. " + connectionTransportHelp,
-			},
-			[]string{connectionTransportLabelName},
-		),
-		PrivateAddressConnections: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: m.Namespace,
-				Subsystem: subsystem,
-				Name:      "private_address_connections_total",
-				Help:      "Number of libp2p connections whose remote multiaddr is a private address. " + connectionTransportHelp,
-			},
-			[]string{connectionTransportLabelName},
-		),
+		CreatedConnectionCount: createdConnectionCount,
+		HandledConnectionCount: handledConnectionCount,
 		CreatedStreamCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: m.Namespace,
 			Subsystem: subsystem,
@@ -159,35 +168,15 @@ func (m metrics) incCreatedConnection(addr ma.Multiaddr) {
 }
 
 func (m metrics) observeHandledConnection(addr ma.Multiaddr) {
-	transport := connectionTransportLabel(addr)
-	m.HandledConnectionCount.WithLabelValues(transport).Inc()
+	public := "false"
 	if manet.IsPublicAddr(addr) {
-		m.PublicAddressConnections.WithLabelValues(transport).Inc()
-		return
+		public = "true"
 	}
-	m.PrivateAddressConnections.WithLabelValues(transport).Inc()
+	m.HandledConnectionCount.WithLabelValues(connectionTransportLabel(addr), public).Inc()
 }
 
-// connectionTransportLabel returns the Prometheus transport label for a connection
-// multiaddr. Live WSS connections are often encoded with the deprecated /wss
-// component rather than the /tls/.../ws form used in advertised AutoTLS addresses.
 func connectionTransportLabel(addr ma.Multiaddr) string {
-	if addr == nil {
-		return bzz.TransportUnknown.String()
-	}
-	if _, err := addr.ValueForProtocol(ma.P_WSS); err == nil {
-		return bzz.TransportWSS.String()
-	}
-	if t := bzz.ClassifyTransport(addr); t != bzz.TransportUnknown {
-		return t.String()
-	}
-	if _, err := addr.ValueForProtocol(ma.P_QUIC_V1); err == nil {
-		return "quic-v1"
-	}
-	if _, err := addr.ValueForProtocol(ma.P_QUIC); err == nil {
-		return "quic"
-	}
-	return bzz.TransportUnknown.String()
+	return bzz.ClassifyTransport(addr).String()
 }
 
 func (s *Service) Metrics() []prometheus.Collector {


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
- Add transport label to libp2p created/handled connection metrics (tcp / ws / wss / quic*).
- Move /wss + QUIC classification into bzz.ClassifyTransport.
- Replace separate public/private counters with public="true|false" on handled_connection_count.
- Pre-init label series so unused transports show as 0, not missing.

**Breaking changes**
- created_connection_count / handled_connection_count: Counter → CounterVec.
- handled_connection_count now has labels {transport, public}.
- Removed public_address_connections_total / private_address_connections_total — use handled_connection_count{public=...} instead.
- Dashboards using count(...) as a denominator will under-count after upgrade; prefer sum by (...).

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
https://github.com/ethersphere/bee/issues/5506

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
