### PR TITLE
fix: flaky test by checking ctx cancellation before racing I/O in protobuf reader/writer

### DIFF
--- a/pkg/p2p/libp2p/stream_test.go
+++ b/pkg/p2p/libp2p/stream_test.go
@@ -79,6 +79,7 @@ func TestStreamVersion(t *testing.T) {
 
 			if v == nil {
 				t.Fatal("expected version to be non-nil")
+				return
 			}
 
 			expected := semver.Version{Major: tc.wantMajor, Minor: tc.wantMinor}

--- a/pkg/p2p/protobuf/protobuf.go
+++ b/pkg/p2p/protobuf/protobuf.go
@@ -56,6 +56,10 @@ func newReader(r ggio.Reader) Reader {
 }
 
 func (r Reader) ReadMsgWithContext(ctx context.Context, msg proto.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- r.ReadMsg(msg)
@@ -78,6 +82,10 @@ func newWriter(r ggio.Writer) Writer {
 }
 
 func (w Writer) WriteMsgWithContext(ctx context.Context, msg proto.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- w.WriteMsg(msg)


### PR DESCRIPTION
### Checklist

- [x] I have read the [coding guide](https://github.com/ethersphere/bee/blob/master/CODING.md).
- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixes flaky [`TestIncoming_ContextTimeout`](https://github.com/ethersphere/bee/actions/runs/33604392092/job/100168667421?pr=5590)

`WriteMsgWithContext` and `ReadMsgWithContext` could behave randomly when the context was already canceled.

They started the I/O operation and waited to see whether the I/O finished or the context was canceled. If both happened at the same time, the program could choose either result.

This was especially easy to reproduce with the in-memory `streamtest` stream, where I/O could finish immediately. As a result, `TestIncoming_ContextTimeout` sometimes passed and sometimes failed in CI.

The fix is to check `ctx.Err()` before starting the I/O. If the context is already canceled or expired, the function now immediately returns the context error every time.


### Open API Spec Version Changes (if applicable)
<!--Please indicate the version changes if applicable (see https://semver.org).-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

### AI Disclosure
- [ ] This PR contains code that has been generated by an LLM.
- [ ] I have reviewed the AI generated code thoroughly.
- [ ] I possess the technical expertise to responsibly review the code generated in this PR.
