### PR TITLE
chore: use slim postage snapshot from batch-archive v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/caddyserver/certmagic v0.21.6
 	github.com/coreos/go-semver v0.3.0
 	github.com/ethereum/go-ethereum v1.17.3
-	github.com/ethersphere/batch-archive v0.0.9
+	github.com/ethersphere/batch-archive v0.1.0
 	github.com/ethersphere/go-price-oracle-abi v0.6.9
 	github.com/ethersphere/go-storage-incentives-abi v0.9.4
 	github.com/ethersphere/go-sw3-abi v0.6.9

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1
 github.com/ethereum/go-ethereum v1.10.4/go.mod h1:nEE0TP5MtxGzOMd7egIrbPJMQBnhVU3ELNxhBglIzhg=
 github.com/ethereum/go-ethereum v1.17.3 h1:Ev/sQHH+UdKZHWjuVzhu2pxhi/sXaPZl23Q+Q5LDd4Q=
 github.com/ethereum/go-ethereum v1.17.3/go.mod h1:f2EhRwqewIZkGoQekywI2Y2RZAMTSavLNkD9qItFy1A=
-github.com/ethersphere/batch-archive v0.0.9 h1:lhVbwHmbngJgwXq3gtRCpxkICghPqSrDVy0WIiR6QGM=
-github.com/ethersphere/batch-archive v0.0.9/go.mod h1:41BPb192NoK9CYjNB8BAE1J2MtiI/5aq0Wtas5O7A7Q=
+github.com/ethersphere/batch-archive v0.1.0 h1:zxGK6i1FHg5kEq11NcEjR6Ykw0UxWaAPR9tlpdTQ+xI=
+github.com/ethersphere/batch-archive v0.1.0/go.mod h1:41BPb192NoK9CYjNB8BAE1J2MtiI/5aq0Wtas5O7A7Q=
 github.com/ethersphere/go-price-oracle-abi v0.6.9 h1:bseen6he3PZv5GHOm+KD6s4awaFmVSD9LFx+HpB6rCU=
 github.com/ethersphere/go-price-oracle-abi v0.6.9/go.mod h1:sI/Qj4/zJ23/b1enzwMMv0/hLTpPNVNacEwCWjo6yBk=
 github.com/ethersphere/go-storage-incentives-abi v0.9.4 h1:mSIWXQXg5OQmH10QvXMV5w0vbSibFMaRlBL37gPLTM0=

--- a/pkg/postage/snapshot/snapshot.go
+++ b/pkg/postage/snapshot/snapshot.go
@@ -71,6 +71,16 @@ func (f *SnapshotLogFilterer) loadSnapshot() error {
 	return nil
 }
 
+// parseLogs decodes the snapshot NDJSON into types.Log entries.
+//
+// The snapshot is produced by ethersphere/batch-export, whose default slim
+// encoding carries only the types.Log fields Bee reads today: address, topics,
+// data, blockNumber, transactionHash (and logIndex). Any other field —
+// BlockHash, TxIndex, Removed — decodes to its zero value here with no error.
+// Before consuming a new types.Log field anywhere downstream of this filterer
+// (FilterLogs callers, listener.processEvent, transaction.ParseEvent), extend
+// SlimLog in batch-export's pkg/filestore and republish the snapshot first;
+// otherwise the field is silently empty for snapshot-sourced logs.
 func (f *SnapshotLogFilterer) parseLogs(reader io.Reader) error {
 	var parsedLogs []types.Log
 	var currentMaxBlockHeight uint64


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The snapshot is produced by ethersphere/batch-export, whose default slim encoding carries only the types.Log fields Bee reads today: address, topics, data, blockNumber, transactionHash (and logIndex). Any other field — BlockHash, TxIndex, Removed — decodes to its zero value here with no error.
Before consuming a new types.Log field anywhere downstream of this filterer (FilterLogs callers, listener.processEvent, transaction.ParseEvent), extend SlimLog in batch-export's pkg/filestore and republish the snapshot first; otherwise the field is silently empty for snapshot-sourced logs.
This currently reduces snapshot for 4MB.

### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
