### PR TITLE
fix: limit interfaces in test

### DIFF
--- a/pkg/p2p/libp2p/libp2p_test.go
+++ b/pkg/p2p/libp2p/libp2p_test.go
@@ -55,7 +55,11 @@ func newService(t *testing.T, networkID uint64, o libp2pServiceOpts) (s *libp2p.
 		t.Fatal(err)
 	}
 
-	addr := ":0"
+	// Bind loopback only so host.Addrs() stays small and independent of the
+	// machine's docker/bridge NICs. Handshake truncates underlays to
+	// maxUnderlaysPerPeer; listening on :0 expands to every local interface
+	// and breaks addressbook equality checks on hosts with many addresses.
+	addr := "127.0.0.1:0"
 
 	if o.Logger == nil {
 		o.Logger = log.Noop


### PR DESCRIPTION
### Checklist

- [ ] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Libp2p unit tests were listening on :0, so host.Addrs() expanded to every local interface. On machines with many docker/bridge NICs that list exceeds handshake’s 20-underlay cap, and TestTopologyNotifier / TestTopologyAnnounce failed comparing the addressbook to the full listen set.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
